### PR TITLE
chore(#158): spike emmett event store on neon [do not merge]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ todo.md
 ## Panda
 styled-system
 styled-system-studio
+# spike secrets
+spikes/**/.env

--- a/.nxignore
+++ b/.nxignore
@@ -1,3 +1,4 @@
 .yarn
 .pnp.cjs
 .yarnrc.yml
+spikes

--- a/spikes/157-orpc/.gitignore
+++ b/spikes/157-orpc/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+.output/
+.nitro/
+.tanstack/
+routeTree.gen.ts

--- a/spikes/157-orpc/.npmrc
+++ b/spikes/157-orpc/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/spikes/157-orpc/README.md
+++ b/spikes/157-orpc/README.md
@@ -1,0 +1,69 @@
+# Spike 157 — oRPC on Elysia + TanStack Start
+
+Time-boxed walking skeleton for [#157](https://github.com/zgeoff/vers/issues/157): proves the
+API-layer stack from the #143 evaluation end-to-end before the rebuild (#163/#164/#165) commits to
+it. **Reference only — never merges.** Close the PR once the patterns are encoded properly in the
+rebuild issues.
+
+## Shape
+
+Self-contained pnpm workspace (deliberately mirrors the target turborepo+pnpm+bun state, and stays
+outside the repo's yarn `projects/*` glob so the two package managers never meet):
+
+- `contract/` — `@vers/contract-user`, the unversioned **unbuilt** workspace package pattern:
+  `exports` points straight at TS source; consumers typecheck it in their own program.
+- `service/` — `@vers/service-user`, oRPC procedures implementing the contract via `implement()`,
+  mounted on Elysia (bun runtime) through the fetch handler. Serves the RPC protocol at `/rpc`,
+  the OpenAPI REST surface at `/api`, and the generated OpenAPI 3.1.1 document at `/spec.json`
+  (generated from the **contract**, not the implementation).
+- `web/` — `@vers/app-web`, TanStack Start. Two consumption paths for `getCurrentUser`:
+  1. contract-typed client through `@orpc/tanstack-query` utils, prefetched in the route loader,
+     SSR-hydrated via `@tanstack/react-router-ssr-query`; browser traffic reaches the service
+     through a `/api/rpc/$` proxy server route (the service is private-network in production).
+  2. a Start server function wrapping the client with `safe()`, folding the typed error into a
+     plain result union.
+
+## Run it
+
+```sh
+pnpm install
+pnpm dev:service   # user service on :3001 (bun)
+pnpm dev:web       # start app on :3000 (vite)
+```
+
+Visit http://localhost:3000 — buttons switch the session cookie between valid / expired / absent.
+Session tokens are hard-coded stand-ins: `dev-session-token` (valid), `expired-session-token`
+(expired), anything else counts as no session.
+
+## Verdict
+
+**oRPC decision holds.** Full round-trip type inference browser → Start server → service from the
+contract package alone; typed `UNAUTHORIZED` with its `data.reason` payload survives every hop;
+OpenAPI emission works from the contract with the zod v4 converter, including the typed 401 error
+schema. All three packages typechecked clean on the first pass. No friction anywhere near
+overturning #143 (fallbacks tRPC v11 / Eden not needed).
+
+## Friction notes (none decision-threatening)
+
+- Consumers of a contract-typed client need `@orpc/contract` as a **direct** dependency (for
+  `ContractRouterClient`) under pnpm strict isolation — easy to hit as a confusing type-error
+  cascade ("unknown is not assignable…") rather than a clear missing-module error at the client.
+- SSR dehydration of an **errored** query redacts the `ORPCError` to a plain `Error` (seroval
+  drops the subclass, so `defined`/`code`/`data` are lost) and marks the query invalidated; the
+  browser refetches through the proxy and gets the typed error back. Net UX: the error-state
+  panel SSRs as "Loading…" and resolves client-side. Fine for real apps (auth state usually
+  redirects instead), worth knowing. The server-function path sidesteps it entirely — folding the
+  typed error into a result union is the pattern to prefer when the error state must SSR.
+- `RPCLink` has no default for its context type parameter — annotating a variable/return as bare
+  `RPCLink` is a type error; write `RPCLink<Record<never, never>>` or let inference run.
+- TypeScript 6.0 is current on npm; the spike pins 5.9.3 to keep TS-major noise out of the
+  experiment. The rebuild should evaluate TS 6 separately.
+- Elysia routes wrapping the fetch handlers need `{ parse: 'none' }` so Elysia's body parsing
+  doesn't consume the request before oRPC reads it (documented, but easy to miss).
+- TanStack Start pins `@tanstack/react-router` to an exact version (1.168.27 → 1.170.17); pin the
+  same version wherever the router is a direct dependency or risk a dual-router install.
+
+## Out of scope (deliberately)
+
+React Compiler, Panda/Ark, real session verification, tests, turborepo wiring — all covered by
+their own rebuild issues.

--- a/spikes/157-orpc/contract/package.json
+++ b/spikes/157-orpc/contract/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@vers/contract-user",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@orpc/contract": "1.14.6",
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "typescript": "5.9.3"
+  }
+}

--- a/spikes/157-orpc/contract/src/get-current-user.ts
+++ b/spikes/157-orpc/contract/src/get-current-user.ts
@@ -1,0 +1,26 @@
+import { oc } from '@orpc/contract';
+import * as z from 'zod';
+import { UserSchema } from './user-schema';
+
+/** Why a session failed to authenticate; carried in the UNAUTHORIZED error payload. */
+export const UnauthorizedReasonSchema = z.enum([
+  'missing-session',
+  'expired-session',
+]);
+
+export type UnauthorizedReason = z.infer<typeof UnauthorizedReasonSchema>;
+
+/** Returns the user attached to the caller's session. */
+export const getCurrentUser = oc
+  .route({
+    method: 'GET',
+    path: '/users/me',
+    summary: 'Get the currently authenticated user',
+  })
+  .errors({
+    UNAUTHORIZED: {
+      message: 'No valid session',
+      data: z.object({ reason: UnauthorizedReasonSchema }),
+    },
+  })
+  .output(UserSchema);

--- a/spikes/157-orpc/contract/src/index.ts
+++ b/spikes/157-orpc/contract/src/index.ts
@@ -1,0 +1,14 @@
+import { getCurrentUser } from './get-current-user';
+
+/** Contract for the user service. Implementations and clients both derive their types from this. */
+export const userContract = {
+  getCurrentUser,
+};
+
+export type UserContract = typeof userContract;
+
+export {
+  UnauthorizedReasonSchema,
+  type UnauthorizedReason,
+} from './get-current-user';
+export { UserSchema, type User } from './user-schema';

--- a/spikes/157-orpc/contract/src/user-schema.ts
+++ b/spikes/157-orpc/contract/src/user-schema.ts
@@ -1,0 +1,10 @@
+import * as z from 'zod';
+
+/** Public shape of an authenticated user, as returned by the user service. */
+export const UserSchema = z.object({
+  id: z.string(),
+  email: z.string(),
+  displayName: z.string(),
+});
+
+export type User = z.infer<typeof UserSchema>;

--- a/spikes/157-orpc/contract/tsconfig.json
+++ b/spikes/157-orpc/contract/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.base.json",
+  "include": ["src"]
+}

--- a/spikes/157-orpc/package.json
+++ b/spikes/157-orpc/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "vers-spike-157",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@11.9.0",
+  "scripts": {
+    "dev:service": "pnpm --filter @vers/service-user dev",
+    "dev:web": "pnpm --filter @vers/app-web dev",
+    "typecheck": "pnpm --recursive typecheck"
+  }
+}

--- a/spikes/157-orpc/pnpm-lock.yaml
+++ b/spikes/157-orpc/pnpm-lock.yaml
@@ -1,0 +1,2637 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+  .: {}
+
+  contract:
+    dependencies:
+      '@orpc/contract':
+        specifier: 1.14.6
+        version: 1.14.6
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+    devDependencies:
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
+  service:
+    dependencies:
+      '@orpc/openapi':
+        specifier: 1.14.6
+        version: 1.14.6
+      '@orpc/server':
+        specifier: 1.14.6
+        version: 1.14.6
+      '@orpc/zod':
+        specifier: 1.14.6
+        version: 1.14.6(@orpc/contract@1.14.6)(@orpc/server@1.14.6)(zod@4.4.3)
+      '@vers/contract-user':
+        specifier: workspace:*
+        version: link:../contract
+      elysia:
+        specifier: 1.4.29
+        version: 1.4.29(@sinclair/typebox@0.34.49)(@types/bun@1.3.14)(exact-mirror@1.2.2)(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3)
+    devDependencies:
+      '@types/bun':
+        specifier: 1.3.14
+        version: 1.3.14
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
+  web:
+    dependencies:
+      '@orpc/client':
+        specifier: 1.14.6
+        version: 1.14.6
+      '@orpc/contract':
+        specifier: 1.14.6
+        version: 1.14.6
+      '@orpc/tanstack-query':
+        specifier: 1.14.6
+        version: 1.14.6(@orpc/client@1.14.6)(@tanstack/query-core@5.101.2)
+      '@tanstack/react-query':
+        specifier: 5.101.2
+        version: 5.101.2(react@19.2.7)
+      '@tanstack/react-router':
+        specifier: 1.170.17
+        version: 1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/react-router-ssr-query':
+        specifier: 1.167.1
+        version: 1.167.1(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/router-core@1.171.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/react-start':
+        specifier: 1.168.27
+        version: 1.168.27(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.4)(vite@8.1.3(@types/node@24.10.1)(jiti@2.7.0))
+      '@vers/contract-user':
+        specifier: workspace:*
+        version: link:../contract
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@types/node':
+        specifier: 24.10.1
+        version: 24.10.1
+      '@types/react':
+        specifier: 19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: 6.0.3
+        version: 6.0.3(vite@8.1.3(@types/node@24.10.1)(jiti@2.7.0))
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vite:
+        specifier: 8.1.3
+        version: 8.1.3(@types/node@24.10.1)(jiti@2.7.0)
+
+packages:
+  '@babel/code-frame@7.27.1':
+    resolution:
+      {
+        integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/code-frame@7.29.7':
+    resolution:
+      {
+        integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/compat-data@7.29.7':
+    resolution:
+      {
+        integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/core@7.29.7':
+    resolution:
+      {
+        integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/generator@7.29.7':
+    resolution:
+      {
+        integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution:
+      {
+        integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/helper-globals@7.29.7':
+    resolution:
+      {
+        integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution:
+      {
+        integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution:
+      {
+        integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==,
+      }
+    engines: { node: '>=6.9.0' }
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution:
+      {
+        integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution:
+      {
+        integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution:
+      {
+        integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/helpers@7.29.7':
+    resolution:
+      {
+        integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/parser@7.29.7':
+    resolution:
+      {
+        integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==,
+      }
+    engines: { node: '>=6.0.0' }
+    hasBin: true
+
+  '@babel/template@7.29.7':
+    resolution:
+      {
+        integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/traverse@7.29.7':
+    resolution:
+      {
+        integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/types@7.29.7':
+    resolution:
+      {
+        integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@borewit/text-codec@0.2.2':
+    resolution:
+      {
+        integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==,
+      }
+
+  '@emnapi/core@1.11.1':
+    resolution:
+      {
+        integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==,
+      }
+
+  '@emnapi/runtime@1.11.1':
+    resolution:
+      {
+        integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==,
+      }
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution:
+      {
+        integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==,
+      }
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution:
+      {
+        integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==,
+      }
+
+  '@jridgewell/remapping@2.3.5':
+    resolution:
+      {
+        integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==,
+      }
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution:
+      {
+        integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==,
+      }
+    engines: { node: '>=6.0.0' }
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution:
+      {
+        integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==,
+      }
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution:
+      {
+        integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==,
+      }
+
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution:
+      {
+        integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==,
+      }
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@oozcitak/dom@2.0.2':
+    resolution:
+      {
+        integrity: sha512-GjpKhkSYC3Mj4+lfwEyI1dqnsKTgwGy48ytZEhm4A/xnH/8z9M3ZVXKr/YGQi3uCLs1AEBS+x5T2JPiueEDW8w==,
+      }
+    engines: { node: '>=20.0' }
+
+  '@oozcitak/infra@2.0.2':
+    resolution:
+      {
+        integrity: sha512-2g+E7hoE2dgCz/APPOEK5s3rMhJvNxSMBrP+U+j1OWsIbtSpWxxlUjq1lU8RIsFJNYv7NMlnVsCuHcUzJW+8vA==,
+      }
+    engines: { node: '>=20.0' }
+
+  '@oozcitak/url@3.0.0':
+    resolution:
+      {
+        integrity: sha512-ZKfET8Ak1wsLAiLWNfFkZc/BraDccuTJKR6svTYc7sVjbR+Iu0vtXdiDMY4o6jaFl5TW2TlS7jbLl4VovtAJWQ==,
+      }
+    engines: { node: '>=20.0' }
+
+  '@oozcitak/util@10.0.0':
+    resolution:
+      {
+        integrity: sha512-hAX0pT/73190NLqBPPWSdBVGtbY6VOhWYK3qqHqtXQ1gK7kS2yz4+ivsN07hpJ6I3aeMtKP6J6npsEKOAzuTLA==,
+      }
+    engines: { node: '>=20.0' }
+
+  '@orpc/client@1.14.6':
+    resolution:
+      {
+        integrity: sha512-Y03NcTtmEJdxcqkKBkdGxqe1IHVpD9IorshG4PaTnz9dQIW+RYI8anRo7o0IlbBlzBICN+Ubo1rnw6bpkhagCQ==,
+      }
+
+  '@orpc/contract@1.14.6':
+    resolution:
+      {
+        integrity: sha512-o4i2ciYWtALidF969S8yj/VFk7ZUmHHKaYGRVitX5K2uMaSB8lJM6TMyBKzRC5Clo99VPjCb9mcl6jMLEAgmKw==,
+      }
+
+  '@orpc/interop@1.14.6':
+    resolution:
+      {
+        integrity: sha512-ZjNaHH9754uUkC98DHfm9HaGnniFnFRLdXXBWL2u+o1TVzEbiNX8dA5+oChxoSTUD3GiwpjLjAuTWXvrbhm4fA==,
+      }
+
+  '@orpc/json-schema@1.14.6':
+    resolution:
+      {
+        integrity: sha512-p79GOJ88DpOTsOaAQ8Ef/2J5455Yh2qp3KjY9q6858RozHuPSXHu7MSgE/bilkzbiuGNoen3frw7GSiKfYpKSA==,
+      }
+
+  '@orpc/openapi-client@1.14.6':
+    resolution:
+      {
+        integrity: sha512-Z0rdO+oVJTASat3fIQmLEjKnqRsjg4QsjRFwFamZ5W+Y076I3Lbp8XhVcMoHbKyfgm/TKnZu3y41b4NFfPBYiA==,
+      }
+
+  '@orpc/openapi@1.14.6':
+    resolution:
+      {
+        integrity: sha512-MdQ0KKLdvqZlmpUgw/6W/6dOfwo1GdtW2kE0VL/AJxqaeM6i3sygtIGAzEr6/CfhIJnfGHqo1jMzdlELQjCqYg==,
+      }
+
+  '@orpc/server@1.14.6':
+    resolution:
+      {
+        integrity: sha512-aHn8dW2clr/fRZzMLbRsZ1Pe4AYxg7YmM3tSZSAkPjn5/3UaHnpuwWeY7LYPok23CGYUmjidTmJQjm0zm+vgoA==,
+      }
+    peerDependencies:
+      crossws: '>=0.3.4'
+      ws: '>=8.18.1'
+    peerDependenciesMeta:
+      crossws:
+        optional: true
+      ws:
+        optional: true
+
+  '@orpc/shared@1.14.6':
+    resolution:
+      {
+        integrity: sha512-P2W+DdrUq18kUiF7nIw5wDOA0SR41mM/NsVKDVRsdyhdHk9V9KDuW1JRymyMl+7Wo5SDeSr1Rm/VjA5v08+PHw==,
+      }
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+
+  '@orpc/standard-server-aws-lambda@1.14.6':
+    resolution:
+      {
+        integrity: sha512-8FQX0uBQ2OKkIrF0u5qpd9EH2uqaM1n37NJSw9bvQqLnqoSfzk0xzVkP5s+c8N0Gec6M9mnrLvB7aqQSlpPukw==,
+      }
+
+  '@orpc/standard-server-fastify@1.14.6':
+    resolution:
+      {
+        integrity: sha512-cwS7jRfc+yM8bFyEFVzVcXfgYLfy96KpdPBPUlIQLpInwYvMxePpENM3rEAJ3MHOfMHx1PT5LidrlbR7Npb1Cg==,
+      }
+    peerDependencies:
+      fastify: '>=5.6.1'
+    peerDependenciesMeta:
+      fastify:
+        optional: true
+
+  '@orpc/standard-server-fetch@1.14.6':
+    resolution:
+      {
+        integrity: sha512-XnwEnHaKMMBoilK0QVwgMsUvDbCXyz6CDoLgMN51v+p3VSnwjIkrMdOwbc/sj43z6T4irQDu9Zm8T1pxxh1L8w==,
+      }
+
+  '@orpc/standard-server-node@1.14.6':
+    resolution:
+      {
+        integrity: sha512-CmW/EPu1dxoppYMRmsK+F3Z22wMx74RLUtjRokXyRKu4XEX/Ja6nwD+xauQcAMiAQYkp39aCMofAW7BvA46Qcg==,
+      }
+
+  '@orpc/standard-server-peer@1.14.6':
+    resolution:
+      {
+        integrity: sha512-jwVGc5yRA5hk1F/W4yw45P2H4fbu4Tfsk62XijJBXRvtlSNKvvPAuwAd6jFv/fxnq2SH/uskgi91Ja9wgfnYDQ==,
+      }
+
+  '@orpc/standard-server@1.14.6':
+    resolution:
+      {
+        integrity: sha512-75Oh4rAZb8K7P46d6v7R2JhjqjLLEo7Qs4+ABdF+f0m0uKM1oaykJWy7leqTJ+WaYm+uDbsZl/3nyWie9aeJTg==,
+      }
+
+  '@orpc/tanstack-query@1.14.6':
+    resolution:
+      {
+        integrity: sha512-uCu6iTT0MDyk+ihba65N2CT56XYMny2N389l8pC+NIOQ7dG46RF98MhaQEvFUQo3atZb6pkKNWkg7BaA1Z9o7g==,
+      }
+    peerDependencies:
+      '@orpc/client': 1.14.6
+      '@tanstack/query-core': '>=5.80.2'
+
+  '@orpc/zod@1.14.6':
+    resolution:
+      {
+        integrity: sha512-skGc5Qj6BLy3ir+VgYZZBJFlxDVAYoJPVymVPEOLawEVSf2mje0/oMPiaQJE4+CyVRSIXUHG8MoQnW0X1OoQ5w==,
+      }
+    peerDependencies:
+      '@orpc/contract': 1.14.6
+      '@orpc/server': 1.14.6
+      zod: '>=3.25.0'
+
+  '@oxc-project/types@0.138.0':
+    resolution:
+      {
+        integrity: sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==,
+      }
+
+  '@rolldown/binding-android-arm64@1.1.4':
+    resolution:
+      {
+        integrity: sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.1.4':
+    resolution:
+      {
+        integrity: sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.1.4':
+    resolution:
+      {
+        integrity: sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.1.4':
+    resolution:
+      {
+        integrity: sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.4':
+    resolution:
+      {
+        integrity: sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.4':
+    resolution:
+      {
+        integrity: sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.1.4':
+    resolution:
+      {
+        integrity: sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.4':
+    resolution:
+      {
+        integrity: sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.4':
+    resolution:
+      {
+        integrity: sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.4':
+    resolution:
+      {
+        integrity: sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.1.4':
+    resolution:
+      {
+        integrity: sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.1.4':
+    resolution:
+      {
+        integrity: sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.1.4':
+    resolution:
+      {
+        integrity: sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.4':
+    resolution:
+      {
+        integrity: sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.4':
+    resolution:
+      {
+        integrity: sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution:
+      {
+        integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==,
+      }
+
+  '@sinclair/typebox@0.34.49':
+    resolution:
+      {
+        integrity: sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==,
+      }
+
+  '@standard-schema/spec@1.1.0':
+    resolution:
+      {
+        integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==,
+      }
+
+  '@tanstack/history@1.162.0':
+    resolution:
+      {
+        integrity: sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==,
+      }
+    engines: { node: '>=20.19' }
+
+  '@tanstack/query-core@5.101.2':
+    resolution:
+      {
+        integrity: sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==,
+      }
+
+  '@tanstack/react-query@5.101.2':
+    resolution:
+      {
+        integrity: sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==,
+      }
+    peerDependencies:
+      react: ^18 || ^19
+
+  '@tanstack/react-router-ssr-query@1.167.1':
+    resolution:
+      {
+        integrity: sha512-W9j5JPnBikyafvuUfykFfHIWod58OAbAAa5leNkXBcoDoocghMmu6w9uZOmUZvAWT7CSvgj5tBUtF7CM2OoHXQ==,
+      }
+    engines: { node: '>=20.19' }
+    peerDependencies:
+      '@tanstack/query-core': '>=5.90.0'
+      '@tanstack/react-query': '>=5.90.0'
+      '@tanstack/react-router': '>=1.127.0'
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
+  '@tanstack/react-router@1.170.17':
+    resolution:
+      {
+        integrity: sha512-ppLkjCfSMaeug9rmFRYzOd4TIqWV+yTE7tzIny7alJsSnM7w4lzEZm6eqCehG0SPetpZ0R3K+UnanSmBgOAVcQ==,
+      }
+    engines: { node: '>=20.19' }
+    peerDependencies:
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
+  '@tanstack/react-start-client@1.168.15':
+    resolution:
+      {
+        integrity: sha512-pW50PHvadgi50iNCw6deUOvqc9rzs30SstyFZY2tcS9z1XlqTlELSvGowjxdu2m0ymtqm1emj1jau1iP7+3+PQ==,
+      }
+    engines: { node: '>=22.12.0' }
+    peerDependencies:
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
+  '@tanstack/react-start-rsc@0.1.26':
+    resolution:
+      {
+        integrity: sha512-+FMm3qtT1gWsl0i5sG/Q70mh1k7tzZUsPBaqbg4v34zVJZ+XGn1mJb34x2w7z1M0/e7co6GkZfV8BRpczrs8UA==,
+      }
+    engines: { node: '>=22.12.0' }
+    peerDependencies:
+      '@rspack/core': '>=2.0.0-0'
+      '@vitejs/plugin-rsc': '>=0.5.20'
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+      react-server-dom-rspack: '>=0.0.2'
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+      '@vitejs/plugin-rsc':
+        optional: true
+      react-server-dom-rspack:
+        optional: true
+
+  '@tanstack/react-start-server@1.167.21':
+    resolution:
+      {
+        integrity: sha512-puJ7eFxaLuDzeM/tiLDJaXCA4uK+PZnEOoIC73zipsFqx865MGzrRS/GSZxeVxjavC5iHU+ZwC+rgI0qYSol1A==,
+      }
+    engines: { node: '>=22.12.0' }
+    peerDependencies:
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
+  '@tanstack/react-start@1.168.27':
+    resolution:
+      {
+        integrity: sha512-rdGFDqfCW71gyofyAxaYxhelNKmeVjpmbpm0uFYbNHORCa///4aBxi7B7ecShibKv9O4GfJ66MPX5F0ozbm+ig==,
+      }
+    engines: { node: '>=22.12.0' }
+    peerDependencies:
+      '@rsbuild/core': ^2.0.0
+      '@vitejs/plugin-rsc': '*'
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+      vite: '>=7.0.0'
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
+      '@vitejs/plugin-rsc':
+        optional: true
+      vite:
+        optional: true
+
+  '@tanstack/react-store@0.9.3':
+    resolution:
+      {
+        integrity: sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==,
+      }
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/router-core@1.171.14':
+    resolution:
+      {
+        integrity: sha512-Mo3hwx0qB0cJsVYGDjG0+Ouf7VV74h/vsoDMGztdlyzDanp4gBA2s7IVvm6hFrmQM6GpD9F0Z7SqD7OldfLE7g==,
+      }
+    engines: { node: '>=20.19' }
+
+  '@tanstack/router-generator@1.167.18':
+    resolution:
+      {
+        integrity: sha512-kFvM4caRds9Q3EXg64bZubJ6rbDxyV0YDSBSGvOGzmKspQPdz5Xrh0uj5T1Ov8avUUg+c761u04VQAaEzSBXRw==,
+      }
+    engines: { node: '>=20.19' }
+
+  '@tanstack/router-plugin@1.168.19':
+    resolution:
+      {
+        integrity: sha512-aFglwLc+bbPTgZlkXn3PvOwpjJAfgUyPGSuql4MP3XrqTTh6WkBiy2RYb6oaG5h0s7EKwivEuq85K3Y4V0Mt1g==,
+      }
+    engines: { node: '>=20.19' }
+    peerDependencies:
+      '@rsbuild/core': '>=1.0.2 || ^2.0.0'
+      '@tanstack/react-router': ^1.170.17
+      vite: '>=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0'
+      vite-plugin-solid: ^2.11.10 || ^3.0.0-0
+      webpack: '>=5.92.0'
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
+      '@tanstack/react-router':
+        optional: true
+      vite:
+        optional: true
+      vite-plugin-solid:
+        optional: true
+      webpack:
+        optional: true
+
+  '@tanstack/router-ssr-query-core@1.169.1':
+    resolution:
+      {
+        integrity: sha512-rngux8s/3mPQzcjLYDLkNU31coYVyCgrVTfpdwqUdY5jIEHqGTXrO73DTkPR1PppwYUeVhmNCgl8TctRcnupjg==,
+      }
+    engines: { node: '>=20.19' }
+    peerDependencies:
+      '@tanstack/query-core': '>=5.90.0'
+      '@tanstack/router-core': '>=1.127.0'
+
+  '@tanstack/router-utils@1.162.2':
+    resolution:
+      {
+        integrity: sha512-hTWqJtqIFFdvuCl8WXNyrodp2L9zo2G37xKRrcVmVRWpAB2h+U1LuRAfS4tsFTiWOIoE/B+WDVFB8JpoEdw6jQ==,
+      }
+    engines: { node: '>=20.19' }
+
+  '@tanstack/start-client-core@1.170.13':
+    resolution:
+      {
+        integrity: sha512-o37M3msIK5ec87kPrIYJWXb1XPnjIe5/jrkGLXiXpFuVL99z7mhoBCzftKtVPtzqI8EElnRE/VGFYT9BHNnWcw==,
+      }
+    engines: { node: '>=22.12.0' }
+
+  '@tanstack/start-fn-stubs@1.162.0':
+    resolution:
+      {
+        integrity: sha512-QWfUZ3Yo923tdQn38LyKMU8rcTw69zc+T4dAvgTWV4O56SqFRsGfS0lSWIMhJRwXIx/bvdi7nTUBDdZtTHtpTQ==,
+      }
+    engines: { node: '>=22.12.0' }
+
+  '@tanstack/start-plugin-core@1.171.19':
+    resolution:
+      {
+        integrity: sha512-+fpW3Z/2vPT8HDV1c5p2WC6/g2k/AV/ujdJVDcn/VFd+gXRtzSX1D/LfozlaDbhDoEsqOnAk/mGwjg60JkUA2Q==,
+      }
+    engines: { node: '>=22.12.0' }
+    peerDependencies:
+      '@rsbuild/core': ^2.0.0
+      vite: '>=7.0.0'
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
+      vite:
+        optional: true
+
+  '@tanstack/start-server-core@1.169.16':
+    resolution:
+      {
+        integrity: sha512-lvAjQpH3nHJtd4xy0iHIaWbsTbyN9EBxuYCxbtXH0EpeBQPg+TCPhu9GQC9WbbA1rE//s82CpE55oYDQMqkU5A==,
+      }
+    engines: { node: '>=22.12.0' }
+
+  '@tanstack/start-storage-context@1.167.16':
+    resolution:
+      {
+        integrity: sha512-zTegxlij4BC1DbCrC6rsVlMOQVMzOuG5IllacZEkrUdhiFwMIMYpk0VWGH+d0ucx5RBkmv8e8GNX3AOVBWclfg==,
+      }
+    engines: { node: '>=22.12.0' }
+
+  '@tanstack/store@0.9.3':
+    resolution:
+      {
+        integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==,
+      }
+
+  '@tanstack/virtual-file-routes@1.162.0':
+    resolution:
+      {
+        integrity: sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA==,
+      }
+    engines: { node: '>=20.19' }
+
+  '@tokenizer/inflate@0.4.1':
+    resolution:
+      {
+        integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==,
+      }
+    engines: { node: '>=18' }
+
+  '@tokenizer/token@0.3.0':
+    resolution:
+      {
+        integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==,
+      }
+
+  '@tybys/wasm-util@0.10.3':
+    resolution:
+      {
+        integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==,
+      }
+
+  '@types/bun@1.3.14':
+    resolution:
+      {
+        integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==,
+      }
+
+  '@types/node@24.10.1':
+    resolution:
+      {
+        integrity: sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==,
+      }
+
+  '@types/react-dom@19.2.3':
+    resolution:
+      {
+        integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==,
+      }
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.17':
+    resolution:
+      {
+        integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==,
+      }
+
+  '@vitejs/plugin-react@6.0.3':
+    resolution:
+      {
+        integrity: sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+
+  ansis@4.3.1:
+    resolution:
+      {
+        integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==,
+      }
+    engines: { node: '>=14' }
+
+  argparse@2.0.1:
+    resolution:
+      {
+        integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==,
+      }
+
+  babel-dead-code-elimination@1.0.12:
+    resolution:
+      {
+        integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==,
+      }
+
+  baseline-browser-mapping@2.10.41:
+    resolution:
+      {
+        integrity: sha512-WwS7MHhqGHHlaVsqRZnhvCEMS0owDX+SxRlve7JkuH7My1Ara3ZriTmCQupPfYjxMZ8I/tgxtJYr2t7taHaH4A==,
+      }
+    engines: { node: '>=6.0.0' }
+    hasBin: true
+
+  browserslist@4.28.4:
+    resolution:
+      {
+        integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==,
+      }
+    engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
+    hasBin: true
+
+  bun-types@1.3.14:
+    resolution:
+      {
+        integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==,
+      }
+
+  caniuse-lite@1.0.30001800:
+    resolution:
+      {
+        integrity: sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==,
+      }
+
+  chokidar@5.0.0:
+    resolution:
+      {
+        integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==,
+      }
+    engines: { node: '>= 20.19.0' }
+
+  convert-source-map@2.0.0:
+    resolution:
+      {
+        integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==,
+      }
+
+  cookie-es@3.1.1:
+    resolution:
+      {
+        integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==,
+      }
+
+  cookie@1.1.1:
+    resolution:
+      {
+        integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==,
+      }
+    engines: { node: '>=18' }
+
+  csstype@3.2.3:
+    resolution:
+      {
+        integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==,
+      }
+
+  debug@4.4.3:
+    resolution:
+      {
+        integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==,
+      }
+    engines: { node: '>=6.0' }
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  detect-libc@2.1.2:
+    resolution:
+      {
+        integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==,
+      }
+    engines: { node: '>=8' }
+
+  diff@8.0.4:
+    resolution:
+      {
+        integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==,
+      }
+    engines: { node: '>=0.3.1' }
+
+  electron-to-chromium@1.5.385:
+    resolution:
+      {
+        integrity: sha512-78sa/M08MNAYHQfjoWMvOlKQqZ0ElhSm/L5HNUc96VZ3b+KvDVnngFm8sYQy0XrhTRgAhggHr5abA7yTvRdo4Q==,
+      }
+
+  elysia@1.4.29:
+    resolution:
+      {
+        integrity: sha512-GwMRGGwSdjfPt+w3LA0fqTuYJtS8uVRJicvoar98/HrO5qdFKDc9CwjIb6Kja+v39lkY+58hr2JvdR9jQzlUuA==,
+      }
+    peerDependencies:
+      '@sinclair/typebox': '>= 0.34.0 < 1'
+      '@types/bun': '>= 1.2.0'
+      exact-mirror: '>= 0.0.9'
+      file-type: '>= 20.0.0'
+      openapi-types: '>= 12.0.0'
+      typescript: '>= 5.0.0'
+    peerDependenciesMeta:
+      '@types/bun':
+        optional: true
+      typescript:
+        optional: true
+
+  escalade@3.2.0:
+    resolution:
+      {
+        integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==,
+      }
+    engines: { node: '>=6' }
+
+  escape-string-regexp@5.0.0:
+    resolution:
+      {
+        integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==,
+      }
+    engines: { node: '>=12' }
+
+  exact-mirror@1.2.2:
+    resolution:
+      {
+        integrity: sha512-jUlRkZOPN3rCAy4kmZeD2HCnoXwJ6KlWNkEBJ3sEJ2rbLSU+tN60hY7XzPZkImRQOJczllvOBYTYEJTYScPh5Q==,
+      }
+    peerDependencies:
+      typebox: '>= 1.1.0'
+    peerDependenciesMeta:
+      typebox:
+        optional: true
+
+  exsolve@1.1.0:
+    resolution:
+      {
+        integrity: sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==,
+      }
+
+  fast-decode-uri-component@1.0.1:
+    resolution:
+      {
+        integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==,
+      }
+
+  fdir@6.5.0:
+    resolution:
+      {
+        integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==,
+      }
+    engines: { node: '>=12.0.0' }
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fetchdts@0.1.7:
+    resolution:
+      {
+        integrity: sha512-YoZjBdafyLIop9lSxXVI33oLD5kN31q4Td+CasofLLYeLXRFeOsuOw0Uo+XNRi9PZlbfdlN2GmRtm4tCEQ9/KA==,
+      }
+
+  file-type@22.0.1:
+    resolution:
+      {
+        integrity: sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA==,
+      }
+    engines: { node: '>=22' }
+
+  fsevents@2.3.3:
+    resolution:
+      {
+        integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==,
+      }
+    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
+    os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution:
+      {
+        integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  h3@2.0.1-rc.20:
+    resolution:
+      {
+        integrity: sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg==,
+      }
+    engines: { node: '>=20.11.1' }
+    hasBin: true
+    peerDependencies:
+      crossws: ^0.4.1
+    peerDependenciesMeta:
+      crossws:
+        optional: true
+
+  ieee754@1.2.1:
+    resolution:
+      {
+        integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==,
+      }
+
+  isbot@5.1.44:
+    resolution:
+      {
+        integrity: sha512-PGEHtwMnKbZpeSEXW2Utx+/JWed7dp6DiH0WWg33vGSDA7RUvpUeJSVlLrVkQ1RCpvDOUc/eH9ql7VsdbBZ8pA==,
+      }
+    engines: { node: '>=18' }
+
+  jiti@2.7.0:
+    resolution:
+      {
+        integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==,
+      }
+    hasBin: true
+
+  js-tokens@4.0.0:
+    resolution:
+      {
+        integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==,
+      }
+
+  js-yaml@4.3.0:
+    resolution:
+      {
+        integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==,
+      }
+    hasBin: true
+
+  jsesc@3.1.0:
+    resolution:
+      {
+        integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==,
+      }
+    engines: { node: '>=6' }
+    hasBin: true
+
+  json-schema-typed@8.0.2:
+    resolution:
+      {
+        integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==,
+      }
+
+  json5@2.2.3:
+    resolution:
+      {
+        integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==,
+      }
+    engines: { node: '>=6' }
+    hasBin: true
+
+  lightningcss-android-arm64@1.32.0:
+    resolution:
+      {
+        integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution:
+      {
+        integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution:
+      {
+        integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution:
+      {
+        integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution:
+      {
+        integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution:
+      {
+        integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution:
+      {
+        integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution:
+      {
+        integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution:
+      {
+        integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution:
+      {
+        integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution:
+      {
+        integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution:
+      {
+        integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==,
+      }
+    engines: { node: '>= 12.0.0' }
+
+  lru-cache@5.1.1:
+    resolution:
+      {
+        integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==,
+      }
+
+  magic-string@0.30.21:
+    resolution:
+      {
+        integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
+      }
+
+  memoirist@0.4.0:
+    resolution:
+      {
+        integrity: sha512-zxTgA0mSYELa66DimuNQDvyLq36AwDlTuVRbnQtB+VuTcKWm5Qc4z3WkSpgsFWHNhexqkIooqpv4hdcqrX5Nmg==,
+      }
+
+  ms@2.1.3:
+    resolution:
+      {
+        integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
+      }
+
+  nanoid@3.3.15:
+    resolution:
+      {
+        integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==,
+      }
+    engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
+    hasBin: true
+
+  node-releases@2.0.50:
+    resolution:
+      {
+        integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==,
+      }
+    engines: { node: '>=18' }
+
+  openapi-types@12.1.3:
+    resolution:
+      {
+        integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==,
+      }
+
+  pathe@2.0.3:
+    resolution:
+      {
+        integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
+      }
+
+  picocolors@1.1.1:
+    resolution:
+      {
+        integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
+      }
+
+  picomatch@4.0.5:
+    resolution:
+      {
+        integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==,
+      }
+    engines: { node: '>=12' }
+
+  postcss@8.5.16:
+    resolution:
+      {
+        integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==,
+      }
+    engines: { node: ^10 || ^12 || >=14 }
+
+  prettier@3.9.4:
+    resolution:
+      {
+        integrity: sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==,
+      }
+    engines: { node: '>=14' }
+    hasBin: true
+
+  radash@12.1.1:
+    resolution:
+      {
+        integrity: sha512-h36JMxKRqrAxVD8201FrCpyeNuUY9Y5zZwujr20fFO77tpUtGa6EZzfKw/3WaiBX95fq7+MpsuMLNdSnORAwSA==,
+      }
+    engines: { node: '>=14.18.0' }
+
+  react-dom@19.2.7:
+    resolution:
+      {
+        integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==,
+      }
+    peerDependencies:
+      react: ^19.2.7
+
+  react@19.2.7:
+    resolution:
+      {
+        integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==,
+      }
+    engines: { node: '>=0.10.0' }
+
+  readdirp@5.0.0:
+    resolution:
+      {
+        integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==,
+      }
+    engines: { node: '>= 20.19.0' }
+
+  rolldown@1.1.4:
+    resolution:
+      {
+        integrity: sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    hasBin: true
+
+  rou3@0.7.12:
+    resolution:
+      {
+        integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==,
+      }
+
+  rou3@0.8.1:
+    resolution:
+      {
+        integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==,
+      }
+
+  scheduler@0.27.0:
+    resolution:
+      {
+        integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==,
+      }
+
+  semver@6.3.1:
+    resolution:
+      {
+        integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==,
+      }
+    hasBin: true
+
+  seroval-plugins@1.5.4:
+    resolution:
+      {
+        integrity: sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==,
+      }
+    engines: { node: '>=10' }
+    peerDependencies:
+      seroval: ^1.0
+
+  seroval@1.5.4:
+    resolution:
+      {
+        integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==,
+      }
+    engines: { node: '>=10' }
+
+  source-map-js@1.2.1:
+    resolution:
+      {
+        integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==,
+      }
+    engines: { node: '>=0.10.0' }
+
+  source-map@0.7.6:
+    resolution:
+      {
+        integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==,
+      }
+    engines: { node: '>= 12' }
+
+  srvx@0.11.20:
+    resolution:
+      {
+        integrity: sha512-gdPvbwpJOJpMyBYcp39q78C4pmv/Aw5WwZKB3+/pfeUVxo3EvNXlOi1fxzoy2ECGvUeBhouXy9rBxstjQQOPog==,
+      }
+    engines: { node: '>=20.16.0' }
+    hasBin: true
+
+  strtok3@10.3.5:
+    resolution:
+      {
+        integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==,
+      }
+    engines: { node: '>=18' }
+
+  tagged-tag@1.0.0:
+    resolution:
+      {
+        integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==,
+      }
+    engines: { node: '>=20' }
+
+  tinyglobby@0.2.17:
+    resolution:
+      {
+        integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==,
+      }
+    engines: { node: '>=12.0.0' }
+
+  token-types@6.1.2:
+    resolution:
+      {
+        integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==,
+      }
+    engines: { node: '>=14.16' }
+
+  tslib@2.8.1:
+    resolution:
+      {
+        integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
+      }
+
+  type-fest@5.7.0:
+    resolution:
+      {
+        integrity: sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==,
+      }
+    engines: { node: '>=20' }
+
+  typescript@5.9.3:
+    resolution:
+      {
+        integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==,
+      }
+    engines: { node: '>=14.17' }
+    hasBin: true
+
+  ufo@1.6.4:
+    resolution:
+      {
+        integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==,
+      }
+
+  uint8array-extras@1.5.0:
+    resolution:
+      {
+        integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==,
+      }
+    engines: { node: '>=18' }
+
+  undici-types@7.16.0:
+    resolution:
+      {
+        integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==,
+      }
+
+  unplugin@3.3.0:
+    resolution:
+      {
+        integrity: sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    peerDependencies:
+      '@farmfe/core': '*'
+      '@rspack/core': '*'
+      bun-types-no-globals: '*'
+      esbuild: '*'
+      rolldown: '*'
+      rollup: '*'
+      unloader: '*'
+      vite: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      '@farmfe/core':
+        optional: true
+      '@rspack/core':
+        optional: true
+      bun-types-no-globals:
+        optional: true
+      esbuild:
+        optional: true
+      rolldown:
+        optional: true
+      rollup:
+        optional: true
+      unloader:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
+
+  update-browserslist-db@1.2.3:
+    resolution:
+      {
+        integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==,
+      }
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  use-sync-external-store@1.6.0:
+    resolution:
+      {
+        integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==,
+      }
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  vite@8.1.3:
+    resolution:
+      {
+        integrity: sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.3.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitefu@1.1.3:
+    resolution:
+      {
+        integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==,
+      }
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
+  webpack-virtual-modules@0.6.2:
+    resolution:
+      {
+        integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==,
+      }
+
+  wildcard-match@5.1.4:
+    resolution:
+      {
+        integrity: sha512-wldeCaczs8XXq7hj+5d/F38JE2r7EXgb6WQDM84RVwxy81T/sxB5e9+uZLK9Q9oNz1mlvjut+QtvgaOQFPVq/g==,
+      }
+
+  xmlbuilder2@4.0.3:
+    resolution:
+      {
+        integrity: sha512-bx8Q1STctnNaaDymWnkfQLKofs0mGNN7rLLapJlGuV3VlvegD7Ls4ggMjE3aUSWItCCzU0PEv45lI87iSigiCA==,
+      }
+    engines: { node: '>=20.0' }
+
+  yallist@3.1.1:
+    resolution:
+      {
+        integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==,
+      }
+
+  zod@4.4.3:
+    resolution:
+      {
+        integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==,
+      }
+
+snapshots:
+  '@babel/code-frame@7.27.1':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.4
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@borewit/text-codec@0.2.2': {}
+
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@oozcitak/dom@2.0.2':
+    dependencies:
+      '@oozcitak/infra': 2.0.2
+      '@oozcitak/url': 3.0.0
+      '@oozcitak/util': 10.0.0
+
+  '@oozcitak/infra@2.0.2':
+    dependencies:
+      '@oozcitak/util': 10.0.0
+
+  '@oozcitak/url@3.0.0':
+    dependencies:
+      '@oozcitak/infra': 2.0.2
+      '@oozcitak/util': 10.0.0
+
+  '@oozcitak/util@10.0.0': {}
+
+  '@orpc/client@1.14.6':
+    dependencies:
+      '@orpc/shared': 1.14.6
+      '@orpc/standard-server': 1.14.6
+      '@orpc/standard-server-fetch': 1.14.6
+      '@orpc/standard-server-peer': 1.14.6
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+
+  '@orpc/contract@1.14.6':
+    dependencies:
+      '@orpc/client': 1.14.6
+      '@orpc/shared': 1.14.6
+      '@standard-schema/spec': 1.1.0
+      openapi-types: 12.1.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+
+  '@orpc/interop@1.14.6': {}
+
+  '@orpc/json-schema@1.14.6':
+    dependencies:
+      '@orpc/contract': 1.14.6
+      '@orpc/interop': 1.14.6
+      '@orpc/openapi': 1.14.6
+      '@orpc/server': 1.14.6
+      '@orpc/shared': 1.14.6
+      json-schema-typed: 8.0.2
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - crossws
+      - fastify
+      - ws
+
+  '@orpc/openapi-client@1.14.6':
+    dependencies:
+      '@orpc/client': 1.14.6
+      '@orpc/contract': 1.14.6
+      '@orpc/shared': 1.14.6
+      '@orpc/standard-server': 1.14.6
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+
+  '@orpc/openapi@1.14.6':
+    dependencies:
+      '@orpc/client': 1.14.6
+      '@orpc/contract': 1.14.6
+      '@orpc/interop': 1.14.6
+      '@orpc/openapi-client': 1.14.6
+      '@orpc/server': 1.14.6
+      '@orpc/shared': 1.14.6
+      '@orpc/standard-server': 1.14.6
+      json-schema-typed: 8.0.2
+      rou3: 0.7.12
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - crossws
+      - fastify
+      - ws
+
+  '@orpc/server@1.14.6':
+    dependencies:
+      '@orpc/client': 1.14.6
+      '@orpc/contract': 1.14.6
+      '@orpc/interop': 1.14.6
+      '@orpc/shared': 1.14.6
+      '@orpc/standard-server': 1.14.6
+      '@orpc/standard-server-aws-lambda': 1.14.6
+      '@orpc/standard-server-fastify': 1.14.6
+      '@orpc/standard-server-fetch': 1.14.6
+      '@orpc/standard-server-node': 1.14.6
+      '@orpc/standard-server-peer': 1.14.6
+      cookie: 1.1.1
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - fastify
+
+  '@orpc/shared@1.14.6':
+    dependencies:
+      radash: 12.1.1
+      type-fest: 5.7.0
+
+  '@orpc/standard-server-aws-lambda@1.14.6':
+    dependencies:
+      '@orpc/shared': 1.14.6
+      '@orpc/standard-server': 1.14.6
+      '@orpc/standard-server-fetch': 1.14.6
+      '@orpc/standard-server-node': 1.14.6
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+
+  '@orpc/standard-server-fastify@1.14.6':
+    dependencies:
+      '@orpc/shared': 1.14.6
+      '@orpc/standard-server': 1.14.6
+      '@orpc/standard-server-node': 1.14.6
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+
+  '@orpc/standard-server-fetch@1.14.6':
+    dependencies:
+      '@orpc/shared': 1.14.6
+      '@orpc/standard-server': 1.14.6
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+
+  '@orpc/standard-server-node@1.14.6':
+    dependencies:
+      '@orpc/shared': 1.14.6
+      '@orpc/standard-server': 1.14.6
+      '@orpc/standard-server-fetch': 1.14.6
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+
+  '@orpc/standard-server-peer@1.14.6':
+    dependencies:
+      '@orpc/shared': 1.14.6
+      '@orpc/standard-server': 1.14.6
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+
+  '@orpc/standard-server@1.14.6':
+    dependencies:
+      '@orpc/shared': 1.14.6
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+
+  '@orpc/tanstack-query@1.14.6(@orpc/client@1.14.6)(@tanstack/query-core@5.101.2)':
+    dependencies:
+      '@orpc/client': 1.14.6
+      '@orpc/shared': 1.14.6
+      '@tanstack/query-core': 5.101.2
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+
+  '@orpc/zod@1.14.6(@orpc/contract@1.14.6)(@orpc/server@1.14.6)(zod@4.4.3)':
+    dependencies:
+      '@orpc/contract': 1.14.6
+      '@orpc/json-schema': 1.14.6
+      '@orpc/openapi': 1.14.6
+      '@orpc/server': 1.14.6
+      '@orpc/shared': 1.14.6
+      escape-string-regexp: 5.0.0
+      wildcard-match: 5.1.4
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - crossws
+      - fastify
+      - ws
+
+  '@oxc-project/types@0.138.0': {}
+
+  '@rolldown/binding-android-arm64@1.1.4':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.1.4':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.1.4':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.1.4':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.4':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.1.4':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.4':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.1.4':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@sinclair/typebox@0.34.49': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tanstack/history@1.162.0': {}
+
+  '@tanstack/query-core@5.101.2': {}
+
+  '@tanstack/react-query@5.101.2(react@19.2.7)':
+    dependencies:
+      '@tanstack/query-core': 5.101.2
+      react: 19.2.7
+
+  '@tanstack/react-router-ssr-query@1.167.1(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/router-core@1.171.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/query-core': 5.101.2
+      '@tanstack/react-query': 5.101.2(react@19.2.7)
+      '@tanstack/react-router': 1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/router-ssr-query-core': 1.169.1(@tanstack/query-core@5.101.2)(@tanstack/router-core@1.171.14)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    transitivePeerDependencies:
+      - '@tanstack/router-core'
+
+  '@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/history': 1.162.0
+      '@tanstack/react-store': 0.9.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/router-core': 1.171.14
+      isbot: 5.1.44
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@tanstack/react-start-client@1.168.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/react-router': 1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/router-core': 1.171.14
+      '@tanstack/start-client-core': 1.170.13
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@tanstack/react-start-rsc@0.1.26(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.4)(vite@8.1.3(@types/node@24.10.1)(jiti@2.7.0))':
+    dependencies:
+      '@tanstack/react-router': 1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/router-core': 1.171.14
+      '@tanstack/router-utils': 1.162.2
+      '@tanstack/start-client-core': 1.170.13
+      '@tanstack/start-fn-stubs': 1.162.0
+      '@tanstack/start-plugin-core': 1.171.19(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(rolldown@1.1.4)(vite@8.1.3(@types/node@24.10.1)(jiti@2.7.0))
+      '@tanstack/start-server-core': 1.169.16
+      '@tanstack/start-storage-context': 1.167.16
+      pathe: 2.0.3
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rsbuild/core'
+      - bun-types-no-globals
+      - crossws
+      - esbuild
+      - rolldown
+      - rollup
+      - supports-color
+      - unloader
+      - vite
+      - vite-plugin-solid
+      - webpack
+
+  '@tanstack/react-start-server@1.167.21(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/react-router': 1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/router-core': 1.171.14
+      '@tanstack/start-server-core': 1.169.16
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    transitivePeerDependencies:
+      - crossws
+
+  '@tanstack/react-start@1.168.27(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.4)(vite@8.1.3(@types/node@24.10.1)(jiti@2.7.0))':
+    dependencies:
+      '@tanstack/react-router': 1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/react-start-client': 1.168.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/react-start-rsc': 0.1.26(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.4)(vite@8.1.3(@types/node@24.10.1)(jiti@2.7.0))
+      '@tanstack/react-start-server': 1.167.21(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/router-utils': 1.162.2
+      '@tanstack/start-client-core': 1.170.13
+      '@tanstack/start-plugin-core': 1.171.19(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(rolldown@1.1.4)(vite@8.1.3(@types/node@24.10.1)(jiti@2.7.0))
+      '@tanstack/start-server-core': 1.169.16
+      pathe: 2.0.3
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      vite: 8.1.3(@types/node@24.10.1)(jiti@2.7.0)
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - crossws
+      - esbuild
+      - react-server-dom-rspack
+      - rolldown
+      - rollup
+      - supports-color
+      - unloader
+      - vite-plugin-solid
+      - webpack
+
+  '@tanstack/react-store@0.9.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/store': 0.9.3
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.7)
+
+  '@tanstack/router-core@1.171.14':
+    dependencies:
+      '@tanstack/history': 1.162.0
+      cookie-es: 3.1.1
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
+
+  '@tanstack/router-generator@1.167.18':
+    dependencies:
+      '@babel/types': 7.29.7
+      '@tanstack/router-core': 1.171.14
+      '@tanstack/router-utils': 1.162.2
+      '@tanstack/virtual-file-routes': 1.162.0
+      jiti: 2.7.0
+      magic-string: 0.30.21
+      prettier: 3.9.4
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tanstack/router-plugin@1.168.19(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(rolldown@1.1.4)(vite@8.1.3(@types/node@24.10.1)(jiti@2.7.0))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      '@tanstack/router-core': 1.171.14
+      '@tanstack/router-generator': 1.167.18
+      '@tanstack/router-utils': 1.162.2
+      chokidar: 5.0.0
+      unplugin: 3.3.0(rolldown@1.1.4)(vite@8.1.3(@types/node@24.10.1)(jiti@2.7.0))
+      zod: 4.4.3
+    optionalDependencies:
+      '@tanstack/react-router': 1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      vite: 8.1.3(@types/node@24.10.1)(jiti@2.7.0)
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rolldown
+      - rollup
+      - supports-color
+      - unloader
+
+  '@tanstack/router-ssr-query-core@1.169.1(@tanstack/query-core@5.101.2)(@tanstack/router-core@1.171.14)':
+    dependencies:
+      '@tanstack/query-core': 5.101.2
+      '@tanstack/router-core': 1.171.14
+
+  '@tanstack/router-utils@1.162.2':
+    dependencies:
+      '@babel/generator': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      ansis: 4.3.1
+      babel-dead-code-elimination: 1.0.12
+      diff: 8.0.4
+      pathe: 2.0.3
+      tinyglobby: 0.2.17
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tanstack/start-client-core@1.170.13':
+    dependencies:
+      '@tanstack/router-core': 1.171.14
+      '@tanstack/start-fn-stubs': 1.162.0
+      '@tanstack/start-storage-context': 1.167.16
+      seroval: 1.5.4
+
+  '@tanstack/start-fn-stubs@1.162.0': {}
+
+  '@tanstack/start-plugin-core@1.171.19(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(rolldown@1.1.4)(vite@8.1.3(@types/node@24.10.1)(jiti@2.7.0))':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/core': 7.29.7
+      '@babel/types': 7.29.7
+      '@tanstack/router-core': 1.171.14
+      '@tanstack/router-generator': 1.167.18
+      '@tanstack/router-plugin': 1.168.19(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(rolldown@1.1.4)(vite@8.1.3(@types/node@24.10.1)(jiti@2.7.0))
+      '@tanstack/router-utils': 1.162.2
+      '@tanstack/start-server-core': 1.169.16
+      exsolve: 1.1.0
+      lightningcss: 1.32.0
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      seroval: 1.5.4
+      source-map: 0.7.6
+      srvx: 0.11.20
+      tinyglobby: 0.2.17
+      ufo: 1.6.4
+      vitefu: 1.1.3(vite@8.1.3(@types/node@24.10.1)(jiti@2.7.0))
+      xmlbuilder2: 4.0.3
+      zod: 4.4.3
+    optionalDependencies:
+      vite: 8.1.3(@types/node@24.10.1)(jiti@2.7.0)
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - '@tanstack/react-router'
+      - bun-types-no-globals
+      - crossws
+      - esbuild
+      - rolldown
+      - rollup
+      - supports-color
+      - unloader
+      - vite-plugin-solid
+      - webpack
+
+  '@tanstack/start-server-core@1.169.16':
+    dependencies:
+      '@tanstack/history': 1.162.0
+      '@tanstack/router-core': 1.171.14
+      '@tanstack/start-client-core': 1.170.13
+      '@tanstack/start-storage-context': 1.167.16
+      fetchdts: 0.1.7
+      h3-v2: h3@2.0.1-rc.20
+      seroval: 1.5.4
+    transitivePeerDependencies:
+      - crossws
+
+  '@tanstack/start-storage-context@1.167.16':
+    dependencies:
+      '@tanstack/router-core': 1.171.14
+
+  '@tanstack/store@0.9.3': {}
+
+  '@tanstack/virtual-file-routes@1.162.0': {}
+
+  '@tokenizer/inflate@0.4.1':
+    dependencies:
+      debug: 4.4.3
+      token-types: 6.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/token@0.3.0': {}
+
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/bun@1.3.14':
+    dependencies:
+      bun-types: 1.3.14
+
+  '@types/node@24.10.1':
+    dependencies:
+      undici-types: 7.16.0
+
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
+
+  '@types/react@19.2.17':
+    dependencies:
+      csstype: 3.2.3
+
+  '@vitejs/plugin-react@6.0.3(vite@8.1.3(@types/node@24.10.1)(jiti@2.7.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.1.3(@types/node@24.10.1)(jiti@2.7.0)
+
+  ansis@4.3.1: {}
+
+  argparse@2.0.1: {}
+
+  babel-dead-code-elimination@1.0.12:
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  baseline-browser-mapping@2.10.41: {}
+
+  browserslist@4.28.4:
+    dependencies:
+      baseline-browser-mapping: 2.10.41
+      caniuse-lite: 1.0.30001800
+      electron-to-chromium: 1.5.385
+      node-releases: 2.0.50
+      update-browserslist-db: 1.2.3(browserslist@4.28.4)
+
+  bun-types@1.3.14:
+    dependencies:
+      '@types/node': 24.10.1
+
+  caniuse-lite@1.0.30001800: {}
+
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
+  convert-source-map@2.0.0: {}
+
+  cookie-es@3.1.1: {}
+
+  cookie@1.1.1: {}
+
+  csstype@3.2.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  detect-libc@2.1.2: {}
+
+  diff@8.0.4: {}
+
+  electron-to-chromium@1.5.385: {}
+
+  elysia@1.4.29(@sinclair/typebox@0.34.49)(@types/bun@1.3.14)(exact-mirror@1.2.2)(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3):
+    dependencies:
+      '@sinclair/typebox': 0.34.49
+      cookie: 1.1.1
+      exact-mirror: 1.2.2
+      fast-decode-uri-component: 1.0.1
+      file-type: 22.0.1
+      memoirist: 0.4.0
+      openapi-types: 12.1.3
+    optionalDependencies:
+      '@types/bun': 1.3.14
+      typescript: 5.9.3
+
+  escalade@3.2.0: {}
+
+  escape-string-regexp@5.0.0: {}
+
+  exact-mirror@1.2.2: {}
+
+  exsolve@1.1.0: {}
+
+  fast-decode-uri-component@1.0.1: {}
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  fetchdts@0.1.7: {}
+
+  file-type@22.0.1:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.5
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  fsevents@2.3.3:
+    optional: true
+
+  gensync@1.0.0-beta.2: {}
+
+  h3@2.0.1-rc.20:
+    dependencies:
+      rou3: 0.8.1
+      srvx: 0.11.20
+
+  ieee754@1.2.1: {}
+
+  isbot@5.1.44: {}
+
+  jiti@2.7.0: {}
+
+  js-tokens@4.0.0: {}
+
+  js-yaml@4.3.0:
+    dependencies:
+      argparse: 2.0.1
+
+  jsesc@3.1.0: {}
+
+  json-schema-typed@8.0.2: {}
+
+  json5@2.2.3: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  memoirist@0.4.0: {}
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.15: {}
+
+  node-releases@2.0.50: {}
+
+  openapi-types@12.1.3: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.5: {}
+
+  postcss@8.5.16:
+    dependencies:
+      nanoid: 3.3.15
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  prettier@3.9.4: {}
+
+  radash@12.1.1: {}
+
+  react-dom@19.2.7(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+
+  react@19.2.7: {}
+
+  readdirp@5.0.0: {}
+
+  rolldown@1.1.4:
+    dependencies:
+      '@oxc-project/types': 0.138.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.4
+      '@rolldown/binding-darwin-arm64': 1.1.4
+      '@rolldown/binding-darwin-x64': 1.1.4
+      '@rolldown/binding-freebsd-x64': 1.1.4
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.4
+      '@rolldown/binding-linux-arm64-gnu': 1.1.4
+      '@rolldown/binding-linux-arm64-musl': 1.1.4
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.4
+      '@rolldown/binding-linux-s390x-gnu': 1.1.4
+      '@rolldown/binding-linux-x64-gnu': 1.1.4
+      '@rolldown/binding-linux-x64-musl': 1.1.4
+      '@rolldown/binding-openharmony-arm64': 1.1.4
+      '@rolldown/binding-wasm32-wasi': 1.1.4
+      '@rolldown/binding-win32-arm64-msvc': 1.1.4
+      '@rolldown/binding-win32-x64-msvc': 1.1.4
+
+  rou3@0.7.12: {}
+
+  rou3@0.8.1: {}
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
+
+  seroval-plugins@1.5.4(seroval@1.5.4):
+    dependencies:
+      seroval: 1.5.4
+
+  seroval@1.5.4: {}
+
+  source-map-js@1.2.1: {}
+
+  source-map@0.7.6: {}
+
+  srvx@0.11.20: {}
+
+  strtok3@10.3.5:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+
+  tagged-tag@1.0.0: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  token-types@6.1.2:
+    dependencies:
+      '@borewit/text-codec': 0.2.2
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
+
+  tslib@2.8.1:
+    optional: true
+
+  type-fest@5.7.0:
+    dependencies:
+      tagged-tag: 1.0.0
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.4: {}
+
+  uint8array-extras@1.5.0: {}
+
+  undici-types@7.16.0: {}
+
+  unplugin@3.3.0(rolldown@1.1.4)(vite@8.1.3(@types/node@24.10.1)(jiti@2.7.0)):
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      picomatch: 4.0.5
+      webpack-virtual-modules: 0.6.2
+    optionalDependencies:
+      rolldown: 1.1.4
+      vite: 8.1.3(@types/node@24.10.1)(jiti@2.7.0)
+
+  update-browserslist-db@1.2.3(browserslist@4.28.4):
+    dependencies:
+      browserslist: 4.28.4
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  use-sync-external-store@1.6.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+
+  vite@8.1.3(@types/node@24.10.1)(jiti@2.7.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.16
+      rolldown: 1.1.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.10.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
+
+  vitefu@1.1.3(vite@8.1.3(@types/node@24.10.1)(jiti@2.7.0)):
+    optionalDependencies:
+      vite: 8.1.3(@types/node@24.10.1)(jiti@2.7.0)
+
+  webpack-virtual-modules@0.6.2: {}
+
+  wildcard-match@5.1.4: {}
+
+  xmlbuilder2@4.0.3:
+    dependencies:
+      '@oozcitak/dom': 2.0.2
+      '@oozcitak/infra': 2.0.2
+      '@oozcitak/util': 10.0.0
+      js-yaml: 4.3.0
+
+  yallist@3.1.1: {}
+
+  zod@4.4.3: {}

--- a/spikes/157-orpc/pnpm-workspace.yaml
+++ b/spikes/157-orpc/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - contract
+  - service
+  - web

--- a/spikes/157-orpc/service/package.json
+++ b/spikes/157-orpc/service/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@vers/service-user",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "bun --watch src/serve.ts",
+    "start": "bun src/serve.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@orpc/openapi": "1.14.6",
+    "@orpc/server": "1.14.6",
+    "@orpc/zod": "1.14.6",
+    "@vers/contract-user": "workspace:*",
+    "elysia": "1.4.29"
+  },
+  "devDependencies": {
+    "@types/bun": "1.3.14",
+    "typescript": "5.9.3"
+  }
+}

--- a/spikes/157-orpc/service/src/build-session-from-request.ts
+++ b/spikes/157-orpc/service/src/build-session-from-request.ts
@@ -1,0 +1,23 @@
+import type { SessionResolution } from './types';
+
+/**
+ * Resolves a session token from the `authorization` header (`Bearer <token>`) or the `session`
+ * cookie. Spike-grade stand-in for real session verification: one hard-coded valid token, one
+ * hard-coded expired token, everything else counts as no session.
+ */
+export function buildSessionFromRequest(request: Request): SessionResolution {
+  const token = findToken(request);
+  if (token === null) return { failure: 'missing-session' };
+  if (token === 'expired-session-token') return { failure: 'expired-session' };
+  if (token === 'dev-session-token') return { userId: 'user-1' };
+  return { failure: 'missing-session' };
+}
+
+function findToken(request: Request): string | null {
+  const authorization = request.headers.get('authorization');
+  if (authorization?.startsWith('Bearer '))
+    return authorization.slice('Bearer '.length);
+  const cookie = request.headers.get('cookie');
+  const match = cookie?.match(/(?:^|;\s*)session=([^;]+)/);
+  return match?.[1] ?? null;
+}

--- a/spikes/157-orpc/service/src/serve.ts
+++ b/spikes/157-orpc/service/src/serve.ts
@@ -1,0 +1,55 @@
+import { OpenAPIGenerator } from '@orpc/openapi';
+import { OpenAPIHandler } from '@orpc/openapi/fetch';
+import { RPCHandler } from '@orpc/server/fetch';
+import { ZodToJsonSchemaConverter } from '@orpc/zod/zod4';
+import { userContract } from '@vers/contract-user';
+import { Elysia } from 'elysia';
+import { buildSessionFromRequest } from './build-session-from-request';
+import { userRouter } from './user-router';
+
+/**
+ * Serves the user service over both oRPC transports: the RPC protocol under /rpc (consumed by
+ * typed clients) and the OpenAPI-shaped REST surface under /api, plus the generated OpenAPI
+ * document at /spec.json. The spec is generated from the contract alone — no implementation
+ * types involved — which is what lets a client package depend on the contract only.
+ */
+const rpcHandler = new RPCHandler(userRouter);
+const openAPIHandler = new OpenAPIHandler(userRouter);
+
+const openAPIGenerator = new OpenAPIGenerator({
+  schemaConverters: [new ZodToJsonSchemaConverter()],
+});
+
+const spec = await openAPIGenerator.generate(userContract, {
+  info: { title: 'vers user service (spike)', version: '0.0.0' },
+});
+
+const port = Number(process.env.PORT ?? 3001);
+
+const app = new Elysia()
+  .all(
+    '/rpc*',
+    async ({ request }) => {
+      const { response } = await rpcHandler.handle(request, {
+        prefix: '/rpc',
+        context: { session: buildSessionFromRequest(request) },
+      });
+      return response ?? new Response('Not Found', { status: 404 });
+    },
+    { parse: 'none' },
+  )
+  .all(
+    '/api*',
+    async ({ request }) => {
+      const { response } = await openAPIHandler.handle(request, {
+        prefix: '/api',
+        context: { session: buildSessionFromRequest(request) },
+      });
+      return response ?? new Response('Not Found', { status: 404 });
+    },
+    { parse: 'none' },
+  )
+  .get('/spec.json', () => spec)
+  .listen(port);
+
+console.log(`user service listening on http://localhost:${app.server?.port}`);

--- a/spikes/157-orpc/service/src/types.ts
+++ b/spikes/157-orpc/service/src/types.ts
@@ -1,0 +1,11 @@
+import type { UnauthorizedReason } from '@vers/contract-user';
+
+/** Outcome of resolving the caller's session token: an authenticated user or the reason there isn't one. */
+export type SessionResolution =
+  | { userId: string }
+  | { failure: UnauthorizedReason };
+
+/** Per-request context available to every procedure handler. */
+export interface ServiceContext {
+  session: SessionResolution;
+}

--- a/spikes/157-orpc/service/src/user-router.ts
+++ b/spikes/157-orpc/service/src/user-router.ts
@@ -1,0 +1,30 @@
+import { implement } from '@orpc/server';
+import { userContract, type User } from '@vers/contract-user';
+import type { ServiceContext } from './types';
+
+const os = implement(userContract).$context<ServiceContext>();
+
+/** Spike-grade user store: the single user the hard-coded valid session token resolves to. */
+const USERS: Record<string, User> = {
+  'user-1': {
+    id: 'user-1',
+    email: 'geoff@example.com',
+    displayName: 'Geoff',
+  },
+};
+
+const getCurrentUser = os.getCurrentUser.handler(({ context, errors }) => {
+  if ('failure' in context.session) {
+    throw errors.UNAUTHORIZED({ data: { reason: context.session.failure } });
+  }
+  const user = USERS[context.session.userId];
+  if (user === undefined) {
+    throw errors.UNAUTHORIZED({ data: { reason: 'missing-session' } });
+  }
+  return user;
+});
+
+/** Implementation router for the user contract; the shape is enforced against the contract. */
+export const userRouter = os.router({
+  getCurrentUser,
+});

--- a/spikes/157-orpc/service/tsconfig.json
+++ b/spikes/157-orpc/service/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["bun"]
+  },
+  "include": ["src"]
+}

--- a/spikes/157-orpc/tsconfig.base.json
+++ b/spikes/157-orpc/tsconfig.base.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2023"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": []
+  }
+}

--- a/spikes/157-orpc/web/package.json
+++ b/spikes/157-orpc/web/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@vers/app-web",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@orpc/client": "1.14.6",
+    "@orpc/contract": "1.14.6",
+    "@orpc/tanstack-query": "1.14.6",
+    "@tanstack/react-query": "5.101.2",
+    "@tanstack/react-router": "1.170.17",
+    "@tanstack/react-router-ssr-query": "1.167.1",
+    "@tanstack/react-start": "1.168.27",
+    "@vers/contract-user": "workspace:*",
+    "react": "19.2.7",
+    "react-dom": "19.2.7"
+  },
+  "devDependencies": {
+    "@types/node": "24.10.1",
+    "@types/react": "19.2.17",
+    "@types/react-dom": "19.2.3",
+    "@vitejs/plugin-react": "6.0.3",
+    "typescript": "5.9.3",
+    "vite": "8.1.3"
+  }
+}

--- a/spikes/157-orpc/web/src/orpc-client.ts
+++ b/spikes/157-orpc/web/src/orpc-client.ts
@@ -1,0 +1,37 @@
+import { createORPCClient } from '@orpc/client';
+import { RPCLink } from '@orpc/client/fetch';
+import type { ContractRouterClient } from '@orpc/contract';
+import { createIsomorphicFn } from '@tanstack/react-start';
+import { getRequestHeaders } from '@tanstack/react-start/server';
+import type { UserContract } from '@vers/contract-user';
+
+/**
+ * Contract-typed oRPC client. During SSR it talks straight to the service (forwarding the
+ * caller's session headers); in the browser it goes through this app's /api/rpc proxy route,
+ * since the service is not reachable from outside the private network.
+ */
+export const orpcClient: ContractRouterClient<UserContract> =
+  createORPCClient(buildLink());
+
+function buildLink(): RPCLink<Record<never, never>> {
+  return createIsomorphicFn()
+    .server(
+      () =>
+        new RPCLink({
+          url: `${process.env.SERVICE_URL ?? 'http://localhost:3001'}/rpc`,
+          headers: () => pickSessionHeaders(getRequestHeaders()),
+        }),
+    )
+    .client(() => new RPCLink({ url: `${window.location.origin}/api/rpc` }))();
+}
+
+const SESSION_HEADER_NAMES = ['authorization', 'cookie'] as const;
+
+function pickSessionHeaders(incoming: Headers): Record<string, string> {
+  const picked: Record<string, string> = {};
+  for (const name of SESSION_HEADER_NAMES) {
+    const value = incoming.get(name);
+    if (value !== null) picked[name] = value;
+  }
+  return picked;
+}

--- a/spikes/157-orpc/web/src/orpc.ts
+++ b/spikes/157-orpc/web/src/orpc.ts
@@ -1,0 +1,5 @@
+import { createTanstackQueryUtils } from '@orpc/tanstack-query';
+import { orpcClient } from './orpc-client';
+
+/** TanStack Query bindings for the oRPC client: query options and keys derived from the contract. */
+export const orpc = createTanstackQueryUtils(orpcClient);

--- a/spikes/157-orpc/web/src/read-current-user.ts
+++ b/spikes/157-orpc/web/src/read-current-user.ts
@@ -1,0 +1,22 @@
+import { safe } from '@orpc/client';
+import { createServerFn } from '@tanstack/react-start';
+import type { UnauthorizedReason, User } from '@vers/contract-user';
+import { orpcClient } from './orpc-client';
+
+export type CurrentUserResult =
+  | { authenticated: true; user: User }
+  | { authenticated: false; reason: UnauthorizedReason | 'transport-error' };
+
+/**
+ * Server-function consumption path: the oRPC call happens on the Start server and the typed
+ * error is folded into a plain result union, so nothing error-shaped has to survive the
+ * server-function serialization boundary.
+ */
+export const readCurrentUser = createServerFn({ method: 'GET' }).handler(
+  async (): Promise<CurrentUserResult> => {
+    const { error, data, isDefined } = await safe(orpcClient.getCurrentUser());
+    if (error === null) return { authenticated: true, user: data };
+    if (isDefined) return { authenticated: false, reason: error.data.reason };
+    return { authenticated: false, reason: 'transport-error' };
+  },
+);

--- a/spikes/157-orpc/web/src/router.tsx
+++ b/spikes/157-orpc/web/src/router.tsx
@@ -1,0 +1,15 @@
+import { QueryClient } from '@tanstack/react-query';
+import { createRouter } from '@tanstack/react-router';
+import { setupRouterSsrQueryIntegration } from '@tanstack/react-router-ssr-query';
+import { routeTree } from './routeTree.gen';
+
+export function getRouter() {
+  const queryClient = new QueryClient();
+  const router = createRouter({
+    routeTree,
+    context: { queryClient },
+    scrollRestoration: true,
+  });
+  setupRouterSsrQueryIntegration({ router, queryClient });
+  return router;
+}

--- a/spikes/157-orpc/web/src/routes/__root.tsx
+++ b/spikes/157-orpc/web/src/routes/__root.tsx
@@ -1,0 +1,45 @@
+import type { QueryClient } from '@tanstack/react-query';
+import {
+  createRootRouteWithContext,
+  HeadContent,
+  Outlet,
+  Scripts,
+} from '@tanstack/react-router';
+import type { ReactNode } from 'react';
+
+export interface RouterAppContext {
+  queryClient: QueryClient;
+}
+
+export const Route = createRootRouteWithContext<RouterAppContext>()({
+  head: () => ({
+    meta: [
+      { charSet: 'utf-8' },
+      { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+      { title: 'vers spike 157 — oRPC / Elysia / TanStack Start' },
+    ],
+  }),
+  component: RootComponent,
+});
+
+function RootComponent() {
+  return (
+    <RootDocument>
+      <Outlet />
+    </RootDocument>
+  );
+}
+
+function RootDocument(props: Readonly<{ children: ReactNode }>) {
+  return (
+    <html lang="en">
+      <head>
+        <HeadContent />
+      </head>
+      <body>
+        {props.children}
+        <Scripts />
+      </body>
+    </html>
+  );
+}

--- a/spikes/157-orpc/web/src/routes/api/rpc.$.ts
+++ b/spikes/157-orpc/web/src/routes/api/rpc.$.ts
@@ -1,0 +1,28 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+/**
+ * Forwards browser oRPC traffic to the user service, which is not directly reachable from the
+ * browser (in production it lives on the private network). Cookies ride along because the
+ * browser calls this route same-origin.
+ */
+export const Route = createFileRoute('/api/rpc/$')({
+  server: {
+    handlers: {
+      ANY: async ({ request }) => {
+        const incoming = new URL(request.url);
+        const serviceOrigin =
+          process.env.SERVICE_URL ?? 'http://localhost:3001';
+        const target = new URL(
+          incoming.pathname.replace(/^\/api\/rpc/, '/rpc') + incoming.search,
+          serviceOrigin,
+        );
+        const hasBody = request.method !== 'GET' && request.method !== 'HEAD';
+        return fetch(target, {
+          method: request.method,
+          headers: request.headers,
+          body: hasBody ? await request.blob() : undefined,
+        });
+      },
+    },
+  },
+});

--- a/spikes/157-orpc/web/src/routes/index.tsx
+++ b/spikes/157-orpc/web/src/routes/index.tsx
@@ -1,0 +1,130 @@
+import { isDefinedError } from '@orpc/client';
+import {
+  queryOptions,
+  useQuery,
+  useQueryClient,
+  useSuspenseQuery,
+} from '@tanstack/react-query';
+import { createFileRoute, useRouter } from '@tanstack/react-router';
+import { orpc } from '../orpc';
+import { readCurrentUser } from '../read-current-user';
+
+const serverFnUserQueryOptions = queryOptions({
+  queryKey: ['current-user', 'via-server-fn'],
+  queryFn: () => readCurrentUser(),
+});
+
+export const Route = createFileRoute('/')({
+  loader: async ({ context }) => {
+    await Promise.all([
+      // Direct-RPC prefetch: signed out, this rejects with the typed UNAUTHORIZED error; the
+      // panel renders the error state instead of failing the route, so swallow it here.
+      context.queryClient
+        .ensureQueryData(orpc.getCurrentUser.queryOptions())
+        .catch(() => undefined),
+      context.queryClient.ensureQueryData(serverFnUserQueryOptions),
+    ]);
+  },
+  component: HomePage,
+});
+
+function HomePage() {
+  return (
+    <main
+      style={{
+        fontFamily: 'system-ui',
+        maxWidth: '40rem',
+        margin: '2rem auto',
+      }}
+    >
+      <h1>spike 157 — oRPC / Elysia / TanStack Start</h1>
+      <SessionControls />
+      <DirectRPCPanel />
+      <ServerFnPanel />
+    </main>
+  );
+}
+
+function SessionControls() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  async function refreshSession(token: string | null) {
+    updateSessionCookie(token);
+    await queryClient.invalidateQueries();
+    await router.invalidate();
+  }
+
+  return (
+    <p>
+      <button onClick={() => refreshSession('dev-session-token')}>
+        Sign in
+      </button>{' '}
+      <button onClick={() => refreshSession('expired-session-token')}>
+        Use expired session
+      </button>{' '}
+      <button onClick={() => refreshSession(null)}>Sign out</button>
+    </p>
+  );
+}
+
+/**
+ * Consumption path 1: the contract-typed client called through TanStack Query, prefetched in
+ * the loader and SSR-hydrated. The typed UNAUTHORIZED error surfaces on `query.error` with its
+ * `data.reason` payload intact.
+ */
+function DirectRPCPanel() {
+  const query = useQuery(orpc.getCurrentUser.queryOptions({ retry: false }));
+
+  return (
+    <section>
+      <h2>Direct RPC via Query hydration</h2>
+      {query.isPending && <p>Loading…</p>}
+      {query.data && (
+        <p>
+          Signed in as <strong>{query.data.displayName}</strong> (
+          {query.data.email})
+        </p>
+      )}
+      {query.error &&
+        (isDefinedError(query.error) ? (
+          <p>
+            Not signed in — typed reason: <code>{query.error.data.reason}</code>
+          </p>
+        ) : (
+          <p>Untyped error: {query.error.message}</p>
+        ))}
+    </section>
+  );
+}
+
+/**
+ * Consumption path 2: a Start server function wraps the client and returns a plain result
+ * union, so the error case is ordinary data by the time it crosses to the browser.
+ */
+function ServerFnPanel() {
+  const query = useSuspenseQuery(serverFnUserQueryOptions);
+
+  return (
+    <section>
+      <h2>Server function via Query hydration</h2>
+      {query.data.authenticated ? (
+        <p>
+          Signed in as <strong>{query.data.user.displayName}</strong> (
+          {query.data.user.email})
+        </p>
+      ) : (
+        <p>
+          Not signed in — typed reason: <code>{query.data.reason}</code>
+        </p>
+      )}
+    </section>
+  );
+}
+
+function updateSessionCookie(token: string | null) {
+  document.cookie =
+    token === null
+      ? 'session=; path=/; max-age=0'
+      : `session=${token}; path=/; max-age=86400; samesite=lax`;
+}

--- a/spikes/157-orpc/web/tsconfig.json
+++ b/spikes/157-orpc/web/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "types": ["vite/client", "node"]
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/spikes/157-orpc/web/vite.config.ts
+++ b/spikes/157-orpc/web/vite.config.ts
@@ -1,0 +1,8 @@
+import { tanstackStart } from '@tanstack/react-start/plugin/vite';
+import viteReact from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  server: { port: 3000 },
+  plugins: [tanstackStart(), viteReact()],
+});

--- a/spikes/158-emmett-neon/.gitignore
+++ b/spikes/158-emmett-neon/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/spikes/158-emmett-neon/.npmrc
+++ b/spikes/158-emmett-neon/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/spikes/158-emmett-neon/Dockerfile
+++ b/spikes/158-emmett-neon/Dockerfile
@@ -1,0 +1,19 @@
+# Deps resolve under node/pnpm (workspace symlinks), runtime is bun — mirrors
+# the target stack where pnpm manages the workspace and bun runs services.
+FROM node:24-slim AS deps
+RUN corepack enable
+WORKDIR /app
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY store/package.json store/package.json
+COPY probe/package.json probe/package.json
+RUN pnpm install --frozen-lockfile
+
+FROM oven/bun:1.3-slim
+WORKDIR /app
+COPY --from=deps /app /app
+COPY tsconfig.base.json ./
+COPY store/ store/
+COPY probe/ probe/
+ENV PORT=3002
+EXPOSE 3002
+CMD ["bun", "probe/src/serve.ts"]

--- a/spikes/158-emmett-neon/README.md
+++ b/spikes/158-emmett-neon/README.md
@@ -1,0 +1,61 @@
+# Spike 158 — Emmett event store on Neon
+
+Time-boxed validation for [#158](https://github.com/zgeoff/vers/issues/158): proves the
+checkpoint event store from the #143 evaluation (emmett-on-postgres, hosted on Neon Sydney)
+before #127 builds the activities service on it. **Reference only — never merges.**
+
+## Shape
+
+Self-contained pnpm workspace (bun runtime), outside the repo's yarn `projects/*` glob:
+
+- `store/` — `@vers/spike-store`: emmett PostgreSQL event store with a stream per activity
+  (`activity:<id>`), hash-chain links (`prevHash`/`hash`) carried in event data, an inline pongo
+  projection for "latest progress for activity X", and the verifier-path replay that recomputes
+  the whole chain.
+- `probe/` — `@vers/spike-probe`: elysia bench server deployed to Fly (syd) so every timing is
+  measured next to the database. `POST /bench/run` drives the full scenario: create stream,
+  N hash-chained batch appends with optimistic concurrency, projection point reads, full replay
+  + chain verification, and a stale-version append that must be rejected.
+
+## Run it
+
+```sh
+pnpm install
+# .env needs DATABASE_URL (Neon) — see the issue for the spike project
+set -a && source .env && set +a
+pnpm dev:probe                 # probe on :3002
+pnpm bench                     # drives PROBE_URL (default localhost:3002)
+```
+
+Fly deployment: `flyctl deploy --ha=false` with `DATABASE_URL` as a secret. The cold-start phase
+of `pnpm bench` needs `NEON_API_KEY`, `NEON_PROJECT_ID`, `NEON_ENDPOINT_ID` to force suspends.
+
+## Numbers (fly syd shared-cpu-1x → Neon Sydney free tier, PG 17)
+
+Steady state (compute warm), 200-batch scenario:
+
+| Path                                        | Latency                        |
+| ------------------------------------------- | ------------------------------ |
+| Append (txn incl. inline projection)        | p50 17.1ms · p95 18.7ms        |
+| Projection point read (latest progress)     | p50 2.0ms · p95 2.4ms          |
+| Full replay + chain verify (201 events)     | 41ms (51 events: ~9ms)         |
+| Fresh connection (TCP+TLS+auth+query), warm | ~55–70ms                       |
+
+Scale-to-zero (endpoint suspended via API, measured on next request):
+
+| Path                                | Latency                       |
+| ----------------------------------- | ----------------------------- |
+| Cold read through existing pool     | ~600–625ms                    |
+| Cold fresh connection               | ~1.1s                         |
+| Cold first write (stream create)    | ~770–790ms                    |
+| Worst observed full-stack cold path | 12.7s (one-off, see verdict)  |
+
+Optimistic concurrency: stale `expectedStreamVersion` rejected on every run
+(`ExpectedVersionConflictError`).
+
+## Verdict
+
+**Go.** See the findings comment on #158 for detail and caveats (fixed emmett schema — chain
+lives in event data, not columns; `instanceof` hazard on emmett errors across its bundled dist,
+use `isExpectedVersionConflictError`; the 12.7s outlier stacked fly machine cold boot + first
+schema-migration check + Neon resume — mitigations noted there).

--- a/spikes/158-emmett-neon/fly.toml
+++ b/spikes/158-emmett-neon/fly.toml
@@ -1,0 +1,16 @@
+app = "vers-spike-158-probe"
+primary_region = "syd"
+
+[build]
+dockerfile = "Dockerfile"
+
+[http_service]
+internal_port = 3002
+force_https = true
+auto_stop_machines = "stop"
+auto_start_machines = true
+min_machines_running = 0
+
+[[vm]]
+size = "shared-cpu-1x"
+memory = "256mb"

--- a/spikes/158-emmett-neon/package.json
+++ b/spikes/158-emmett-neon/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "vers-spike-158",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@11.9.0",
+  "scripts": {
+    "dev:probe": "pnpm --filter @vers/spike-probe dev",
+    "bench": "pnpm --filter @vers/spike-probe bench",
+    "typecheck": "pnpm --recursive typecheck"
+  }
+}

--- a/spikes/158-emmett-neon/pnpm-lock.yaml
+++ b/spikes/158-emmett-neon/pnpm-lock.yaml
@@ -1,0 +1,639 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}
+
+  probe:
+    dependencies:
+      '@event-driven-io/emmett':
+        specifier: 0.42.3
+        version: 0.42.3(@types/async-retry@1.4.9)(async-retry@1.3.3)(commander@12.1.0)(uuid@10.0.0)
+      '@vers/spike-store':
+        specifier: workspace:*
+        version: link:../store
+      elysia:
+        specifier: 1.4.29
+        version: 1.4.29(@sinclair/typebox@0.34.49)(@types/bun@1.3.14)(exact-mirror@1.2.2)(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3)
+    devDependencies:
+      '@types/bun':
+        specifier: 1.3.14
+        version: 1.3.14
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
+  store:
+    dependencies:
+      '@event-driven-io/emmett':
+        specifier: 0.42.3
+        version: 0.42.3(@types/async-retry@1.4.9)(async-retry@1.3.3)(commander@12.1.0)(uuid@10.0.0)
+      '@event-driven-io/emmett-postgresql':
+        specifier: 0.42.3
+        version: 0.42.3(@event-driven-io/emmett@0.42.3(@types/async-retry@1.4.9)(async-retry@1.3.3)(commander@12.1.0)(uuid@10.0.0))(@event-driven-io/pongo@0.16.11(@event-driven-io/dumbo@0.12.7(@types/pg@8.20.0)(@types/uuid@10.0.0)(pg-connection-string@2.14.0)(pg@8.22.0)(uuid@10.0.0))(@types/mongodb@4.0.7)(@types/pg@8.20.0)(@types/uuid@10.0.0)(ansis@3.17.0)(cli-table3@0.6.5)(commander@12.1.0)(pg-connection-string@2.14.0)(pg@8.22.0)(uuid@10.0.0))
+      '@event-driven-io/pongo':
+        specifier: 0.16.11
+        version: 0.16.11(@event-driven-io/dumbo@0.12.7(@types/pg@8.20.0)(@types/uuid@10.0.0)(pg-connection-string@2.14.0)(pg@8.22.0)(uuid@10.0.0))(@types/mongodb@4.0.7)(@types/pg@8.20.0)(@types/uuid@10.0.0)(ansis@3.17.0)(cli-table3@0.6.5)(commander@12.1.0)(pg-connection-string@2.14.0)(pg@8.22.0)(uuid@10.0.0)
+    devDependencies:
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
+packages:
+
+  '@borewit/text-codec@0.2.2':
+    resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
+
+  '@colors/colors@1.5.0':
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
+    engines: {node: '>=0.1.90'}
+
+  '@event-driven-io/dumbo@0.12.7':
+    resolution: {integrity: sha512-E4JqJZPSeu1u0pKIYQnTjiDd6tMjlt8in9VitW4qkxA+QWzttXpM6EGUwkDCKgignhUOdIAQI5IZuzgTwIHjRw==}
+    peerDependencies:
+      '@types/pg': ^8.11.6
+      '@types/uuid': ^10.0.0
+      pg: ^8.12.0
+      pg-connection-string: ^2.6.4
+      uuid: ^10.0.0
+
+  '@event-driven-io/emmett-postgresql@0.42.3':
+    resolution: {integrity: sha512-ZpaOZlA04PC8gYaMaUyNwCSCIu3uIYMqLmTxkM9DvNjFVzNS90ht9ysxCOY975MhcEPcWhkc5e/IbCPxeg5PQA==}
+    peerDependencies:
+      '@event-driven-io/emmett': 0.42.3
+      '@event-driven-io/pongo': 0.16.11
+
+  '@event-driven-io/emmett@0.42.3':
+    resolution: {integrity: sha512-vwKlsMXZjOorUG9yWjVWe7Fq/fdq6jVwIhYz7OsY8rjIh5AOlnXuNZGr/58fCWfCmkTbL0uUl6oOxIoPmzCOWA==}
+    hasBin: true
+    peerDependencies:
+      '@types/async-retry': ^1.4.9
+      async-retry: ^1.3.3
+      commander: ^12.1.0
+      uuid: ^10.0.0
+
+  '@event-driven-io/pongo@0.16.11':
+    resolution: {integrity: sha512-ioeKWHUPnAGH1yFCr+4tXl5ZQ8vOCgwfyXEY1IVHAu1FxW1xhstIHUMQHemd7A/E2FdYXrikJhf0Fm+BwI3+Mw==}
+    hasBin: true
+    peerDependencies:
+      '@event-driven-io/dumbo': 0.12.7
+      '@types/mongodb': ^4.0.7
+      '@types/pg': ^8.11.6
+      '@types/uuid': ^10.0.0
+      ansis: ^3.3.2
+      cli-table3: ^0.6.5
+      commander: ^12.1.0
+      pg: ^8.12.0
+      pg-connection-string: ^2.6.4
+      uuid: ^10.0.0
+
+  '@mongodb-js/saslprep@1.4.12':
+    resolution: {integrity: sha512-QAfAMwNgnYxZ2C6D1HgeP7Gc4i/uvJRim415PCIL9ptRxWMNbWeLBYb2/9R4pGKny/s1FVu2JA2cxCUBUOggrA==}
+
+  '@sinclair/typebox@0.34.49':
+    resolution: {integrity: sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==}
+
+  '@tokenizer/inflate@0.4.1':
+    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
+  '@types/async-retry@1.4.9':
+    resolution: {integrity: sha512-s1ciZQJzRh3708X/m3vPExr5KJlzlZJvXsKpbtE2luqNcbROr64qU+3KpJsYHqWMeaxI839OvXf9PrUSw1Xtyg==}
+
+  '@types/bun@1.3.14':
+    resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
+
+  '@types/mongodb@4.0.7':
+    resolution: {integrity: sha512-lPUYPpzA43baXqnd36cZ9xxorprybxXDzteVKCPAdp14ppHtFJHnXYvNpmBvtMUTb5fKXVv6sVbzo1LHkWhJlw==}
+    deprecated: mongodb provides its own types. @types/mongodb is no longer needed.
+
+  '@types/node@26.1.0':
+    resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
+
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
+
+  '@types/retry@0.12.5':
+    resolution: {integrity: sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==}
+
+  '@types/uuid@10.0.0':
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
+
+  '@types/webidl-conversions@7.0.3':
+    resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
+
+  '@types/whatwg-url@13.0.0':
+    resolution: {integrity: sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansis@3.17.0:
+    resolution: {integrity: sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==}
+    engines: {node: '>=14'}
+
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
+
+  bson@7.3.1:
+    resolution: {integrity: sha512-h/C0qe6857pQhcSJHLfsR1uYGj98Ge3wKAD3Ed9KqH3wcVh+BM4Jq4xISD7vs9OPuT07n+q3QQVjslJ286j6ag==}
+    engines: {node: '>=20.19.0'}
+
+  bun-types@1.3.14:
+    resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
+
+  cli-table3@0.6.5:
+    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
+    engines: {node: 10.* || >= 12.*}
+
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  elysia@1.4.29:
+    resolution: {integrity: sha512-GwMRGGwSdjfPt+w3LA0fqTuYJtS8uVRJicvoar98/HrO5qdFKDc9CwjIb6Kja+v39lkY+58hr2JvdR9jQzlUuA==}
+    peerDependencies:
+      '@sinclair/typebox': '>= 0.34.0 < 1'
+      '@types/bun': '>= 1.2.0'
+      exact-mirror: '>= 0.0.9'
+      file-type: '>= 20.0.0'
+      openapi-types: '>= 12.0.0'
+      typescript: '>= 5.0.0'
+    peerDependenciesMeta:
+      '@types/bun':
+        optional: true
+      typescript:
+        optional: true
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  exact-mirror@1.2.2:
+    resolution: {integrity: sha512-jUlRkZOPN3rCAy4kmZeD2HCnoXwJ6KlWNkEBJ3sEJ2rbLSU+tN60hY7XzPZkImRQOJczllvOBYTYEJTYScPh5Q==}
+    peerDependencies:
+      typebox: '>= 1.1.0'
+    peerDependenciesMeta:
+      typebox:
+        optional: true
+
+  fast-decode-uri-component@1.0.1:
+    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
+
+  file-type@22.0.1:
+    resolution: {integrity: sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA==}
+    engines: {node: '>=22'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  memoirist@0.4.0:
+    resolution: {integrity: sha512-zxTgA0mSYELa66DimuNQDvyLq36AwDlTuVRbnQtB+VuTcKWm5Qc4z3WkSpgsFWHNhexqkIooqpv4hdcqrX5Nmg==}
+
+  memory-pager@1.5.0:
+    resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
+
+  mongodb-connection-string-url@7.0.1:
+    resolution: {integrity: sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==}
+    engines: {node: '>=20.19.0'}
+
+  mongodb@7.4.0:
+    resolution: {integrity: sha512-giySkkdYiwoBFo/oCc8nzov3xOYZ/sB8OpAYk5GINRLEjVw0LDsm8xgQL0XMTyU4extQlDZjhdUr1ZEwKFaazw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@aws-sdk/credential-providers': ^3.806.0
+      '@mongodb-js/zstd': ^7.0.0
+      gcp-metadata: ^7.0.1
+      kerberos: ^7.0.0
+      mongodb-client-encryption: '>=7.0.0 <7.1.0'
+      snappy: ^7.3.2
+      socks: ^2.8.6
+    peerDependenciesMeta:
+      '@aws-sdk/credential-providers':
+        optional: true
+      '@mongodb-js/zstd':
+        optional: true
+      gcp-metadata:
+        optional: true
+      kerberos:
+        optional: true
+      mongodb-client-encryption:
+        optional: true
+      snappy:
+        optional: true
+      socks:
+        optional: true
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  openapi-types@12.1.3:
+    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
+
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
+
+  pg-connection-string@2.14.0:
+    resolution: {integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.15.0:
+    resolution: {integrity: sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.22.0:
+    resolution: {integrity: sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
+  sparse-bitfield@3.0.3:
+    resolution: {integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strtok3@10.3.5:
+    resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
+    engines: {node: '>=18'}
+
+  token-types@6.1.2:
+    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
+    engines: {node: '>=14.16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
+
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
+snapshots:
+
+  '@borewit/text-codec@0.2.2': {}
+
+  '@colors/colors@1.5.0':
+    optional: true
+
+  '@event-driven-io/dumbo@0.12.7(@types/pg@8.20.0)(@types/uuid@10.0.0)(pg-connection-string@2.14.0)(pg@8.22.0)(uuid@10.0.0)':
+    dependencies:
+      '@types/pg': 8.20.0
+      '@types/uuid': 10.0.0
+      pg: 8.22.0
+      pg-connection-string: 2.14.0
+      uuid: 10.0.0
+
+  '@event-driven-io/emmett-postgresql@0.42.3(@event-driven-io/emmett@0.42.3(@types/async-retry@1.4.9)(async-retry@1.3.3)(commander@12.1.0)(uuid@10.0.0))(@event-driven-io/pongo@0.16.11(@event-driven-io/dumbo@0.12.7(@types/pg@8.20.0)(@types/uuid@10.0.0)(pg-connection-string@2.14.0)(pg@8.22.0)(uuid@10.0.0))(@types/mongodb@4.0.7)(@types/pg@8.20.0)(@types/uuid@10.0.0)(ansis@3.17.0)(cli-table3@0.6.5)(commander@12.1.0)(pg-connection-string@2.14.0)(pg@8.22.0)(uuid@10.0.0))':
+    dependencies:
+      '@event-driven-io/emmett': 0.42.3(@types/async-retry@1.4.9)(async-retry@1.3.3)(commander@12.1.0)(uuid@10.0.0)
+      '@event-driven-io/pongo': 0.16.11(@event-driven-io/dumbo@0.12.7(@types/pg@8.20.0)(@types/uuid@10.0.0)(pg-connection-string@2.14.0)(pg@8.22.0)(uuid@10.0.0))(@types/mongodb@4.0.7)(@types/pg@8.20.0)(@types/uuid@10.0.0)(ansis@3.17.0)(cli-table3@0.6.5)(commander@12.1.0)(pg-connection-string@2.14.0)(pg@8.22.0)(uuid@10.0.0)
+
+  '@event-driven-io/emmett@0.42.3(@types/async-retry@1.4.9)(async-retry@1.3.3)(commander@12.1.0)(uuid@10.0.0)':
+    dependencies:
+      '@types/async-retry': 1.4.9
+      async-retry: 1.3.3
+      commander: 12.1.0
+      uuid: 10.0.0
+
+  '@event-driven-io/pongo@0.16.11(@event-driven-io/dumbo@0.12.7(@types/pg@8.20.0)(@types/uuid@10.0.0)(pg-connection-string@2.14.0)(pg@8.22.0)(uuid@10.0.0))(@types/mongodb@4.0.7)(@types/pg@8.20.0)(@types/uuid@10.0.0)(ansis@3.17.0)(cli-table3@0.6.5)(commander@12.1.0)(pg-connection-string@2.14.0)(pg@8.22.0)(uuid@10.0.0)':
+    dependencies:
+      '@event-driven-io/dumbo': 0.12.7(@types/pg@8.20.0)(@types/uuid@10.0.0)(pg-connection-string@2.14.0)(pg@8.22.0)(uuid@10.0.0)
+      '@types/mongodb': 4.0.7
+      '@types/pg': 8.20.0
+      '@types/uuid': 10.0.0
+      ansis: 3.17.0
+      cli-table3: 0.6.5
+      commander: 12.1.0
+      pg: 8.22.0
+      pg-connection-string: 2.14.0
+      uuid: 10.0.0
+
+  '@mongodb-js/saslprep@1.4.12':
+    dependencies:
+      sparse-bitfield: 3.0.3
+
+  '@sinclair/typebox@0.34.49': {}
+
+  '@tokenizer/inflate@0.4.1':
+    dependencies:
+      debug: 4.4.3
+      token-types: 6.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/token@0.3.0': {}
+
+  '@types/async-retry@1.4.9':
+    dependencies:
+      '@types/retry': 0.12.5
+
+  '@types/bun@1.3.14':
+    dependencies:
+      bun-types: 1.3.14
+
+  '@types/mongodb@4.0.7':
+    dependencies:
+      mongodb: 7.4.0
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@mongodb-js/zstd'
+      - gcp-metadata
+      - kerberos
+      - mongodb-client-encryption
+      - snappy
+      - socks
+
+  '@types/node@26.1.0':
+    dependencies:
+      undici-types: 8.3.0
+
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 26.1.0
+      pg-protocol: 1.15.0
+      pg-types: 2.2.0
+
+  '@types/retry@0.12.5': {}
+
+  '@types/uuid@10.0.0': {}
+
+  '@types/webidl-conversions@7.0.3': {}
+
+  '@types/whatwg-url@13.0.0':
+    dependencies:
+      '@types/webidl-conversions': 7.0.3
+
+  ansi-regex@5.0.1: {}
+
+  ansis@3.17.0: {}
+
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
+
+  bson@7.3.1: {}
+
+  bun-types@1.3.14:
+    dependencies:
+      '@types/node': 26.1.0
+
+  cli-table3@0.6.5:
+    dependencies:
+      string-width: 4.2.3
+    optionalDependencies:
+      '@colors/colors': 1.5.0
+
+  commander@12.1.0: {}
+
+  cookie@1.1.1: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  elysia@1.4.29(@sinclair/typebox@0.34.49)(@types/bun@1.3.14)(exact-mirror@1.2.2)(file-type@22.0.1)(openapi-types@12.1.3)(typescript@5.9.3):
+    dependencies:
+      '@sinclair/typebox': 0.34.49
+      cookie: 1.1.1
+      exact-mirror: 1.2.2
+      fast-decode-uri-component: 1.0.1
+      file-type: 22.0.1
+      memoirist: 0.4.0
+      openapi-types: 12.1.3
+    optionalDependencies:
+      '@types/bun': 1.3.14
+      typescript: 5.9.3
+
+  emoji-regex@8.0.0: {}
+
+  exact-mirror@1.2.2: {}
+
+  fast-decode-uri-component@1.0.1: {}
+
+  file-type@22.0.1:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.5
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  ieee754@1.2.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  memoirist@0.4.0: {}
+
+  memory-pager@1.5.0: {}
+
+  mongodb-connection-string-url@7.0.1:
+    dependencies:
+      '@types/whatwg-url': 13.0.0
+      whatwg-url: 14.2.0
+
+  mongodb@7.4.0:
+    dependencies:
+      '@mongodb-js/saslprep': 1.4.12
+      bson: 7.3.1
+      mongodb-connection-string-url: 7.0.1
+
+  ms@2.1.3: {}
+
+  openapi-types@12.1.3: {}
+
+  pg-cloudflare@1.4.0:
+    optional: true
+
+  pg-connection-string@2.14.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.14.0(pg@8.22.0):
+    dependencies:
+      pg: 8.22.0
+
+  pg-protocol@1.15.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.22.0:
+    dependencies:
+      pg-connection-string: 2.14.0
+      pg-pool: 3.14.0(pg@8.22.0)
+      pg-protocol: 1.15.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
+
+  punycode@2.3.1: {}
+
+  retry@0.13.1: {}
+
+  sparse-bitfield@3.0.3:
+    dependencies:
+      memory-pager: 1.5.0
+
+  split2@4.2.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strtok3@10.3.5:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+
+  token-types@6.1.2:
+    dependencies:
+      '@borewit/text-codec': 0.2.2
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
+
+  typescript@5.9.3: {}
+
+  uint8array-extras@1.5.0: {}
+
+  undici-types@8.3.0: {}
+
+  uuid@10.0.0: {}
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
+
+  xtend@4.0.2: {}

--- a/spikes/158-emmett-neon/pnpm-workspace.yaml
+++ b/spikes/158-emmett-neon/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - store
+  - probe

--- a/spikes/158-emmett-neon/probe/package.json
+++ b/spikes/158-emmett-neon/probe/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@vers/spike-probe",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "bun --watch src/serve.ts",
+    "start": "bun src/serve.ts",
+    "bench": "bun src/run-bench.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@event-driven-io/emmett": "0.42.3",
+    "@vers/spike-store": "workspace:*",
+    "elysia": "1.4.29"
+  },
+  "devDependencies": {
+    "@types/bun": "1.3.14",
+    "typescript": "5.9.3"
+  }
+}

--- a/spikes/158-emmett-neon/probe/src/build-stats.ts
+++ b/spikes/158-emmett-neon/probe/src/build-stats.ts
@@ -1,0 +1,26 @@
+export type LatencyStats = {
+  count: number;
+  min: number;
+  p50: number;
+  p95: number;
+  max: number;
+  mean: number;
+};
+
+/** Latency summary over millisecond samples; percentiles by nearest-rank. */
+export function buildStats(samples: number[]): LatencyStats {
+  const sorted = [...samples].sort((a, b) => a - b);
+  const at = (quantile: number) => sorted[Math.min(sorted.length - 1, Math.ceil(quantile * sorted.length) - 1)] ?? 0;
+  return {
+    count: sorted.length,
+    min: round(sorted[0] ?? 0),
+    p50: round(at(0.5)),
+    p95: round(at(0.95)),
+    max: round(sorted[sorted.length - 1] ?? 0),
+    mean: round(sorted.reduce((sum, sample) => sum + sample, 0) / Math.max(1, sorted.length)),
+  };
+}
+
+function round(value: number): number {
+  return Math.round(value * 10) / 10;
+}

--- a/spikes/158-emmett-neon/probe/src/run-bench-scenario.ts
+++ b/spikes/158-emmett-neon/probe/src/run-bench-scenario.ts
@@ -1,0 +1,98 @@
+import { isExpectedVersionConflictError } from '@event-driven-io/emmett';
+import type { ActivityStore, Checkpoint } from '@vers/spike-store';
+import { buildStats, type LatencyStats } from './build-stats';
+import { withTiming } from './with-timing';
+
+export type BenchScenarioInput = {
+  batches: number;
+  checkpointsPerBatch: number;
+  pointReads: number;
+};
+
+export type BenchScenarioReport = {
+  activityId: string;
+  createStreamMs: number;
+  append: LatencyStats;
+  pointRead: LatencyStats;
+  replayMs: number;
+  replayEventCount: number;
+  chainValid: boolean;
+  finalProgress: number | null;
+  conflictDetected: boolean;
+  conflictError: string | null;
+};
+
+/**
+ * The full exercise against one fresh activity stream: create, append
+ * `batches` checkpoint batches (each hash-chained to the last), point-read the
+ * inline projection `pointReads` times, replay the stream through the chain
+ * verifier, then confirm a stale expected version is rejected.
+ */
+export async function runBenchScenario(
+  store: ActivityStore,
+  input: BenchScenarioInput,
+): Promise<BenchScenarioReport> {
+  const activityId = crypto.randomUUID();
+
+  const created = await withTiming(() =>
+    store.createActivityStream({ activityId, seed: `seed-${activityId}`, difficulty: 3 }),
+  );
+  let prevHash = created.result.genesisHash;
+  let version = created.result.nextExpectedStreamVersion;
+
+  const appendSamples: number[] = [];
+  let progress = 0;
+  for (let batch = 0; batch < input.batches; batch++) {
+    const checkpoints: Checkpoint[] = Array.from({ length: input.checkpointsPerBatch }, (_, index) => ({
+      tick: batch * input.checkpointsPerBatch + index,
+      progress: Math.min(1, (batch * input.checkpointsPerBatch + index + 1) / (input.batches * input.checkpointsPerBatch)),
+      statsDelta: { xp: 10, kills: 1 },
+    }));
+    progress = checkpoints[checkpoints.length - 1]?.progress ?? progress;
+    const appended = await withTiming(() =>
+      store.appendCheckpointBatch({ activityId, checkpoints, progress, prevHash, expectedStreamVersion: version }),
+    );
+    prevHash = appended.result.hash;
+    version = appended.result.nextExpectedStreamVersion;
+    appendSamples.push(appended.ms);
+  }
+
+  const pointReadSamples: number[] = [];
+  let latestProgress: number | null = null;
+  for (let read = 0; read < input.pointReads; read++) {
+    const found = await withTiming(() => store.readProgress(activityId));
+    latestProgress = found.result?.progress ?? null;
+    pointReadSamples.push(found.ms);
+  }
+
+  const replayed = await withTiming(() => store.replayActivity(activityId));
+
+  let conflictDetected = false;
+  let conflictError: string | null = null;
+  try {
+    await store.appendCheckpointBatch({
+      activityId,
+      checkpoints: [{ tick: 0, progress: 0, statsDelta: { xp: 1 } }],
+      progress,
+      prevHash,
+      expectedStreamVersion: 1n,
+    });
+    conflictError = 'append with stale version unexpectedly succeeded';
+  } catch (error) {
+    conflictDetected = isExpectedVersionConflictError(error);
+    if (!conflictDetected) conflictError = `${(error as Error).constructor.name}: ${(error as Error).message}`;
+  }
+
+  return {
+    activityId,
+    createStreamMs: Math.round(created.ms * 10) / 10,
+    append: buildStats(appendSamples),
+    pointRead: buildStats(pointReadSamples),
+    replayMs: Math.round(replayed.ms * 10) / 10,
+    replayEventCount: replayed.result.eventCount,
+    chainValid: replayed.result.chain.valid,
+    finalProgress: latestProgress,
+    conflictDetected,
+    conflictError,
+  };
+}

--- a/spikes/158-emmett-neon/probe/src/run-bench.ts
+++ b/spikes/158-emmett-neon/probe/src/run-bench.ts
@@ -1,0 +1,46 @@
+/**
+ * Bench driver: hits a running probe (local or fly) over HTTP so all timings
+ * are measured server-side, next to the database. With Neon API credentials it
+ * also forces a suspend to measure scale-to-zero cold start.
+ *
+ * Env: PROBE_URL (default http://localhost:3002), and for the cold-start
+ * phase: NEON_API_KEY, NEON_PROJECT_ID, NEON_ENDPOINT_ID.
+ */
+export {};
+
+const probeURL = process.env.PROBE_URL ?? 'http://localhost:3002';
+
+const health = await readJSON('/health');
+console.log(`probe: ${probeURL} (region: ${health.region})`);
+
+console.log('\n== bench scenario (20 batches x 10 checkpoints, 20 point reads) ==');
+const report = await readJSON('/bench/run', {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ batches: 20, checkpointsPerBatch: 10, pointReads: 20 }),
+});
+console.log(JSON.stringify(report, null, 2));
+
+const { NEON_API_KEY, NEON_PROJECT_ID, NEON_ENDPOINT_ID } = process.env;
+if (NEON_API_KEY && NEON_PROJECT_ID && NEON_ENDPOINT_ID) {
+  console.log('\n== cold start (forcing Neon endpoint suspend) ==');
+  const suspended = await fetch(
+    `https://console.neon.tech/api/v2/projects/${NEON_PROJECT_ID}/endpoints/${NEON_ENDPOINT_ID}/suspend`,
+    { method: 'POST', headers: { Authorization: `Bearer ${NEON_API_KEY}` } },
+  );
+  console.log(`suspend: ${suspended.status}`);
+  await Bun.sleep(3000);
+
+  console.log(`ping-fresh (cold): ${JSON.stringify(await readJSON('/ping-fresh'))}`);
+  console.log(`ping-fresh (warm): ${JSON.stringify(await readJSON('/ping-fresh'))}`);
+  console.log(`ping-pooled (after suspend): ${JSON.stringify(await readJSON('/ping-pooled'))}`);
+  console.log(`ping-pooled (retry):         ${JSON.stringify(await readJSON('/ping-pooled'))}`);
+} else {
+  console.log('\n(cold-start phase skipped: NEON_API_KEY / NEON_PROJECT_ID / NEON_ENDPOINT_ID not set)');
+}
+
+async function readJSON(path: string, init?: RequestInit): Promise<any> {
+  const response = await fetch(`${probeURL}${path}`, init);
+  if (!response.ok) throw new Error(`${path} -> ${response.status}: ${await response.text()}`);
+  return response.json();
+}

--- a/spikes/158-emmett-neon/probe/src/serve.ts
+++ b/spikes/158-emmett-neon/probe/src/serve.ts
@@ -1,0 +1,72 @@
+import { createActivityStore } from '@vers/spike-store';
+import { Elysia, t } from 'elysia';
+import { SQL } from 'bun';
+import { runBenchScenario } from './run-bench-scenario';
+import { withTiming } from './with-timing';
+
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) throw new Error('DATABASE_URL is required');
+
+const store = createActivityStore(connectionString);
+
+const app = new Elysia()
+  .get('/health', () => ({ ok: true, region: process.env.FLY_REGION ?? 'local' }))
+
+  /** Query through the store's long-lived pool — pool behaviour after a Neon suspend. */
+  .get('/ping-pooled', async () => {
+    try {
+      const pinged = await withTiming(() => store.eventStore.streamExists('activity:ping'));
+      return { ok: true, ms: Math.round(pinged.ms * 10) / 10 };
+    } catch (error) {
+      return { ok: false, error: String(error) };
+    }
+  })
+
+  /** Full fresh connection (TCP+TLS+auth) plus SELECT 1 — the cold-start number. */
+  .get('/ping-fresh', async () => {
+    const pinged = await withTiming(async () => {
+      const sql = new SQL(connectionString);
+      await sql`select 1`;
+      await sql.close();
+    });
+    return { ok: true, ms: Math.round(pinged.ms * 10) / 10 };
+  })
+
+  .get('/progress/:activityId', async ({ params }) => {
+    const read = await withTiming(() => store.readProgress(params.activityId));
+    return { ms: Math.round(read.ms * 10) / 10, progress: read.result };
+  })
+
+  .get('/replay/:activityId', async ({ params }) => {
+    const replayed = await withTiming(() => store.replayActivity(params.activityId));
+    return {
+      ms: Math.round(replayed.ms * 10) / 10,
+      streamExists: replayed.result.streamExists,
+      currentStreamVersion: Number(replayed.result.currentStreamVersion),
+      eventCount: replayed.result.eventCount,
+      chain: replayed.result.chain,
+    };
+  })
+
+  .post(
+    '/bench/run',
+    ({ body }) =>
+      runBenchScenario(store, {
+        batches: body?.batches ?? 20,
+        checkpointsPerBatch: body?.checkpointsPerBatch ?? 10,
+        pointReads: body?.pointReads ?? 20,
+      }),
+    {
+      body: t.Optional(
+        t.Object({
+          batches: t.Optional(t.Number()),
+          checkpointsPerBatch: t.Optional(t.Number()),
+          pointReads: t.Optional(t.Number()),
+        }),
+      ),
+    },
+  )
+
+  .listen(Number(process.env.PORT ?? 3002));
+
+console.log(`spike-158 probe listening on :${app.server?.port} (region: ${process.env.FLY_REGION ?? 'local'})`);

--- a/spikes/158-emmett-neon/probe/src/with-timing.ts
+++ b/spikes/158-emmett-neon/probe/src/with-timing.ts
@@ -1,0 +1,6 @@
+/** Runs the callback and reports its wall-clock duration in milliseconds. */
+export async function withTiming<T>(callback: () => Promise<T>): Promise<{ result: T; ms: number }> {
+  const start = performance.now();
+  const result = await callback();
+  return { result, ms: performance.now() - start };
+}

--- a/spikes/158-emmett-neon/probe/tsconfig.json
+++ b/spikes/158-emmett-neon/probe/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["bun"]
+  },
+  "include": ["src"]
+}

--- a/spikes/158-emmett-neon/store/package.json
+++ b/spikes/158-emmett-neon/store/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@vers/spike-store",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@event-driven-io/emmett": "0.42.3",
+    "@event-driven-io/emmett-postgresql": "0.42.3",
+    "@event-driven-io/pongo": "0.16.11"
+  },
+  "devDependencies": {
+    "typescript": "5.9.3"
+  }
+}

--- a/spikes/158-emmett-neon/store/src/activity-progress-projection.ts
+++ b/spikes/158-emmett-neon/store/src/activity-progress-projection.ts
@@ -1,0 +1,46 @@
+import { pongoSingleStreamProjection } from '@event-driven-io/emmett-postgresql';
+import type { ActivityEvent, ActivityProgressDoc } from './types';
+
+/** Pongo collection (postgres table) the inline projection writes to. */
+export const activityProgressCollection = 'activityProgress';
+
+/**
+ * Inline projection maintaining "latest progress for activity X", updated in
+ * the same transaction as the append. Document id is the stream name.
+ */
+export const activityProgressProjection = pongoSingleStreamProjection<ActivityProgressDoc, ActivityEvent>({
+  collectionName: activityProgressCollection,
+  canHandle: ['ActivityStarted', 'CheckpointBatchRecorded', 'ActivityCompleted'],
+  evolve: (document: ActivityProgressDoc | null, { type, data }: ActivityEvent): ActivityProgressDoc | null => {
+    switch (type) {
+      case 'ActivityStarted':
+        return {
+          activityId: data.activityId,
+          status: 'active',
+          progress: 0,
+          lastHash: '',
+          batchCount: 0,
+          startedAt: data.startedAt,
+          updatedAt: data.startedAt,
+        };
+      case 'CheckpointBatchRecorded':
+        if (!document) return null;
+        return {
+          ...document,
+          progress: data.progress,
+          lastHash: data.hash,
+          batchCount: document.batchCount + 1,
+          updatedAt: data.recordedAt,
+        };
+      case 'ActivityCompleted':
+        if (!document) return null;
+        return {
+          ...document,
+          status: 'completed',
+          progress: data.finalProgress,
+          lastHash: data.hash,
+          updatedAt: data.completedAt,
+        };
+    }
+  },
+});

--- a/spikes/158-emmett-neon/store/src/build-checkpoint-hash.ts
+++ b/spikes/158-emmett-neon/store/src/build-checkpoint-hash.ts
@@ -1,0 +1,26 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Next link of an activity's hash chain: sha256 over the previous link and the
+ * canonical JSON of the payload being recorded.
+ */
+export function buildCheckpointHash(prevHash: string, payload: unknown): string {
+  return createHash('sha256').update(prevHash).update(toCanonicalJSON(payload)).digest('hex');
+}
+
+/** JSON with object keys sorted recursively, so hashes don't depend on key order. */
+function toCanonicalJSON(value: unknown): string {
+  return JSON.stringify(sortKeys(value));
+}
+
+function sortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeys);
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([a], [b]) => (a < b ? -1 : 1))
+        .map(([key, child]) => [key, sortKeys(child)]),
+    );
+  }
+  return value;
+}

--- a/spikes/158-emmett-neon/store/src/build-genesis-hash.ts
+++ b/spikes/158-emmett-neon/store/src/build-genesis-hash.ts
@@ -1,0 +1,6 @@
+import { createHash } from 'node:crypto';
+
+/** First link of an activity's hash chain, derived from its identity and seed. */
+export function buildGenesisHash(activityId: string, seed: string): string {
+  return createHash('sha256').update(`${activityId}:${seed}`).digest('hex');
+}

--- a/spikes/158-emmett-neon/store/src/check-hash-chain.ts
+++ b/spikes/158-emmett-neon/store/src/check-hash-chain.ts
@@ -1,0 +1,43 @@
+import { buildCheckpointHash } from './build-checkpoint-hash';
+import { buildGenesisHash } from './build-genesis-hash';
+import type { ActivityEvent } from './types';
+
+export type HashChainReport = {
+  valid: boolean;
+  length: number;
+  /** 0-based index of the first event whose link fails; absent when valid. */
+  brokenAt?: number;
+  reason?: string;
+};
+
+/**
+ * The verifier path: recomputes every link of an activity's hash chain from
+ * the replayed events and reports the first break, if any.
+ */
+export function checkHashChain(events: ActivityEvent[]): HashChainReport {
+  const [first, ...rest] = events;
+  if (!first) return { valid: false, length: 0, brokenAt: 0, reason: 'empty stream' };
+  if (first.type !== 'ActivityStarted') {
+    return { valid: false, length: events.length, brokenAt: 0, reason: 'stream must start with ActivityStarted' };
+  }
+
+  let chainHash = buildGenesisHash(first.data.activityId, first.data.seed);
+  for (const [index, event] of rest.entries()) {
+    if (event.type === 'ActivityStarted') {
+      return { valid: false, length: events.length, brokenAt: index + 1, reason: 'duplicate ActivityStarted' };
+    }
+    if (event.data.prevHash !== chainHash) {
+      return { valid: false, length: events.length, brokenAt: index + 1, reason: 'prevHash does not match chain' };
+    }
+    const payload =
+      event.type === 'CheckpointBatchRecorded'
+        ? { checkpoints: event.data.checkpoints, progress: event.data.progress }
+        : { finalProgress: event.data.finalProgress };
+    const expected = buildCheckpointHash(chainHash, payload);
+    if (event.data.hash !== expected) {
+      return { valid: false, length: events.length, brokenAt: index + 1, reason: 'hash does not match payload' };
+    }
+    chainHash = event.data.hash;
+  }
+  return { valid: true, length: events.length };
+}

--- a/spikes/158-emmett-neon/store/src/create-activity-store.ts
+++ b/spikes/158-emmett-neon/store/src/create-activity-store.ts
@@ -1,0 +1,85 @@
+import { event, projections, STREAM_DOES_NOT_EXIST } from '@event-driven-io/emmett';
+import { getPostgreSQLEventStore } from '@event-driven-io/emmett-postgresql';
+import { pongoClient } from '@event-driven-io/pongo';
+import { activityProgressCollection, activityProgressProjection } from './activity-progress-projection';
+import { buildCheckpointHash } from './build-checkpoint-hash';
+import { buildGenesisHash } from './build-genesis-hash';
+import { checkHashChain } from './check-hash-chain';
+import { toActivityStreamName } from './to-activity-stream-name';
+import type { ActivityEvent, ActivityProgressDoc, ActivityStarted, Checkpoint, CheckpointBatchRecorded } from './types';
+
+export type ActivityStore = ReturnType<typeof createActivityStore>;
+
+/**
+ * The spike's whole surface: emmett postgres event store with the inline
+ * progress projection, plus the append / point-read / replay operations the
+ * probe exercises. One instance per process; `close` tears down both pools.
+ */
+export function createActivityStore(connectionString: string) {
+  const eventStore = getPostgreSQLEventStore(connectionString, {
+    projections: projections.inline([activityProgressProjection]),
+  });
+  const pongo = pongoClient(connectionString);
+  const progressCollection = pongo.db().collection<ActivityProgressDoc>(activityProgressCollection);
+
+  return {
+    eventStore,
+
+    async createActivityStream(input: { activityId: string; seed: string; difficulty: number }) {
+      const started = event<ActivityStarted>('ActivityStarted', {
+        ...input,
+        startedAt: new Date().toISOString(),
+      });
+      const result = await eventStore.appendToStream(toActivityStreamName(input.activityId), [started], {
+        expectedStreamVersion: STREAM_DOES_NOT_EXIST,
+      });
+      return {
+        genesisHash: buildGenesisHash(input.activityId, input.seed),
+        nextExpectedStreamVersion: result.nextExpectedStreamVersion,
+      };
+    },
+
+    async appendCheckpointBatch(input: {
+      activityId: string;
+      checkpoints: Checkpoint[];
+      progress: number;
+      prevHash: string;
+      expectedStreamVersion: bigint;
+    }) {
+      const hash = buildCheckpointHash(input.prevHash, {
+        checkpoints: input.checkpoints,
+        progress: input.progress,
+      });
+      const recorded = event<CheckpointBatchRecorded>('CheckpointBatchRecorded', {
+        checkpoints: input.checkpoints,
+        progress: input.progress,
+        prevHash: input.prevHash,
+        hash,
+        recordedAt: new Date().toISOString(),
+      });
+      const result = await eventStore.appendToStream(toActivityStreamName(input.activityId), [recorded], {
+        expectedStreamVersion: input.expectedStreamVersion,
+      });
+      return { hash, nextExpectedStreamVersion: result.nextExpectedStreamVersion };
+    },
+
+    async readProgress(activityId: string): Promise<ActivityProgressDoc | null> {
+      return progressCollection.findOne({ _id: toActivityStreamName(activityId) });
+    },
+
+    async replayActivity(activityId: string) {
+      const result = await eventStore.readStream<ActivityEvent>(toActivityStreamName(activityId));
+      return {
+        streamExists: result.streamExists,
+        currentStreamVersion: result.currentStreamVersion,
+        eventCount: result.events.length,
+        chain: checkHashChain(result.events),
+      };
+    },
+
+    async close() {
+      await eventStore.close();
+      await pongo.close();
+    },
+  };
+}

--- a/spikes/158-emmett-neon/store/src/index.ts
+++ b/spikes/158-emmett-neon/store/src/index.ts
@@ -1,0 +1,7 @@
+export { activityProgressCollection, activityProgressProjection } from './activity-progress-projection';
+export { buildCheckpointHash } from './build-checkpoint-hash';
+export { buildGenesisHash } from './build-genesis-hash';
+export { checkHashChain, type HashChainReport } from './check-hash-chain';
+export { createActivityStore, type ActivityStore } from './create-activity-store';
+export { toActivityStreamName } from './to-activity-stream-name';
+export type * from './types';

--- a/spikes/158-emmett-neon/store/src/to-activity-stream-name.ts
+++ b/spikes/158-emmett-neon/store/src/to-activity-stream-name.ts
@@ -1,0 +1,4 @@
+/** Stream-per-activity naming: emmett derives the stream type from the prefix. */
+export function toActivityStreamName(activityId: string): string {
+  return `activity:${activityId}`;
+}

--- a/spikes/158-emmett-neon/store/src/types.ts
+++ b/spikes/158-emmett-neon/store/src/types.ts
@@ -1,0 +1,56 @@
+import type { Event } from '@event-driven-io/emmett';
+
+/** One simulation checkpoint inside a batch submitted by the client. */
+export type Checkpoint = {
+  tick: number;
+  progress: number;
+  statsDelta: Record<string, number>;
+};
+
+export type ActivityStarted = Event<
+  'ActivityStarted',
+  {
+    activityId: string;
+    seed: string;
+    difficulty: number;
+    startedAt: string;
+  }
+>;
+
+/**
+ * A batch of client-simulated checkpoints. `prevHash` links to the previous
+ * event's `hash`, forming the per-activity hash chain the verifier replays.
+ */
+export type CheckpointBatchRecorded = Event<
+  'CheckpointBatchRecorded',
+  {
+    checkpoints: Checkpoint[];
+    progress: number;
+    prevHash: string;
+    hash: string;
+    recordedAt: string;
+  }
+>;
+
+export type ActivityCompleted = Event<
+  'ActivityCompleted',
+  {
+    finalProgress: number;
+    prevHash: string;
+    hash: string;
+    completedAt: string;
+  }
+>;
+
+export type ActivityEvent = ActivityStarted | CheckpointBatchRecorded | ActivityCompleted;
+
+/** Inline-projection document: latest progress per activity stream. */
+export type ActivityProgressDoc = {
+  activityId: string;
+  status: 'active' | 'completed';
+  progress: number;
+  lastHash: string;
+  batchCount: number;
+  startedAt: string;
+  updatedAt: string;
+};

--- a/spikes/158-emmett-neon/store/tsconfig.json
+++ b/spikes/158-emmett-neon/store/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.base.json",
+  "include": ["src"]
+}

--- a/spikes/158-emmett-neon/tsconfig.base.json
+++ b/spikes/158-emmett-neon/tsconfig.base.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2023"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": []
+  }
+}


### PR DESCRIPTION
## Description

Spike for #158 — validates the #143 event-store decision (emmett-on-postgres, hosted on Neon Sydney) before #127 builds the activities service on it. Verdict: **go**; latency and behaviour all inside hobby-scale tolerances.

- `@vers/spike-store` proves stream-per-activity checkpoint events, hash-chain links in event data, `UNIQUE(stream_id, version)` optimistic concurrency via emmett's expected-version API
- inline pongo projection answers "latest progress for activity X" in ~2ms from a fly syd machine
- full-stream replay + chain verification (the verifier path): 201 events in 41ms
- appends p50 17ms; Neon cold start ~0.6–1.1s; stale-version appends rejected every run
- numbers and friction notes in `spikes/158-emmett-neon/README.md`; go/no-go detail on #158

## Testing

- [x] `pnpm typecheck` passes (spike workspace)
- [ ] New tests added for new functionality — n/a, throwaway spike

## Context

**Never merges.** Draft + `do-not-merge`: reference while #127/#163 encode the patterns properly. Self-contained pnpm workspace under `spikes/`, outside the yarn `projects/*` glob; branched from the #157 spike branch for the `.nxignore` carve-out.