### PR TITLE
feat(#121): degrade gracefully without shared-worker support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -338,6 +338,10 @@ files contain no `beforeAll`/`beforeEach`/`afterEach`/`afterAll`. This is what k
   upstream-failure cases. For oRPC procedures, build those handlers with `buildMockService` /
   `mockService` (`@vers/client-test-utils/rpc-msw`).
 - **Global mock reset** lives in the preload's `afterEach` (`mock.restore()`), never per-test.
+- **A test that mutates global or environment state** restores it in an `onTestFinished(...)`
+  callback registered inside the test — not `try`/`finally`, not a lifecycle hook — so teardown runs
+  after the test whether it passes or throws. A setup helper may register the `onTestFinished`
+  itself, giving callers restoration without wrapping their body.
 - **jest-extended matchers** come from the `@zgeoff/bun-test-extended` preload; a package-local
   `augment-bun-test.ts` side-effect import brings their types into `tsc`.
 - `toStrictEqual`, not `toEqual`, for object assertions.

--- a/agents/project.md
+++ b/agents/project.md
@@ -135,6 +135,10 @@ files contain no `beforeAll`/`beforeEach`/`afterEach`/`afterAll`. This is what k
   upstream-failure cases. For oRPC procedures, build those handlers with `buildMockService` /
   `mockService` (`@vers/client-test-utils/rpc-msw`).
 - **Global mock reset** lives in the preload's `afterEach` (`mock.restore()`), never per-test.
+- **A test that mutates global or environment state** restores it in an `onTestFinished(...)`
+  callback registered inside the test — not `try`/`finally`, not a lifecycle hook — so teardown runs
+  after the test whether it passes or throws. A setup helper may register the `onTestFinished`
+  itself, giving callers restoration without wrapping their body.
 - **jest-extended matchers** come from the `@zgeoff/bun-test-extended` preload; a package-local
   `augment-bun-test.ts` side-effect import brings their types into `tsc`.
 - `toStrictEqual`, not `toEqual`, for object assertions.

--- a/projects/app-web/src/components/simulation-unsupported-notice.test.tsx
+++ b/projects/app-web/src/components/simulation-unsupported-notice.test.tsx
@@ -1,0 +1,9 @@
+import { expect, test } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import { SimulationUnsupportedNotice } from './simulation-unsupported-notice';
+
+test('it reports the simulation as unavailable', () => {
+  render(<SimulationUnsupportedNotice />);
+
+  expect(screen.getByRole('status')).toHaveTextContent(/activity simulation is unavailable/i);
+});

--- a/projects/app-web/src/components/simulation-unsupported-notice.tsx
+++ b/projects/app-web/src/components/simulation-unsupported-notice.tsx
@@ -1,0 +1,29 @@
+import { Text } from '@vers/design-system';
+import { css } from '@vers/styled-system/css';
+
+/**
+ * Shown where the idle simulation would render in a browser without SharedWorker: the rest of the
+ * game stays usable, so this reports the degraded feature rather than blocking the screen.
+ */
+export function SimulationUnsupportedNotice() {
+  return (
+    <output
+      className={css({
+        backgroundColor: 'bg.panel',
+        borderColor: 'border',
+        borderRadius: 'md',
+        borderWidth: '[1px]',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '2',
+        padding: '6',
+      })}
+    >
+      <Text bold>Activity simulation is unavailable in this browser</Text>
+      <Text className={css({ color: 'text.muted' })}>
+        Running activities needs SharedWorker support. Open the game in a desktop browser like
+        Chrome or Firefox to use this part of the game — the rest works here.
+      </Text>
+    </output>
+  );
+}

--- a/projects/app-web/src/lib/platform/is-shared-worker-supported.test.ts
+++ b/projects/app-web/src/lib/platform/is-shared-worker-supported.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from 'bun:test';
+import { removeSharedWorker } from '../../test-utils/remove-shared-worker';
+import { isSharedWorkerSupported } from './is-shared-worker-supported';
+
+test('it reports support when the SharedWorker constructor exists', () => {
+  expect(isSharedWorkerSupported()).toBe(true);
+});
+
+test('it reports no support when the SharedWorker constructor is absent', () => {
+  removeSharedWorker();
+
+  expect(isSharedWorkerSupported()).toBe(false);
+});

--- a/projects/app-web/src/lib/platform/is-shared-worker-supported.ts
+++ b/projects/app-web/src/lib/platform/is-shared-worker-supported.ts
@@ -1,0 +1,7 @@
+/**
+ * Whether this runtime exposes the `SharedWorker` constructor. False on the server and in browsers
+ * that lack it (Android Chrome, older Safari), where the idle simulation cannot run.
+ */
+export function isSharedWorkerSupported(): boolean {
+  return typeof SharedWorker !== 'undefined';
+}

--- a/projects/app-web/src/lib/platform/use-is-shared-worker-supported.test.tsx
+++ b/projects/app-web/src/lib/platform/use-is-shared-worker-supported.test.tsx
@@ -1,0 +1,18 @@
+import { expect, test } from 'bun:test';
+import { renderHook } from '@testing-library/react';
+import { removeSharedWorker } from '../../test-utils/remove-shared-worker';
+import { useIsSharedWorkerSupported } from './use-is-shared-worker-supported';
+
+test('it reports support when the SharedWorker constructor exists', () => {
+  const hook = renderHook(() => useIsSharedWorkerSupported());
+
+  expect(hook.result.current).toBe(true);
+});
+
+test('it reports no support when the SharedWorker constructor is absent', () => {
+  removeSharedWorker();
+
+  const hook = renderHook(() => useIsSharedWorkerSupported());
+
+  expect(hook.result.current).toBe(false);
+});

--- a/projects/app-web/src/lib/platform/use-is-shared-worker-supported.ts
+++ b/projects/app-web/src/lib/platform/use-is-shared-worker-supported.ts
@@ -1,0 +1,23 @@
+import { useSyncExternalStore } from 'react';
+import { isSharedWorkerSupported } from './is-shared-worker-supported';
+
+/**
+ * SSR-safe read of SharedWorker support. The server snapshot is always false, so the first client
+ * render matches the server and the real value resolves after hydration — a component may gate on
+ * this without a hydration mismatch.
+ */
+export function useIsSharedWorkerSupported(): boolean {
+  return useSyncExternalStore(subscribe, isSharedWorkerSupported, getServerSnapshot);
+}
+
+function subscribe(): () => void {
+  return unsubscribe;
+}
+
+function unsubscribe(): void {
+  // SharedWorker support is fixed for a page's lifetime, so there is nothing to tear down.
+}
+
+function getServerSnapshot(): boolean {
+  return false;
+}

--- a/projects/app-web/src/routes/-aether-current/aether-current-panel.test.tsx
+++ b/projects/app-web/src/routes/-aether-current/aether-current-panel.test.tsx
@@ -2,6 +2,7 @@ import { expect, test } from 'bun:test';
 import { render, screen } from '@testing-library/react';
 import { setSelectedNode } from '@vers/aether-client';
 import type { ActivityAppState } from '@vers/idle-core';
+import { removeSharedWorker } from '../../test-utils/remove-shared-worker';
 import { withIdleWorkerHandle } from '../../test-utils/with-idle-worker-handle';
 import { AetherCurrentPanel } from './aether-current-panel';
 
@@ -40,6 +41,17 @@ test('it shows a spinner and sends initialize before the worker reports its stat
 
   expect(calls).toStrictEqual([{ type: 'initialize' }]);
   expect(screen.queryByTestId('aether-node-codex-stub')).not.toBeInTheDocument();
+});
+
+test('it reports the simulation as unavailable when SharedWorker is unsupported', async () => {
+  setSelectedNode(null);
+  removeSharedWorker();
+
+  await withIdleWorkerHandle({ activity: undefined, initialized: false, worker: undefined }, () => {
+    render(<AetherCurrentPanel />);
+  });
+
+  expect(screen.getByRole('status')).toHaveTextContent(/activity simulation is unavailable/i);
 });
 
 test('it sends set-activity once initialized but the worker has not caught up yet', async () => {

--- a/projects/app-web/src/routes/-aether-current/aether-current-panel.tsx
+++ b/projects/app-web/src/routes/-aether-current/aether-current-panel.tsx
@@ -3,10 +3,12 @@ import { Spinner } from '@vers/design-system';
 import { createMockActivityData, createMockAvatarData } from '@vers/idle-core';
 import { Suspense, useEffect } from 'react';
 import { AetherNodeCodexSlot } from '../../components/aether-node-codex-slot';
+import { SimulationUnsupportedNotice } from '../../components/simulation-unsupported-notice';
 import { IdleAetherNode } from '../../lib/idle/idle-aether-node';
 import { sendIdleInitialize } from '../../lib/idle/send-idle-initialize';
 import { sendIdleSetActivity } from '../../lib/idle/send-idle-set-activity';
 import { useIdleWorkerHandle } from '../../lib/idle/use-idle-worker-handle';
+import { useIsSharedWorkerSupported } from '../../lib/platform/use-is-shared-worker-supported';
 
 /**
  * Module-scoped so its identity — and its `id` — stays stable across renders.
@@ -19,6 +21,7 @@ const PLACEHOLDER_AVATAR = createMockAvatarData();
  * sent, then renders the node and its codex slot.
  */
 export function AetherCurrentPanel() {
+  const isSharedWorkerSupported = useIsSharedWorkerSupported();
   const idleWorkerHandle = useIdleWorkerHandle();
   const selectedNode = useSelectedNode().node;
   const isActivityReady = idleWorkerHandle.activity?.id === PLACEHOLDER_ACTIVITY.id;
@@ -38,6 +41,10 @@ export function AetherCurrentPanel() {
       sendIdleSetActivity(idleWorkerHandle.worker, PLACEHOLDER_ACTIVITY, PLACEHOLDER_AVATAR);
     }
   }, [idleWorkerHandle.worker, idleWorkerHandle.initialized, isActivityReady]);
+
+  if (!isSharedWorkerSupported) {
+    return <SimulationUnsupportedNotice />;
+  }
 
   if (!isActivityReady) {
     return <Spinner />;

--- a/projects/app-web/src/test-utils/remove-shared-worker.ts
+++ b/projects/app-web/src/test-utils/remove-shared-worker.ts
@@ -1,0 +1,15 @@
+import { onTestFinished } from 'bun:test';
+
+/**
+ * Removes `SharedWorker` from the global scope for the running test — the unsupported-browser
+ * path — and restores the placeholder the preload installs once the test finishes.
+ */
+export function removeSharedWorker(): void {
+  const original = globalThis.SharedWorker;
+
+  Reflect.set(globalThis, 'SharedWorker', undefined);
+
+  onTestFinished(() => {
+    globalThis.SharedWorker = original;
+  });
+}

--- a/projects/app-web/test-setup.ts
+++ b/projects/app-web/test-setup.ts
@@ -17,6 +17,15 @@ faker.seed(1);
 
 GlobalRegistrator.register();
 
+// happy-dom ships no `SharedWorker`; define a placeholder so the app's support check reports the
+// supported path real browsers take. The worker handle is mocked, so nothing constructs it. Tests
+// covering the unsupported path remove it locally.
+function SharedWorkerPlaceholder(): void {
+  throw new Error('SharedWorker placeholder is not constructable under bun test');
+}
+
+Reflect.set(globalThis, 'SharedWorker', SharedWorkerPlaceholder);
+
 expect.extend(jestDOMMatchers);
 
 registerMSWLifecycle(server);

--- a/projects/lib-idle-client/src/worker/use-simulation-worker.test.ts
+++ b/projects/lib-idle-client/src/worker/use-simulation-worker.test.ts
@@ -2,8 +2,9 @@ import { renderHook } from '@testing-library/react';
 import { postMessageAndWaitForReply } from '@vers/client-test-utils';
 import { createMockActivityData, createMockAvatarData } from '@vers/idle-core';
 import invariant from 'tiny-invariant';
-import { afterEach, expect, test } from 'vitest';
+import { afterEach, expect, onTestFinished, test } from 'vitest';
 import { setSimulationWorker } from '../state/set-simulation-worker';
+import { useSimulationStore } from '../state/use-simulation-store';
 import type { InitializeMessage, SetActivityMessage } from '../types';
 import { ClientMessageType, WorkerMessageType } from '../types';
 import { useSimulationWorker } from './use-simulation-worker';
@@ -40,6 +41,26 @@ test('it returns an existing worker instead of creating a new one', () => {
   const hook = renderHook(() => useSimulationWorker());
 
   expect(hook.result.current).toBe(worker);
+});
+
+test('it creates no worker when SharedWorker is unsupported', () => {
+  useSimulationStore.setState({ worker: null });
+
+  const originalSharedWorker = globalThis.SharedWorker;
+
+  Reflect.set(globalThis, 'SharedWorker', undefined);
+
+  onTestFinished(() => {
+    globalThis.SharedWorker = originalSharedWorker;
+  });
+
+  const hook = renderHook(() => useSimulationWorker());
+
+  hook.rerender();
+
+  expect(hook.result.current).toBeNull();
+
+  hook.unmount();
 });
 
 test('it handles state updates from worker', async () => {

--- a/projects/lib-idle-client/src/worker/use-simulation-worker.ts
+++ b/projects/lib-idle-client/src/worker/use-simulation-worker.ts
@@ -13,6 +13,12 @@ export function useSimulationWorker() {
   const existingWorker = useSimulationStore((state) => state.worker);
 
   useEffect(() => {
+    // Browsers without SharedWorker (Android Chrome, older Safari) would throw on construction;
+    // the worker stays undefined and every consumer degrades to its no-worker branch.
+    if (typeof SharedWorker === 'undefined') {
+      return;
+    }
+
     const worker = existingWorker ?? new SimulationWorker();
 
     setSimulationWorker(worker);


### PR DESCRIPTION
## Description

Closes #121

Browsers without `SharedWorker` (Android Chrome, older Safari) crashed the game — the idle simulation hook constructed one unconditionally. Detect support, skip the worker, and degrade the activity view instead.

- Guard the worker mount so it never constructs a `SharedWorker` when absent; the handle stays undefined, which every consumer already handles.
- Add `isSharedWorkerSupported` + an SSR-safe `useIsSharedWorkerSupported` hook as a reusable capability gate for future selective gating.
- Show a minimal degradation notice where the activity panel would render; avatar, nexus, and the aether map keep working.
- Document `onTestFinished` for per-test global/env cleanup (both runners ship it).

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes (`@vers/web`, `@vers/idle-client`)
- [x] `bun run lint` passes
- [x] `bun run format:check` / `boundaries` pass