### PR TITLE
fix(#282): patch kysely-codegen to lazy-load typescript

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -660,6 +660,9 @@
       },
     },
   },
+  "patchedDependencies": {
+    "kysely-codegen@0.20.0": "patches/kysely-codegen@0.20.0.patch",
+  },
   "catalog": {
     "@faker-js/faker": "10.5.0",
     "@hono/node-server": "1.13.8",

--- a/package.json
+++ b/package.json
@@ -97,5 +97,8 @@
     "typescript": "catalog:",
     "vitest": "catalog:"
   },
-  "packageManager": "bun@1.3.10"
+  "packageManager": "bun@1.3.10",
+  "patchedDependencies": {
+    "kysely-codegen@0.20.0": "patches/kysely-codegen@0.20.0.patch"
+  }
 }

--- a/patches/kysely-codegen@0.20.0.patch
+++ b/patches/kysely-codegen@0.20.0.patch
@@ -1,0 +1,20 @@
+diff --git a/dist/generator/parser/type-expression-parser.js b/dist/generator/parser/type-expression-parser.js
+index 4ad30a0204710b29a9d6d257b7b6b8636abc2ade..16d8dccce95271276aeb3d90069c6f2a73cdaca2 100644
+--- a/dist/generator/parser/type-expression-parser.js
++++ b/dist/generator/parser/type-expression-parser.js
+@@ -16,7 +16,14 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
+ var _TypeExpressionParser_instances, _TypeExpressionParser_sourceFile, _TypeExpressionParser_collectTypeReferences, _TypeExpressionParser_convertTypeNode;
+ Object.defineProperty(exports, "__esModule", { value: true });
+ exports.typeExpressionParser = exports.TypeExpressionParser = void 0;
+-const typescript_1 = __importDefault(require("typescript"));
++// Lazily load typescript: it is only needed to parse type-override strings,
++// and an eager require crashes under typescript >= 7 (no CJS entrypoint).
++let _typescript;
++const typescript_1 = {
++    get default() {
++        return (_typescript ??= __importDefault(require("typescript")).default);
++    },
++};
+ const generic_expression_node_1 = require("../ast/generic-expression-node");
+ const identifier_node_1 = require("../ast/identifier-node");
+ const literal_node_1 = require("../ast/literal-node");

--- a/projects/lib-db/package.json
+++ b/projects/lib-db/package.json
@@ -7,7 +7,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "db:codegen": "kysely-codegen --camel-case --out-file src/schema.generated.ts",
+    "db:codegen": "kysely-codegen --camel-case --out-file src/schema.generated.ts && oxfmt src/schema.generated.ts",
     "db:migrate": "kysely migrate:latest",
     "db:migrate:make": "kysely migrate:make",
     "db:rollback": "kysely migrate:down",


### PR DESCRIPTION
## Description

Closes #282

`bun run db:codegen` crashed at load under TS 7: kysely-codegen eagerly `require`s typescript, whose CJS entrypoint TS 7 removed. A bun patch defers that require to first use — it only parses type-override strings, which our config never supplies — so codegen runs without touching typescript.

- typescript is a phantom dep of kysely-codegen (undeclared, resolved from our root), so upstream can't be version-pinned around it
- db:codegen now runs oxfmt over its output, making regeneration byte-stable with the committed schema in one command
- Verified end-to-end: migrated a fresh test-container database, ran db:codegen, output byte-identical to the committed file

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality (n/a — dependency patch, verified by regeneration round-trip)