### PR TITLE
fix: disable prefer-destructuring in oxlint config

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -82,16 +82,9 @@
       { "argsIgnorePattern": "^_", "ignoreRestSiblings": true, "varsIgnorePattern": "^_" }
     ],
 
-    // destructuring reads well at declaration sites, but satisfying it on
-    // assignments forces the parenthesized `({ x } = y)` form — plain member
-    // assignment instead
-    "prefer-destructuring": [
-      "error",
-      {
-        "VariableDeclarator": { "array": true, "object": true },
-        "AssignmentExpression": { "array": false, "object": false }
-      }
-    ],
+    // house style is direct member access; "off" because the "style" category
+    // default would otherwise re-enable this with stock options
+    "prefer-destructuring": "off",
 
     // consistent function syntax — declarations top level, arrows for inside
     // blocks and callbacks

--- a/projects/service-user/src/handlers/update-email.ts
+++ b/projects/service-user/src/handlers/update-email.ts
@@ -25,7 +25,6 @@ export async function updateEmail(
   db: Kysely<DB>,
   opts: UpdateEmailOpts,
 ): Promise<{ updatedID: string }> {
-  // oxlint-disable-next-line prefer-destructuring -- narrowed capture: TS narrowing does not cross the closure boundary
   const actingUserId = opts.context.actingUserId;
 
   if (actingUserId === null) {


### PR DESCRIPTION
## Description

Disables `prefer-destructuring`, which entered via the oxlint migration (#221) without an explicit decision and mandates the opposite of house style (destructuring over direct member access); its pre-commit autofix rewrote conforming code into destructures.

- Explicit `"off"` rather than deletion — the `"style": "error"` category default would re-enable it with stock options
- Removes the one now-stale disable directive (service-user `update-email.ts`, which had suppressed the rule to keep correct code)
- Upstream shared config: zgeoff/tools#36

## Testing

- [x] `bun run lint` passes (including the unused-directive ratchet)
- [x] `bun run typecheck` passes
- [x] `bun run test` passes (pre-push affected)
