### PR TITLE
fix(#213): stage only generated output in lint-staged

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -2,7 +2,7 @@
 export default {
   'projects/{app-web,service-api}/**/*.{ts,tsx}': () => [
     `bun run codegen:graphql`,
-    'git add .',
+    'git add projects/app-web/app/gql schema.graphql',
   ],
   'projects/**/*.{ts,tsx}': () => [
     'bun run codegen:styles',
@@ -11,15 +11,15 @@ export default {
     // that need the test container running
     'bunx vitest run --changed',
   ],
+  // format/lint fixes land via lint-staged's own staging of task modifications
   'projects/**/*.{js,ts,jsx,tsx,json}': (files) => [
     `bun run format --files ${files.join(',')}`,
     `bun run lint --files ${files.join(',')}`,
-    'git add .',
   ],
   'projects/lib-postgres-schema/**/*.ts': () => [
     'bun run pg:migrations-generate',
-    'git add .',
+    'git add projects/db-postgres/migrations',
   ],
-  '**/*.graphql': () => ['bun run format', 'git add .'],
+  '**/*.graphql': () => ['bun run format'],
 };
 /* eslint-enable perfectionist/sort-objects */


### PR DESCRIPTION
## Description

Closes #213

`git add .` in lint-staged tasks staged the entire working tree on every commit, silently absorbing unstaged and untracked changes and making partial commits impossible.

- Codegen tasks now add only their output (`app/gql` + `schema.graphql`, `db-postgres/migrations`)
- Format/lint block drops the add entirely — lint-staged stages task modifications itself
- Verified behaviourally: with an untracked scratch file and an unstaged edit present, a commit contains only the staged file; both others stay out

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality (hook config; verified behaviourally as above)