### PR TITLE
docs(game-design): defensive archetypes note + azimuth attribute rework

### DIFF
--- a/docs/game-design/001-core-themes-world-fiction.md
+++ b/docs/game-design/001-core-themes-world-fiction.md
@@ -181,8 +181,8 @@ itself.
 ## Vocabulary Register
 
 The register covers world vocabulary and cross-cutting provisional terms. System vocabulary — damage
-types, defensive layers, attributes — is defined in the damage-model note and is canonical under the
-naming grammar's first rule.
+types, hit deliveries, defensive layers, the Compass — is defined in the damage-model and
+defensive-archetypes notes and is canonical under the naming grammar's first rule.
 
 | Term       | Status      | Notes                                                                            |
 | ---------- | ----------- | -------------------------------------------------------------------------------- |
@@ -195,5 +195,5 @@ naming grammar's first rule.
 | loot       | Keep        | Core ARPG promise.                                                               |
 | power      | Keep        | Umbrella term for rewards that help the player push farther or more efficiently. |
 | Reserve    | Provisional | The single avatar skill resource; name open until itemisation settles.           |
-| buffer     | Reserved    | Held for a future deferred-damage defensive mechanic; distinct from Barrier.     |
+| Buffer     | Canonical   | Deferred-damage defensive layer; defined in the defensive-archetypes note.       |
 | glyph      | Not canon   | Visual candidate for mythic systems, not yet a world rule.                       |

--- a/docs/game-design/001-core-themes-world-fiction.md
+++ b/docs/game-design/001-core-themes-world-fiction.md
@@ -20,8 +20,8 @@ long-term avatar investment, and the steady conversion of rewards into power. Po
 result of successful expeditions: equipment, materials, knowledge, access, avatar enhancement, and
 anything else that helps the player push farther or more efficiently.
 
-Idle is not a secondary wrapper. The fantasy is not direct action combat; it is shaping your avatar,
-sending them into the world, and watching their build prove itself over time.
+Idle is the fantasy itself: shaping your avatar, sending them into the world, and watching their
+build prove itself over time.
 
 ### World Premise
 
@@ -53,13 +53,11 @@ without making lore the main activity.
 
 ### Avatar Premise
 
-Avatar is the canonical term.
-
 An avatar is an enhanced human shaped by the player and capable of entering regions that ordinary
 people cannot survive. "Avatar" is the worn remnant of a longer phrase — avatar _of_ something — and
 what filled the blank is lost, contested knowledge. What is known: the capacity is inborn, appearing
 by chance in some and not others, and no institution can manufacture it. The player-facing fantasy
-stays simple: shape your avatar, send them into danger, recover power, and push deeper.
+stays simple — the contract, embodied in one person.
 
 Avatars are embodied people, not disposable drones. They can be augmented, equipped, specialized,
 injured, defeated, recovered, ranked, and eventually set against other avatars.
@@ -81,10 +79,10 @@ Three institutions anchor Respite, each defined by what it wants from an avatar'
   how its work held up in the field. The crafting screens are its artifacts.
 
 Each institution owns the screens that express it: a major screen reads as an artifact of the
-institution behind it, so each feels distinct and inhabited. These are thematic anchors — mechanics
-attach to them as later notes need a licensor, a market, or a fabricator, and institution names wait
-for the world's naming grammar. Players may eventually align with an institution for perks; that is
-later system design, noted here so institutions are built to bear it.
+institution behind it, so each feels distinct and inhabited. These are thematic anchors: downstream
+notes attach mechanics to them as they need a licensor, a market, or a fabricator, and institution
+names follow the world's naming grammar. Institutions are built to bear player alignment and perks;
+that design belongs to its own note.
 
 The other habitats are the external axis. Records are incomplete: some habitats fell and are ruin,
 some still run with no one left inside, some broke away and became societies Respite no longer
@@ -112,8 +110,8 @@ through danger, comparison, mastery, and eventual direct conflict.
 The MMO layer is economic and competitive, not spatial: play is instanced, and players meet through
 a shared market, ladders, and eventually direct PvP. Loot is tradeable, and drop, crafting, and
 currency design should assume a player economy from the start. Direct PvP is build against build —
-two players' planning resolved in a fight both can study — and arrives after the PvE loop is proven.
-Competition over regions is comparative (who pushes farther, faster), not territorial.
+two players' planning resolved in a fight both can study. Competition over regions is comparative
+(who pushes farther, faster), not territorial.
 
 ### Defeat Stakes
 
@@ -124,8 +122,8 @@ Defeat costs progress, not the avatar: experience toward the next level is lost 
 removed; yield from the run that was not already extracted is lost; and any investment in the
 activity instance is lost — the instance resets to baseline. Extraction is the player's mid-run
 banking decision: yield stays at risk until it is pulled out. Extraction is set as policy, not
-performed by hand — automated rules (extract at a yield threshold, or when defenses degrade) are
-intended, so unattended runs bank deliberately.
+performed by hand — automated rules (extract at a yield threshold, or when defenses degrade) let
+unattended runs bank deliberately.
 
 Exact loss rates, floors, and extraction mechanics belong to the progression and economy notes.
 
@@ -163,14 +161,13 @@ to master, but strangely enough to feel deep.
 ### Competitive Expedition
 
 Progress is measured by how far and efficiently avatars can push into the world. Ladders and PvP
-should eventually make that competition explicit, but the core pressure starts with the world
-itself.
+make that competition explicit, but the core pressure starts with the world itself.
 
 ## Naming Grammar
 
-1. **Two registers.** System vocabulary (damage types, defensive layers, attributes) is clinical and
-   stable — it lives in tables and logs. World vocabulary (places, factions, enemies, items) is worn
-   and human. Never swap them.
+1. **Two registers.** System vocabulary (damage types, hit deliveries, defensive layers, the
+   Compass) is clinical and stable — it lives in tables and logs. World vocabulary (places,
+   factions, enemies, items) is worn and human. Never swap them.
 2. **The worn-name pattern.** World things carry an official designation and the vernacular name
    that won: Habitat Nine → Respite. The pattern is the template, not a one-off.
 3. **Numbers are history.** Serials and indices read as accumulated record, not decoration.
@@ -180,9 +177,8 @@ itself.
 
 ## Vocabulary Register
 
-The register covers world vocabulary and cross-cutting provisional terms. System vocabulary — damage
-types, hit deliveries, defensive layers, the Compass — is defined in the damage-model and
-defensive-archetypes notes and is canonical under the naming grammar's first rule.
+The register covers world vocabulary and cross-cutting provisional terms. System vocabulary lives in
+the damage-model and defensive-archetypes notes.
 
 | Term       | Status      | Notes                                                                            |
 | ---------- | ----------- | -------------------------------------------------------------------------------- |
@@ -195,5 +191,4 @@ defensive-archetypes notes and is canonical under the naming grammar's first rul
 | loot       | Keep        | Core ARPG promise.                                                               |
 | power      | Keep        | Umbrella term for rewards that help the player push farther or more efficiently. |
 | Reserve    | Provisional | The single avatar skill resource; name open until itemisation settles.           |
-| Buffer     | Canonical   | Deferred-damage defensive layer; defined in the defensive-archetypes note.       |
 | glyph      | Not canon   | Visual candidate for mythic systems, not yet a world rule.                       |

--- a/docs/game-design/001-core-themes-world-fiction.md
+++ b/docs/game-design/001-core-themes-world-fiction.md
@@ -167,10 +167,11 @@ make that competition explicit, but the core pressure starts with the world itse
 ## Naming Grammar
 
 1. **Two registers.** System vocabulary (damage types, hit deliveries, defensive layers, the
-   Compass) is clinical and stable — it lives in tables and logs. World vocabulary (places,
+   Azimuth) is clinical and stable — it lives in tables and logs. World vocabulary (places,
    factions, enemies, items) is worn and human. Never swap them.
 2. **The worn-name pattern.** World things carry an official designation and the vernacular name
-   that won: Habitat Nine → Respite. The pattern is the template, not a one-off.
+   that won: Habitat Nine → Respite, Formulation Eight → Aether. The pattern is the template, not a
+   one-off.
 3. **Numbers are history.** Serials and indices read as accumulated record, not decoration.
 4. **Institutions are called what citizens call them**, never their charter name.
 5. **Register bans.** No fantasy-magic words in either vocabulary. No console words (`root`,
@@ -178,18 +179,19 @@ make that competition explicit, but the core pressure starts with the world itse
 
 ## Vocabulary Register
 
-The register covers world vocabulary and cross-cutting provisional terms. System vocabulary lives in
-the damage-model and defensive-archetypes notes.
+The register covers world vocabulary and cross-cutting terms. System vocabulary lives in the
+damage-model and defensive-archetypes notes.
 
-| Term       | Status      | Notes                                                                            |
-| ---------- | ----------- | -------------------------------------------------------------------------------- |
-| Vers       | Keep        | Carries universe and versus: world exploration plus competition.                 |
-| avatar     | Canonical   | Enhanced human shaped by the player and sent into dangerous regions.             |
-| Respite    | Canonical   | The largest human center; officially Habitat Nine — the vernacular name won.     |
-| world      | Keep        | The broad play space and fiction layer; not just a menu.                         |
-| region     | Provisional | Neutral term for world-map areas.                                                |
-| expedition | Provisional | The core activity: outfit an avatar, send it out, recover what returns.          |
-| loot       | Keep        | Core ARPG promise.                                                               |
-| power      | Keep        | Umbrella term for rewards that help the player push farther or more efficiently. |
-| Reserve    | Provisional | The single avatar skill resource; name open until itemisation settles.           |
-| glyph      | Not canon   | Visual candidate for mythic systems, not yet a world rule.                       |
+| Term       | Status      | Notes                                                                                                                           |
+| ---------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| Vers       | Keep        | Carries universe and versus: world exploration plus competition.                                                                |
+| avatar     | Canonical   | Enhanced human shaped by the player and sent into dangerous regions.                                                            |
+| Respite    | Canonical   | The largest human center; officially Habitat Nine — the vernacular name won.                                                    |
+| world      | Keep        | The broad play space and fiction layer; not just a menu.                                                                        |
+| region     | Provisional | Neutral term for world-map areas.                                                                                               |
+| expedition | Provisional | The core activity: outfit an avatar, send it out, recover what returns.                                                         |
+| loot       | Keep        | Core ARPG promise.                                                                                                              |
+| power      | Keep        | Umbrella term for rewards that help the player push farther or more efficiently.                                                |
+| Aether     | Canonical   | The single avatar skill resource: the medium avatars are infused with. Officially Formulation Eight — the old physics word won. |
+| commitment | Provisional | UI label for a build's distance from center; prose uses committed and centered as plain descriptions.                           |
+| glyph      | Not canon   | Visual candidate for mythic systems, not yet a world rule.                                                                      |

--- a/docs/game-design/001-core-themes-world-fiction.md
+++ b/docs/game-design/001-core-themes-world-fiction.md
@@ -55,9 +55,10 @@ without making lore the main activity.
 
 An avatar is an enhanced human shaped by the player and capable of entering regions that ordinary
 people cannot survive. "Avatar" is the worn remnant of a longer phrase — avatar _of_ something — and
-what filled the blank is lost, contested knowledge. What is known: the capacity is inborn, appearing
-by chance in some and not others, and no institution can manufacture it. The player-facing fantasy
-stays simple — the contract, embodied in one person.
+what filled the blank is lost; rival accounts contest what it was. What is known: the capacity is
+inborn, appearing by chance in some and not others, and no institution can manufacture it. The
+player-facing fantasy stays simple: shape your avatar, send them into danger, recover power, push
+deeper — the contract, embodied in one person.
 
 Avatars are embodied people, not disposable drones. They can be augmented, equipped, specialized,
 injured, defeated, recovered, ranked, and eventually set against other avatars.
@@ -81,8 +82,8 @@ Three institutions anchor Respite, each defined by what it wants from an avatar'
 Each institution owns the screens that express it: a major screen reads as an artifact of the
 institution behind it, so each feels distinct and inhabited. These are thematic anchors: downstream
 notes attach mechanics to them as they need a licensor, a market, or a fabricator, and institution
-names follow the world's naming grammar. Institutions are built to bear player alignment and perks;
-that design belongs to its own note.
+names follow the world's naming grammar. Institutions are designed to carry player alignment and
+perks; that design belongs to its own note.
 
 The other habitats are the external axis. Records are incomplete: some habitats fell and are ruin,
 some still run with no one left inside, some broke away and became societies Respite no longer

--- a/docs/game-design/001-core-themes-world-fiction.md
+++ b/docs/game-design/001-core-themes-world-fiction.md
@@ -170,7 +170,7 @@ make that competition explicit, but the core pressure starts with the world itse
    Azimuth) is clinical and stable — it lives in tables and logs. World vocabulary (places,
    factions, enemies, items) is worn and human. Never swap them.
 2. **The worn-name pattern.** World things carry an official designation and the vernacular name
-   that won: Habitat Nine → Respite, Formulation Eight → Aether. The pattern is the template, not a
+   that won: Habitat Nine → Respite, the somatic factor → Aether. The pattern is the template, not a
    one-off.
 3. **Numbers are history.** Serials and indices read as accumulated record, not decoration.
 4. **Institutions are called what citizens call them**, never their charter name.
@@ -182,16 +182,16 @@ make that competition explicit, but the core pressure starts with the world itse
 The register covers world vocabulary and cross-cutting terms. System vocabulary lives in the
 damage-model and defensive-archetypes notes.
 
-| Term       | Status      | Notes                                                                                                                           |
-| ---------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| Vers       | Keep        | Carries universe and versus: world exploration plus competition.                                                                |
-| avatar     | Canonical   | Enhanced human shaped by the player and sent into dangerous regions.                                                            |
-| Respite    | Canonical   | The largest human center; officially Habitat Nine — the vernacular name won.                                                    |
-| world      | Keep        | The broad play space and fiction layer; not just a menu.                                                                        |
-| region     | Provisional | Neutral term for world-map areas.                                                                                               |
-| expedition | Provisional | The core activity: outfit an avatar, send it out, recover what returns.                                                         |
-| loot       | Keep        | Core ARPG promise.                                                                                                              |
-| power      | Keep        | Umbrella term for rewards that help the player push farther or more efficiently.                                                |
-| Aether     | Canonical   | The single avatar skill resource: the medium avatars are infused with. Officially Formulation Eight — the old physics word won. |
-| commitment | Provisional | UI label for a build's distance from center; prose uses committed and centered as plain descriptions.                           |
-| glyph      | Not canon   | Visual candidate for mythic systems, not yet a world rule.                                                                      |
+| Term       | Status      | Notes                                                                                                                                                                      |
+| ---------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Vers       | Keep        | Carries universe and versus: world exploration plus competition.                                                                                                           |
+| avatar     | Canonical   | Enhanced human shaped by the player and sent into dangerous regions.                                                                                                       |
+| Respite    | Canonical   | The largest human center; officially Habitat Nine — the vernacular name won.                                                                                               |
+| world      | Keep        | The broad play space and fiction layer; not just a menu.                                                                                                                   |
+| region     | Provisional | Neutral term for world-map areas.                                                                                                                                          |
+| expedition | Provisional | The core activity: outfit an avatar, send it out, recover what returns.                                                                                                    |
+| loot       | Keep        | Core ARPG promise.                                                                                                                                                         |
+| power      | Keep        | Umbrella term for rewards that help the player push farther or more efficiently.                                                                                           |
+| Aether     | Canonical   | The single avatar skill resource: the medium avatars are infused with. Officially the somatic factor — found in avatar blood, never synthesized; the old physics word won. |
+| commitment | Provisional | UI label for a build's distance from center; prose uses committed and centered as plain descriptions.                                                                      |
+| glyph      | Not canon   | Visual candidate for mythic systems, not yet a world rule.                                                                                                                 |

--- a/docs/game-design/002-attributes-damage-model.md
+++ b/docs/game-design/002-attributes-damage-model.md
@@ -165,43 +165,43 @@ table is reading the region's biography.
 ## Resource
 
 Avatars act on cadence: attacks, skills, and recovery run on their own beats, and idle play means
-those beats fire without piloting. Reserve (provisional name) is the single avatar resource layered
-over that cadence. Skills relate to it in one of three ways:
+those beats fire without piloting. Aether — the medium an avatar is infused with — is the single
+avatar resource layered over that cadence. Skills relate to it in one of three ways:
 
 - **Free** skills fire on their beat at no cost. They are the baseline lane: a starved avatar
   degrades to its free skills instead of stalling.
-- **Costed** skills spend Reserve to fire. A costed skill that cannot pay skips its beat rather than
+- **Costed** skills spend Aether to fire. A costed skill that cannot pay skips its beat rather than
   blocking the avatar — free skills keep the rotation firing, and the real tax is the output gap
   between that baseline and what the costed beat would have added. A costed skill should be stronger
   per beat than a free one by roughly the value of its cost, and the build question is whether
   regeneration can sustain it.
-- **Optional-cost** skills fire either way and consume Reserve for a stronger outcome when it is
-  available. Empowerment converts Reserve less efficiently than a costed skill's cost does —
+- **Optional-cost** skills fire either way and consume Aether for a stronger outcome when it is
+  available. Empowerment converts Aether less efficiently than a costed skill's cost does —
   flexibility is taxed, so costed skills remain the efficient way to spend. Empowerment uptime is a
   build outcome worth reporting to the player.
 
 Cost shape is a skill property, not a class rule. Archetypes may still skew the flow — heavy
-spenders, or generators that build Reserve by acting or being hit — through skills and passives;
+spenders, or generators that build Aether by acting or being hit — through skills and passives;
 generation is a behaviour a skill carries, orthogonal to its cost shape. Some abilities recur on
 cooldowns longer than a beat; the skills note owns cooldown design.
 
-Reserve regeneration and capacity are stats worth building around. Specific regeneration, cost,
+Aether regeneration and capacity are stats worth building around. Specific regeneration, cost,
 capacity, and on-full/on-empty investment stays in itemisation and skills.
 
 ## Attribute Layers
 
-Vers uses two attribute layers: the Compass, which positions an avatar, and metagame attributes,
+Vers uses two attribute layers: the Azimuth, which positions an avatar, and metagame attributes,
 which are persistent player progression. They should not compete for the same items or progression
 choices.
 
-The Compass is local to an avatar and determines what equipment and skills the avatar qualifies for.
+The Azimuth is local to an avatar and determines what equipment and skills the avatar qualifies for.
 Metagame attributes can appear on metagame passive trees, idol-like systems, account progression, or
 other long-term systems; they determine how the player stabilizes, discovers, and extracts value
 from the world.
 
-## The Compass
+## The Azimuth
 
-The Compass is the avatar attribute system: three axes, each with two poles, on which a build holds
+The Azimuth is the avatar attribute system: three axes, each with two poles, on which a build holds
 a position rather than accumulating a quantity. A fresh avatar sits at dead center.
 
 ### Axes
@@ -221,17 +221,17 @@ Position comes from the passive tree. Nodes carry directional weight — toward 
 split across axes, or none — and an avatar's position on each axis is the sum of the weight along
 its allocated path. Augments may reweight regions of the tree.
 
-Specialization is an avatar's distance from center. It is emergent — no system assigns it — and it
-distinguishes committed builds (far from center in their chosen directions) from deliberate
-generalists (near it).
+An avatar's distance from center is emergent — no system assigns it — and it distinguishes committed
+builds (far from center in their chosen directions) from deliberate generalists (near it). The
+distance is not a named stat; committed and centered are descriptions of position.
 
 ### Requirements
 
-The Compass sets requirements; it never grants stats. Position qualifies equipment and skills.
+The Azimuth sets requirements; it never grants stats. Position qualifies equipment and skills.
 
 - **Pole requirements** demand a minimum position toward a pole ("requires heavy 60"). They mark
   identity equipment, and exist only where the item's nature earns them.
-- **Center requirements** demand Specialization at or below a threshold. They mark adaptive
+- **Center requirements** demand a position within a threshold of center. They mark adaptive
   equipment that wants an uncommitted chassis — staying centered is a build choice with its own
   exclusive kit.
 
@@ -244,7 +244,7 @@ changes what a build can do, never just how big its numbers are.
 
 Enemies and regions hold positions on the same axes, and their fingerprints carry more: damage mix
 and hit deliveries. A build renders as a silhouette on a six-spoke chart — opposing spokes per axis,
-at most one lit per axis, Specialization visible as the silhouette's size. Enemy and region
+at most one lit per axis, distance from center visible as the silhouette's size. Enemy and region
 silhouettes show what they emit, so both poles of an axis may light, and a matchup reads offense
 against defense: their damage and deliveries against a build's answers.
 
@@ -272,7 +272,7 @@ and the market. Alignment mechanics may draw on that geometry.
 
 ## Scaling Philosophy
 
-The Compass positions a build without scaling it: action rate, recovery, and damage scaling live in
+The Azimuth positions a build without scaling it: action rate, recovery, and damage scaling live in
 gear, skills, and passives.
 
 Build archetypes come primarily from skills, gear, passives, damage types, status effects, summons,
@@ -289,6 +289,6 @@ meaningful build or encounter identity.
 ## Non-Goals
 
 This note does not define exact formulas, ailment lists, resistance caps, interception math,
-avoidance math, critical chance or magnitude baselines, Reserve cost or regeneration baselines,
-Compass requirement thresholds or weight magnitudes, or complete itemisation rules. Those belong in
+avoidance math, critical chance or magnitude baselines, Aether cost or regeneration baselines,
+Azimuth requirement thresholds or weight magnitudes, or complete itemisation rules. Those belong in
 downstream combat, itemisation, enemy, and progression notes.

--- a/docs/game-design/002-attributes-damage-model.md
+++ b/docs/game-design/002-attributes-damage-model.md
@@ -243,8 +243,8 @@ changes what a build can do, never just how big its numbers are.
 ### Fingerprints
 
 Enemies and regions hold positions on the same axes, and their fingerprints carry more: damage mix
-and hit deliveries. A build renders as a silhouette on a six-spoke chart — opposing spokes per
-axis, at most one lit per axis, Specialization visible as the silhouette's size. Enemy and region
+and hit deliveries. A build renders as a silhouette on a six-spoke chart — opposing spokes per axis,
+at most one lit per axis, Specialization visible as the silhouette's size. Enemy and region
 silhouettes show what they emit, so both poles of an axis may light, and a matchup reads offense
 against defense: their damage and deliveries against a build's answers.
 

--- a/docs/game-design/002-attributes-damage-model.md
+++ b/docs/game-design/002-attributes-damage-model.md
@@ -272,7 +272,8 @@ and the market. Alignment mechanics may draw on that geometry.
 
 ## Scaling Philosophy
 
-Action rate, recovery, and damage scaling live in gear, skills, and passives.
+The Compass positions a build without scaling it: action rate, recovery, and damage scaling live in
+gear, skills, and passives.
 
 Build archetypes come primarily from skills, gear, passives, damage types, status effects, summons,
 region interactions, and defensive-layer investment.

--- a/docs/game-design/002-attributes-damage-model.md
+++ b/docs/game-design/002-attributes-damage-model.md
@@ -1,14 +1,13 @@
 # Attributes & Damage Model
 
-This note defines the first stable combat stat and damage-system spine for Vers. It should support
-PoE-like long-term build complexity without front-loading that complexity into the first playable
-loop.
+This note defines the combat stats and damage model for Vers. It supports PoE-like long-term build
+complexity without front-loading that complexity into the first playable loop.
 
 ## Damage Types
 
-Vers starts with seven damage types, each named for its mechanism of harm. The set is intentionally
-wider than a traditional fantasy ARPG element spread, so itemisation should not expect every build
-to cover every offensive or defensive type equally.
+Vers has seven damage types, each named for its mechanism of harm. The set is intentionally wider
+than a traditional fantasy ARPG element spread, so itemisation should not expect every build to
+cover every offensive or defensive type equally.
 
 ### Physical
 
@@ -81,8 +80,7 @@ status effects, skills, enemies, or item modifiers.
 Status effects are secondary outcomes caused by damage types, skills, enemies, regions, or item
 modifiers. They may impair, amplify, control, reveal, weaken, protect, or otherwise alter combat.
 
-Status effects should not be fully enumerated in the first pass. The damage model only needs enough
-structure to support them later.
+Status effects are not enumerated here; the damage model carries only the structure they need.
 
 ## Defensive Layers
 
@@ -97,25 +95,28 @@ Dodge; the defensive-archetypes note defines them.
 ### Interception
 
 Interception reduces a connected hit before mitigation. Its forms are Block and Deflect; the
-defensive-archetypes note defines them. Interception stays distinct from avoidance: avoidance stops
-connection, interception handles a connected event.
+defensive-archetypes note defines them.
 
 ### Mitigation
 
-Mitigation reduces the impact of damage that was not avoided or fully blocked. It includes
+Mitigation reduces the impact of damage that was not avoided or fully intercepted. It includes
 type-appropriate defenses and other reductions that make incoming damage smaller.
+
+### Buffer
+
+Buffer defers damage: a portion of a qualifying hit lands as decaying damage over following beats
+instead of instantly. The defensive-archetypes note defines it.
 
 ### Barrier
 
-Barrier is recoverable protection consumed before Life. It fits the synthetic-world premise better
-than a fantasy shield while still giving builds a recoverable layer above Life.
+Barrier is recoverable protection consumed before Life.
 
 ### Life
 
-Life is the avatar's health. Reaching zero life causes defeat or activity failure according to the
-surrounding activity rules.
+Life is the avatar's health. Reaching zero Life ends the activity; the core note owns the defeat
+rules.
 
-## Resolution Spine
+## Resolution Order
 
 The default resolution order is:
 
@@ -124,15 +125,16 @@ The default resolution order is:
 3. Interception may reduce a connected hit.
 4. A connected hit may resolve as critical, scaling its damage.
 5. Mitigation reduces remaining damage.
-6. Barrier absorbs damage before life.
-7. Life is reduced by unabsorbed damage.
-8. Status effects and secondary outcomes are checked from the resolved event.
+6. Buffer may defer a portion of the remaining damage across following beats.
+7. Barrier absorbs damage before Life.
+8. Life is reduced by unabsorbed damage.
+9. Status effects and secondary outcomes are checked from the resolved event.
 
-This order is a design spine, not a final formula. Individual skills, items, enemies, and regions
+This order is the default shape, not a final formula. Individual skills, items, enemies, and regions
 may alter it when a specific build or encounter needs a rule-breaking hook.
 
 The order is also the structure of expedition reporting: each defensive layer consumed is
-escalation, and a hit that reaches life is a close call worth reporting. Reporting carries both a
+escalation, and a hit that reaches Life is a close call worth reporting. Reporting carries both a
 high-level summary and the drill-down that explains it — including what failed on defeat; its own
 design note owns the specifics.
 
@@ -144,17 +146,17 @@ for the types its target regions deal. Physical is not resistable — it is the 
 type, handled through the other defensive layers rather than a resistance stat.
 
 Regions are weighted toward a dominant damage type but never deal it exclusively. Type mitigation is
-specced against a region's mix, and the type-agnostic layers — Avoidance, Interception, Barrier —
-are the floor under whatever a build has not covered.
+specced against a region's mix; Avoidance, Interception, and Barrier work against every damage type
+and catch what a build has not covered.
 
-Every damage type has at least one region or faction that expresses it. The strange types are
-progression-gated: Cognitive appears later, and Null is endgame. The type spectrum deepens as
-avatars push farther from Respite.
+Every damage type has at least one region or faction that expresses it. The strange types arrive
+with progression: Cognitive appears later, and Null is endgame. The type spectrum deepens as avatars
+push farther from Respite.
 
-Enemies use the same defensive layers as avatars, including Physical mitigation of their own — so
-Physical is universal pressure in both directions, not a strictly-best attacking type. Layer
-distribution across enemy families is a tuning choice (heavily avoidance-stacked enemies are rarely
-fun), and no mechanic converts incoming Physical into a resistable type.
+Enemies use the same defensive layers as avatars, including Physical mitigation of their own —
+Physical is universal pressure in both directions. Layer distribution across enemy families is a
+tuning choice (heavily avoidance-stacked enemies are rarely fun), and incoming damage never converts
+between types.
 
 A region's damage mix is also its history: mechanical drift reads as Physical, Heat, Cold, and
 Electric; ecological drift as Toxic; human drift as Cognitive; total drift as Null. Reading a threat
@@ -169,8 +171,8 @@ over that cadence. Skills relate to it in one of three ways:
 - **Free** skills fire on their beat at no cost. They are the baseline lane: a starved avatar
   degrades to its free skills instead of stalling.
 - **Costed** skills spend Reserve to fire. A costed skill that cannot pay skips its beat rather than
-  blocking the avatar — free skills hold the rotation's floor, and the real tax is the output gap
-  between that floor and what the costed beat would have added. A costed skill should be stronger
+  blocking the avatar — free skills keep the rotation firing, and the real tax is the output gap
+  between that baseline and what the costed beat would have added. A costed skill should be stronger
   per beat than a free one by roughly the value of its cost, and the build question is whether
   regeneration can sustain it.
 - **Optional-cost** skills fire either way and consume Reserve for a stronger outcome when it is
@@ -179,17 +181,18 @@ over that cadence. Skills relate to it in one of three ways:
   build outcome worth reporting to the player.
 
 Cost shape is a skill property, not a class rule. Archetypes may still skew the flow — heavy
-spenders, or generators that build Reserve by acting or being hit — through skills and passives.
-Generation is a skill behaviour orthogonal to cost shape, not a fourth shape.
+spenders, or generators that build Reserve by acting or being hit — through skills and passives;
+generation is a behaviour a skill carries, orthogonal to its cost shape. Some abilities recur on
+cooldowns longer than a beat; the skills note owns cooldown design.
 
-Reserve regeneration and capacity are first-class build stats. Specific regeneration, cost,
+Reserve regeneration and capacity are stats worth building around. Specific regeneration, cost,
 capacity, and on-full/on-empty investment stays in itemisation and skills.
 
 ## Attribute Layers
 
 Vers uses two attribute layers: the Compass, which positions an avatar, and metagame attributes,
-which are persistent player progression. They should not compete for the same item budget or
-progression choices.
+which are persistent player progression. They should not compete for the same items or progression
+choices.
 
 The Compass is local to an avatar and determines what equipment and skills the avatar qualifies for.
 Metagame attributes can appear on metagame passive trees, idol-like systems, account progression, or
@@ -198,60 +201,59 @@ from the world.
 
 ## The Compass
 
-The Compass is the avatar attribute system: three bipolar axes on which a build holds a position
-rather than accumulating a quantity. A fresh avatar sits at dead center.
+The Compass is the avatar attribute system: three axes, each with two poles, on which a build holds
+a position rather than accumulating a quantity. A fresh avatar sits at dead center.
 
 ### Axes
 
 - **Melee ↔ Ranged** — where the avatar fights: contact technique, or delivery from distance.
 - **Light ↔ Heavy** — the avatar's rhythm: fast beats at small magnitudes, or slow beats that land
   massively.
-- **Innate ↔ Altered** — what the avatar fights with: the inborn capacity, conditioned and
-  sharpened, or acquired systems — implants, interfaces, and instruments that operate on the world's
-  stranger terms. Altered equipment and skills lean toward direct delivery, Barrier-led defense, and
-  the strange damage types; innate ones toward material force and bodily technique.
+- **Innate ↔ Altered** — how the avatar's power behaves: innate technique is immediate and
+  self-contained — decisive beats, cooldown-driven bursts, effects that resolve on the spot; altered
+  instruments linger — durations, ailments, and effects that keep working after the beat that placed
+  them. The axis names the behaviour, never a damage type or a defense; what any item or skill asks
+  for is its own choice.
 
 ### Position
 
-Position comes from the passive tree. Nodes carry directional weight — positive, negative, split
-between poles, or none — and an avatar's position on each axis is the sum of the weight along its
-allocated path. Augments that reweight regions of the tree are a sanctioned extension.
+Position comes from the passive tree. Nodes carry directional weight — toward a pole, away from one,
+split across axes, or none — and an avatar's position on each axis is the sum of the weight along
+its allocated path. Augments may reweight regions of the tree.
 
 Specialization is an avatar's distance from center. It is emergent — no system assigns it — and it
 distinguishes committed builds (far from center in their chosen directions) from deliberate
 generalists (near it).
 
-### Gates
+### Requirements
 
-The Compass gates; it does not scale. Position qualifies equipment and skills and never grants stats
-directly.
+The Compass sets requirements; it never grants stats. Position qualifies equipment and skills.
 
-- **Pole gates** require a minimum position toward a pole ("requires heavy 60"). They mark identity
-  equipment, and exist only where the item's nature earns them.
-- **Center gates** require Specialization at or below a threshold. They mark adaptive equipment that
-  demands an uncommitted chassis — staying centered is a build choice with its own exclusive kit,
-  not a default.
+- **Pole requirements** demand a minimum position toward a pole ("requires heavy 60"). They mark
+  identity equipment, and exist only where the item's nature earns them.
+- **Center requirements** demand Specialization at or below a threshold. They mark adaptive
+  equipment that wants an uncommitted chassis — staying centered is a build choice with its own
+  exclusive kit.
 
-Staple equipment is ungated. A gate is the admission ticket to identity gear, never a power tax on
-basics: a build that cannot equip ordinary equipment marks a misdesigned item, not a misbuilt
-avatar.
+Staple equipment carries no requirements: a requirement is the admission ticket to identity gear,
+never a power tax on basics, and a build that cannot equip ordinary equipment marks a misdesigned
+item, not a misbuilt avatar. Identity equipment enables rather than outscales: passing a requirement
+changes what a build can do, never just how big its numbers are.
 
 ### Fingerprints
 
-Enemies and regions hold positions on the same axes. Builds, enemy families, and regions each render
-as a silhouette on a six-spoke chart — opposing spokes per axis, at most one lit per axis,
-Specialization visible as the silhouette's size — and a matchup reads as the overlap of two
-silhouettes.
+Enemies and regions hold positions on the same axes, and their fingerprints carry more: damage mix,
+hit deliveries, and attack rhythm. A build renders as a silhouette on a six-spoke chart — opposing
+spokes per axis, at most one lit per axis, Specialization visible as the silhouette's size. Enemy
+and region silhouettes show what they emit, so both poles of an axis may light, and a matchup reads
+offense against defense: their deliveries and rhythm against a build's answers.
 
 ## Metagame Attributes
 
 ### Discipline
 
-Discipline is consistency. It represents stable progression, reduced friction, safer outcomes, and
-less variance across repeated expeditions.
-
-Discipline's variance reduction is non-combat only — yield spread, extraction reliability,
-progression friction — never incoming damage or defeat chance. Survival stays with the avatar's own
+Discipline is consistency across the metagame: yield spread, extraction reliability, progression
+friction — stable outcomes across repeated expeditions. Survival stays with the avatar's own
 defenses.
 
 ### Insight
@@ -266,29 +268,26 @@ long-term tools that turn resources into better outcomes.
 
 Each metagame attribute sits between two of Respite's institutions: Discipline between the authority
 and the industry, Insight between the authority and the market, and Aptitude between the industry
-and the market. Later alignment mechanics may draw on that geometry.
+and the market. Alignment mechanics may draw on that geometry.
 
 ## Scaling Philosophy
 
-No avatar attribute grants combat stats: the Compass gates, and action rate, recovery, and damage
-scaling live in gear, skills, and passives.
+Action rate, recovery, and damage scaling live in gear, skills, and passives.
 
-Build archetypes should come primarily from skills, gear, passives, damage types, status effects,
-summons, region interactions, and defensive-layer investment. Compass position shapes which of those
-choices a build can make; it never substitutes for them.
+Build archetypes come primarily from skills, gear, passives, damage types, status effects, summons,
+region interactions, and defensive-layer investment.
 
 Archetype is a per-system term, not a single system: skills, defenses, classes, and specializations
-each carry their own archetypes, and build archetypes emerge from combining them. Classes are
-intended, including a later chosen divergence into a specialized class tier — its name and design
-belong to the base-classes note.
+each carry their own archetypes, and build archetypes emerge from combining them. Classes —
+including a chosen divergence into a specialized class tier — belong to the base-classes note.
 
-The damage model should support long-term complexity through item, skill, passive, enemy, and region
-interactions. The first implementation should expose a small stable core, then add specialized rules
-only when they create meaningful build or encounter identity.
+The damage model supports long-term complexity through item, skill, passive, enemy, and region
+interactions. The model exposes a small stable core; specialized rules exist only where they create
+meaningful build or encounter identity.
 
 ## Non-Goals
 
-This note does not define exact formulas, ailment lists, resistance caps, block math, avoidance
-math, critical chance or magnitude baselines, Reserve cost or regeneration baselines, Compass gate
-thresholds or weight magnitudes, or complete itemisation rules. Those belong in downstream combat,
-itemisation, enemy, and progression notes.
+This note does not define exact formulas, ailment lists, resistance caps, interception math,
+avoidance math, critical chance or magnitude baselines, Reserve cost or regeneration baselines,
+Compass requirement thresholds or weight magnitudes, or complete itemisation rules. Those belong in
+downstream combat, itemisation, enemy, and progression notes.

--- a/docs/game-design/002-attributes-damage-model.md
+++ b/docs/game-design/002-attributes-damage-model.md
@@ -242,11 +242,11 @@ changes what a build can do, never just how big its numbers are.
 
 ### Fingerprints
 
-Enemies and regions hold positions on the same axes, and their fingerprints carry more: damage mix,
-hit deliveries, and attack rhythm. A build renders as a silhouette on a six-spoke chart — opposing
-spokes per axis, at most one lit per axis, Specialization visible as the silhouette's size. Enemy
-and region silhouettes show what they emit, so both poles of an axis may light, and a matchup reads
-offense against defense: their deliveries and rhythm against a build's answers.
+Enemies and regions hold positions on the same axes, and their fingerprints carry more: damage mix
+and hit deliveries. A build renders as a silhouette on a six-spoke chart — opposing spokes per
+axis, at most one lit per axis, Specialization visible as the silhouette's size. Enemy and region
+silhouettes show what they emit, so both poles of an axis may light, and a matchup reads offense
+against defense: their damage and deliveries against a build's answers.
 
 ## Metagame Attributes
 

--- a/docs/game-design/002-attributes-damage-model.md
+++ b/docs/game-design/002-attributes-damage-model.md
@@ -6,24 +6,28 @@ loop.
 
 ## Damage Types
 
-Vers starts with six damage types. The set is intentionally wider than a traditional fantasy ARPG
-element spread, so itemisation should not expect every build to cover every offensive or defensive
-type equally.
+Vers starts with seven damage types, each named for its mechanism of harm. The set is intentionally
+wider than a traditional fantasy ARPG element spread, so itemisation should not expect every build
+to cover every offensive or defensive type equally.
 
-### Kinetic
+### Physical
 
-Kinetic damage is physical force: impact, rupture, blades, ballistics, crushing pressure, and other
+Physical damage is material force: impact, rupture, blades, ballistics, crushing pressure, and other
 direct material trauma.
 
-### Thermal
+### Heat
 
-Thermal damage is temperature stress: heat, cold, plasma, burning, freezing, and extreme energetic
-transfer.
+Heat damage is destructive temperature gain: burning, plasma, friction, and radiant transfer.
 
-### Voltaic
+### Cold
 
-Voltaic damage is charge and overload: electricity, arcs, signal disruption, shorting, and hostile
-energy flow through bodies or systems.
+Cold damage is destructive temperature loss: freezing, thermal shock, coolant exposure, and the
+failure of tissue and systems in deep cold.
+
+### Electric
+
+Electric damage is charge and overload: current, arcs, shorting, and hostile energy flow through
+bodies or systems.
 
 ### Toxic
 
@@ -87,14 +91,14 @@ expression.
 
 ### Avoidance
 
-Avoidance is the chance or condition that prevents a hostile action from connecting. It is the broad
-layer name; future mechanics may express it through evasion, misdirection, prediction, interference,
-or other sources.
+Avoidance is the chance that prevents a hostile action from connecting. Its forms are Evasion and
+Dodge; the defensive-archetypes note defines them.
 
-### Block
+### Interception
 
-Block intercepts a connected hit and reduces, changes, or negates its impact. It should remain
-distinct from avoidance: avoidance stops connection, block handles a connected event.
+Interception reduces a connected hit before mitigation. Its forms are Block and Deflect; the
+defensive-archetypes note defines them. Interception stays distinct from avoidance: avoidance stops
+connection, interception handles a connected event.
 
 ### Mitigation
 
@@ -103,8 +107,8 @@ type-appropriate defenses and other reductions that make incoming damage smaller
 
 ### Barrier
 
-Barrier is recoverable protection consumed before life. It fits the synthetic-world premise better
-than a fantasy shield while still giving builds a clear buffer layer.
+Barrier is recoverable protection consumed before Life. It fits the synthetic-world premise better
+than a fantasy shield while still giving builds a recoverable layer above Life.
 
 ### Life
 
@@ -117,7 +121,7 @@ The default resolution order is:
 
 1. A hostile action attempts to connect.
 2. Avoidance may prevent connection.
-3. Block may intercept a connected hit.
+3. Interception may reduce a connected hit.
 4. A connected hit may resolve as critical, scaling its damage.
 5. Mitigation reduces remaining damage.
 6. Barrier absorbs damage before life.
@@ -134,27 +138,27 @@ design note owns the specifics.
 
 ## Threat Mix & Coverage
 
-Five of the six damage types are resistable: type-specific mitigation exists for Thermal, Voltaic,
-Toxic, Cognitive, and Null, and an endgame avatar is expected to reach the mitigation cap for the
-types its target regions deal. Kinetic is not resistable — it is the universal pressure type,
-handled through the other defensive layers rather than a resistance stat.
+Six of the seven damage types are resistable: type-specific mitigation exists for Heat, Cold,
+Electric, Toxic, Cognitive, and Null, and an endgame avatar is expected to reach the mitigation cap
+for the types its target regions deal. Physical is not resistable — it is the universal pressure
+type, handled through the other defensive layers rather than a resistance stat.
 
 Regions are weighted toward a dominant damage type but never deal it exclusively. Type mitigation is
-specced against a region's mix, and the type-agnostic layers — Avoidance, Block, Barrier — are the
-floor under whatever a build has not covered.
+specced against a region's mix, and the type-agnostic layers — Avoidance, Interception, Barrier —
+are the floor under whatever a build has not covered.
 
 Every damage type has at least one region or faction that expresses it. The strange types are
 progression-gated: Cognitive appears later, and Null is endgame. The type spectrum deepens as
 avatars push farther from Respite.
 
-Enemies use the same defensive layers as avatars, including Kinetic mitigation of their own — so
-Kinetic is universal pressure in both directions, not a strictly-best attacking type. Layer
+Enemies use the same defensive layers as avatars, including Physical mitigation of their own — so
+Physical is universal pressure in both directions, not a strictly-best attacking type. Layer
 distribution across enemy families is a tuning choice (heavily avoidance-stacked enemies are rarely
-fun), and no mechanic converts incoming Kinetic into a resistable type.
+fun), and no mechanic converts incoming Physical into a resistable type.
 
-A region's damage mix is also its history: mechanical drift reads as Kinetic, Voltaic, and Thermal;
-ecological drift as Toxic; human drift as Cognitive; total drift as Null. Reading a threat table is
-reading the region's biography.
+A region's damage mix is also its history: mechanical drift reads as Physical, Heat, Cold, and
+Electric; ecological drift as Toxic; human drift as Cognitive; total drift as Null. Reading a threat
+table is reading the region's biography.
 
 ## Resource
 
@@ -178,49 +182,66 @@ Cost shape is a skill property, not a class rule. Archetypes may still skew the 
 spenders, or generators that build Reserve by acting or being hit — through skills and passives.
 Generation is a skill behaviour orthogonal to cost shape, not a fourth shape.
 
-Reserve regeneration falls under Vigor's global-regeneration mandate, and Reserve regeneration and
-capacity are first-class build stats. Specific regeneration, cost, capacity, and on-full/on-empty
-investment stays in itemisation and skills, as with every attribute.
+Reserve regeneration and capacity are first-class build stats. Specific regeneration, cost,
+capacity, and on-full/on-empty investment stays in itemisation and skills.
 
 ## Attribute Layers
 
-Vers uses two attribute layers: avatar attributes and metagame attributes. They should not compete
-for the same item budget or progression choices.
+Vers uses two attribute layers: the Compass, which positions an avatar, and metagame attributes,
+which are persistent player progression. They should not compete for the same item budget or
+progression choices.
 
-Avatar attributes are local to an avatar. They can appear on gear, avatar passives, class systems,
-and other character-power systems. They determine how an avatar survives and performs inside
-regions.
+The Compass is local to an avatar and determines what equipment and skills the avatar qualifies for.
+Metagame attributes can appear on metagame passive trees, idol-like systems, account progression, or
+other long-term systems; they determine how the player stabilizes, discovers, and extracts value
+from the world.
 
-Metagame attributes are persistent player/world progression. They can appear on metagame passive
-trees, idol-like systems, account progression, or other long-term systems. They determine how the
-player stabilizes, discovers, and extracts value from the world.
+## The Compass
 
-## Avatar Attributes
+The Compass is the avatar attribute system: three bipolar axes on which a build holds a position
+rather than accumulating a quantity. A fresh avatar sits at dead center.
 
-### Focus
+### Axes
 
-Focus is cadence. It governs action rate: how quickly an avatar's skill beats recur. It is not an
-attack- or cast-speed modifier — speed of execution stays specific itemisation.
+- **Melee ↔ Ranged** — where the avatar fights: contact technique, or delivery from distance.
+- **Light ↔ Heavy** — the avatar's rhythm: fast beats at small magnitudes, or slow beats that land
+  massively.
+- **Innate ↔ Altered** — what the avatar fights with: the inborn capacity, conditioned and
+  sharpened, or acquired systems — implants, interfaces, and instruments that operate on the world's
+  stranger terms. Altered equipment and skills lean toward direct delivery, Barrier-led defense, and
+  the strange damage types; innate ones toward material force and bodily technique.
 
-Focus should improve how often an avatar can act, but it should not replace specific attack-speed,
-cooldown, or trigger itemisation.
+### Position
 
-### Vigor
+Position comes from the passive tree. Nodes carry directional weight — positive, negative, split
+between poles, or none — and an avatar's position on each axis is the sum of the weight along its
+allocated path. Augments that reweight regions of the tree are a sanctioned extension.
 
-Vigor is sustain. It governs the global regeneration rate: Life, Barrier, and Reserve all recover
-faster under Vigor. Because one stat touches all three pools its power is deliberately curbed — and
-long-form idle combat keeps even curbed regeneration useful.
+Specialization is an avatar's distance from center. It is emergent — no system assigns it — and it
+distinguishes committed builds (far from center in their chosen directions) from deliberate
+generalists (near it).
 
-Vigor should improve an avatar's broad staying power, but it should not replace specific investment
-into Life, Barrier, Block, recovery, or other defensive mechanics.
+### Gates
 
-### Will
+The Compass gates; it does not scale. Position qualifies equipment and skills and never grants stats
+directly.
 
-Will is effect. It represents the avatar's capacity to impose outcomes on the world.
+- **Pole gates** require a minimum position toward a pole ("requires heavy 60"). They mark identity
+  equipment, and exist only where the item's nature earns them.
+- **Center gates** require Specialization at or below a threshold. They mark adaptive equipment that
+  demands an uncommitted chassis — staying centered is a build choice with its own exclusive kit,
+  not a default.
 
-Will can scale damage, healing, shielding, control, summons, persistent effects, and other applied
-combat outcomes. It should provide broad baseline pressure without replacing specific investment
-into damage types, skills, ailments, minions, or other archetype-defining systems.
+Staple equipment is ungated. A gate is the admission ticket to identity gear, never a power tax on
+basics: a build that cannot equip ordinary equipment marks a misdesigned item, not a misbuilt
+avatar.
+
+### Fingerprints
+
+Enemies and regions hold positions on the same axes. Builds, enemy families, and regions each render
+as a silhouette on a six-spoke chart — opposing spokes per axis, at most one lit per axis,
+Specialization visible as the silhouette's size — and a matchup reads as the overlap of two
+silhouettes.
 
 ## Metagame Attributes
 
@@ -249,13 +270,12 @@ and the market. Later alignment mechanics may draw on that geometry.
 
 ## Scaling Philosophy
 
-Focus, Vigor, and Will should be universally useful but modest. They provide broad pressure,
-sustain, and effect so every avatar benefits from them, but they should not become the only stats
-that matter.
+No avatar attribute grants combat stats: the Compass gates, and action rate, recovery, and damage
+scaling live in gear, skills, and passives.
 
 Build archetypes should come primarily from skills, gear, passives, damage types, status effects,
-summons, region interactions, and defensive-layer investment. Attribute stacking can exist, but it
-should not erase those more specific choices.
+summons, region interactions, and defensive-layer investment. Compass position shapes which of those
+choices a build can make; it never substitutes for them.
 
 Archetype is a per-system term, not a single system: skills, defenses, classes, and specializations
 each carry their own archetypes, and build archetypes emerge from combining them. Classes are
@@ -269,5 +289,6 @@ only when they create meaningful build or encounter identity.
 ## Non-Goals
 
 This note does not define exact formulas, ailment lists, resistance caps, block math, avoidance
-math, critical chance or magnitude baselines, Reserve cost or regeneration baselines, or complete
-itemisation rules. Those belong in downstream combat, itemisation, enemy, and progression notes.
+math, critical chance or magnitude baselines, Reserve cost or regeneration baselines, Compass gate
+thresholds or weight magnitudes, or complete itemisation rules. Those belong in downstream combat,
+itemisation, enemy, and progression notes.

--- a/docs/game-design/002-attributes-damage-model.md
+++ b/docs/game-design/002-attributes-damage-model.md
@@ -240,14 +240,6 @@ never a power tax on basics, and a build that cannot equip ordinary equipment ma
 item, not a misbuilt avatar. Identity equipment enables rather than outscales: passing a requirement
 changes what a build can do, never just how big its numbers are.
 
-### Fingerprints
-
-Enemies and regions hold positions on the same axes, and their fingerprints carry more: damage mix
-and hit deliveries. A build renders as a silhouette on a six-spoke chart — opposing spokes per axis,
-at most one lit per axis, distance from center visible as the silhouette's size. Enemy and region
-silhouettes show what they emit, so both poles of an axis may light, and a matchup reads offense
-against defense: their damage and deliveries against a build's answers.
-
 ## Metagame Attributes
 
 ### Discipline

--- a/docs/game-design/003-defensive-archetypes.md
+++ b/docs/game-design/003-defensive-archetypes.md
@@ -147,14 +147,6 @@ The defensive layers cost no Aether to run: a starved avatar keeps its defenses.
 defensive skills, cooldowns, or pools are an option the skills and itemisation notes may take up,
 not a rule here.
 
-## Azimuth Interaction
-
-Azimuth position sets requirements for identity equipment on every axis, defensive pieces included;
-no position strengthens a defensive layer directly. Melee-side builds live in strike delivery and
-lean on Evasion and Block; ranged-side builds live in projectile exposure and lean on Dodge and
-Deflect. Equipment bases that carry layer identities are an option the itemisation note may take up,
-not a rule here.
-
 ## Non-Goals
 
 This note does not define avoidance or interception math, smoothing functions, the armour curve,

--- a/docs/game-design/003-defensive-archetypes.md
+++ b/docs/game-design/003-defensive-archetypes.md
@@ -59,7 +59,8 @@ Two properties of an activity decide what defense matters:
 - **Encounter density** — monsters per encounter — decides how much hit volume matters: dense packs
   feed avoidance and armour, sparse elites feed interception.
 
-Carried debuffs make persistent-leaning regions genuinely attritional — that is their identity.
+Carried debuffs make persistent-leaning regions genuinely attritional: the avatar wears down across
+the encounter chain, and that attrition is those regions' identity.
 
 ## Avoidance: Evasion & Dodge
 

--- a/docs/game-design/003-defensive-archetypes.md
+++ b/docs/game-design/003-defensive-archetypes.md
@@ -2,9 +2,9 @@
 
 This note defines the forms of the damage model's defensive layers and the structure of play they
 defend inside. Defensive identity in Vers is emergent: an archetype is a recognized pattern of layer
-investment, never an enforced kit. Defensive stats compete for the shared gear and passive budget,
-and each layer answers a different threat profile, so redundant stacking wastes budget and mixing
-against a region's profile is always a real decision.
+investment, never an enforced kit. Defensive stats compete for the same gear slots and passive
+points, and each layer answers a different threat profile, so redundant stacking wastes investment
+and mixing against a region's profile is always a real decision.
 
 ## Hit Deliveries
 
@@ -19,11 +19,14 @@ Every hit carries a delivery:
 
 Persistent damage is not a hit and has no delivery.
 
-Strange damage lean direct: Cognitive and Null arrive mostly as impositions rather than objects. A
-region or enemy family's delivery profile characterizes it as strongly as its damage mix, and both
-appear in its fingerprint.
+The strange damage types lean direct: Cognitive and Null arrive mostly as impositions rather than
+objects. A region or enemy family's delivery profile characterizes it as strongly as its damage mix,
+and both appear in its fingerprint.
 
-| Layer       | Strike | Projectile | Direct | Area | Persistent |
+No region deals a single delivery exclusively: direct and area pressure always arrives alongside
+enough strike and projectile that avoidance and interception keep their value.
+
+| Defense     | Strike | Projectile | Direct | Area | Persistent |
 | ----------- | ------ | ---------- | ------ | ---- | ---------- |
 | Evasion     | ✓      | —          | —      | —    | —          |
 | Dodge       | —      | ✓          | —      | —    | —          |
@@ -31,15 +34,41 @@ appear in its fingerprint.
 | Deflect     | —      | ✓          | —      | —    | —          |
 | Armour      | ✓      | ✓          | ✓      | ✓    | ✓          |
 | Resistances | ✓      | ✓          | ✓      | ✓    | ✓          |
+| Buffer      | ✓      | ✓          | ✓      | ✓    | —          |
 | Barrier     | ✓      | ✓          | ✓      | ✓    | ✓          |
+
+Armour and Resistances apply within their type scope: Armour mitigates Physical damage from any
+delivery, Resistances their own types. Which hits qualify for Buffer is combat-note territory.
+
+## Activities & Encounters
+
+The activity is the unit of play, and progression, region, and skill design inherit this structure.
+An avatar enters an activity at full state and resets to full state between activities. Inside an
+activity, encounters chain with no time between them: each encounter begins immediately, seeded with
+the avatar's carried state.
+
+Across an encounter boundary, pools keep their values; buffs, debuffs, statuses, and cooldown
+progress persist; beat alignment resets. The boundary grants nothing else: no recovery, no
+recharge-delay progress, and outstanding deferred damage carries. Encounters are therefore
+independently simulable from their entry state, and reporting can resolve per encounter.
+
+Two properties of an activity decide what defense matters:
+
+- **Encounter count** decides how much sustain matters: short activities reward per-encounter
+  survival; long chains reward leech, regeneration, and encounter-start investment.
+- **Encounter density** — monsters per encounter — decides how much hit volume matters: dense packs
+  feed avoidance and armour, sparse elites feed interception.
+
+Carried debuffs make persistent-leaning regions genuinely attritional — that is their identity.
 
 ## Avoidance: Evasion & Dodge
 
-Avoidance fully negates a hit before it connects. **Evasion** applies to strike hits; **Dodge**
-applies to projectile hits.
+Avoidance removes the whole event — the hit, its critical, and the statuses it would have caused —
+before it connects. **Evasion** applies to strike hits; **Dodge** applies to projectile hits.
 
 Both forms are chance-shaped and smoothed: realized avoidance tracks stated avoidance without lucky
-or unlucky streaks, so an unattended avatar's survival never rests on a roll sequence. Avoidance
+or unlucky streaks, so an unattended avatar's survival never rests on a roll sequence. Smoothing is
+statistical over a stream of hits, never a counter a build can bank against a chosen hit. Avoidance
 thins a hit stream in proportion to its volume — it is strongest against many small hits and
 contributes least against a single decisive one.
 
@@ -50,14 +79,16 @@ Interception spends a charge to reduce a connecting hit. **Block** intercepts st
 
 Both forms draw on one shared charge pool. Pool capacity and refill rate are shared investment;
 trigger chance and the amount mitigated are invested per form. Trigger chance is smoothed like
-avoidance. Interception reduces at baseline — full negation is the ceiling of deep investment, not
-the default.
+avoidance, and a charge is consumed only when interception triggers — an eligible hit that passes
+untriggered spends nothing. Interception reduces at baseline — full negation is the ceiling of deep
+investment, not the default.
 
-Charge economics bound interception without a cap: refill rate against enemy hit rate limits how
-much of a stream can be intercepted. Sparse heavy hitters meet a charge on every swing; dense fast
+Charge supply bounds interception without a cap: refill rate against enemy hit rate limits how much
+of a stream can be intercepted. Sparse heavy hitters meet a charge on every swing; dense fast
 streams drain the pool and land past it. Interception is strongest against few large hits and
 weakest against volume — the inverse of avoidance, so the two compose instead of stacking: avoidance
-thins the stream, interception catches the haymakers.
+thins the stream, interception catches the haymakers. Charge refunds from any effect stay below one
+charge per intercept, so refill remains the binding limit.
 
 ## Armour
 
@@ -69,9 +100,12 @@ hit-size spectrum.
 ## Resistances
 
 Resistances are the six type-specific mitigations, capped, specced against a region's damage mix.
-With Life, they are the deterministic floor: baseline content is tuned so resistances and Life alone
-survive it, and every avoidance and interception stat is elective headroom. Direct and area hits are
-answered here.
+Armour, Resistances, and Life are the dependable core: baseline content is tuned so they alone
+survive it, and every avoidance and interception stat is extra safety a build chooses. Direct and
+area hits are answered here.
+
+The hardest case is a large Physical area hit — nothing avoids or intercepts it, no resistance
+applies, and Armour fades against it. Max-hit tuning is bound by that case.
 
 ## Barrier
 
@@ -79,8 +113,8 @@ Barrier is the pool consumed before Life. Its native recovery is **recharge**: a
 taking a hit, Barrier refills rapidly until touched again. Investment is pool size, recharge delay,
 and recharge rate.
 
-Barrier regeneration exists at a base of zero: steady per-beat recovery is bought as its own
-percent-based investment, and without that investment no amount of scaling produces any.
+Barrier has no innate regeneration: steady per-beat recovery is bought as its own percent-based
+investment.
 
 Barrier is the tempo layer: it favors fights that grant untouched windows and degrades under
 relentless pressure. Dense encounters and persistent damage are anti-Barrier by nature.
@@ -89,8 +123,12 @@ relentless pressure. Dense encounters and persistent damage are anti-Barrier by 
 
 Buffer defers damage: a portion of a qualifying hit lands as decaying damage over the following
 beats instead of instantly. Deferral converts spikes into pressure that recovery can answer — the
-counterpart to interception, which removes spike damage rather than smearing it. Which hits qualify,
-how much defers, and the decay rate are combat-note territory.
+counterpart to interception, which removes spike damage rather than smearing it.
+
+Deferral always costs: decay outpaces recovery enough that a deferred pool is never erased before it
+lands. Buffer's own deferred ticks do not count as being hit for Barrier's recharge delay. Which
+hits qualify, how much defers, decay rates, and where deferred damage lands are combat-note
+territory.
 
 ## Life & Recovery
 
@@ -100,43 +138,25 @@ Recovery styles are separate investments, never one stat:
 
 - **Regeneration** — steady per-beat recovery of a pool.
 - **Leech** — recovery from damage dealt, invested separately for Life, Barrier, and Reserve.
-- **On-intercept effects** — recovery or charge economy triggered by a successful Block or Deflect.
+- **On-intercept effects** — recovery or charge effects triggered by a successful Block or Deflect.
 - **Encounter-start effects** — recovery or resources granted at the start of every encounter after
   an activity's first. This is the only between-fight recovery in the game.
 
-## Activities & Encounters
-
-The activity is the unit of play, and progression, region, and skill design inherit this structure.
-An avatar enters an activity at full state and resets to full state between activities. Inside an
-activity, encounters chain with no time between them: each encounter begins immediately, seeded with
-the avatar's carried state.
-
-Across an encounter boundary, pools keep their values; buffs, debuffs, statuses, and cooldown
-progress persist; beat alignment resets. Nothing else restores. Encounters are therefore
-independently simulable from their entry state, and reporting can resolve per encounter.
-
-Two dials price defense:
-
-- **Encounter count** prices sustain: short activities reward per-encounter survival, long chains
-  reward leech, regeneration, and encounter-start investment.
-- **Encounter density** — monsters per encounter — prices hit volume: dense packs feed avoidance and
-  armour, sparse elites feed interception.
-
-Carried debuffs make persistent-leaning regions genuinely attritional; that is their identity, not a
-tuning accident.
+Defensive uptime never depends on spendable Reserve: a starved avatar keeps its defenses.
 
 ## Compass Interaction
 
-Compass position gates identity equipment on every axis, defensive pieces included. No Compass
-position scales a defensive layer directly. Melee-side builds live in strike delivery and lean on
-Evasion and Block; ranged-side builds live in projectile exposure and lean on Dodge and Deflect;
-Altered-side builds lean on Barrier. Equipment bases that carry layer identities are an option the
-itemisation note may take up, not a rule here.
+Compass position sets requirements for identity equipment on every axis, defensive pieces included;
+no position strengthens a defensive layer directly. Melee-side builds live in strike delivery and
+lean on Evasion and Block; ranged-side builds live in projectile exposure and lean on Dodge and
+Deflect. Equipment bases that carry layer identities are an option the itemisation note may take up,
+not a rule here.
 
 ## Non-Goals
 
 This note does not define avoidance or interception math, smoothing functions, the armour curve,
 recharge timings, buffer ratios, resistance cap values, or enemy layer distributions. Formulas
-belong to the combat note; enemy distributions to the enemy-families note; single-target-versus-
-area spread and burst-versus-sustain endurance are equipment and skill properties owned by the
-itemisation and skills notes.
+belong to the combat note; enemy distributions to the enemy-families note; making interception's
+effective value legible per region belongs to the reporting note; single-target-versus-area spread
+and burst-versus-sustain endurance are equipment and skill properties owned by the itemisation and
+skills notes.

--- a/docs/game-design/003-defensive-archetypes.md
+++ b/docs/game-design/003-defensive-archetypes.md
@@ -143,7 +143,9 @@ Recovery styles are separate investments, never one stat:
 - **Encounter-start effects** — recovery or resources granted at the start of every encounter after
   an activity's first. This is the only between-fight recovery in the game.
 
-Defensive uptime never depends on spendable Aether: a starved avatar keeps its defenses.
+The defensive layers cost no Aether to run: a starved avatar keeps its defenses. Aether-costed
+defensive skills, cooldowns, or pools are an option the skills and itemisation notes may take up,
+not a rule here.
 
 ## Azimuth Interaction
 

--- a/docs/game-design/003-defensive-archetypes.md
+++ b/docs/game-design/003-defensive-archetypes.md
@@ -56,7 +56,7 @@ Two properties of an activity decide what defense matters:
 
 - **Encounter count** decides how much sustain matters: short activities reward per-encounter
   survival; long chains reward leech, regeneration, and encounter-start investment.
-- **Encounter density** — monsters per encounter — decides how much hit volume matters: dense packs
+- **Encounter density** — enemies per encounter — decides how much hit volume matters: dense packs
   feed avoidance and armour, sparse elites feed interception.
 
 Carried debuffs make persistent-leaning regions genuinely attritional: the avatar wears down across

--- a/docs/game-design/003-defensive-archetypes.md
+++ b/docs/game-design/003-defensive-archetypes.md
@@ -1,0 +1,142 @@
+# Defensive Archetypes
+
+This note defines the forms of the damage model's defensive layers and the structure of play they
+defend inside. Defensive identity in Vers is emergent: an archetype is a recognized pattern of layer
+investment, never an enforced kit. Defensive stats compete for the shared gear and passive budget,
+and each layer answers a different threat profile, so redundant stacking wastes budget and mixing
+against a region's profile is always a real decision.
+
+## Hit Deliveries
+
+Every hit carries a delivery:
+
+- **Strike** — contact: blows, blades, grapples, rams.
+- **Projectile** — a traveling object: rounds, thrown mass, launched fragments.
+- **Direct** — delivered without a travel vector: signal, lock, imposition. Direct hits cannot be
+  avoided or intercepted.
+- **Area** — a detonation across a space: explosions, shockwaves, eruptions. Area hits cannot be
+  avoided or intercepted.
+
+Persistent damage is not a hit and has no delivery.
+
+Strange damage lean direct: Cognitive and Null arrive mostly as impositions rather than objects. A
+region or enemy family's delivery profile characterizes it as strongly as its damage mix, and both
+appear in its fingerprint.
+
+| Layer       | Strike | Projectile | Direct | Area | Persistent |
+| ----------- | ------ | ---------- | ------ | ---- | ---------- |
+| Evasion     | ✓      | —          | —      | —    | —          |
+| Dodge       | —      | ✓          | —      | —    | —          |
+| Block       | ✓      | —          | —      | —    | —          |
+| Deflect     | —      | ✓          | —      | —    | —          |
+| Armour      | ✓      | ✓          | ✓      | ✓    | ✓          |
+| Resistances | ✓      | ✓          | ✓      | ✓    | ✓          |
+| Barrier     | ✓      | ✓          | ✓      | ✓    | ✓          |
+
+## Avoidance: Evasion & Dodge
+
+Avoidance fully negates a hit before it connects. **Evasion** applies to strike hits; **Dodge**
+applies to projectile hits.
+
+Both forms are chance-shaped and smoothed: realized avoidance tracks stated avoidance without lucky
+or unlucky streaks, so an unattended avatar's survival never rests on a roll sequence. Avoidance
+thins a hit stream in proportion to its volume — it is strongest against many small hits and
+contributes least against a single decisive one.
+
+## Interception: Block & Deflect
+
+Interception spends a charge to reduce a connecting hit. **Block** intercepts strike hits;
+**Deflect** intercepts projectile hits.
+
+Both forms draw on one shared charge pool. Pool capacity and refill rate are shared investment;
+trigger chance and the amount mitigated are invested per form. Trigger chance is smoothed like
+avoidance. Interception reduces at baseline — full negation is the ceiling of deep investment, not
+the default.
+
+Charge economics bound interception without a cap: refill rate against enemy hit rate limits how
+much of a stream can be intercepted. Sparse heavy hitters meet a charge on every swing; dense fast
+streams drain the pool and land past it. Interception is strongest against few large hits and
+weakest against volume — the inverse of avoidance, so the two compose instead of stacking: avoidance
+thins the stream, interception catches the haymakers.
+
+## Armour
+
+Armour is Physical mitigation. Its reduction scales inversely with the size of the incoming hit:
+small hits are mostly absorbed, massive hits punch through. Armour erases chaff and fades against
+giants — the mirror of interception, and the pairing that lets a committed defender cover the full
+hit-size spectrum.
+
+## Resistances
+
+Resistances are the six type-specific mitigations, capped, specced against a region's damage mix.
+With Life, they are the deterministic floor: baseline content is tuned so resistances and Life alone
+survive it, and every avoidance and interception stat is elective headroom. Direct and area hits are
+answered here.
+
+## Barrier
+
+Barrier is the pool consumed before Life. Its native recovery is **recharge**: after a delay without
+taking a hit, Barrier refills rapidly until touched again. Investment is pool size, recharge delay,
+and recharge rate.
+
+Barrier regeneration exists at a base of zero: steady per-beat recovery is bought as its own
+percent-based investment, and without that investment no amount of scaling produces any.
+
+Barrier is the tempo layer: it favors fights that grant untouched windows and degrades under
+relentless pressure. Dense encounters and persistent damage are anti-Barrier by nature.
+
+## Buffer
+
+Buffer defers damage: a portion of a qualifying hit lands as decaying damage over the following
+beats instead of instantly. Deferral converts spikes into pressure that recovery can answer — the
+counterpart to interception, which removes spike damage rather than smearing it. Which hits qualify,
+how much defers, and the decay rate are combat-note territory.
+
+## Life & Recovery
+
+Life is the final pool; reaching zero ends the activity under the defeat rules of the core note.
+
+Recovery styles are separate investments, never one stat:
+
+- **Regeneration** — steady per-beat recovery of a pool.
+- **Leech** — recovery from damage dealt, invested separately for Life, Barrier, and Reserve.
+- **On-intercept effects** — recovery or charge economy triggered by a successful Block or Deflect.
+- **Encounter-start effects** — recovery or resources granted at the start of every encounter after
+  an activity's first. This is the only between-fight recovery in the game.
+
+## Activities & Encounters
+
+The activity is the unit of play, and progression, region, and skill design inherit this structure.
+An avatar enters an activity at full state and resets to full state between activities. Inside an
+activity, encounters chain with no time between them: each encounter begins immediately, seeded with
+the avatar's carried state.
+
+Across an encounter boundary, pools keep their values; buffs, debuffs, statuses, and cooldown
+progress persist; beat alignment resets. Nothing else restores. Encounters are therefore
+independently simulable from their entry state, and reporting can resolve per encounter.
+
+Two dials price defense:
+
+- **Encounter count** prices sustain: short activities reward per-encounter survival, long chains
+  reward leech, regeneration, and encounter-start investment.
+- **Encounter density** — monsters per encounter — prices hit volume: dense packs feed avoidance and
+  armour, sparse elites feed interception.
+
+Carried debuffs make persistent-leaning regions genuinely attritional; that is their identity, not a
+tuning accident.
+
+## Compass Interaction
+
+Compass position gates identity equipment on every axis, defensive pieces included. No Compass
+position scales a defensive layer directly. Melee-side builds live in strike delivery and lean on
+Evasion and Block; ranged-side builds live in projectile exposure and lean on Dodge and Deflect;
+Altered-side builds lean on Barrier. Equipment bases that carry layer identities are an option the
+itemisation note may take up, not a rule here.
+
+## Non-Goals
+
+This note does not define avoidance or interception math, smoothing functions, the armour curve,
+recharge timings, buffer ratios, resistance cap values, or enemy layer distributions. Formulas
+belong to the combat note; enemy distributions to the enemy-families note; single-target-versus-
+area spread and burst-versus-sustain endurance are equipment and skill properties owned by the
+itemisation and skills notes.

--- a/docs/game-design/003-defensive-archetypes.md
+++ b/docs/game-design/003-defensive-archetypes.md
@@ -138,16 +138,16 @@ Life is the final pool; reaching zero ends the activity under the defeat rules o
 Recovery styles are separate investments, never one stat:
 
 - **Regeneration** — steady per-beat recovery of a pool.
-- **Leech** — recovery from damage dealt, invested separately for Life, Barrier, and Reserve.
+- **Leech** — recovery from damage dealt, invested separately for Life, Barrier, and Aether.
 - **On-intercept effects** — recovery or charge effects triggered by a successful Block or Deflect.
 - **Encounter-start effects** — recovery or resources granted at the start of every encounter after
   an activity's first. This is the only between-fight recovery in the game.
 
-Defensive uptime never depends on spendable Reserve: a starved avatar keeps its defenses.
+Defensive uptime never depends on spendable Aether: a starved avatar keeps its defenses.
 
-## Compass Interaction
+## Azimuth Interaction
 
-Compass position sets requirements for identity equipment on every axis, defensive pieces included;
+Azimuth position sets requirements for identity equipment on every axis, defensive pieces included;
 no position strengthens a defensive layer directly. Melee-side builds live in strike delivery and
 lean on Evasion and Block; ranged-side builds live in projectile exposure and lean on Dodge and
 Deflect. Equipment bases that carry layer identities are an option the itemisation note may take up,


### PR DESCRIPTION
## Description

Closes #227. Adds the defensive-archetypes design note and amends the foundation notes with the decisions it forced.

- 003: hit deliveries (strike/projectile/direct/area), Evasion/Dodge + Block/Deflect on a shared charge pool, Armour, Barrier recharge, Buffer (deferred damage), per-pool recovery styles, activity/encounter structure
- 002: damage roster is now Physical/Heat/Cold/Electric/Toxic/Cognitive/Null; Focus/Vigor/Will replaced by the Azimuth — three gates-only bipolar axes (melee↔ranged, light↔heavy, innate↔altered) weighted by passive-tree pathing, distance from center emergent and unnamed
- Names settled: the resource is Aether (officially the somatic factor — worn-name pattern), the attribute system is the Azimuth
- 001: register scoping, Buffer canonized, vocabulary register updated

## Testing

- [x] `bun run format:check` passes (docs-only)

## Context

Design decisions from an interactive session; combat math stays with #270.

https://claude.ai/code/session_014N5Sgo59yF75mBeVX23TvF
