### PR TITLE
feat(#201): add email preview workflow and two-factor template

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "typecheck": "nx run-many -t typecheck",
     "e2e": "nx run-many -t e2e",
     "format": "tsx --tsconfig ./scripts/tsconfig.json ./scripts/format.ts",
+    "email:preview": "tsx --tsconfig ./scripts/tsconfig.json ./scripts/email-preview.ts",
     "codegen:graphql": "TS_NODE_PROJECT=./tsconfig.codegen.json dotenvx run -f projects/service-api/.env.development -- graphql-codegen --require tsconfig-paths/register --import jiti/register",
     "codegen:styles": "nx run-many -t codegen",
     "codegen:types": "nx run-many -t typegen",

--- a/projects/lib-email-templates/src/generate-two-factor-email.test.tsx
+++ b/projects/lib-email-templates/src/generate-two-factor-email.test.tsx
@@ -1,0 +1,16 @@
+import { expect, test } from 'vitest';
+import { generateTwoFactorEmail } from './generate-two-factor-email';
+
+test('it generates a two-factor email with the provided configuration', async () => {
+  const config = {
+    verificationCode: '123456',
+  };
+
+  const { html, plainText } = await generateTwoFactorEmail(config);
+
+  expect(html).include('Your two-factor sign-in code');
+  expect(html).include(config.verificationCode);
+
+  expect(plainText).include('YOUR TWO-FACTOR SIGN-IN CODE');
+  expect(plainText).include(config.verificationCode);
+});

--- a/projects/lib-email-templates/src/generate-two-factor-email.tsx
+++ b/projects/lib-email-templates/src/generate-two-factor-email.tsx
@@ -1,0 +1,17 @@
+import * as E from '@react-email/components';
+import { generateEmail } from './generate-email';
+import { TwoFactorEmail } from './templates/two-factor-email';
+
+interface Config {
+  verificationCode: string;
+}
+
+export async function generateTwoFactorEmail(config: Config) {
+  return generateEmail({
+    component: (
+      <E.Html dir="ltr" lang="en">
+        <TwoFactorEmail verificationCode={config.verificationCode} />
+      </E.Html>
+    ),
+  });
+}

--- a/projects/lib-email-templates/src/index.ts
+++ b/projects/lib-email-templates/src/index.ts
@@ -3,4 +3,5 @@ export { generateChangeEmailVerificationEmail } from './generate-change-email-ve
 export { generateExistingAccountEmail } from './generate-existing-account-email';
 export { generatePasswordChangedEmail } from './generate-password-changed-email';
 export { generateResetPasswordEmail } from './generate-reset-password-email';
+export { generateTwoFactorEmail } from './generate-two-factor-email';
 export { generateWelcomeEmail } from './generate-welcome-email';

--- a/projects/lib-email-templates/src/previews.test.ts
+++ b/projects/lib-email-templates/src/previews.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from 'vitest';
+import * as generators from './index';
+import { previews } from './previews';
+
+test('it has a preview entry for every template generator', () => {
+  const expectedNames = Object.keys(generators).map((exportName) =>
+    exportName
+      .replace(/^generate/, '')
+      .replace(/Email$/, '')
+      .replaceAll(/(?<=[a-z])(?=[A-Z])/g, '-')
+      .toLowerCase(),
+  );
+
+  expect(previews.map((preview) => preview.name).sort()).toStrictEqual(
+    expectedNames.sort(),
+  );
+});
+
+test('it renders html and plain text for every preview entry', async () => {
+  for (const preview of previews) {
+    const { html, plainText } = await preview.render();
+
+    expect(html).include('<html');
+    expect(plainText).not.toBe('');
+  }
+});

--- a/projects/lib-email-templates/src/previews.ts
+++ b/projects/lib-email-templates/src/previews.ts
@@ -1,0 +1,70 @@
+import { generateChangeEmailNotificationEmail } from './generate-change-email-notification';
+import { generateChangeEmailVerificationEmail } from './generate-change-email-verification';
+import { generateExistingAccountEmail } from './generate-existing-account-email';
+import { generatePasswordChangedEmail } from './generate-password-changed-email';
+import { generateResetPasswordEmail } from './generate-reset-password-email';
+import { generateTwoFactorEmail } from './generate-two-factor-email';
+import { generateWelcomeEmail } from './generate-welcome-email';
+
+interface Preview {
+  name: string;
+  render: () => Promise<{ html: string; plainText: string }>;
+}
+
+/**
+ * Sample-data render entries for every template generator, consumed by the
+ * email-preview workflow (`yarn email:preview`). Entry names are the
+ * generator export names kebab-cased with the `generate` prefix and `Email`
+ * suffix stripped; a co-located test enforces one entry per generator export.
+ */
+export const previews: ReadonlyArray<Preview> = [
+  {
+    name: 'change-email-notification',
+    render: () => generateChangeEmailNotificationEmail(),
+  },
+  {
+    name: 'change-email-verification',
+    render: () =>
+      generateChangeEmailVerificationEmail({
+        newEmail: 'new-email@example.com',
+        verificationCode: '123456',
+        verificationURL: 'https://versidle.com/verify-email?code=123456',
+      }),
+  },
+  {
+    name: 'existing-account',
+    render: () =>
+      generateExistingAccountEmail({
+        email: 'player@example.com',
+      }),
+  },
+  {
+    name: 'password-changed',
+    render: () =>
+      generatePasswordChangedEmail({
+        email: 'player@example.com',
+      }),
+  },
+  {
+    name: 'reset-password',
+    render: () =>
+      generateResetPasswordEmail({
+        resetURL: 'https://versidle.com/reset-password?token=123456',
+      }),
+  },
+  {
+    name: 'two-factor',
+    render: () =>
+      generateTwoFactorEmail({
+        verificationCode: '123456',
+      }),
+  },
+  {
+    name: 'welcome',
+    render: () =>
+      generateWelcomeEmail({
+        verificationCode: '123456',
+        verificationURL: 'https://versidle.com/verification?token=123456',
+      }),
+  },
+];

--- a/projects/lib-email-templates/src/templates/two-factor-email.test.tsx
+++ b/projects/lib-email-templates/src/templates/two-factor-email.test.tsx
@@ -1,0 +1,23 @@
+import { expect, test } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TwoFactorEmail } from './two-factor-email';
+
+test('it renders a two-factor email with the provided configuration', () => {
+  const props = {
+    verificationCode: '123456',
+  };
+
+  render(<TwoFactorEmail {...props} />);
+
+  const heading = screen.getByText('Your two-factor sign-in code');
+  const codeText = screen.getByText(/123456/);
+  const resetLink = screen.getByRole('link', { name: 'here' });
+
+  expect(heading).toBeInTheDocument();
+  expect(codeText).toBeInTheDocument();
+  expect(resetLink).toBeInTheDocument();
+  expect(resetLink).toHaveAttribute(
+    'href',
+    'https://versidle.com/forgot-password',
+  );
+});

--- a/projects/lib-email-templates/src/templates/two-factor-email.tsx
+++ b/projects/lib-email-templates/src/templates/two-factor-email.tsx
@@ -1,0 +1,25 @@
+import type { ReactElement } from 'react';
+import * as E from '@react-email/components';
+
+interface Props {
+  verificationCode: string;
+}
+
+export function TwoFactorEmail(props: Props): ReactElement {
+  return (
+    <E.Container>
+      <E.Heading as="h1">
+        <E.Text>Your two-factor sign-in code</E.Text>
+      </E.Heading>
+      <E.Text>
+        Enter the following code to finish signing in to your vers account:{' '}
+        <strong>{props.verificationCode}</strong>
+      </E.Text>
+      <E.Text>
+        If you did not attempt to sign in, someone else may know your password.
+        Please reset it immediately{' '}
+        <E.Link href="https://versidle.com/forgot-password">here</E.Link>.
+      </E.Text>
+    </E.Container>
+  );
+}

--- a/scripts/email-preview.ts
+++ b/scripts/email-preview.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { Command } from 'commander';
+import { oraPromise } from 'ora';
+import { previews } from '../projects/lib-email-templates/src/previews';
+
+const defaultOutDir = 'dist/email-preview';
+
+interface PreviewArgs {
+  out: string;
+}
+
+const program = new Command()
+  .name('email-preview')
+  .description('CLI to render every email template to static preview files')
+  .option('-o, --out <dir>', 'directory to write previews into', defaultOutDir)
+  .action(async ({ out }: PreviewArgs) => {
+    await writePreviews(out);
+  });
+
+const spinnerConfig = {
+  failText: 'Failed to render email previews',
+  successText: `Rendered ${previews.length} email previews`,
+  text: 'Rendering email previews...',
+};
+
+async function writePreviews(outDir: string) {
+  const resolvedOutDir = path.resolve(outDir);
+
+  await mkdir(resolvedOutDir, { recursive: true });
+
+  await oraPromise(
+    Promise.all(
+      previews.map(async (preview) => {
+        const { html, plainText } = await preview.render();
+
+        await Promise.all([
+          writeFile(path.join(resolvedOutDir, `${preview.name}.html`), html),
+          writeFile(
+            path.join(resolvedOutDir, `${preview.name}.txt`),
+            plainText,
+          ),
+        ]);
+      }),
+    ),
+    spinnerConfig,
+  );
+
+  await writeFile(path.join(resolvedOutDir, 'index.html'), renderIndexPage());
+
+  console.log(`Preview index: ${path.join(resolvedOutDir, 'index.html')}`);
+}
+
+function renderIndexPage() {
+  const items = previews
+    .map(
+      (preview) =>
+        `      <li><a href="./${preview.name}.html">${preview.name}</a> (<a href="./${preview.name}.txt">plain text</a>)</li>`,
+    )
+    .join('\n');
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>vers email previews</title>
+  </head>
+  <body>
+    <h1>vers email previews</h1>
+    <ul>
+${items}
+    </ul>
+  </body>
+</html>
+`;
+}
+
+program.parse();

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,6 +1,11 @@
 {
   "extends": "../tsconfig.base.json",
-  "include": ["**/*.ts", "**/*.tsx"],
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "../projects/**/*.ts",
+    "../projects/**/*.tsx"
+  ],
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
## Description

Closes #201

Adds a static email-preview workflow and the missing two-factor template, so #82 becomes styling-only once the design language (#198) lands.

- `yarn email:preview` renders every generator with sample data to `dist/email-preview/` (HTML + plain text + index page)
- previews registry lives in the lib; a test enforces one entry per generator export, so new templates can't skip preview coverage
- `TwoFactorEmail` template + `generateTwoFactorEmail`, unstyled to match the existing set; wiring into a sign-in flow arrives with #164
- scripts tsconfig now includes `projects/` sources — tsx compiled imported lib JSX with esbuild's classic default and crashed on `React is not defined`
- chose static rendering over the react-email CLI preview app: it scaffolds its own Next app, which fights yarn PnP and the in-flight tooling migration

## Testing

- [x] `yarn typecheck` passes
- [x] `yarn test` passes
- [x] `yarn lint` passes
- [x] New tests added for new functionality