### PR TITLE
docs: rewrite agent partials and technical docs as final-state prose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,20 +262,33 @@ name minus the taxonomy prefix: `lib-` and `app-` strip (`lib-utils` → `@vers/
 ## Styling
 
 Panda CSS 2.0 spans all four consumers (lib-panda-preset, lib-styled-system, lib-design-system,
-app-web). lib-panda-preset composes `presets: [presetBase, presetPanda]` from
+app-web), pinned at 2.0.0-beta.8 — no stable 2.0 release exists — through `bunfig.toml`'s
+`minimumReleaseAgeExcludes`. lib-panda-preset composes `presets: [presetBase, presetPanda]` from
 `@pandacss/preset-base` and `@pandacss/preset-panda` — Panda 2.0 ships no bundled default preset.
 CSS values that aren't theme tokens need the bracket escape hatch (`cursor: '[pointer]'`,
 `borderWidth: '[1px]'`) — 2.0's `SystemStyleObject` value types reject arbitrary strings/numbers.
+
+### Screens
+
+Screens and routes are built workable-only: compose existing `lib-design-system` components and
+semantic tokens (`bg.*`, `text.*`, `border.*`, `accent.*`) — no bespoke visual styling beyond
+layout, no new one-off colors/fonts/animations, no polish passes. The semantic-token layer is the
+stable contract: re-skins change token values, never token names, so screens that stick to it adapt
+for free. A screen needing a component that doesn't exist yet builds the minimal version in its own
+PR and promotes it into `lib-design-system` when a second consumer appears.
 
 ## Running things
 
 - `bun install` — whole workspace (`--frozen-lockfile` in CI; `bun.lock` is committed).
 - `bun run typecheck` — `turbo run typecheck` (per-project `tsc --noEmit`); one project via
   `--filter=@vers/<name>`.
-- `bun run test` — `turbo run test` (per-project `bun test`); one project via `--filter`.
-  Postgres-backed suites need `bun run pg:test-container:start` first. Each package carries its own
-  `bunfig.toml` (bunfig is read from cwd, not merged up) — root-invoked `bun test <file>` still
-  resolves jest-extended matchers from the root preload.
+- `bun run test` — `turbo run test`, each project's own runner; one project via `--filter`. The
+  repo's test runner is `bun test`; a package runs vitest exactly when it has a `vitest.config.ts`
+  (the root `vitest.workspace.ts` globs those, and deleting the config drops the package from the
+  vitest run). Never add vitest to a new package, and never re-add it to a converted one to "match"
+  a vitest neighbour. Postgres-backed suites need `bun run pg:test-container:start` first. bun-test
+  packages each carry their own `bunfig.toml` (bunfig is read from cwd, not merged up) —
+  root-invoked `bun test <file>` still resolves jest-extended matchers from the root preload.
 - `bun run lint` / `bun run lint:fix` — `turbo run codegen typegen`, then
   `oxlint --type-aware --type-check --report-unused-disable-directives-severity error` over the
   whole tree (`.oxlintrc.json` at the root; oxlint-tsgolint underneath, needs the TS7 toolchain —
@@ -284,13 +297,17 @@ CSS values that aren't theme tokens need the bracket escape hatch (`cursor: '[po
   hundreds of false violations. Every type-aware rule is on. Two exceptions are permanent:
   `only-throw-error`'s documented app-web override, and the inline directives on
   `lib-idle-core`/`lib-aether-core` tick/lifecycle handlers that mutate their entity parameter by
-  design. For `typescript/prefer-readonly-parameter-types`, a function's own
-  data/config/props/option types are made `readonly` (or the param `Readonly<…>`-wrapped; React
-  props `Readonly<Props>`), and framework/library handles that have no readonly form (a
-  `Kysely`/`Elysia`/`RPCHandler`/`Request` handle, a `Date`, …) are exempted per-type via the rule's
-  `allow` list in `.oxlintrc.json` — never an inline marker. Only a genuinely un-`readonly`-able own
-  type (a generic callback-arg object, a `ZodType`-bearing shape, a React-element wrapper) carries a
-  single honest inline directive stating why; `allow` covers the rest.
+  design. Pre-existing violations are baselined inline with
+  `// oxlint-disable-next-line <rule> -- baseline(#236)` comments rather than turned off in config;
+  the unused-directive check is the ratchet — fixing a baselined site makes its comment stale and
+  lint fails until the comment is deleted. `typescript/prefer-readonly-parameter-types` is never
+  baselined: a function's own data/config/props/option types are made `readonly` (or the param
+  `Readonly<…>`-wrapped; React props `Readonly<Props>`), and framework/library handles that have no
+  readonly form (a `Kysely`/`Elysia`/`RPCHandler`/`Request` handle, a `Date`, …) are exempted
+  per-type via the rule's `allow` list in `.oxlintrc.json` — never an inline marker. Only a
+  genuinely un-`readonly`-able own type (a generic callback-arg object, a `ZodType`-bearing shape, a
+  React-element wrapper) carries a single honest inline directive stating why; `allow` covers the
+  rest.
 - `bun run format` — `oxfmt .` (`.oxfmtrc.json` at the root), then `format-codemod` (blank-line
   padding) over the whole tree. The codemod's exclusions live in the root `.formatignore` (one glob
   per line, `#` comments) — that file keeps it off committed codegen output (panda's `styled-system`
@@ -466,33 +483,3 @@ Services, apps, and DB-backed libraries whose tests exercise a real postgres fol
   `registerBunTestCleanup()`.
 - **Auth.** s2s tests use the real verification path: an asymmetric keypair from
   `getTestServiceKeyPair()`, tokens minted with `createServiceToken`.
-
-## TO BE CLEANED UP
-
-Temporary states of the tree, each tagged with the issue that retires it — delete a bullet when its
-issue closes.
-
-- **Vitest survives in unswept packages (#266).** The repo's test runner is `bun test`; a package is
-  on vitest exactly when it has a `vitest.config.ts` (the root `vitest.workspace.ts` globs those,
-  `turbo run test` uses each package's own runner, and deleting the config drops the package from
-  the vitest run). Never add vitest to a new package, and never re-add it to a converted one to
-  "match" a still-on-vitest neighbour. Where `agents/shared.md` assumes bun test everywhere (e.g.
-  "run `bun test` from the repo root"), still-on-vitest packages follow their own config until
-  swept.
-- **Lint baseline backlog (#236).** ~550 pre-existing sites are baselined inline with
-  `// oxlint-disable-next-line <rule> -- baseline(#236)` comments rather than turned off in config;
-  the unused-directive check is the ratchet — fixing a baselined site makes its comment stale and
-  lint fails until the comment is deleted. `typescript/prefer-readonly-parameter-types` is never
-  baselined: new code makes its own types `readonly` and exempts framework handles via the rule's
-  `allow` list.
-- **Panda CSS is a beta pin.** 2.0.0-beta.8 — no stable release exists, so the packages are pinned
-  through `bunfig.toml`'s `minimumReleaseAgeExcludes`, with a removal issue tracking the jump to
-  stable.
-- **Screens are functional-first until the design-system rebuild (#246, fed by the #245 design pass)
-  closes.** Screens and routes are built workable-only: compose existing `lib-design-system`
-  components and semantic tokens (`bg.*`, `text.*`, `border.*`, `accent.*`) — no bespoke visual
-  styling beyond layout, no new one-off colors/fonts/animations, no polish passes. The
-  semantic-token layer is the stable contract: the #246 re-skin keeps token names unchanged, so
-  screens that stick to it adapt for free. A screen needing a component that doesn't exist yet
-  builds the minimal version in its own PR and promotes it into `lib-design-system` when a second
-  consumer appears.

--- a/agents/project.md
+++ b/agents/project.md
@@ -59,20 +59,33 @@ name minus the taxonomy prefix: `lib-` and `app-` strip (`lib-utils` → `@vers/
 ## Styling
 
 Panda CSS 2.0 spans all four consumers (lib-panda-preset, lib-styled-system, lib-design-system,
-app-web). lib-panda-preset composes `presets: [presetBase, presetPanda]` from
+app-web), pinned at 2.0.0-beta.8 — no stable 2.0 release exists — through `bunfig.toml`'s
+`minimumReleaseAgeExcludes`. lib-panda-preset composes `presets: [presetBase, presetPanda]` from
 `@pandacss/preset-base` and `@pandacss/preset-panda` — Panda 2.0 ships no bundled default preset.
 CSS values that aren't theme tokens need the bracket escape hatch (`cursor: '[pointer]'`,
 `borderWidth: '[1px]'`) — 2.0's `SystemStyleObject` value types reject arbitrary strings/numbers.
+
+### Screens
+
+Screens and routes are built workable-only: compose existing `lib-design-system` components and
+semantic tokens (`bg.*`, `text.*`, `border.*`, `accent.*`) — no bespoke visual styling beyond
+layout, no new one-off colors/fonts/animations, no polish passes. The semantic-token layer is the
+stable contract: re-skins change token values, never token names, so screens that stick to it adapt
+for free. A screen needing a component that doesn't exist yet builds the minimal version in its own
+PR and promotes it into `lib-design-system` when a second consumer appears.
 
 ## Running things
 
 - `bun install` — whole workspace (`--frozen-lockfile` in CI; `bun.lock` is committed).
 - `bun run typecheck` — `turbo run typecheck` (per-project `tsc --noEmit`); one project via
   `--filter=@vers/<name>`.
-- `bun run test` — `turbo run test` (per-project `bun test`); one project via `--filter`.
-  Postgres-backed suites need `bun run pg:test-container:start` first. Each package carries its own
-  `bunfig.toml` (bunfig is read from cwd, not merged up) — root-invoked `bun test <file>` still
-  resolves jest-extended matchers from the root preload.
+- `bun run test` — `turbo run test`, each project's own runner; one project via `--filter`. The
+  repo's test runner is `bun test`; a package runs vitest exactly when it has a `vitest.config.ts`
+  (the root `vitest.workspace.ts` globs those, and deleting the config drops the package from the
+  vitest run). Never add vitest to a new package, and never re-add it to a converted one to "match"
+  a vitest neighbour. Postgres-backed suites need `bun run pg:test-container:start` first. bun-test
+  packages each carry their own `bunfig.toml` (bunfig is read from cwd, not merged up) —
+  root-invoked `bun test <file>` still resolves jest-extended matchers from the root preload.
 - `bun run lint` / `bun run lint:fix` — `turbo run codegen typegen`, then
   `oxlint --type-aware --type-check --report-unused-disable-directives-severity error` over the
   whole tree (`.oxlintrc.json` at the root; oxlint-tsgolint underneath, needs the TS7 toolchain —
@@ -81,13 +94,17 @@ CSS values that aren't theme tokens need the bracket escape hatch (`cursor: '[po
   hundreds of false violations. Every type-aware rule is on. Two exceptions are permanent:
   `only-throw-error`'s documented app-web override, and the inline directives on
   `lib-idle-core`/`lib-aether-core` tick/lifecycle handlers that mutate their entity parameter by
-  design. For `typescript/prefer-readonly-parameter-types`, a function's own
-  data/config/props/option types are made `readonly` (or the param `Readonly<…>`-wrapped; React
-  props `Readonly<Props>`), and framework/library handles that have no readonly form (a
-  `Kysely`/`Elysia`/`RPCHandler`/`Request` handle, a `Date`, …) are exempted per-type via the rule's
-  `allow` list in `.oxlintrc.json` — never an inline marker. Only a genuinely un-`readonly`-able own
-  type (a generic callback-arg object, a `ZodType`-bearing shape, a React-element wrapper) carries a
-  single honest inline directive stating why; `allow` covers the rest.
+  design. Pre-existing violations are baselined inline with
+  `// oxlint-disable-next-line <rule> -- baseline(#236)` comments rather than turned off in config;
+  the unused-directive check is the ratchet — fixing a baselined site makes its comment stale and
+  lint fails until the comment is deleted. `typescript/prefer-readonly-parameter-types` is never
+  baselined: a function's own data/config/props/option types are made `readonly` (or the param
+  `Readonly<…>`-wrapped; React props `Readonly<Props>`), and framework/library handles that have no
+  readonly form (a `Kysely`/`Elysia`/`RPCHandler`/`Request` handle, a `Date`, …) are exempted
+  per-type via the rule's `allow` list in `.oxlintrc.json` — never an inline marker. Only a
+  genuinely un-`readonly`-able own type (a generic callback-arg object, a `ZodType`-bearing shape, a
+  React-element wrapper) carries a single honest inline directive stating why; `allow` covers the
+  rest.
 - `bun run format` — `oxfmt .` (`.oxfmtrc.json` at the root), then `format-codemod` (blank-line
   padding) over the whole tree. The codemod's exclusions live in the root `.formatignore` (one glob
   per line, `#` comments) — that file keeps it off committed codegen output (panda's `styled-system`
@@ -263,33 +280,3 @@ Services, apps, and DB-backed libraries whose tests exercise a real postgres fol
   `registerBunTestCleanup()`.
 - **Auth.** s2s tests use the real verification path: an asymmetric keypair from
   `getTestServiceKeyPair()`, tokens minted with `createServiceToken`.
-
-## TO BE CLEANED UP
-
-Temporary states of the tree, each tagged with the issue that retires it — delete a bullet when its
-issue closes.
-
-- **Vitest survives in unswept packages (#266).** The repo's test runner is `bun test`; a package is
-  on vitest exactly when it has a `vitest.config.ts` (the root `vitest.workspace.ts` globs those,
-  `turbo run test` uses each package's own runner, and deleting the config drops the package from
-  the vitest run). Never add vitest to a new package, and never re-add it to a converted one to
-  "match" a still-on-vitest neighbour. Where `agents/shared.md` assumes bun test everywhere (e.g.
-  "run `bun test` from the repo root"), still-on-vitest packages follow their own config until
-  swept.
-- **Lint baseline backlog (#236).** ~550 pre-existing sites are baselined inline with
-  `// oxlint-disable-next-line <rule> -- baseline(#236)` comments rather than turned off in config;
-  the unused-directive check is the ratchet — fixing a baselined site makes its comment stale and
-  lint fails until the comment is deleted. `typescript/prefer-readonly-parameter-types` is never
-  baselined: new code makes its own types `readonly` and exempts framework handles via the rule's
-  `allow` list.
-- **Panda CSS is a beta pin.** 2.0.0-beta.8 — no stable release exists, so the packages are pinned
-  through `bunfig.toml`'s `minimumReleaseAgeExcludes`, with a removal issue tracking the jump to
-  stable.
-- **Screens are functional-first until the design-system rebuild (#246, fed by the #245 design pass)
-  closes.** Screens and routes are built workable-only: compose existing `lib-design-system`
-  components and semantic tokens (`bg.*`, `text.*`, `border.*`, `accent.*`) — no bespoke visual
-  styling beyond layout, no new one-off colors/fonts/animations, no polish passes. The
-  semantic-token layer is the stable contract: the #246 re-skin keeps token names unchanged, so
-  screens that stick to it adapt for free. A screen needing a component that doesn't exist yet
-  builds the minimal version in its own PR and promotes it into `lib-design-system` when a second
-  consumer appears.

--- a/docs/database.md
+++ b/docs/database.md
@@ -71,8 +71,8 @@ cd projects/lib-db
 bun --env-file=.env.local run db:migrate   # also db:seed, db:rollback
 ```
 
-`db:codegen` is broken under the workspace's TypeScript 7 (#282); regenerate through an isolated
-kysely-codegen + TS5 install until that closes.
+`db:codegen` is broken under the workspace's TypeScript 7; regenerate through an isolated
+kysely-codegen + TS5 install.
 
 For isolated experiments, branch the database instead of sharing `main`:
 

--- a/docs/service-contracts.md
+++ b/docs/service-contracts.md
@@ -97,8 +97,7 @@ keeps clients contract-only.
 
 `@vers/service-runtime` provides the shell around this — a `createService(...)` entry composing the
 runtime's Elysia plugins — so a new service is roughly: a contract package, handlers, and one
-`createService` call. OpenTelemetry is part of the shell (Grafana-flavored sink; the shared service
-gauges are tracked in #182).
+`createService` call. OpenTelemetry is part of the shell (Grafana-flavored sink).
 
 ## The client side
 


### PR DESCRIPTION
## Description

Rewrites the agent partials and technical docs as final-state prose: no temporary state, no roadmap narrative, no issue references (verbatim code tokens like the `baseline(#236)` marker excepted), no relational framing.

- `agents/project.md`: TO BE CLEANED UP section deleted; every operative rule redistributed timelessly (vitest membership stated as its mechanical criterion, lint baseline, panda pin, screens gate, frozen GraphQL artifacts)
- `docs/000-overview.md`: topology and core-technology corrected to the tree; framework naming for the unbuilt web stack removed
- `docs/001-auth.md`: ADR form converted to present-tense reference; facts and diagram unchanged
- `docs/002-service-contracts.md`, `docs/003-database.md`: issue refs and narrative framing removed
- `agents/shared.md`: phrasing only; its delta upstreams to zgeoff/tools separately

## Testing

- [x] `bun run build:agents` regenerated AGENTS.md; `format:check` passes

## Context

Written under the docs-writing skill (global, `~/.claude/skills/docs-writing`).
