### PR TITLE
docs(#225): anchor core game-design pillars

### DIFF
--- a/docs/game-design/001-core-themes-world-fiction.md
+++ b/docs/game-design/001-core-themes-world-fiction.md
@@ -1,0 +1,125 @@
+# Core Themes & World Fiction
+
+This note defines the core game-design direction for Vers. It is not a lore bible: it names the
+player contract, the world premise, the identity pillars, and the vocabulary that downstream design
+notes inherit.
+
+## Contract
+
+Vers is an idle ARPG/MMO where you shape your avatar, send them into dangerous regions, turn loot
+into power, and push farther into harder, stranger parts of the world.
+
+Shape your avatar. Send them into the world. Recover power. Push deeper. Compete.
+
+## Decisions
+
+### Genre
+
+Vers is an idle ARPG/MMO first. Its core appeal is loot, builds, region progression, enemy pressure,
+long-term avatar investment, and the steady conversion of rewards into power. Power is the broad
+result of successful expeditions: equipment, materials, knowledge, access, avatar enhancement, and
+anything else that helps the player push farther or more efficiently.
+
+Idle is not a secondary wrapper. The fantasy is not direct action combat; it is shaping your avatar,
+sending them into the world, and watching their build prove itself over time.
+
+### World Premise
+
+Vers takes place in a far-future human world where civilization persists around Sanctuary, the
+largest known human center. Beyond it are older, stranger, partially autonomous regions that most
+people cannot safely enter.
+
+Those regions are the world map: real places and systems that can be entered, cleared, revisited,
+pushed through, and eventually competed over. They include abandoned infrastructure, synthetic
+ecologies, failed habitats, hostile machine systems, contested frontiers, and other places where
+ordinary life cannot safely operate. They are dangerous because they are no longer fully governed by
+human civilization, and valuable because they contain the power, materials, knowledge, and enemies
+that drive progression.
+
+The world should feel artificial, luminous, polluted, overbuilt, and old. Civilization is advanced,
+but not clean. Its systems have accumulated for so long that infrastructure can feel like terrain,
+history, hazard, and myth at the same time.
+
+Sanctuary is central, but it is not omniscient. Its maps, institutions, factions, and public
+histories can be incomplete, biased, or deliberately constrained. This gives the world room for
+discovery without making lore the main activity.
+
+### Avatar Premise
+
+Avatar is the canonical term.
+
+An avatar is an enhanced human shaped by the player and capable of entering regions that ordinary
+people cannot survive. The term has deeper historical meaning in the world, but the player-facing
+fantasy is simple: shape your avatar, send them into danger, recover power, and push deeper.
+
+Avatars are embodied people, not disposable drones. They can be augmented, equipped, specialized,
+injured, defeated, recovered, ranked, and eventually set against other avatars.
+
+### Story Weight
+
+Vers is story-light, not lore-empty. It does not need a campaign narrative as the main activity, but
+named enemies, bosses, regions, factions, events, items, and systems should gradually imply a larger
+world.
+
+Lore should be discovered as texture around progression. It should explain why the world works, not
+interrupt the idle ARPG loop.
+
+### Competition
+
+Competition is part of Vers, but it should not dominate the first playable identity. The design
+should leave room for ladders and PvP from the beginning, even if the first loop is PvE region
+progression.
+
+The word `versus` is part of the name's meaning, but early game design should express that pressure
+through danger, comparison, mastery, and eventual direct conflict.
+
+## Pillars
+
+### Dangerous Regions
+
+The world map is dangerous territory, not a passive level select. Regions should imply risk,
+resistance, discovery, escalation, and reward.
+
+A good region should answer: what makes this place unsafe, what makes it valuable, and how does it
+change as the avatar pushes deeper?
+
+Regions become harder and stranger as they move farther from Sanctuary's influence. Distance does
+not need to be purely geographic: age, autonomy, corruption, hostile control, system drift, and lost
+history can all make a region more dangerous and more valuable.
+
+### Synthetic World
+
+Vers is science fiction grounded in human civilization, enhanced bodies, artificial environments,
+old infrastructure, and advanced systems. It should not default to fantasy magic, medieval
+symbolism, or space-opera scale.
+
+The strange parts of the world should feel engineered, emergent, or historical rather than
+supernatural.
+
+### Mythic Systems
+
+The world's technology can feel ritualized, symbolic, and only partly understood. Interfaces,
+materials, enemy forms, region rules, and item language can carry a sense of hidden structure.
+
+This is how Vers gets mystery without becoming fantasy: advanced systems behave consistently enough
+to master, but strangely enough to feel deep.
+
+### Competitive Expedition
+
+Progress is measured by how far and efficiently avatars can push into the world. Ladders and PvP
+should eventually make that competition explicit, but the core pressure starts with the world
+itself.
+
+## Vocabulary Register
+
+| Term      | Status      | Notes                                                                            |
+| --------- | ----------- | -------------------------------------------------------------------------------- |
+| Vers      | Keep        | Carries universe and versus: world exploration plus competition.                 |
+| avatar    | Canonical   | Enhanced human shaped by the player and sent into dangerous regions.             |
+| Sanctuary | Canonical   | The largest known human center and the player's operational home.                |
+| world     | Keep        | The broad play space and fiction layer; not just a menu.                         |
+| region    | Provisional | Neutral term for world-map areas.                                                |
+| loot      | Keep        | Core ARPG promise.                                                               |
+| power     | Keep        | Umbrella term for rewards that help the player push farther or more efficiently. |
+| aether    | Not canon   | Existing placeholder; only survives if it beats alternatives.                    |
+| glyph     | Not canon   | Visual candidate for mythic systems, not yet a world rule.                       |


### PR DESCRIPTION
## Description

Adds the first game-design note for #225, scoped under `docs/game-design` so it stays separate from architecture docs.

- Captures the current Vers player contract and seed line.
- Defines provisional pillars without canonizing current placeholder terms.
- Records open questions and vocabulary status for downstream design notes.

## Testing

- [ ] `yarn typecheck` passes
- [ ] `yarn test` passes
- [ ] `yarn lint` passes
- [ ] New tests added for new functionality

Docs-only change; not run.