### PR TITLE
docs(game-design): flesh out core fiction and damage model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,12 +199,12 @@ implementing that algorithm — forcing list verbs onto textbook terms hides the
 
 ### Banned words
 
-Overused jargon a plainer word covers. Applies to all prose — docs, comments, PR descriptions,
-issue text. An exception is allowed only when no other word logically represents the meaning and
-the sentence can't be simplified without losing it.
+Overused jargon a plainer word covers. Applies to all prose — docs, comments, PR descriptions, issue
+text. An exception is allowed only when no other word logically represents the meaning and the
+sentence can't be simplified without losing it.
 
-- `load-bearing` / `load bearing` — say what breaks without it: "required", "essential", or name
-  the failure.
+- `load-bearing` / `load bearing` — say what breaks without it: "required", "essential", or name the
+  failure.
 - `seam` — "boundary", "join", "integration point".
 - `surface` — noun: "area", "API", the concrete thing itself; verb: "show", "raise", "report".
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,19 @@ implementing that algorithm — forcing list verbs onto textbook terms hides the
 - Pin exact versions — no `^`/`~` ranges. (`bun add` saves exact automatically via `exact = true` in
   bunfig.toml — the rule applies to hand-written edits.)
 
+## Writing
+
+### Banned words
+
+Overused jargon a plainer word covers. Applies to all prose — docs, comments, PR descriptions,
+issue text. An exception is allowed only when no other word logically represents the meaning and
+the sentence can't be simplified without losing it.
+
+- `load-bearing` / `load bearing` — say what breaks without it: "required", "essential", or name
+  the failure.
+- `seam` — "boundary", "join", "integration point".
+- `surface` — noun: "area", "API", the concrete thing itself; verb: "show", "raise", "report".
+
 ## Monorepo layout
 
 27 projects live under `projects/*` (the sole bun workspace glob). Every project has its own
@@ -264,7 +277,7 @@ its own PR and promotes it into `lib-design-system` when a second consumer appea
 - `bun run lint` / `bun run lint:fix` — `turbo run codegen typegen`, then
   `oxlint --type-aware --type-check --report-unused-disable-directives-severity error` over the
   whole tree (`.oxlintrc.json` at the root; oxlint-tsgolint underneath, needs the TS7 toolchain —
-  ~5s wall with warm caches). The codegen leg is load-bearing: without generated output (panda's
+  ~5s wall with warm caches). The codegen leg is required: without generated output (panda's
   `styled-system`, react-router's `+types`) those imports degrade to `any` and the unsafe-\* rules
   report hundreds of false violations. Every type-aware rule is on; `only-throw-error`'s app-web
   override is the one permanent, documented exception. The pre-#236 backlog (~1,047 sites) is
@@ -304,7 +317,7 @@ Each deployable (`app-web`, `db-postgres`, the 4 services) has a multi-stage Doc
 2. **installer** — full `bun install` against `out/json` for build-time tooling.
 3. **builder** — copies `out/full` plus `scripts/build-esbuild.ts` and `tsconfig.base.json` (outside
    any package, so prune doesn't carry them), then runs the project's `build` script.
-4. **prod-deps** — `bun install --production --linker=hoisted`. Hoisting is load-bearing: a bundle
+4. **prod-deps** — `bun install --production --linker=hoisted`. Hoisting is essential: a bundle
    inlines source from several packages, and its external imports (`pino`, …) must resolve from the
    bundle's own location — only a flat `node_modules` serves them all.
 5. **runtime** — `node:24.18.0-alpine` with the prod-deps `node_modules` and built output only.

--- a/agents/project.md
+++ b/agents/project.md
@@ -1,3 +1,16 @@
+## Writing
+
+### Banned words
+
+Overused jargon a plainer word covers. Applies to all prose — docs, comments, PR descriptions, issue
+text. An exception is allowed only when no other word logically represents the meaning and the
+sentence can't be simplified without losing it.
+
+- `load-bearing` / `load bearing` — say what breaks without it: "required", "essential", or name the
+  failure.
+- `seam` — "boundary", "join", "integration point".
+- `surface` — noun: "area", "API", the concrete thing itself; verb: "show", "raise", "report".
+
 ## Monorepo layout
 
 27 projects live under `projects/*` (the sole bun workspace glob). Every project has its own
@@ -67,7 +80,7 @@ its own PR and promotes it into `lib-design-system` when a second consumer appea
 - `bun run lint` / `bun run lint:fix` — `turbo run codegen typegen`, then
   `oxlint --type-aware --type-check --report-unused-disable-directives-severity error` over the
   whole tree (`.oxlintrc.json` at the root; oxlint-tsgolint underneath, needs the TS7 toolchain —
-  ~5s wall with warm caches). The codegen leg is load-bearing: without generated output (panda's
+  ~5s wall with warm caches). The codegen leg is required: without generated output (panda's
   `styled-system`, react-router's `+types`) those imports degrade to `any` and the unsafe-\* rules
   report hundreds of false violations. Every type-aware rule is on; `only-throw-error`'s app-web
   override is the one permanent, documented exception. The pre-#236 backlog (~1,047 sites) is
@@ -107,7 +120,7 @@ Each deployable (`app-web`, `db-postgres`, the 4 services) has a multi-stage Doc
 2. **installer** — full `bun install` against `out/json` for build-time tooling.
 3. **builder** — copies `out/full` plus `scripts/build-esbuild.ts` and `tsconfig.base.json` (outside
    any package, so prune doesn't carry them), then runs the project's `build` script.
-4. **prod-deps** — `bun install --production --linker=hoisted`. Hoisting is load-bearing: a bundle
+4. **prod-deps** — `bun install --production --linker=hoisted`. Hoisting is essential: a bundle
    inlines source from several packages, and its external imports (`pino`, …) must resolve from the
    bundle's own location — only a flat `node_modules` serves them all.
 5. **runtime** — `node:24.18.0-alpine` with the prod-deps `node_modules` and built output only.

--- a/docs/game-design/001-core-themes-world-fiction.md
+++ b/docs/game-design/001-core-themes-world-fiction.md
@@ -56,20 +56,25 @@ without making lore the main activity.
 Avatar is the canonical term.
 
 An avatar is an enhanced human shaped by the player and capable of entering regions that ordinary
-people cannot survive. The term has deeper historical meaning in the world, but the player-facing
-fantasy is simple: shape your avatar, send them into danger, recover power, and push deeper.
+people cannot survive. "Avatar" is the worn remnant of a longer phrase — avatar _of_ something — and
+what filled the blank is lost, contested knowledge. What is known: the capacity is inborn, appearing
+by chance in some and not others, and no institution can manufacture it. The player-facing fantasy
+stays simple: shape your avatar, send them into danger, recover power, and push deeper.
 
 Avatars are embodied people, not disposable drones. They can be augmented, equipped, specialized,
 injured, defeated, recovered, ranked, and eventually set against other avatars.
 
 ### Defeat Stakes
 
-Defeat ends the activity. Avatars are always recovered, never permanently lost.
+Defeat ends the activity — an expedition, or any future instanced undertaking. Avatars are always
+recovered, never permanently lost.
 
 Defeat costs progress, not the avatar: experience toward the next level is lost but levels are never
 removed; yield from the run that was not already extracted is lost; and any investment in the
 activity instance is lost — the instance resets to baseline. Extraction is the player's mid-run
-banking decision: yield stays at risk until it is pulled out.
+banking decision: yield stays at risk until it is pulled out. Extraction is set as policy, not
+performed by hand — automated rules (extract at a yield threshold, or when defenses degrade) are
+intended, so unattended runs bank deliberately.
 
 Exact loss rates, floors, and extraction mechanics belong to the progression and economy notes.
 
@@ -175,12 +180,15 @@ itself.
 
 ## Vocabulary Register
 
+The register covers world vocabulary and cross-cutting provisional terms. System vocabulary — damage
+types, defensive layers, attributes — is defined in the damage-model note and is canonical under the
+naming grammar's first rule.
+
 | Term       | Status      | Notes                                                                            |
 | ---------- | ----------- | -------------------------------------------------------------------------------- |
 | Vers       | Keep        | Carries universe and versus: world exploration plus competition.                 |
 | avatar     | Canonical   | Enhanced human shaped by the player and sent into dangerous regions.             |
-| Respite    | Canonical   | The largest known human center and the player's operational home. Officially     |
-|            |             | Habitat Nine; the vernacular name won. Implies habitats one through eight.       |
+| Respite    | Canonical   | The largest human center; officially Habitat Nine — the vernacular name won.     |
 | world      | Keep        | The broad play space and fiction layer; not just a menu.                         |
 | region     | Provisional | Neutral term for world-map areas.                                                |
 | expedition | Provisional | The core activity: outfit an avatar, send it out, recover what returns.          |
@@ -188,5 +196,4 @@ itself.
 | power      | Keep        | Umbrella term for rewards that help the player push farther or more efficiently. |
 | Reserve    | Provisional | The single avatar skill resource; name open until itemisation settles.           |
 | buffer     | Reserved    | Held for a future deferred-damage defensive mechanic; distinct from Barrier.     |
-| aether     | Not canon   | Existing placeholder; only survives if it beats alternatives.                    |
 | glyph      | Not canon   | Visual candidate for mythic systems, not yet a world rule.                       |

--- a/docs/game-design/001-core-themes-world-fiction.md
+++ b/docs/game-design/001-core-themes-world-fiction.md
@@ -25,9 +25,16 @@ sending them into the world, and watching their build prove itself over time.
 
 ### World Premise
 
-Vers takes place in a far-future human world where civilization persists around Sanctuary, the
-largest known human center. Beyond it are older, stranger, partially autonomous regions that most
-people cannot safely enter.
+Vers takes place in a far-future human world where civilization persists around Respite — officially
+Habitat Nine — the largest known human center. Beyond it are older, stranger, partially autonomous
+regions that most people cannot safely enter.
+
+The world was never destroyed; it stopped answering. Civilization built on itself for so long that
+most of the world now runs on its own accumulated logic — infrastructure that no longer recognizes
+anyone's authority, ecologies that were designed once and have since gone their own way, and human
+societies that broke from Respite and became something stranger. Respite is simply the largest place
+that still answers to the people living inside it. A region's danger is a measure of how far it has
+drifted — mechanical, ecological, or human; its value is what it still produces, protects, or knows.
 
 Those regions are the world map: real places and systems that can be entered, cleared, revisited,
 pushed through, and eventually competed over. They include abandoned infrastructure, synthetic
@@ -40,9 +47,9 @@ The world should feel artificial, luminous, polluted, overbuilt, and old. Civili
 but not clean. Its systems have accumulated for so long that infrastructure can feel like terrain,
 history, hazard, and myth at the same time.
 
-Sanctuary is central, but it is not omniscient. Its maps, institutions, factions, and public
-histories can be incomplete, biased, or deliberately constrained. This gives the world room for
-discovery without making lore the main activity.
+Respite is central, but it is not omniscient. Its maps, institutions, factions, and public histories
+can be incomplete, biased, or deliberately constrained. This gives the world room for discovery
+without making lore the main activity.
 
 ### Avatar Premise
 
@@ -54,6 +61,44 @@ fantasy is simple: shape your avatar, send them into danger, recover power, and 
 
 Avatars are embodied people, not disposable drones. They can be augmented, equipped, specialized,
 injured, defeated, recovered, ranked, and eventually set against other avatars.
+
+### Defeat Stakes
+
+Defeat ends the activity. Avatars are always recovered, never permanently lost.
+
+Defeat costs progress, not the avatar: experience toward the next level is lost but levels are never
+removed; yield from the run that was not already extracted is lost; and any investment in the
+activity instance is lost — the instance resets to baseline. Extraction is the player's mid-run
+banking decision: yield stays at risk until it is pulled out.
+
+Exact loss rates, floors, and extraction mechanics belong to the progression and economy notes.
+
+### Institutions & Factions
+
+Factions run on two axes: the institutions inside Respite, and what remains of the other habitats
+outside it.
+
+Three institutions anchor Respite, each defined by what it wants from an avatar's expeditions:
+
+- **The authority over the outside** licenses expeditions and keeps the maps, catalogues, and public
+  histories. It wants what an expedition learned. What it publishes is incomplete by design — the
+  bias in Respite's picture of the world has an author. The in-game codex is its artifact.
+- **The market** turns salvage into value: commerce, currency, and the funding that makes
+  expeditions worth mounting. It wants what an expedition carried back.
+- **The industry** transforms what the world yields: refinement, equipment, crafting, and the
+  augmentation of avatars among its trades. It wants raw material from expeditions — and proof of
+  how its work held up in the field. The crafting screens are its artifacts.
+
+Each institution owns the screens that express it: a major screen reads as an artifact of the
+institution behind it, so each feels distinct and inhabited. These are thematic anchors — mechanics
+attach to them as later notes need a licensor, a market, or a fabricator, and institution names wait
+for the world's naming grammar. Players may eventually align with an institution for perks; that is
+later system design, noted here so institutions are built to bear it.
+
+The other habitats are the external axis. Records are incomplete: some habitats fell and are ruin,
+some still run with no one left inside, some broke away and became societies Respite no longer
+recognizes — and some numbers have no entry at all. Habitats can anchor region, faction, and enemy
+identities — including the stranger damage types — as downstream notes need them.
 
 ### Story Weight
 
@@ -73,6 +118,12 @@ progression.
 The word `versus` is part of the name's meaning, but early game design should express that pressure
 through danger, comparison, mastery, and eventual direct conflict.
 
+The MMO layer is economic and competitive, not spatial: play is instanced, and players meet through
+a shared market, ladders, and eventually direct PvP. Loot is tradeable, and drop, crafting, and
+currency design should assume a player economy from the start. Direct PvP is build against build —
+two players' planning resolved in a fight both can study — and arrives after the PvE loop is proven.
+Competition over regions is comparative (who pushes farther, faster), not territorial.
+
 ## Pillars
 
 ### Dangerous Regions
@@ -83,8 +134,8 @@ resistance, discovery, escalation, and reward.
 A good region should answer: what makes this place unsafe, what makes it valuable, and how does it
 change as the avatar pushes deeper?
 
-Regions become harder and stranger as they move farther from Sanctuary's influence. Distance does
-not need to be purely geographic: age, autonomy, corruption, hostile control, system drift, and lost
+Regions become harder and stranger as they move farther from Respite's influence. Distance does not
+need to be purely geographic: age, autonomy, corruption, hostile control, system drift, and lost
 history can all make a region more dangerous and more valuable.
 
 ### Synthetic World
@@ -110,16 +161,32 @@ Progress is measured by how far and efficiently avatars can push into the world.
 should eventually make that competition explicit, but the core pressure starts with the world
 itself.
 
+## Naming Grammar
+
+1. **Two registers.** System vocabulary (damage types, defensive layers, attributes) is clinical and
+   stable — it lives in tables and logs. World vocabulary (places, factions, enemies, items) is worn
+   and human. Never swap them.
+2. **The worn-name pattern.** World things carry an official designation and the vernacular name
+   that won: Habitat Nine → Respite. The pattern is the template, not a one-off.
+3. **Numbers are history.** Serials and indices read as accumulated record, not decoration.
+4. **Institutions are called what citizens call them**, never their charter name.
+5. **Register bans.** No fantasy-magic words in either vocabulary. No console words (`root`,
+   `admin`, `null`) in world vocabulary — they are fine in system vocabulary.
+
 ## Vocabulary Register
 
-| Term      | Status      | Notes                                                                            |
-| --------- | ----------- | -------------------------------------------------------------------------------- |
-| Vers      | Keep        | Carries universe and versus: world exploration plus competition.                 |
-| avatar    | Canonical   | Enhanced human shaped by the player and sent into dangerous regions.             |
-| Sanctuary | Canonical   | The largest known human center and the player's operational home.                |
-| world     | Keep        | The broad play space and fiction layer; not just a menu.                         |
-| region    | Provisional | Neutral term for world-map areas.                                                |
-| loot      | Keep        | Core ARPG promise.                                                               |
-| power     | Keep        | Umbrella term for rewards that help the player push farther or more efficiently. |
-| aether    | Not canon   | Existing placeholder; only survives if it beats alternatives.                    |
-| glyph     | Not canon   | Visual candidate for mythic systems, not yet a world rule.                       |
+| Term       | Status      | Notes                                                                            |
+| ---------- | ----------- | -------------------------------------------------------------------------------- |
+| Vers       | Keep        | Carries universe and versus: world exploration plus competition.                 |
+| avatar     | Canonical   | Enhanced human shaped by the player and sent into dangerous regions.             |
+| Respite    | Canonical   | The largest known human center and the player's operational home. Officially     |
+|            |             | Habitat Nine; the vernacular name won. Implies habitats one through eight.       |
+| world      | Keep        | The broad play space and fiction layer; not just a menu.                         |
+| region     | Provisional | Neutral term for world-map areas.                                                |
+| expedition | Provisional | The core activity: outfit an avatar, send it out, recover what returns.          |
+| loot       | Keep        | Core ARPG promise.                                                               |
+| power      | Keep        | Umbrella term for rewards that help the player push farther or more efficiently. |
+| Reserve    | Provisional | The single avatar skill resource; name open until itemisation settles.           |
+| buffer     | Reserved    | Held for a future deferred-damage defensive mechanic; distinct from Barrier.     |
+| aether     | Not canon   | Existing placeholder; only survives if it beats alternatives.                    |
+| glyph      | Not canon   | Visual candidate for mythic systems, not yet a world rule.                       |

--- a/docs/game-design/001-core-themes-world-fiction.md
+++ b/docs/game-design/001-core-themes-world-fiction.md
@@ -64,20 +64,6 @@ stays simple: shape your avatar, send them into danger, recover power, and push 
 Avatars are embodied people, not disposable drones. They can be augmented, equipped, specialized,
 injured, defeated, recovered, ranked, and eventually set against other avatars.
 
-### Defeat Stakes
-
-Defeat ends the activity — an expedition, or any future instanced undertaking. Avatars are always
-recovered, never permanently lost.
-
-Defeat costs progress, not the avatar: experience toward the next level is lost but levels are never
-removed; yield from the run that was not already extracted is lost; and any investment in the
-activity instance is lost — the instance resets to baseline. Extraction is the player's mid-run
-banking decision: yield stays at risk until it is pulled out. Extraction is set as policy, not
-performed by hand — automated rules (extract at a yield threshold, or when defenses degrade) are
-intended, so unattended runs bank deliberately.
-
-Exact loss rates, floors, and extraction mechanics belong to the progression and economy notes.
-
 ### Institutions & Factions
 
 Factions run on two axes: the institutions inside Respite, and what remains of the other habitats
@@ -128,6 +114,20 @@ a shared market, ladders, and eventually direct PvP. Loot is tradeable, and drop
 currency design should assume a player economy from the start. Direct PvP is build against build —
 two players' planning resolved in a fight both can study — and arrives after the PvE loop is proven.
 Competition over regions is comparative (who pushes farther, faster), not territorial.
+
+### Defeat Stakes
+
+Defeat ends the activity — an expedition, or any future instanced undertaking. Avatars are always
+recovered, never permanently lost.
+
+Defeat costs progress, not the avatar: experience toward the next level is lost but levels are never
+removed; yield from the run that was not already extracted is lost; and any investment in the
+activity instance is lost — the instance resets to baseline. Extraction is the player's mid-run
+banking decision: yield stays at risk until it is pulled out. Extraction is set as policy, not
+performed by hand — automated rules (extract at a yield threshold, or when defenses degrade) are
+intended, so unattended runs bank deliberately.
+
+Exact loss rates, floors, and extraction mechanics belong to the progression and economy notes.
 
 ## Pillars
 

--- a/docs/game-design/002-attributes-damage-model.md
+++ b/docs/game-design/002-attributes-damage-model.md
@@ -10,7 +10,7 @@ Vers uses two attribute layers: avatar attributes and metagame attributes. They 
 for the same item budget or progression choices.
 
 Avatar attributes are local to an avatar. They can appear on gear, avatar passives, class systems,
-and other character-power surfaces. They determine how an avatar survives and performs inside
+and other character-power systems. They determine how an avatar survives and performs inside
 regions.
 
 Metagame attributes are persistent player/world progression. They can appear on metagame passive
@@ -59,6 +59,27 @@ and the ability to recognize what the world is offering.
 Aptitude is refinement. It represents practical capability with items, systems, upgrades, and other
 long-term tools that turn resources into better outcomes.
 
+## Resource
+
+Avatars act on cadence: attacks, skills, and recovery run on their own beats, and idle play means
+those beats fire without piloting. Reserve (provisional name) is the single avatar resource layered
+over that cadence. Skills relate to it in one of three ways:
+
+- **Free** skills fire on their beat at no cost. They are the baseline lane: a starved avatar
+  degrades to its free skills instead of stalling.
+- **Costed** skills spend Reserve to fire. A costed skill that cannot pay skips its beat rather than
+  blocking the avatar. A costed skill should be stronger per beat than a free one by roughly the
+  value of its cost — the cost is a tax on throughput, and the build question is whether
+  regeneration can sustain it.
+- **Optional-cost** skills fire either way and consume Reserve for a stronger outcome when it is
+  available. Empowerment uptime is a build outcome worth reporting to the player.
+
+Cost shape is a skill property, not a class rule. Archetypes may still skew the flow — heavy
+spenders, or generators that build Reserve by acting or being hit — through skills and passives.
+
+Focus's recovery mandate includes Reserve regeneration. Specific regeneration, cost, capacity, and
+on-full/on-empty investment stays in itemisation and skills, as with every attribute.
+
 ## Damage Types
 
 Vers starts with six damage types. The set is intentionally wider than a traditional fantasy ARPG
@@ -90,10 +111,25 @@ environmental taint, and other damaging intrusion.
 Cognitive damage is hostile patterning: perception attack, neural interference, signal confusion,
 memory pressure, and other effects that harm through thought, control, or understanding.
 
-### Void
+### Null
 
-Void damage is absence and impossibility: entropy, null effects, erasure, unreality, and forces that
-do not fit cleanly into the known material systems.
+Null damage is absence and impossibility: entropy, erasure, unreality, and forces that do not fit
+cleanly into the known material systems.
+
+## Threat Mix & Coverage
+
+Five of the six damage types are resistable: type-specific mitigation exists for Thermal, Voltaic,
+Toxic, Cognitive, and Null, and an endgame avatar is expected to reach the mitigation cap for the
+types its target regions deal. Kinetic is not resistable — it is the universal pressure type,
+handled through the other defensive layers rather than a resistance stat.
+
+Regions are weighted toward a dominant damage type but never deal it exclusively. Type mitigation is
+specced against a region's mix, and the type-agnostic layers — avoidance, block, barrier — are the
+floor under whatever a build has not covered.
+
+Every damage type has at least one region or faction that expresses it. The strange types are
+progression-gated: Cognitive appears later, and Null is endgame. The type spectrum deepens as
+avatars push farther from Respite.
 
 ## Damage Events
 
@@ -104,6 +140,19 @@ interactions.
 
 Hits are discrete damage events. They are the baseline event type for attacks, skills, and enemy
 actions that connect at a point in time.
+
+### Critical Hits
+
+A hit may resolve as critical, scaling that hit's impact. Criticals are a property of hits, not a
+separate event type: persistent damage and status effects do not crit on their own, though a
+critical hit may strengthen the secondary outcomes it causes.
+
+Criticals are symmetric. Avatar criticals are a build lever: chance and magnitude are both
+investable through gear, skills, and passives. Enemy criticals are spike pressure — the reason
+defensive layers and recovery need headroom above average incoming damage rather than being tuned to
+it. An unattended avatar must be able to survive unlucky sequences, so enemy critical magnitude is a
+tuning lever for region danger, not a source of unavoidable loss. That tuning belongs to the
+progression and enemy notes.
 
 ### Persistent Damage
 
@@ -156,13 +205,19 @@ The default resolution order is:
 1. A hostile action attempts to connect.
 2. Avoidance may prevent connection.
 3. Block may intercept a connected hit.
-4. Mitigation reduces remaining damage.
-5. Barrier absorbs damage before life.
-6. Life is reduced by unabsorbed damage.
-7. Status effects and secondary outcomes are checked from the resolved event.
+4. A connected hit may resolve as critical, scaling its damage.
+5. Mitigation reduces remaining damage.
+6. Barrier absorbs damage before life.
+7. Life is reduced by unabsorbed damage.
+8. Status effects and secondary outcomes are checked from the resolved event.
 
 This order is a design spine, not a final formula. Individual skills, items, enemies, and regions
 may alter it when a specific build or encounter needs a rule-breaking hook.
+
+The order is also the structure of expedition reporting: each defensive layer consumed is
+escalation, and a hit that reaches life is a close call worth reporting. Reporting carries both a
+high-level summary and the drill-down that explains it — including what failed on defeat; its own
+design note owns the specifics.
 
 ## Scaling Philosophy
 
@@ -181,5 +236,5 @@ only when they create meaningful build or encounter identity.
 ## Non-Goals
 
 This note does not define exact formulas, ailment lists, resistance caps, block math, avoidance
-math, or complete itemisation rules. Those belong in downstream combat, itemisation, enemy, and
-progression notes.
+math, critical chance or magnitude baselines, Reserve cost or regeneration baselines, or complete
+itemisation rules. Those belong in downstream combat, itemisation, enemy, and progression notes.

--- a/docs/game-design/002-attributes-damage-model.md
+++ b/docs/game-design/002-attributes-damage-model.md
@@ -21,18 +21,20 @@ player stabilizes, discovers, and extracts value from the world.
 
 ### Focus
 
-Focus is cadence. It represents rate, recovery, and action tempo.
+Focus is cadence. It governs action rate: how quickly an avatar's skill beats recur. It is not an
+attack- or cast-speed modifier — speed of execution stays specific itemisation.
 
-Focus should improve how often an avatar can act or recover, but it should not replace specific
-attack-speed, cooldown, recovery, or trigger itemisation.
+Focus should improve how often an avatar can act, but it should not replace specific attack-speed,
+cooldown, or trigger itemisation.
 
 ### Vigor
 
-Vigor is sustain. It represents regeneration, retention, endurance, and the ability to stay active
-under pressure.
+Vigor is sustain. It governs the global regeneration rate: Life, Barrier, and Reserve all recover
+faster under Vigor. Because one stat touches all three pools its power is deliberately curbed — and
+long-form idle combat keeps even curbed regeneration useful.
 
 Vigor should improve an avatar's broad staying power, but it should not replace specific investment
-into life, barrier, block, recovery, or other defensive mechanics.
+into Life, Barrier, Block, recovery, or other defensive mechanics.
 
 ### Will
 
@@ -49,6 +51,10 @@ into damage types, skills, ailments, minions, or other archetype-defining system
 Discipline is consistency. It represents stable progression, reduced friction, safer outcomes, and
 less variance across repeated expeditions.
 
+Discipline's variance reduction is non-combat only — yield spread, extraction reliability,
+progression friction — never incoming damage or defeat chance. Survival stays with the avatar's own
+defenses.
+
 ### Insight
 
 Insight is discovery. It represents information, understanding, hidden opportunities, map knowledge,
@@ -59,6 +65,10 @@ and the ability to recognize what the world is offering.
 Aptitude is refinement. It represents practical capability with items, systems, upgrades, and other
 long-term tools that turn resources into better outcomes.
 
+Each metagame attribute sits between two of Respite's institutions: Discipline between the authority
+and the industry, Insight between the authority and the market, and Aptitude between the industry
+and the market. Later alignment mechanics may draw on that geometry.
+
 ## Resource
 
 Avatars act on cadence: attacks, skills, and recovery run on their own beats, and idle play means
@@ -68,17 +78,22 @@ over that cadence. Skills relate to it in one of three ways:
 - **Free** skills fire on their beat at no cost. They are the baseline lane: a starved avatar
   degrades to its free skills instead of stalling.
 - **Costed** skills spend Reserve to fire. A costed skill that cannot pay skips its beat rather than
-  blocking the avatar. A costed skill should be stronger per beat than a free one by roughly the
-  value of its cost — the cost is a tax on throughput, and the build question is whether
+  blocking the avatar — free skills hold the rotation's floor, and the real tax is the output gap
+  between that floor and what the costed beat would have added. A costed skill should be stronger
+  per beat than a free one by roughly the value of its cost, and the build question is whether
   regeneration can sustain it.
 - **Optional-cost** skills fire either way and consume Reserve for a stronger outcome when it is
-  available. Empowerment uptime is a build outcome worth reporting to the player.
+  available. Empowerment converts Reserve less efficiently than a costed skill's cost does —
+  flexibility is taxed, so costed skills remain the efficient way to spend. Empowerment uptime is a
+  build outcome worth reporting to the player.
 
 Cost shape is a skill property, not a class rule. Archetypes may still skew the flow — heavy
 spenders, or generators that build Reserve by acting or being hit — through skills and passives.
+Generation is a skill behaviour orthogonal to cost shape, not a fourth shape.
 
-Focus's recovery mandate includes Reserve regeneration. Specific regeneration, cost, capacity, and
-on-full/on-empty investment stays in itemisation and skills, as with every attribute.
+Reserve regeneration falls under Vigor's global-regeneration mandate, and Reserve regeneration and
+capacity are first-class build stats. Specific regeneration, cost, capacity, and on-full/on-empty
+investment stays in itemisation and skills, as with every attribute.
 
 ## Damage Types
 
@@ -124,12 +139,21 @@ types its target regions deal. Kinetic is not resistable — it is the universal
 handled through the other defensive layers rather than a resistance stat.
 
 Regions are weighted toward a dominant damage type but never deal it exclusively. Type mitigation is
-specced against a region's mix, and the type-agnostic layers — avoidance, block, barrier — are the
+specced against a region's mix, and the type-agnostic layers — Avoidance, Block, Barrier — are the
 floor under whatever a build has not covered.
 
 Every damage type has at least one region or faction that expresses it. The strange types are
 progression-gated: Cognitive appears later, and Null is endgame. The type spectrum deepens as
 avatars push farther from Respite.
+
+Enemies use the same defensive layers as avatars, including Kinetic mitigation of their own — so
+Kinetic is universal pressure in both directions, not a strictly-best attacking type. Layer
+distribution across enemy families is a tuning choice (heavily avoidance-stacked enemies are rarely
+fun), and no mechanic converts incoming Kinetic into a resistable type.
+
+A region's damage mix is also its history: mechanical drift reads as Kinetic, Voltaic, and Thermal;
+ecological drift as Toxic; human drift as Cognitive; total drift as Null. Reading a threat table is
+reading the region's biography.
 
 ## Damage Events
 
@@ -147,12 +171,16 @@ A hit may resolve as critical, scaling that hit's impact. Criticals are a proper
 separate event type: persistent damage and status effects do not crit on their own, though a
 critical hit may strengthen the secondary outcomes it causes.
 
-Criticals are symmetric. Avatar criticals are a build lever: chance and magnitude are both
-investable through gear, skills, and passives. Enemy criticals are spike pressure — the reason
-defensive layers and recovery need headroom above average incoming damage rather than being tuned to
-it. An unattended avatar must be able to survive unlucky sequences, so enemy critical magnitude is a
-tuning lever for region danger, not a source of unavoidable loss. That tuning belongs to the
-progression and enemy notes.
+Criticals apply to both sides. Avatar criticals are a build lever: chance and magnitude are both
+investable through gear, skills, and passives. Enemy criticals are spike pressure: their chance and
+magnitude are independent tuning levers, not inherited from player scaling, and crit mitigation is
+an investable defensive answer — circumstantial heavy crits are designed threats that reward
+preparing for them.
+
+Baseline content is tuned so an unattended avatar's defeat is predictable from its build rather than
+from unlucky sequences — max-hit ceilings against expected defensive pools, not hard caps. Players
+who juice an instance deliberately trade that safety for yield; the appetite to go deeper should
+never hit a wall. Exact numbers belong to the progression and enemy notes.
 
 ### Persistent Damage
 
@@ -228,6 +256,11 @@ that matter.
 Build archetypes should come primarily from skills, gear, passives, damage types, status effects,
 summons, region interactions, and defensive-layer investment. Attribute stacking can exist, but it
 should not erase those more specific choices.
+
+Archetype is a per-system term, not a single system: skills, defenses, classes, and specializations
+each carry their own archetypes, and build archetypes emerge from combining them. Classes are
+intended, including a later chosen divergence into a specialized class tier — its name and design
+belong to the base-classes note.
 
 The damage model should support long-term complexity through item, skill, passive, enemy, and region
 interactions. The first implementation should expose a small stable core, then add specialized rules

--- a/docs/game-design/002-attributes-damage-model.md
+++ b/docs/game-design/002-attributes-damage-model.md
@@ -4,97 +4,6 @@ This note defines the first stable combat stat and damage-system spine for Vers.
 PoE-like long-term build complexity without front-loading that complexity into the first playable
 loop.
 
-## Attribute Layers
-
-Vers uses two attribute layers: avatar attributes and metagame attributes. They should not compete
-for the same item budget or progression choices.
-
-Avatar attributes are local to an avatar. They can appear on gear, avatar passives, class systems,
-and other character-power systems. They determine how an avatar survives and performs inside
-regions.
-
-Metagame attributes are persistent player/world progression. They can appear on metagame passive
-trees, idol-like systems, account progression, or other long-term systems. They determine how the
-player stabilizes, discovers, and extracts value from the world.
-
-## Avatar Attributes
-
-### Focus
-
-Focus is cadence. It governs action rate: how quickly an avatar's skill beats recur. It is not an
-attack- or cast-speed modifier — speed of execution stays specific itemisation.
-
-Focus should improve how often an avatar can act, but it should not replace specific attack-speed,
-cooldown, or trigger itemisation.
-
-### Vigor
-
-Vigor is sustain. It governs the global regeneration rate: Life, Barrier, and Reserve all recover
-faster under Vigor. Because one stat touches all three pools its power is deliberately curbed — and
-long-form idle combat keeps even curbed regeneration useful.
-
-Vigor should improve an avatar's broad staying power, but it should not replace specific investment
-into Life, Barrier, Block, recovery, or other defensive mechanics.
-
-### Will
-
-Will is effect. It represents the avatar's capacity to impose outcomes on the world.
-
-Will can scale damage, healing, shielding, control, summons, persistent effects, and other applied
-combat outcomes. It should provide broad baseline pressure without replacing specific investment
-into damage types, skills, ailments, minions, or other archetype-defining systems.
-
-## Metagame Attributes
-
-### Discipline
-
-Discipline is consistency. It represents stable progression, reduced friction, safer outcomes, and
-less variance across repeated expeditions.
-
-Discipline's variance reduction is non-combat only — yield spread, extraction reliability,
-progression friction — never incoming damage or defeat chance. Survival stays with the avatar's own
-defenses.
-
-### Insight
-
-Insight is discovery. It represents information, understanding, hidden opportunities, map knowledge,
-and the ability to recognize what the world is offering.
-
-### Aptitude
-
-Aptitude is refinement. It represents practical capability with items, systems, upgrades, and other
-long-term tools that turn resources into better outcomes.
-
-Each metagame attribute sits between two of Respite's institutions: Discipline between the authority
-and the industry, Insight between the authority and the market, and Aptitude between the industry
-and the market. Later alignment mechanics may draw on that geometry.
-
-## Resource
-
-Avatars act on cadence: attacks, skills, and recovery run on their own beats, and idle play means
-those beats fire without piloting. Reserve (provisional name) is the single avatar resource layered
-over that cadence. Skills relate to it in one of three ways:
-
-- **Free** skills fire on their beat at no cost. They are the baseline lane: a starved avatar
-  degrades to its free skills instead of stalling.
-- **Costed** skills spend Reserve to fire. A costed skill that cannot pay skips its beat rather than
-  blocking the avatar — free skills hold the rotation's floor, and the real tax is the output gap
-  between that floor and what the costed beat would have added. A costed skill should be stronger
-  per beat than a free one by roughly the value of its cost, and the build question is whether
-  regeneration can sustain it.
-- **Optional-cost** skills fire either way and consume Reserve for a stronger outcome when it is
-  available. Empowerment converts Reserve less efficiently than a costed skill's cost does —
-  flexibility is taxed, so costed skills remain the efficient way to spend. Empowerment uptime is a
-  build outcome worth reporting to the player.
-
-Cost shape is a skill property, not a class rule. Archetypes may still skew the flow — heavy
-spenders, or generators that build Reserve by acting or being hit — through skills and passives.
-Generation is a skill behaviour orthogonal to cost shape, not a fourth shape.
-
-Reserve regeneration falls under Vigor's global-regeneration mandate, and Reserve regeneration and
-capacity are first-class build stats. Specific regeneration, cost, capacity, and on-full/on-empty
-investment stays in itemisation and skills, as with every attribute.
-
 ## Damage Types
 
 Vers starts with six damage types. The set is intentionally wider than a traditional fantasy ARPG
@@ -130,30 +39,6 @@ memory pressure, and other effects that harm through thought, control, or unders
 
 Null damage is absence and impossibility: entropy, erasure, unreality, and forces that do not fit
 cleanly into the known material systems.
-
-## Threat Mix & Coverage
-
-Five of the six damage types are resistable: type-specific mitigation exists for Thermal, Voltaic,
-Toxic, Cognitive, and Null, and an endgame avatar is expected to reach the mitigation cap for the
-types its target regions deal. Kinetic is not resistable — it is the universal pressure type,
-handled through the other defensive layers rather than a resistance stat.
-
-Regions are weighted toward a dominant damage type but never deal it exclusively. Type mitigation is
-specced against a region's mix, and the type-agnostic layers — Avoidance, Block, Barrier — are the
-floor under whatever a build has not covered.
-
-Every damage type has at least one region or faction that expresses it. The strange types are
-progression-gated: Cognitive appears later, and Null is endgame. The type spectrum deepens as
-avatars push farther from Respite.
-
-Enemies use the same defensive layers as avatars, including Kinetic mitigation of their own — so
-Kinetic is universal pressure in both directions, not a strictly-best attacking type. Layer
-distribution across enemy families is a tuning choice (heavily avoidance-stacked enemies are rarely
-fun), and no mechanic converts incoming Kinetic into a resistable type.
-
-A region's damage mix is also its history: mechanical drift reads as Kinetic, Voltaic, and Thermal;
-ecological drift as Toxic; human drift as Cognitive; total drift as Null. Reading a threat table is
-reading the region's biography.
 
 ## Damage Events
 
@@ -246,6 +131,121 @@ The order is also the structure of expedition reporting: each defensive layer co
 escalation, and a hit that reaches life is a close call worth reporting. Reporting carries both a
 high-level summary and the drill-down that explains it — including what failed on defeat; its own
 design note owns the specifics.
+
+## Threat Mix & Coverage
+
+Five of the six damage types are resistable: type-specific mitigation exists for Thermal, Voltaic,
+Toxic, Cognitive, and Null, and an endgame avatar is expected to reach the mitigation cap for the
+types its target regions deal. Kinetic is not resistable — it is the universal pressure type,
+handled through the other defensive layers rather than a resistance stat.
+
+Regions are weighted toward a dominant damage type but never deal it exclusively. Type mitigation is
+specced against a region's mix, and the type-agnostic layers — Avoidance, Block, Barrier — are the
+floor under whatever a build has not covered.
+
+Every damage type has at least one region or faction that expresses it. The strange types are
+progression-gated: Cognitive appears later, and Null is endgame. The type spectrum deepens as
+avatars push farther from Respite.
+
+Enemies use the same defensive layers as avatars, including Kinetic mitigation of their own — so
+Kinetic is universal pressure in both directions, not a strictly-best attacking type. Layer
+distribution across enemy families is a tuning choice (heavily avoidance-stacked enemies are rarely
+fun), and no mechanic converts incoming Kinetic into a resistable type.
+
+A region's damage mix is also its history: mechanical drift reads as Kinetic, Voltaic, and Thermal;
+ecological drift as Toxic; human drift as Cognitive; total drift as Null. Reading a threat table is
+reading the region's biography.
+
+## Resource
+
+Avatars act on cadence: attacks, skills, and recovery run on their own beats, and idle play means
+those beats fire without piloting. Reserve (provisional name) is the single avatar resource layered
+over that cadence. Skills relate to it in one of three ways:
+
+- **Free** skills fire on their beat at no cost. They are the baseline lane: a starved avatar
+  degrades to its free skills instead of stalling.
+- **Costed** skills spend Reserve to fire. A costed skill that cannot pay skips its beat rather than
+  blocking the avatar — free skills hold the rotation's floor, and the real tax is the output gap
+  between that floor and what the costed beat would have added. A costed skill should be stronger
+  per beat than a free one by roughly the value of its cost, and the build question is whether
+  regeneration can sustain it.
+- **Optional-cost** skills fire either way and consume Reserve for a stronger outcome when it is
+  available. Empowerment converts Reserve less efficiently than a costed skill's cost does —
+  flexibility is taxed, so costed skills remain the efficient way to spend. Empowerment uptime is a
+  build outcome worth reporting to the player.
+
+Cost shape is a skill property, not a class rule. Archetypes may still skew the flow — heavy
+spenders, or generators that build Reserve by acting or being hit — through skills and passives.
+Generation is a skill behaviour orthogonal to cost shape, not a fourth shape.
+
+Reserve regeneration falls under Vigor's global-regeneration mandate, and Reserve regeneration and
+capacity are first-class build stats. Specific regeneration, cost, capacity, and on-full/on-empty
+investment stays in itemisation and skills, as with every attribute.
+
+## Attribute Layers
+
+Vers uses two attribute layers: avatar attributes and metagame attributes. They should not compete
+for the same item budget or progression choices.
+
+Avatar attributes are local to an avatar. They can appear on gear, avatar passives, class systems,
+and other character-power systems. They determine how an avatar survives and performs inside
+regions.
+
+Metagame attributes are persistent player/world progression. They can appear on metagame passive
+trees, idol-like systems, account progression, or other long-term systems. They determine how the
+player stabilizes, discovers, and extracts value from the world.
+
+## Avatar Attributes
+
+### Focus
+
+Focus is cadence. It governs action rate: how quickly an avatar's skill beats recur. It is not an
+attack- or cast-speed modifier — speed of execution stays specific itemisation.
+
+Focus should improve how often an avatar can act, but it should not replace specific attack-speed,
+cooldown, or trigger itemisation.
+
+### Vigor
+
+Vigor is sustain. It governs the global regeneration rate: Life, Barrier, and Reserve all recover
+faster under Vigor. Because one stat touches all three pools its power is deliberately curbed — and
+long-form idle combat keeps even curbed regeneration useful.
+
+Vigor should improve an avatar's broad staying power, but it should not replace specific investment
+into Life, Barrier, Block, recovery, or other defensive mechanics.
+
+### Will
+
+Will is effect. It represents the avatar's capacity to impose outcomes on the world.
+
+Will can scale damage, healing, shielding, control, summons, persistent effects, and other applied
+combat outcomes. It should provide broad baseline pressure without replacing specific investment
+into damage types, skills, ailments, minions, or other archetype-defining systems.
+
+## Metagame Attributes
+
+### Discipline
+
+Discipline is consistency. It represents stable progression, reduced friction, safer outcomes, and
+less variance across repeated expeditions.
+
+Discipline's variance reduction is non-combat only — yield spread, extraction reliability,
+progression friction — never incoming damage or defeat chance. Survival stays with the avatar's own
+defenses.
+
+### Insight
+
+Insight is discovery. It represents information, understanding, hidden opportunities, map knowledge,
+and the ability to recognize what the world is offering.
+
+### Aptitude
+
+Aptitude is refinement. It represents practical capability with items, systems, upgrades, and other
+long-term tools that turn resources into better outcomes.
+
+Each metagame attribute sits between two of Respite's institutions: Discipline between the authority
+and the industry, Insight between the authority and the market, and Aptitude between the industry
+and the market. Later alignment mechanics may draw on that geometry.
 
 ## Scaling Philosophy
 


### PR DESCRIPTION
## Description

Fleshes out design notes 001/002 with the decisions their first landing deferred, following an interactive design pass and a four-lens agent review (creative/systems/consistency/downstream-readiness).

- Respite (officially Habitat Nine) replaces Sanctuary; Null replaces Void; aether removed
- Post-administrative world premise; avatar canonized as worn remnant of "avatar of ___", capacity inborn
- Defeat stakes: XP loss without de-level, unbanked yield and instance investment lost; extraction is automatable policy
- Reserve resource: free/costed/optional-cost skills, free skills as rotation floor, generation orthogonal
- Focus = cooldown rate; Vigor = global regen of Life/Barrier/Reserve
- Crits both sides, independent enemy levers, no hard ceilings; enemies share player defensive layers incl. Kinetic mitigation
- Institutions (authority/market/industry) + outer-habitat faction axis; naming grammar; MMO shape (market/ladders/PvP, instanced)
- Adds banned-words list to agent guidelines (separate commit)

## Testing

- [x] `bun run format:check` passes (docs-only change)

## Context

Companion design tickets filed: #270 combat model, #271 expedition reporting, #272 regions & world map.