### PR TITLE
fix(#214): declare react in lib-styled-system

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -485,6 +485,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@vers/panda-preset": "workspace:*",
+        "react": "catalog:",
       },
       "devDependencies": {
         "@pandacss/dev": "1.11.3",

--- a/projects/lib-styled-system/package.json
+++ b/projects/lib-styled-system/package.json
@@ -12,7 +12,8 @@
     }
   },
   "dependencies": {
-    "@vers/panda-preset": "workspace:*"
+    "@vers/panda-preset": "workspace:*",
+    "react": "catalog:"
   },
   "devDependencies": {
     "@pandacss/dev": "1.11.3",


### PR DESCRIPTION
## Description

Closes #214

Panda's generated `styled-system/` output imports `react`, but `@vers/styled-system` never declared it — so `bun run boundaries` failed on any tree where codegen had run (CI only stays green because it runs boundaries before codegen).

- Declares `react: catalog:` in `lib-styled-system`, matching sibling packages
- Verified: `bun run codegen:styles` then `bun run boundaries` → 28 packages, no issues

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality (manifest-only change)