### PR TITLE
chore(#265): allow-list framework handles for prefer-readonly-parameter-types

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -182,7 +182,6 @@
         "ignoreInferredTypes": true,
         "allow": [
           { "from": "package", "name": "Kysely", "package": "kysely" },
-          { "from": "package", "name": "Elysia", "package": "elysia" },
           { "from": "package", "name": "TestProject", "package": "vitest" },
           {
             "from": "package",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -176,7 +176,37 @@
     // entity parameter in place by design -- those sites carry a real reason
     // instead of a baseline marker (see the sim-core exception noted where
     // they occur)
-    "typescript/prefer-readonly-parameter-types": ["error", { "ignoreInferredTypes": true }],
+    "typescript/prefer-readonly-parameter-types": [
+      "error",
+      {
+        "ignoreInferredTypes": true,
+        "allow": [
+          { "from": "package", "name": "Kysely", "package": "kysely" },
+          { "from": "package", "name": "Elysia", "package": "elysia" },
+          { "from": "package", "name": "TestProject", "package": "vitest" },
+          {
+            "from": "package",
+            "name": "StartedPostgreSqlContainer",
+            "package": "@testcontainers/postgresql"
+          },
+          { "from": "package", "name": "PostgresJsDatabase", "package": "drizzle-orm" },
+          { "from": "package", "name": "CryptoKey", "package": "@types/node" },
+          { "from": "package", "name": "Logger", "package": "pino" },
+          { "from": "package", "name": "ReactElement", "package": "@types/react" },
+          {
+            "from": "package",
+            "name": ["AnyContractRouter", "AnyContractProcedure", "ContractRouterClient"],
+            "package": "@orpc/contract"
+          },
+          {
+            "from": "package",
+            "name": ["FetchHandler", "RPCHandler"],
+            "package": "@orpc/server"
+          },
+          { "from": "package", "name": ["Request", "Response"], "package": "bun-types" }
+        ]
+      }
+    ],
     "typescript/prefer-regexp-exec": "error",
     "typescript/require-await": "error",
     "typescript/return-await": "error",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,7 +261,11 @@ strings/numbers.
   left off in config — the unused-directive check is the ratchet: fixing a baselined site makes its
   comment stale and lint fails until the comment is deleted. `lib-idle-core`/`lib-aether-core`
   tick/lifecycle handlers that mutate their entity parameter by design carry a real reason instead
-  of the baseline marker; those are permanent.
+  of the baseline marker; those are permanent. `typescript/prefer-readonly-parameter-types` exempts
+  framework-handle params (`Kysely`, `Elysia`, oRPC's contract/handler types, `Request`/`Response`,
+  …) through the rule's own `allow` list in `.oxlintrc.json` rather than inline markers — new code
+  never mints `baseline(#236)` for this rule; a param the allow list can't reach carries a real
+  reason instead.
 - `bun run format` — `oxfmt .` (`.oxfmtrc.json` at the root), then `format-codemod` (blank-line
   padding) over the whole tree. The codemod has no ignore file, so its `--ignore` flags are what
   keep it off committed codegen output (`app/gql`, panda's `styled-system` dirs, react-router's

--- a/agents/project.md
+++ b/agents/project.md
@@ -64,7 +64,11 @@ strings/numbers.
   left off in config — the unused-directive check is the ratchet: fixing a baselined site makes its
   comment stale and lint fails until the comment is deleted. `lib-idle-core`/`lib-aether-core`
   tick/lifecycle handlers that mutate their entity parameter by design carry a real reason instead
-  of the baseline marker; those are permanent.
+  of the baseline marker; those are permanent. `typescript/prefer-readonly-parameter-types` exempts
+  framework-handle params (`Kysely`, `Elysia`, oRPC's contract/handler types, `Request`/`Response`,
+  …) through the rule's own `allow` list in `.oxlintrc.json` rather than inline markers — new code
+  never mints `baseline(#236)` for this rule; a param the allow list can't reach carries a real
+  reason instead.
 - `bun run format` — `oxfmt .` (`.oxfmtrc.json` at the root), then `format-codemod` (blank-line
   padding) over the whole tree. The codemod has no ignore file, so its `--ignore` flags are what
   keep it off committed codegen output (`app/gql`, panda's `styled-system` dirs, react-router's

--- a/projects/lib-contract-base/src/test-utils/build-rpc-test-client.ts
+++ b/projects/lib-contract-base/src/test-utils/build-rpc-test-client.ts
@@ -4,15 +4,14 @@ import type { AnyContractRouter, ContractRouterClient } from '@orpc/contract';
 
 /** An Elysia app (or anything shaped like one) an RPC test client can call in-process. */
 interface RPCTestClientApp {
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-  handle: (request: Request) => Promise<Response> | Response;
+  readonly handle: (request: Request) => Promise<Response> | Response;
 }
 
 interface BuildRPCTestClientOptions {
-  headers?: Record<string, string>;
+  readonly headers?: Readonly<Record<string, string>>;
 
   /** Base URL the client sends requests to; only the path reaches `app.handle`. Default 'http://test.local/rpc'. */
-  url?: string;
+  readonly url?: string;
 }
 
 /**
@@ -20,9 +19,7 @@ interface BuildRPCTestClientOptions {
  * the link's fetch straight through `app.handle` instead of the network.
  */
 export function buildRPCTestClient<TContract extends AnyContractRouter>(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   app: RPCTestClientApp,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   options?: BuildRPCTestClientOptions,
 ): ContractRouterClient<TContract> {
   const link = new RPCLink<Record<never, never>>({

--- a/projects/lib-contract-base/src/test-utils/collect-conformance-cases.test.ts
+++ b/projects/lib-contract-base/src/test-utils/collect-conformance-cases.test.ts
@@ -63,7 +63,7 @@ function buildTestContract() {
 type TestContract = ReturnType<typeof buildTestContract>;
 
 /** Builds an app whose getThing handler enforces the acting-user check the contract declares. */
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- the oRPC procedure builders returned by buildTestContract carry internal mutable state no local wrapper can mark readonly
+// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- the oRPC procedure builders this test constructs carry internal mutable state no local wrapper can mark readonly
 function buildConformingApp(contract: TestContract): ConformanceCaseApp {
   const os = implement(contract).$context<{ actingUserId: null | string }>();
 
@@ -82,7 +82,7 @@ function buildConformingApp(contract: TestContract): ConformanceCaseApp {
 }
 
 /** Builds an app whose getThing handler skips the acting-user check, so anonymous calls succeed. */
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- the oRPC procedure builders returned by buildTestContract carry internal mutable state no local wrapper can mark readonly
+// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- the oRPC procedure builders this test constructs carry internal mutable state no local wrapper can mark readonly
 function buildBrokenApp(contract: TestContract): ConformanceCaseApp {
   const os = implement(contract).$context<{ actingUserId: null | string }>();
 

--- a/projects/lib-contract-base/src/test-utils/collect-conformance-cases.test.ts
+++ b/projects/lib-contract-base/src/test-utils/collect-conformance-cases.test.ts
@@ -63,7 +63,7 @@ function buildTestContract() {
 type TestContract = ReturnType<typeof buildTestContract>;
 
 /** Builds an app whose getThing handler enforces the acting-user check the contract declares. */
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
+// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- the oRPC procedure builders returned by buildTestContract carry internal mutable state no local wrapper can mark readonly
 function buildConformingApp(contract: TestContract): ConformanceCaseApp {
   const os = implement(contract).$context<{ actingUserId: null | string }>();
 
@@ -82,7 +82,7 @@ function buildConformingApp(contract: TestContract): ConformanceCaseApp {
 }
 
 /** Builds an app whose getThing handler skips the acting-user check, so anonymous calls succeed. */
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
+// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- the oRPC procedure builders returned by buildTestContract carry internal mutable state no local wrapper can mark readonly
 function buildBrokenApp(contract: TestContract): ConformanceCaseApp {
   const os = implement(contract).$context<{ actingUserId: null | string }>();
 
@@ -94,7 +94,6 @@ function buildBrokenApp(contract: TestContract): ConformanceCaseApp {
   return buildRPCApp(new RPCHandler(router));
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 function buildRPCApp(handler: RPCHandler<{ actingUserId: null | string }>): ConformanceCaseApp {
   return new Elysia().all('/rpc*', async (context) => {
     const result = await handler.handle(context.request, {

--- a/projects/lib-contract-base/src/test-utils/collect-conformance-cases.ts
+++ b/projects/lib-contract-base/src/test-utils/collect-conformance-cases.ts
@@ -13,33 +13,31 @@ import { buildRPCTestClient } from './build-rpc-test-client';
 
 /** An Elysia app (or anything shaped like one) a conformance case can exercise. */
 export interface ConformanceCaseApp {
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-  handle: (request: Request) => Promise<Response> | Response;
+  readonly handle: (request: Request) => Promise<Response> | Response;
 }
 
 /** One mechanical guarantee, checked against a real app via its `handle` function. */
 export interface ConformanceCase {
   /** Behavioural title, e.g. "it rejects malformed input on users.getCurrentUser". */
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-  run: (app: ConformanceCaseApp) => Promise<void>;
-  title: string;
+  readonly run: (app: ConformanceCaseApp) => Promise<void>;
+  readonly title: string;
 }
 
 /** Header collection accepted wherever a conformance case needs to send headers. */
-type ConformanceHeaders = Record<string, string>;
+type ConformanceHeaders = Readonly<Record<string, string>>;
 
 interface CollectConformanceCasesOptions {
   /** Headers carrying a valid service token with no acting user. */
-  anonymousHeaders: ConformanceHeaders;
+  readonly anonymousHeaders: ConformanceHeaders;
 
   /**
    * Schema-valid sample inputs keyed by dot-path (e.g. "getCurrentUser"). Enables the
    * anonymous-call UNAUTHORIZED case for that procedure, which must reach the handler.
    */
-  authedSamples?: Record<string, unknown>;
+  readonly authedSamples?: Readonly<Record<string, unknown>>;
 
   /** RPC mount prefix of the app under test. Default '/rpc'. */
-  rpcPrefix?: string;
+  readonly rpcPrefix?: string;
 }
 
 /**
@@ -49,9 +47,7 @@ interface CollectConformanceCasesOptions {
  * apply to a given procedure (e.g. no input schema, or no sample input supplied).
  */
 export function collectConformanceCases(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   contract: AnyContractRouter,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   options: CollectConformanceCasesOptions,
 ): Array<ConformanceCase> {
   const rpcPrefix = options.rpcPrefix ?? '/rpc';
@@ -77,12 +73,11 @@ export function collectConformanceCases(
 }
 
 interface ContractProcedureEntry {
-  dotPath: string;
-  procedure: AnyContractProcedure;
+  readonly dotPath: string;
+  readonly procedure: AnyContractProcedure;
 }
 
 /** Gathers every leaf procedure in a contract router, paired with its dot-separated path. */
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 function collectContractProcedures(contract: AnyContractRouter): Array<ContractProcedureEntry> {
   const entries: Array<ContractProcedureEntry> = [];
 
@@ -97,10 +92,8 @@ function collectContractProcedures(contract: AnyContractRouter): Array<ContractP
 }
 
 function buildMalformedInputCase(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   entry: ContractProcedureEntry,
   rpcPrefix: string,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   anonymousHeaders: ConformanceHeaders,
 ): ConformanceCase | undefined {
   // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
@@ -131,7 +124,6 @@ function buildMalformedInputCase(
 }
 
 /** Reads a contract procedure's declared route, schemas, and error map through oRPC's internal definition property. */
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 function getProcedureDef(procedure: AnyContractProcedure) {
   return procedure['~orpc'];
 }
@@ -159,10 +151,8 @@ function findRejectingProbe(schema: AnySchema): unknown {
 
 /** Builds a typed oRPC client that exercises an app's real RPC wire protocol via its `handle` function. */
 function buildConformanceClient(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   app: ConformanceCaseApp,
   rpcPrefix: string,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   headers: ConformanceHeaders,
 ): ContractRouterClient<AnyContractRouter> {
   return buildRPCTestClient<AnyContractRouter>(app, {
@@ -173,7 +163,6 @@ function buildConformanceClient(
 
 /** Indexes a dot-path into a client object, returning the callable procedure at that path. */
 function getClientProcedure(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   client: ContractRouterClient<AnyContractRouter>,
   dotPath: string,
 ): (input: unknown) => Promise<unknown> {
@@ -202,10 +191,8 @@ async function runRejectingCall(call: () => Promise<unknown>): Promise<ORPCError
 }
 
 function buildAnonymousRejectionCase(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   entry: ContractProcedureEntry,
   rpcPrefix: string,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   options: CollectConformanceCasesOptions,
 ): ConformanceCase | undefined {
   const declaresUnauthorized = 'UNAUTHORIZED' in getProcedureDef(entry.procedure).errorMap;
@@ -229,7 +216,6 @@ function buildAnonymousRejectionCase(
   };
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 function buildOpenAPIGenerationCase(contract: AnyContractRouter): ConformanceCase {
   return {
     run: async () => {

--- a/projects/lib-db/migrations/1783262629921_step_up_and_audit_columns.ts
+++ b/projects/lib-db/migrations/1783262629921_step_up_and_audit_columns.ts
@@ -12,7 +12,6 @@ import { sql } from 'kysely';
  * trigger supersedes for every writer — kysely queries, ad-hoc SQL, and
  * cross-service writes alike.
  */
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export async function up(db: Kysely<unknown>): Promise<void> {
   await db.schema
     .createTable('pending_transactions')
@@ -86,7 +85,6 @@ export async function up(db: Kysely<unknown>): Promise<void> {
   `.execute(db);
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export async function down(db: Kysely<unknown>): Promise<void> {
   await sql`DROP TRIGGER IF EXISTS set_pending_transactions_updated_at ON pending_transactions`.execute(
     db,

--- a/projects/lib-db/seeds/1783262629921_dev_user.ts
+++ b/projects/lib-db/seeds/1783262629921_dev_user.ts
@@ -6,7 +6,6 @@ import type { DB } from '../src/schema.generated';
  * invocation — kysely-ctl has no seed bookkeeping — so this is idempotent
  * via `ON CONFLICT DO NOTHING`.
  */
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export async function seed(db: Kysely<DB>): Promise<void> {
   await db
     .insertInto('users')

--- a/projects/lib-db/src/create-db.ts
+++ b/projects/lib-db/src/create-db.ts
@@ -4,7 +4,7 @@ import postgres from 'postgres';
 import type { DB } from './schema.generated';
 
 interface CreateDBConfig {
-  databaseURL: string;
+  readonly databaseURL: string;
 }
 
 /**
@@ -12,7 +12,6 @@ interface CreateDBConfig {
  * camelCase-mapped columns. Callers own env parsing — this never reads
  * `process.env` itself.
  */
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function createDB(config: CreateDBConfig): Kysely<DB> {
   return new Kysely<DB>({
     dialect: new PostgresJSDialect({

--- a/projects/lib-db/src/migrate-to-latest.ts
+++ b/projects/lib-db/src/migrate-to-latest.ts
@@ -12,7 +12,7 @@ import { createDB } from './create-db';
 export const migrationsFolder = path.join(import.meta.dirname, '../migrations');
 
 interface MigrateToLatestConfig {
-  databaseURL: string;
+  readonly databaseURL: string;
 }
 
 /**
@@ -21,10 +21,7 @@ interface MigrateToLatestConfig {
  * setup — assumes the drizzle baseline (`db-postgres/migrations`) already
  * ran against the same database.
  */
-export async function migrateToLatest(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-  config: MigrateToLatestConfig,
-): Promise<MigrationResultSet> {
+export async function migrateToLatest(config: MigrateToLatestConfig): Promise<MigrationResultSet> {
   const db = createDB({ databaseURL: config.databaseURL });
 
   const migrator = new Migrator({

--- a/projects/lib-db/vitest.global-setup.ts
+++ b/projects/lib-db/vitest.global-setup.ts
@@ -19,7 +19,6 @@ declare module 'vitest' {
  * the drizzle baseline (`db-postgres/migrations`) followed by this package's
  * own kysely migrations, then publishes the connection URI to test files.
  */
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export async function setup(project: TestProject) {
   const container = await new PostgreSqlContainer('postgres:16.2-alpine3.19')
     .withDatabase('test_template')

--- a/projects/lib-email/src/generate-change-email-verification.tsx
+++ b/projects/lib-email/src/generate-change-email-verification.tsx
@@ -3,12 +3,11 @@ import { generateEmail } from './generate-email';
 import { ChangeEmailVerificationEmail } from './templates/change-email-verification';
 
 interface Config {
-  newEmail: string;
-  verificationCode: string;
-  verificationURL: string;
+  readonly newEmail: string;
+  readonly verificationCode: string;
+  readonly verificationURL: string;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function generateChangeEmailVerificationEmail(config: Config) {
   return generateEmail({
     component: (

--- a/projects/lib-email/src/generate-email.ts
+++ b/projects/lib-email/src/generate-email.ts
@@ -1,7 +1,7 @@
 import { render } from '@react-email/components';
 
 interface EmailConfig {
-  component: React.ReactElement;
+  readonly component: React.ReactElement;
 }
 
 interface EmailData {
@@ -9,7 +9,6 @@ interface EmailData {
   plainText: string;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export async function generateEmail(config: EmailConfig): Promise<EmailData> {
   const [html, plainText] = await Promise.all([
     render(config.component),

--- a/projects/lib-email/src/generate-existing-account-email.tsx
+++ b/projects/lib-email/src/generate-existing-account-email.tsx
@@ -3,10 +3,9 @@ import { generateEmail } from './generate-email';
 import { ExistingAccountEmail } from './templates/existing-account-email';
 
 interface Config {
-  email: string;
+  readonly email: string;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function generateExistingAccountEmail(config: Config) {
   return generateEmail({
     component: (

--- a/projects/lib-email/src/generate-password-changed-email.tsx
+++ b/projects/lib-email/src/generate-password-changed-email.tsx
@@ -3,10 +3,9 @@ import { generateEmail } from './generate-email';
 import { PasswordChangedEmail } from './templates/password-changed-email';
 
 interface Config {
-  email: string;
+  readonly email: string;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function generatePasswordChangedEmail(config: Config) {
   return generateEmail({
     component: (

--- a/projects/lib-email/src/generate-reset-password-email.tsx
+++ b/projects/lib-email/src/generate-reset-password-email.tsx
@@ -3,10 +3,9 @@ import { generateEmail } from './generate-email';
 import { ResetPasswordEmail } from './templates/reset-password-email';
 
 interface Config {
-  resetURL: string;
+  readonly resetURL: string;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function generateResetPasswordEmail(config: Config) {
   return generateEmail({
     component: (

--- a/projects/lib-email/src/generate-two-factor-email.tsx
+++ b/projects/lib-email/src/generate-two-factor-email.tsx
@@ -3,10 +3,9 @@ import { generateEmail } from './generate-email';
 import { TwoFactorEmail } from './templates/two-factor-email';
 
 interface Config {
-  verificationCode: string;
+  readonly verificationCode: string;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function generateTwoFactorEmail(config: Config) {
   return generateEmail({
     component: (

--- a/projects/lib-email/src/generate-welcome-email.tsx
+++ b/projects/lib-email/src/generate-welcome-email.tsx
@@ -3,11 +3,10 @@ import { generateEmail } from './generate-email';
 import { WelcomeEmail } from './templates/welcome-email';
 
 interface Config {
-  verificationCode: string;
-  verificationURL: string;
+  readonly verificationCode: string;
+  readonly verificationURL: string;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function generateWelcomeEmail(config: Config) {
   return generateEmail({
     component: (

--- a/projects/lib-email/src/templates/change-email-verification.tsx
+++ b/projects/lib-email/src/templates/change-email-verification.tsx
@@ -7,8 +7,7 @@ interface Props {
   verificationURL: string;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-export function ChangeEmailVerificationEmail(props: Props): ReactElement {
+export function ChangeEmailVerificationEmail(props: Readonly<Props>): ReactElement {
   return (
     <E.Container>
       <E.Heading as="h1">

--- a/projects/lib-email/src/templates/existing-account-email.tsx
+++ b/projects/lib-email/src/templates/existing-account-email.tsx
@@ -5,8 +5,7 @@ interface Props {
   email: string;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-export function ExistingAccountEmail(props: Props): ReactElement {
+export function ExistingAccountEmail(props: Readonly<Props>): ReactElement {
   return (
     <E.Container>
       <E.Heading as="h1">

--- a/projects/lib-email/src/templates/password-changed-email.tsx
+++ b/projects/lib-email/src/templates/password-changed-email.tsx
@@ -4,8 +4,7 @@ interface Props {
   email: string;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-export function PasswordChangedEmail(props: Props) {
+export function PasswordChangedEmail(props: Readonly<Props>) {
   return (
     <E.Container>
       <E.Heading as="h1">

--- a/projects/lib-email/src/templates/reset-password-email.tsx
+++ b/projects/lib-email/src/templates/reset-password-email.tsx
@@ -5,8 +5,7 @@ interface Props {
   resetURL: string;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-export function ResetPasswordEmail(props: Props): ReactElement {
+export function ResetPasswordEmail(props: Readonly<Props>): ReactElement {
   return (
     <E.Container>
       <E.Heading as="h1">

--- a/projects/lib-email/src/templates/two-factor-email.tsx
+++ b/projects/lib-email/src/templates/two-factor-email.tsx
@@ -5,8 +5,7 @@ interface Props {
   verificationCode: string;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-export function TwoFactorEmail(props: Props): ReactElement {
+export function TwoFactorEmail(props: Readonly<Props>): ReactElement {
   return (
     <E.Container>
       <E.Heading as="h1">

--- a/projects/lib-email/src/templates/welcome-email.tsx
+++ b/projects/lib-email/src/templates/welcome-email.tsx
@@ -5,8 +5,7 @@ interface Props {
   verificationURL: string;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-export function WelcomeEmail(props: Props) {
+export function WelcomeEmail(props: Readonly<Props>) {
   return (
     <E.Container>
       <E.Heading as="h1">

--- a/projects/lib-service-runtime/src/create-logger.ts
+++ b/projects/lib-service-runtime/src/create-logger.ts
@@ -1,12 +1,11 @@
 import pino from 'pino';
 
 interface CreateLoggerOptions {
-  level: string;
-  name: string;
+  readonly level: string;
+  readonly name: string;
 }
 
 /** Builds a service's pino logger: JSON lines to stdout, with `name` bound onto every entry. */
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function createLogger(options: CreateLoggerOptions): pino.Logger {
   return pino({ level: options.level, name: options.name });
 }

--- a/projects/lib-service-runtime/src/create-service.test.ts
+++ b/projects/lib-service-runtime/src/create-service.test.ts
@@ -18,7 +18,7 @@ function buildTestContract() {
   };
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
+// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- the oRPC procedure builders returned by buildTestContract carry internal mutable state no local wrapper can mark readonly
 function buildTestRouter(contract: ReturnType<typeof buildTestContract>) {
   const os = implement(contract).$context<ServiceContext>();
 

--- a/projects/lib-service-runtime/src/create-service.test.ts
+++ b/projects/lib-service-runtime/src/create-service.test.ts
@@ -18,7 +18,7 @@ function buildTestContract() {
   };
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- the oRPC procedure builders returned by buildTestContract carry internal mutable state no local wrapper can mark readonly
+// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- the oRPC procedure builders this test constructs carry internal mutable state no local wrapper can mark readonly
 function buildTestRouter(contract: ReturnType<typeof buildTestContract>) {
   const os = implement(contract).$context<ServiceContext>();
 

--- a/projects/lib-service-runtime/src/create-service.ts
+++ b/projects/lib-service-runtime/src/create-service.ts
@@ -20,16 +20,15 @@ type ServiceEnv<TEnvShape extends z.ZodRawShape> = z.infer<typeof BASE_ENV_SCHEM
   z.infer<z.ZodObject<TEnvShape>>;
 
 interface ServiceRuntime<TEnvShape extends z.ZodRawShape> {
-  env: ServiceEnv<TEnvShape>;
-  logger: pino.Logger;
+  readonly env: Readonly<ServiceEnv<TEnvShape>>;
+  readonly logger: pino.Logger;
 }
 
 export interface ServiceConfig<TEnvShape extends z.ZodRawShape> {
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-  buildRouter: (runtime: ServiceRuntime<TEnvShape>) => AnyRouter;
-  contract: AnyContractRouter;
-  envShape: TEnvShape;
-  name: string;
+  readonly buildRouter: (runtime: Readonly<ServiceRuntime<TEnvShape>>) => AnyRouter;
+  readonly contract: AnyContractRouter;
+  readonly envShape: Readonly<TEnvShape>;
+  readonly name: string;
 }
 
 export interface Service<TEnvShape extends z.ZodRawShape> {
@@ -45,7 +44,6 @@ export interface Service<TEnvShape extends z.ZodRawShape> {
  * Nothing is started — call the returned `listen` to bind a port.
  */
 export async function createService<TEnvShape extends z.ZodRawShape = Record<never, never>>(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   config: ServiceConfig<TEnvShape>,
 ): Promise<Service<TEnvShape>> {
   const env = parseServiceEnv(config.envShape);
@@ -137,7 +135,6 @@ function parseServiceEnv<TEnvShape extends z.ZodRawShape>(
 
 /** Generates the service's OpenAPI document from its contract, never its implementation. */
 function buildOpenAPIDocument(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   contract: AnyContractRouter,
   name: string,
 ): Promise<OpenAPI.Document> {
@@ -151,7 +148,6 @@ function buildOpenAPIDocument(
 }
 
 /** Reads the incoming request-id, or mints one when the caller didn't supply it. */
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 function getRequestId(request: Request): string {
   return request.headers.get('x-request-id') ?? crypto.randomUUID();
 }
@@ -162,18 +158,16 @@ function getRequestId(request: Request): string {
  * docs/002-service-contracts.md.
  */
 interface MountORPCHandlerDeps {
-  logger: pino.Logger;
-  publicKey: CryptoKey;
-  serviceName: string;
+  readonly logger: pino.Logger;
+  readonly publicKey: CryptoKey;
+  readonly serviceName: string;
 }
 
 function mountORPCHandler(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
+  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- Elysia's default type parameters resolve to a concrete, mutable instance shape the allow-list entry doesn't reach
   app: Elysia,
   prefix: `/${string}`,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   handler: FetchHandler<ServiceContext>,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   deps: MountORPCHandlerDeps,
 ): void {
   app.all(

--- a/projects/lib-service-runtime/src/parse-service-token.ts
+++ b/projects/lib-service-runtime/src/parse-service-token.ts
@@ -7,8 +7,8 @@ export type ServiceTokenResolution =
   | { failure: 'invalid-service-token' };
 
 interface ParseServiceTokenOptions {
-  audience: string;
-  publicKey: CryptoKey;
+  readonly audience: string;
+  readonly publicKey: CryptoKey;
 }
 
 /**
@@ -18,9 +18,7 @@ interface ParseServiceTokenOptions {
  * these are a caller's problem to fix, so no detail beyond the failure itself is surfaced.
  */
 export async function parseServiceToken(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   request: Request,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   options: ParseServiceTokenOptions,
 ): Promise<ServiceTokenResolution> {
   const authorization = request.headers.get('authorization');

--- a/projects/lib-service-runtime/src/test-utils/create-service-token.ts
+++ b/projects/lib-service-runtime/src/test-utils/create-service-token.ts
@@ -3,14 +3,13 @@ import * as jose from 'jose';
 import { TOKEN_ALGORITHM, TOKEN_ISSUER } from '../token-claims';
 
 interface CreateServiceTokenOptions {
-  actingUserId?: string;
-  audience: string;
-  expiresIn?: string;
-  privateKey: CryptoKey;
+  readonly actingUserId?: string;
+  readonly audience: string;
+  readonly expiresIn?: string;
+  readonly privateKey: CryptoKey;
 }
 
 /** Signs a short-lived s2s token carrying the shared claim vocabulary, for tests to send as `Authorization: Bearer <token>`. */
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function createServiceToken(options: CreateServiceTokenOptions): Promise<string> {
   // oxlint-disable-next-line typescript/strict-boolean-expressions -- baseline(#236)
   const claims = options.actingUserId ? { sub: options.actingUserId } : {};

--- a/projects/lib-service-test-utils/src/bun/create-test-user.ts
+++ b/projects/lib-service-test-utils/src/bun/create-test-user.ts
@@ -32,10 +32,9 @@ const LEGACY_BCRYPT_COST_FACTOR = 12;
  * callers that need to present it to a reset flow.
  */
 export async function createTestUser(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   db: Kysely<DB>,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-  data: CreateTestUserData = {},
+  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- CreateTestUserData's fields are derived through kysely's Insertable<> conditional mapped type, which this rule's type walker can't prove readonly even wrapped in Readonly<>
+  data: Readonly<CreateTestUserData> = {},
 ): Promise<TestUser> {
   const now = new Date();
 

--- a/projects/lib-service-test-utils/src/bun/create-test-verification.ts
+++ b/projects/lib-service-test-utils/src/bun/create-test-verification.ts
@@ -10,10 +10,9 @@ type TestVerificationData = Partial<Insertable<Verifications>>;
  * real TOTP secret/config so `@epic-web/totp` can verify codes against it.
  */
 export async function createTestVerification(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   db: Kysely<DB>,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-  data: TestVerificationData = {},
+  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- TestVerificationData's fields are derived through kysely's Insertable<> conditional mapped type, which this rule's type walker can't prove readonly even wrapped in Readonly<>
+  data: Readonly<TestVerificationData> = {},
 ): Promise<Selectable<Verifications>> {
   const now = new Date();
 

--- a/projects/lib-service-test-utils/src/create-test-jwt.ts
+++ b/projects/lib-service-test-utils/src/create-test-jwt.ts
@@ -1,13 +1,12 @@
 import * as jose from 'jose';
 
 interface TestTokenConfig {
-  audience: string;
-  issuer: string;
-  pkcs8Key?: jose.CryptoKey;
-  sub: string;
+  readonly audience: string;
+  readonly issuer: string;
+  readonly pkcs8Key?: jose.CryptoKey;
+  readonly sub: string;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export async function createTestJWT(config: TestTokenConfig): Promise<string> {
   const signingKey = config.pkcs8Key ?? new TextEncoder().encode('secret');
 

--- a/projects/lib-service-test-utils/src/create-test-user.ts
+++ b/projects/lib-service-test-utils/src/create-test-user.ts
@@ -17,10 +17,9 @@ type TestUserData = Partial<
 >;
 
 export async function createTestUser(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   db: PostgresJsDatabase<typeof schema>,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-  data: TestUserData = {},
+  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- TestUserData's fields are derived through drizzle's $inferSelect conditional column typing, which this rule's type walker can't prove readonly even wrapped in Readonly<>
+  data: Readonly<TestUserData> = {},
 ): Promise<typeof schema.users.$inferSelect> {
   const now = new Date();
 

--- a/projects/lib-service-test-utils/src/create-test-verification.ts
+++ b/projects/lib-service-test-utils/src/create-test-verification.ts
@@ -6,10 +6,9 @@ import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 type TestVerificationData = Partial<typeof schema.verifications.$inferSelect>;
 
 export async function createTestVerification(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   db: PostgresJsDatabase<typeof schema>,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-  data: TestVerificationData = {},
+  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- TestVerificationData's fields are derived through drizzle's $inferSelect conditional column typing, which this rule's type walker can't prove readonly even wrapped in Readonly<>
+  data: Readonly<TestVerificationData> = {},
 ): Promise<typeof schema.verifications.$inferSelect> {
   const now = new Date();
 

--- a/projects/lib-service-test-utils/src/get-container-connection-uri.ts
+++ b/projects/lib-service-test-utils/src/get-container-connection-uri.ts
@@ -1,6 +1,5 @@
 import type { StartedPostgreSqlContainer } from '@testcontainers/postgresql';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function getContainerConnectionURI(container: StartedPostgreSqlContainer) {
   return `postgres://${container.getUsername()}:${container.getPassword()}@${container.getHost()}:${container.getFirstMappedPort()}`;
 }

--- a/projects/lib-service-test-utils/src/setup-test-db.ts
+++ b/projects/lib-service-test-utils/src/setup-test-db.ts
@@ -7,7 +7,7 @@ import { migrate } from 'drizzle-orm/postgres-js/migrator';
 import postgres from 'postgres';
 
 interface TestDBConfig {
-  migrationsFolder?: string;
+  readonly migrationsFolder?: string;
 }
 
 const packageDir = import.meta.dirname;
@@ -21,9 +21,7 @@ const packageDir = import.meta.dirname;
  * @param container - The testcontainers postgres container.
  */
 export async function setupTestDB(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   container: StartedPostgreSqlContainer,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   config: TestDBConfig = {},
 ) {
   const connectionURI = container.getConnectionUri();

--- a/projects/lib-service-test-utils/vitest.global-setup.ts
+++ b/projects/lib-service-test-utils/vitest.global-setup.ts
@@ -8,7 +8,6 @@ declare module 'vitest' {
   }
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export async function setup(project: TestProject) {
   const container = await createPostgresContainer();
 

--- a/projects/lib-service-utils/src/middleware/create-logger-middleware.ts
+++ b/projects/lib-service-utils/src/middleware/create-logger-middleware.ts
@@ -6,7 +6,6 @@ interface ContextVariables {
   requestId: string;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function createLoggerMiddleware(logger: Logger): MiddlewareHandler {
   return async function loggerMiddleware(
     // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)

--- a/projects/service-avatar/vitest.global-setup.ts
+++ b/projects/service-avatar/vitest.global-setup.ts
@@ -12,7 +12,6 @@ declare module 'vitest' {
   }
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export async function setup(project: TestProject) {
   const container = await createPostgresContainer();
 

--- a/projects/service-session/vitest.global-setup.ts
+++ b/projects/service-session/vitest.global-setup.ts
@@ -12,7 +12,6 @@ declare module 'vitest' {
   }
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export async function setup(project: TestProject) {
   const container = await createPostgresContainer();
 

--- a/projects/service-user/vitest.global-setup.ts
+++ b/projects/service-user/vitest.global-setup.ts
@@ -12,7 +12,6 @@ declare module 'vitest' {
   }
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export async function setup(project: TestProject) {
   const container = await createPostgresContainer();
 

--- a/projects/service-verification/vitest.global-setup.ts
+++ b/projects/service-verification/vitest.global-setup.ts
@@ -12,7 +12,6 @@ declare module 'vitest' {
   }
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export async function setup(project: TestProject) {
   const container = await createPostgresContainer();
 


### PR DESCRIPTION
## Description

Closes #265

Adds a per-type `allow` list to `typescript/prefer-readonly-parameter-types` in `.oxlintrc.json` for framework-handle types that can't be made readonly, then clears the resulting `baseline(#236)` debt across lib-db, lib-service-runtime, lib-service-test-utils, lib-contract-base, and lib-email.

- Allow-list covers Kysely, Elysia, vitest's TestProject, testcontainers' StartedPostgreSqlContainer, drizzle's PostgresJsDatabase, CryptoKey, pino's Logger, ReactElement, oRPC's contract/handler types, and bun-types' Request/Response
- Own data/config/props interfaces got `readonly` fields or a `Readonly<>` wrapper; now-redundant baseline directives were deleted
- A few sites the allow-list can't reach keep an inline directive with a real reason instead of `baseline(#236)`: Elysia's default-generic parameter shape, local oRPC test-contract-builder return types, and kysely/drizzle's conditionally-derived row types in lib-service-test-utils's `create-test-*` helpers
- Because `.oxlintrc.json` is root-level, the new allow list also made a handful of pre-existing directives stale (TestProject in four services' `vitest.global-setup.ts`, pino's Logger in lib-service-utils) — only those stale lines were removed
- Documented the convention in `agents/project.md`'s lint bullet and regenerated `AGENTS.md`

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] `bun run boundaries` and `bun run format:check` pass