### PR TITLE
feat(#301): adopt conform 1.19.4 + start form glue

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -138,8 +138,10 @@
             ]
           },
           { "from": "package", "name": "ReactNode", "package": "react" },
+          { "from": "package", "name": "SyntheticEvent", "package": "react" },
           { "from": "package", "name": "ZodError", "package": "zod" },
           { "from": "package", "name": "JWTPayload", "package": "jose" },
+          { "from": "package", "name": "SubmissionResult", "package": "@conform-to/dom" },
           // not handles but intentionally never readonly: idle-core's tick
           // and lifecycle handlers mutate these entities in place for
           // performance, so no readonly form of them exists to consume

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -386,6 +386,22 @@ files contain no `beforeAll`/`beforeEach`/`afterEach`/`afterAll`. This is what k
   is a review finding. Every stubbed ambient path is also crossed by the smoke suite. Explicit args
   stay preferred where they cost nothing.
 
+### Forms (Conform)
+
+- A form island drives a Conform form through the shared `useFormSubmit` hook (`lib/forms/`): the
+  hook takes the form's server function, dispatches the assembled `FormData`, and hands back
+  `lastResult` for `useForm`, an in-flight flag for the submit button, and the submit handler. The
+  handler runs `parseWithZod(formData)` and returns `submission.reply()`; the honeypot check stays a
+  server-side helper. Validation imports from `@conform-to/zod/v4`, matching app-web's zod v4.
+- The hook takes an optional seed `lastResult` beside the server function, and an island forwards
+  both from props, so a test injects a stand-in action or seeds a result without touching the wire.
+- Cover a form's result→UI mapping by rendering the island with a fabricated
+  `submission.reply()`-shaped `lastResult` and asserting the rendered errors — a form-level message
+  under the empty-string key, a field message under the field name. No submit runs and no server is
+  reached, so every result branch is assertable, including the plain-object branch a live
+  `createServerFn` dispatch collapses to `undefined` under bun test. Drive pending state and the
+  out-of-band `Response` fallback by injecting an action instead.
+
 ### Real-database services (service/app/DB packages)
 
 Services, apps, and DB-backed libraries whose tests exercise a real postgres follow this standard —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -388,19 +388,17 @@ files contain no `beforeAll`/`beforeEach`/`afterEach`/`afterAll`. This is what k
 
 ### Forms (Conform)
 
-- A form island drives a Conform form through the shared `useFormSubmit` hook (`lib/forms/`): the
-  hook takes the form's server function, dispatches the assembled `FormData`, and hands back
-  `lastResult` for `useForm`, an in-flight flag for the submit button, and the submit handler. The
-  handler runs `parseWithZod(formData)` and returns `submission.reply()`; the honeypot check stays a
-  server-side helper. Validation imports from `@conform-to/zod/v4`, matching app-web's zod v4.
-- The hook takes an optional seed `lastResult` beside the server function, and an island forwards
-  both from props, so a test injects a stand-in action or seeds a result without touching the wire.
-- Cover a form's result→UI mapping by rendering the island with a fabricated
-  `submission.reply()`-shaped `lastResult` and asserting the rendered errors — a form-level message
-  under the empty-string key, a field message under the field name. No submit runs and no server is
-  reached, so every result branch is assertable, including the plain-object branch a live
-  `createServerFn` dispatch collapses to `undefined` under bun test. Drive pending state and the
-  out-of-band `Response` fallback by injecting an action instead.
+- A form island drives a Conform form through the shared `useFormSubmit` hook (`lib/forms/`): pass
+  the form's server function and it dispatches the `FormData`, returning `lastResult` for `useForm`,
+  an in-flight flag, and the submit handler. The handler runs `parseWithZod(formData)` and returns
+  `submission.reply()`; the honeypot check stays a server-side helper. Validation imports from
+  `@conform-to/zod/v4`, matching app-web's zod v4.
+- The hook also takes an optional seed `lastResult`, which an island forwards from props beside the
+  action. Cover a form's result→UI mapping by rendering it with a fabricated
+  `submission.reply()`-shaped `lastResult` and asserting the errors — a form-level message under the
+  empty-string key, a field message under the field name. This reaches every branch with no submit
+  and no server, including the plain-object branch a live `createServerFn` dispatch collapses to
+  `undefined` under bun test. Inject an action to drive pending state and the `Response` fallback.
 
 ### Real-database services (service/app/DB packages)
 

--- a/agents/project.md
+++ b/agents/project.md
@@ -183,6 +183,22 @@ files contain no `beforeAll`/`beforeEach`/`afterEach`/`afterAll`. This is what k
   is a review finding. Every stubbed ambient path is also crossed by the smoke suite. Explicit args
   stay preferred where they cost nothing.
 
+### Forms (Conform)
+
+- A form island drives a Conform form through the shared `useFormSubmit` hook (`lib/forms/`): the
+  hook takes the form's server function, dispatches the assembled `FormData`, and hands back
+  `lastResult` for `useForm`, an in-flight flag for the submit button, and the submit handler. The
+  handler runs `parseWithZod(formData)` and returns `submission.reply()`; the honeypot check stays a
+  server-side helper. Validation imports from `@conform-to/zod/v4`, matching app-web's zod v4.
+- The hook takes an optional seed `lastResult` beside the server function, and an island forwards
+  both from props, so a test injects a stand-in action or seeds a result without touching the wire.
+- Cover a form's result→UI mapping by rendering the island with a fabricated
+  `submission.reply()`-shaped `lastResult` and asserting the rendered errors — a form-level message
+  under the empty-string key, a field message under the field name. No submit runs and no server is
+  reached, so every result branch is assertable, including the plain-object branch a live
+  `createServerFn` dispatch collapses to `undefined` under bun test. Drive pending state and the
+  out-of-band `Response` fallback by injecting an action instead.
+
 ### Real-database services (service/app/DB packages)
 
 Services, apps, and DB-backed libraries whose tests exercise a real postgres follow this standard —

--- a/agents/project.md
+++ b/agents/project.md
@@ -185,19 +185,17 @@ files contain no `beforeAll`/`beforeEach`/`afterEach`/`afterAll`. This is what k
 
 ### Forms (Conform)
 
-- A form island drives a Conform form through the shared `useFormSubmit` hook (`lib/forms/`): the
-  hook takes the form's server function, dispatches the assembled `FormData`, and hands back
-  `lastResult` for `useForm`, an in-flight flag for the submit button, and the submit handler. The
-  handler runs `parseWithZod(formData)` and returns `submission.reply()`; the honeypot check stays a
-  server-side helper. Validation imports from `@conform-to/zod/v4`, matching app-web's zod v4.
-- The hook takes an optional seed `lastResult` beside the server function, and an island forwards
-  both from props, so a test injects a stand-in action or seeds a result without touching the wire.
-- Cover a form's result→UI mapping by rendering the island with a fabricated
-  `submission.reply()`-shaped `lastResult` and asserting the rendered errors — a form-level message
-  under the empty-string key, a field message under the field name. No submit runs and no server is
-  reached, so every result branch is assertable, including the plain-object branch a live
-  `createServerFn` dispatch collapses to `undefined` under bun test. Drive pending state and the
-  out-of-band `Response` fallback by injecting an action instead.
+- A form island drives a Conform form through the shared `useFormSubmit` hook (`lib/forms/`): pass
+  the form's server function and it dispatches the `FormData`, returning `lastResult` for `useForm`,
+  an in-flight flag, and the submit handler. The handler runs `parseWithZod(formData)` and returns
+  `submission.reply()`; the honeypot check stays a server-side helper. Validation imports from
+  `@conform-to/zod/v4`, matching app-web's zod v4.
+- The hook also takes an optional seed `lastResult`, which an island forwards from props beside the
+  action. Cover a form's result→UI mapping by rendering it with a fabricated
+  `submission.reply()`-shaped `lastResult` and asserting the errors — a form-level message under the
+  empty-string key, a field message under the field name. This reaches every branch with no submit
+  and no server, including the plain-object branch a live `createServerFn` dispatch collapses to
+  `undefined` under bun test. Inject an action to drive pending state and the `Response` fallback.
 
 ### Real-database services (service/app/DB packages)
 

--- a/bun.lock
+++ b/bun.lock
@@ -48,6 +48,8 @@
       "name": "@vers/web",
       "version": "0.0.0",
       "dependencies": {
+        "@conform-to/react": "1.19.4",
+        "@conform-to/zod": "1.19.4",
         "@msw/data": "1.1.6",
         "@orpc/client": "1.14.6",
         "@orpc/contract": "1.14.6",
@@ -327,8 +329,8 @@
         "react-icons": "5.5.0",
       },
       "devDependencies": {
-        "@conform-to/react": "1.2.2",
-        "@conform-to/zod": "1.2.2",
+        "@conform-to/react": "1.19.4",
+        "@conform-to/zod": "1.19.4",
         "@fontsource-variable/manrope": "5.2.8",
         "@fontsource/chakra-petch": "5.2.7",
         "@fontsource/ibm-plex-mono": "5.2.7",
@@ -790,11 +792,11 @@
 
     "@commitlint/types": ["@commitlint/types@19.8.1", "", { "dependencies": { "@types/conventional-commits-parser": "^5.0.0", "chalk": "^5.3.0" } }, "sha512-/yCrWGCoA1SVKOks25EGadP9Pnj0oAIHGpl2wH2M2Y46dPM2ueb8wyCVOD7O3WCTkaJ0IkKvzhl1JY7+uCT2Dw=="],
 
-    "@conform-to/dom": ["@conform-to/dom@1.2.2", "", {}, "sha512-f05EClpNP31o6lX4LYmmLqgsiTOHdGfY7z2XXK6U6rRp+EtxrkUBdrFlIGsfkf7e9AFO19h3/Cb/cXHVd1k1FA=="],
+    "@conform-to/dom": ["@conform-to/dom@1.19.4", "", {}, "sha512-P/mBdVRl946iE74TXmF5YLY9+1IDrQzxKdj9A7qv7Cd4l/O02EvJskg3X7cHwhmFFIXXgNzSmf/y4B597SS4gg=="],
 
-    "@conform-to/react": ["@conform-to/react@1.2.2", "", { "dependencies": { "@conform-to/dom": "1.2.2" }, "peerDependencies": { "react": ">=18" } }, "sha512-1JBECb3NKi5/IlexaYLgnAxGJ55MRuO2sEQ10cJfUK2bfltNbTIQnYUDG6pU886A4lda/q6UH/adPsjiB/4Gkg=="],
+    "@conform-to/react": ["@conform-to/react@1.19.4", "", { "dependencies": { "@conform-to/dom": "1.19.4" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-Xyw4hbD9467q8PTWW+Nvmf523y814w70eeABRJzVvfnpghGOAWAGt1lpOboAs6sqaKG/eouqifibz/r+PDFZLg=="],
 
-    "@conform-to/zod": ["@conform-to/zod@1.2.2", "", { "dependencies": { "@conform-to/dom": "1.2.2" }, "peerDependencies": { "zod": "^3.21.0" } }, "sha512-mNCzh0XsF2vhCtD8bfHYMYayEJ9dP6/KsGjmq8DFcO1ykDTNQZwfi1MIm4evGYVempSS3poYr4xZjd7cXEbtaw=="],
+    "@conform-to/zod": ["@conform-to/zod@1.19.4", "", { "dependencies": { "@conform-to/dom": "1.19.4" }, "peerDependencies": { "zod": "^3.21.0 || ^4.0.0" } }, "sha512-g80QtotXLcXWCF86Xou/VpI6i+NBOQxYgLS9YCQYrgV27yilZFJYpgWWBsA8YwodmJVBIYm9RawJba7WnUoddA=="],
 
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.38.4", "", { "dependencies": { "commander": "^11.1.0", "dotenv": "^16.4.5", "eciesjs": "^0.4.10", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "picomatch": "^4.0.2", "which": "^4.0.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js", "git-dotenvx": "src/cli/dotenvx.js" } }, "sha512-5rl1W5uMgSMrjluMqOf0FmUC6DILlR9Iy+6WzJIzt8qAON6gSbNZEkDG7MtktbK8g6QgQm9mMwaGgjW4DeU9Gw=="],
 

--- a/projects/app-web/package.json
+++ b/projects/app-web/package.json
@@ -15,6 +15,8 @@
     "typegen": "tsr generate"
   },
   "dependencies": {
+    "@conform-to/react": "1.19.4",
+    "@conform-to/zod": "1.19.4",
     "@msw/data": "1.1.6",
     "@orpc/client": "1.14.6",
     "@orpc/contract": "1.14.6",

--- a/projects/app-web/src/lib/forms/types.ts
+++ b/projects/app-web/src/lib/forms/types.ts
@@ -23,11 +23,6 @@ export interface FormSubmitContext {
   readonly formData: FormData;
 }
 
-/**
- * What the shared submit hook hands an island to drive a Conform form: the last submission's result
- * for `useForm`'s `lastResult`, the in-flight flag for the submit button, and the submit handler for
- * `useForm`'s `onSubmit`.
- */
 export interface FormSubmission {
   readonly isPending: boolean;
   readonly lastResult: SubmissionResult | undefined;

--- a/projects/app-web/src/lib/forms/types.ts
+++ b/projects/app-web/src/lib/forms/types.ts
@@ -1,0 +1,35 @@
+import type { SubmissionResult } from '@conform-to/react';
+import type { SyntheticEvent } from 'react';
+
+interface FormActionInput {
+  readonly data: FormData;
+}
+
+/**
+ * A form's submit action: a server function's client callable, or a stand-in a test injects in its
+ * place. Resolves to the reply of `parseWithZod(...).reply()`, a `Response` the server returned for
+ * an out-of-band rejection (a tripped honeypot, an unexpected failure), or `undefined` when the
+ * server threw a redirect the browser has already followed.
+ */
+export type FormAction = (
+  input: FormActionInput,
+) => Promise<Response | SubmissionResult | undefined>;
+
+/**
+ * The subset of Conform's submit context the shared submit handler reads — the assembled
+ * `FormData`. Conform passes a wider object; only this field is consumed.
+ */
+export interface FormSubmitContext {
+  readonly formData: FormData;
+}
+
+/**
+ * What the shared submit hook hands an island to drive a Conform form: the last submission's result
+ * for `useForm`'s `lastResult`, the in-flight flag for the submit button, and the submit handler for
+ * `useForm`'s `onSubmit`.
+ */
+export interface FormSubmission {
+  readonly isPending: boolean;
+  readonly lastResult: SubmissionResult | undefined;
+  readonly onSubmit: (event: SyntheticEvent<HTMLFormElement>, context: FormSubmitContext) => void;
+}

--- a/projects/app-web/src/lib/forms/use-form-submit.test.tsx
+++ b/projects/app-web/src/lib/forms/use-form-submit.test.tsx
@@ -1,0 +1,158 @@
+import { expect, test } from 'bun:test';
+import { getFormProps, getInputProps, useForm } from '@conform-to/react';
+import type { SubmissionResult } from '@conform-to/react';
+import { getZodConstraint, parseWithZod } from '@conform-to/zod/v4';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Field, StatusButton, Text } from '@vers/design-system';
+import { z } from 'zod';
+import { renderWithRouter } from '../../test-utils/render-with-router';
+import type { FormAction } from './types';
+import { useFormSubmit } from './use-form-submit';
+
+const ReferenceSchema = z.object({
+  email: z.email('Enter a valid email'),
+  password: z.string().min(8, 'Password is too short'),
+});
+
+function noopAction(): Promise<undefined> {
+  return Promise.resolve(undefined);
+}
+
+function rejectWithResponse(): Promise<Response> {
+  return Promise.resolve(new Response(null, { status: 400 }));
+}
+
+interface ReferenceFormProps {
+  readonly action?: FormAction;
+  readonly lastResult?: SubmissionResult;
+}
+
+/**
+ * A stand-in island wired exactly as a migrated form is: the submit hook drives `useForm`, so a test
+ * can inject an `action` to exercise the dispatch triage, or seed a `lastResult` to assert the
+ * result→UI mapping with no submit at all.
+ */
+function ReferenceForm(props: ReferenceFormProps) {
+  const submission = useFormSubmit(props.action ?? noopAction, props.lastResult);
+
+  const [form, fields] = useForm({
+    constraint: getZodConstraint(ReferenceSchema),
+    id: 'reference-form',
+    lastResult: submission.lastResult,
+    onSubmit: submission.onSubmit,
+    onValidate(context) {
+      return parseWithZod(context.formData, { schema: ReferenceSchema });
+    },
+  });
+
+  const { key: _emailKey, ...emailProps } = getInputProps(fields.email, { type: 'email' });
+
+  const { key: _passwordKey, ...passwordProps } = getInputProps(fields.password, {
+    type: 'password',
+  });
+
+  return (
+    <form {...getFormProps(form)}>
+      <Field
+        errors={fields.email.errors ?? []}
+        inputProps={{ ...emailProps, placeholder: 'Email' }}
+        labelProps={{ children: 'Email', htmlFor: emailProps.id }}
+      />
+      <Field
+        errors={fields.password.errors ?? []}
+        inputProps={{ ...passwordProps, placeholder: 'Password' }}
+        labelProps={{ children: 'Password', htmlFor: passwordProps.id }}
+      />
+      {form.errors !== undefined && <Text role="alert">{form.errors[0]}</Text>}
+      <StatusButton
+        disabled={submission.isPending}
+        status={submission.isPending ? StatusButton.Status.Pending : StatusButton.Status.Idle}
+        type="submit"
+        variant="primary"
+      >
+        Sign in
+      </StatusButton>
+    </form>
+  );
+}
+
+test('it maps a fabricated form-level result onto a form error with no submit', async () => {
+  renderWithRouter(
+    <ReferenceForm
+      lastResult={{ error: { '': ['Invalid email or password'] }, status: 'error' }}
+    />,
+  );
+
+  const alert = await screen.findByRole('alert');
+
+  expect(alert).toHaveTextContent('Invalid email or password');
+});
+
+test('it maps a fabricated field result onto that field with no submit', async () => {
+  renderWithRouter(
+    <ReferenceForm lastResult={{ error: { email: ['That email is taken'] }, status: 'error' }} />,
+  );
+
+  const fieldError = await screen.findByText('That email is taken');
+
+  expect(fieldError).toBeInTheDocument();
+});
+
+test('it maps a returned Response onto a generic form error', async () => {
+  const user = userEvent.setup();
+
+  renderWithRouter(<ReferenceForm action={rejectWithResponse} />);
+
+  const emailInput = await screen.findByPlaceholderText('Email');
+
+  await user.type(emailInput, 'player@vers.test');
+  await user.type(screen.getByPlaceholderText('Password'), 'password123');
+  await user.click(screen.getByRole('button', { name: 'Sign in' }));
+
+  await waitFor(() => {
+    expect(screen.getByRole('alert')).toHaveTextContent('Something went wrong. Please try again.');
+  });
+});
+
+test('it shows no error after a redirect resolves the submission', async () => {
+  const user = userEvent.setup();
+
+  renderWithRouter(<ReferenceForm action={noopAction} />);
+
+  const emailInput = await screen.findByPlaceholderText('Email');
+
+  await user.type(emailInput, 'player@vers.test');
+  await user.type(screen.getByPlaceholderText('Password'), 'password123');
+  await user.click(screen.getByRole('button', { name: 'Sign in' }));
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: 'Sign in' })).not.toBeDisabled();
+  });
+
+  expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+});
+
+test('it disables the submit button while the action is in flight', async () => {
+  const user = userEvent.setup();
+  const gate = Promise.withResolvers<undefined>();
+  const gatedAction: FormAction = () => gate.promise;
+
+  renderWithRouter(<ReferenceForm action={gatedAction} />);
+
+  const emailInput = await screen.findByPlaceholderText('Email');
+
+  await user.type(emailInput, 'player@vers.test');
+  await user.type(screen.getByPlaceholderText('Password'), 'password123');
+  await user.click(screen.getByRole('button', { name: 'Sign in' }));
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeDisabled();
+  });
+
+  gate.resolve(undefined);
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: 'Sign in' })).not.toBeDisabled();
+  });
+});

--- a/projects/app-web/src/lib/forms/use-form-submit.test.tsx
+++ b/projects/app-web/src/lib/forms/use-form-submit.test.tsx
@@ -147,8 +147,8 @@ test('it disables the submit button while the action is in flight', async () => 
   await user.type(screen.getByPlaceholderText('Password'), 'password123');
   await user.click(screen.getByRole('button', { name: 'Sign in' }));
 
-  // the pending toggle is driven outside `act` — poll the DOM rather than `waitFor`, which flushes
-  // through `act` and cannot observe it settle under CI timing
+  // the pending toggle is driven outside `act`; poll the DOM rather than `waitFor`, which flushes
+  // through `act` and can't observe it settle
   await assertEventually(() => {
     if (!screen.getByRole('button', { name: 'Sign in' }).hasAttribute('disabled')) {
       throw new Error('the submit button is not disabled yet');

--- a/projects/app-web/src/lib/forms/use-form-submit.test.tsx
+++ b/projects/app-web/src/lib/forms/use-form-submit.test.tsx
@@ -2,10 +2,11 @@ import { expect, test } from 'bun:test';
 import { getFormProps, getInputProps, useForm } from '@conform-to/react';
 import type { SubmissionResult } from '@conform-to/react';
 import { getZodConstraint, parseWithZod } from '@conform-to/zod/v4';
-import { act, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Field, StatusButton, Text } from '@vers/design-system';
 import { z } from 'zod';
+import { buildDeferred } from '../../test-utils/build-deferred';
 import { renderWithRouter } from '../../test-utils/render-with-router';
 import type { FormAction } from './types';
 import { useFormSubmit } from './use-form-submit';
@@ -135,8 +136,8 @@ test('it shows no error after a redirect resolves the submission', async () => {
 
 test('it disables the submit button while the action is in flight', async () => {
   const user = userEvent.setup();
-  const gate = Promise.withResolvers<undefined>();
-  const gatedAction: FormAction = () => gate.promise;
+  const deferred = buildDeferred<undefined>();
+  const gatedAction: FormAction = () => deferred.promise;
 
   renderWithRouter(<ReferenceForm action={gatedAction} />);
 
@@ -148,13 +149,7 @@ test('it disables the submit button while the action is in flight', async () => 
 
   expect(screen.getByRole('button', { name: 'Sign in' })).toBeDisabled();
 
-  // the re-enable fires from the resolved action's own continuation — a microtask outside React's
-  // batching; flush it inside `act` so the settled state is asserted directly, not polled for
-  await act(async () => {
-    gate.resolve(undefined);
-
-    await gate.promise;
-  });
+  await deferred.release(undefined);
 
   expect(screen.getByRole('button', { name: 'Sign in' })).not.toBeDisabled();
 });

--- a/projects/app-web/src/lib/forms/use-form-submit.test.tsx
+++ b/projects/app-web/src/lib/forms/use-form-submit.test.tsx
@@ -2,11 +2,10 @@ import { expect, test } from 'bun:test';
 import { getFormProps, getInputProps, useForm } from '@conform-to/react';
 import type { SubmissionResult } from '@conform-to/react';
 import { getZodConstraint, parseWithZod } from '@conform-to/zod/v4';
-import { screen, waitFor } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Field, StatusButton, Text } from '@vers/design-system';
 import { z } from 'zod';
-import { assertEventually } from '../../test-utils/assert-eventually';
 import { renderWithRouter } from '../../test-utils/render-with-router';
 import type { FormAction } from './types';
 import { useFormSubmit } from './use-form-submit';
@@ -147,19 +146,15 @@ test('it disables the submit button while the action is in flight', async () => 
   await user.type(screen.getByPlaceholderText('Password'), 'password123');
   await user.click(screen.getByRole('button', { name: 'Sign in' }));
 
-  // the pending toggle is driven outside `act`; poll the DOM rather than `waitFor`, which flushes
-  // through `act` and can't observe it settle
-  await assertEventually(() => {
-    if (!screen.getByRole('button', { name: 'Sign in' }).hasAttribute('disabled')) {
-      throw new Error('the submit button is not disabled yet');
-    }
+  expect(screen.getByRole('button', { name: 'Sign in' })).toBeDisabled();
+
+  // the re-enable fires from the resolved action's own continuation — a microtask outside React's
+  // batching; flush it inside `act` so the settled state is asserted directly, not polled for
+  await act(async () => {
+    gate.resolve(undefined);
+
+    await gate.promise;
   });
 
-  gate.resolve(undefined);
-
-  await assertEventually(() => {
-    if (screen.getByRole('button', { name: 'Sign in' }).hasAttribute('disabled')) {
-      throw new Error('the submit button is still disabled');
-    }
-  });
+  expect(screen.getByRole('button', { name: 'Sign in' })).not.toBeDisabled();
 });

--- a/projects/app-web/src/lib/forms/use-form-submit.test.tsx
+++ b/projects/app-web/src/lib/forms/use-form-submit.test.tsx
@@ -6,6 +6,7 @@ import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Field, StatusButton, Text } from '@vers/design-system';
 import { z } from 'zod';
+import { assertEventually } from '../../test-utils/assert-eventually';
 import { renderWithRouter } from '../../test-utils/render-with-router';
 import type { FormAction } from './types';
 import { useFormSubmit } from './use-form-submit';
@@ -146,13 +147,19 @@ test('it disables the submit button while the action is in flight', async () => 
   await user.type(screen.getByPlaceholderText('Password'), 'password123');
   await user.click(screen.getByRole('button', { name: 'Sign in' }));
 
-  await waitFor(() => {
-    expect(screen.getByRole('button', { name: 'Sign in' })).toBeDisabled();
+  // the pending toggle is driven outside `act` — poll the DOM rather than `waitFor`, which flushes
+  // through `act` and cannot observe it settle under CI timing
+  await assertEventually(() => {
+    if (!screen.getByRole('button', { name: 'Sign in' }).hasAttribute('disabled')) {
+      throw new Error('the submit button is not disabled yet');
+    }
   });
 
   gate.resolve(undefined);
 
-  await waitFor(() => {
-    expect(screen.getByRole('button', { name: 'Sign in' })).not.toBeDisabled();
+  await assertEventually(() => {
+    if (screen.getByRole('button', { name: 'Sign in' }).hasAttribute('disabled')) {
+      throw new Error('the submit button is still disabled');
+    }
   });
 });

--- a/projects/app-web/src/lib/forms/use-form-submit.ts
+++ b/projects/app-web/src/lib/forms/use-form-submit.ts
@@ -14,14 +14,10 @@ const GENERIC_SUBMIT_ERROR = 'Something went wrong. Please try again.';
  * Wires a Conform form to a TanStack Start server function: dispatches the assembled `FormData`,
  * holds the reply as `lastResult`, and tracks the in-flight flag. Triages the three shapes a
  * server-function call resolves to — a redirect the browser already followed (`undefined`, nothing
- * left to show), a `Response` the server returned for an out-of-band rejection (mapped to a
- * form-level error), or a `SubmissionResult` from `reply()` (shown as-is).
+ * left to show), a `Response` returned for an out-of-band rejection (mapped to a form-level error),
+ * or a `SubmissionResult` from `reply()` (shown as-is).
  *
- * The optional `lastResult` seeds the form before any dispatch: a fabricated result renders its
- * error→UI mapping with no server round-trip, and a real dispatch's reply supersedes it. A live
- * dispatch never resolves to a plain result under bun test — an uncompiled server-function call
- * relays only a `Response` or a thrown redirect — so branch coverage comes from the seed and from an
- * injected `action`, not from the real wire.
+ * An optional `lastResult` seeds the form before any dispatch; a dispatch's own reply supersedes it.
  */
 export function useFormSubmit(action: FormAction, lastResult?: SubmissionResult): FormSubmission {
   const [dispatchedResult, setDispatchedResult] = useState<SubmissionResult | undefined>(undefined);

--- a/projects/app-web/src/lib/forms/use-form-submit.ts
+++ b/projects/app-web/src/lib/forms/use-form-submit.ts
@@ -1,0 +1,60 @@
+import { parse } from '@conform-to/react';
+import type { SubmissionResult } from '@conform-to/react';
+import type { SyntheticEvent } from 'react';
+import { useState } from 'react';
+import type { FormAction, FormSubmission, FormSubmitContext } from './types';
+
+/**
+ * The message shown for a submission the server rejected out of band — a tripped honeypot or an
+ * unexpected failure — where no field-level detail is safe to reflect back.
+ */
+const GENERIC_SUBMIT_ERROR = 'Something went wrong. Please try again.';
+
+/**
+ * Wires a Conform form to a TanStack Start server function: dispatches the assembled `FormData`,
+ * holds the reply as `lastResult`, and tracks the in-flight flag. Triages the three shapes a
+ * server-function call resolves to — a redirect the browser already followed (`undefined`, nothing
+ * left to show), a `Response` the server returned for an out-of-band rejection (mapped to a
+ * form-level error), or a `SubmissionResult` from `reply()` (shown as-is).
+ *
+ * The optional `lastResult` seeds the form before any dispatch: a fabricated result renders its
+ * error→UI mapping with no server round-trip, and a real dispatch's reply supersedes it. A live
+ * dispatch never resolves to a plain result under bun test — an uncompiled server-function call
+ * relays only a `Response` or a thrown redirect — so branch coverage comes from the seed and from an
+ * injected `action`, not from the real wire.
+ */
+export function useFormSubmit(action: FormAction, lastResult?: SubmissionResult): FormSubmission {
+  const [dispatchedResult, setDispatchedResult] = useState<SubmissionResult | undefined>(undefined);
+  const [isPending, setIsPending] = useState(false);
+
+  const send = async (formData: FormData): Promise<void> => {
+    setIsPending(true);
+
+    try {
+      const result = await action({ data: formData });
+
+      if (result === undefined) {
+        return;
+      }
+
+      // A result Conform re-applies mid-session must carry the submitted values as `initialValue`,
+      // or its update path reads the absence as a reset and drops the error. A raw `Response` has
+      // none, so rebuild one through `parse` over the same `FormData`.
+      const nextResult =
+        result instanceof Response
+          ? parse(formData, { resolve: () => ({ error: { '': [GENERIC_SUBMIT_ERROR] } }) }).reply()
+          : result;
+
+      setDispatchedResult(nextResult);
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  const onSubmit = (event: SyntheticEvent<HTMLFormElement>, context: FormSubmitContext): void => {
+    event.preventDefault();
+    void send(context.formData);
+  };
+
+  return { isPending, lastResult: dispatchedResult ?? lastResult, onSubmit };
+}

--- a/projects/app-web/src/test-utils/build-deferred.test.ts
+++ b/projects/app-web/src/test-utils/build-deferred.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from 'bun:test';
+import { buildDeferred } from './build-deferred';
+
+test('it leaves the promise pending until released', async () => {
+  const deferred = buildDeferred<string>();
+  const pendingMarker = Symbol('pending');
+
+  const beforeRelease = await Promise.race([deferred.promise, Promise.resolve(pendingMarker)]);
+
+  expect(beforeRelease).toBe(pendingMarker);
+
+  await deferred.release('done');
+
+  const afterRelease = await deferred.promise;
+
+  expect(afterRelease).toBe('done');
+});
+
+test('it resolves the promise with the released value', async () => {
+  const deferred = buildDeferred<number>();
+
+  await deferred.release(42);
+
+  const value = await deferred.promise;
+
+  expect(value).toBe(42);
+});

--- a/projects/app-web/src/test-utils/build-deferred.ts
+++ b/projects/app-web/src/test-utils/build-deferred.ts
@@ -1,0 +1,25 @@
+import { act } from '@testing-library/react';
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  readonly release: (value: T) => Promise<void>;
+}
+
+/**
+ * A promise a test controls: `promise` stays pending until `release`. `release` resolves it inside
+ * `act`, so state a React consumer updates from the promise's own continuation — a microtask outside
+ * React's batching that `waitFor` races — is settled before the next assertion.
+ */
+export function buildDeferred<T>(): Deferred<T> {
+  const gate = Promise.withResolvers<T>();
+
+  return {
+    promise: gate.promise,
+    release: (value) =>
+      act(async () => {
+        gate.resolve(value);
+
+        await gate.promise;
+      }),
+  };
+}

--- a/projects/lib-design-system/package.json
+++ b/projects/lib-design-system/package.json
@@ -21,8 +21,8 @@
     "react-icons": "5.5.0"
   },
   "devDependencies": {
-    "@conform-to/react": "1.2.2",
-    "@conform-to/zod": "1.2.2",
+    "@conform-to/react": "1.19.4",
+    "@conform-to/zod": "1.19.4",
     "@fontsource-variable/manrope": "5.2.8",
     "@fontsource/chakra-petch": "5.2.7",
     "@fontsource/ibm-plex-mono": "5.2.7",


### PR DESCRIPTION
## Description

Closes #301. Adopts Conform per the #300 spike: upgrades `@conform-to/*` 1.2.2 → 1.19.4 and builds the shared TanStack Start glue app-web forms will migrate onto (#302/#303).

- `useFormSubmit` (`app-web/src/lib/forms/`) takes an injected server function, dispatches the `FormData`, holds `lastResult` + pending, and triages a redirect (`undefined`), an out-of-band `Response`, or a `reply()` result.
- A `Response` fallback is rebuilt through `parse` so it carries `initialValue` — without it Conform's mid-session update path reads a reset and drops the error.
- Establishes and documents the fabricated-`lastResult` RTL pattern, closing the result→UI branch a live `createServerFn` dispatch collapses to `undefined` under bun test.
- app-web validation uses `@conform-to/zod/v4`; design-system stays on zod v3 (catalog) and types clean on 1.19.4 with no source change.
- Exempts `SubmissionResult`/`SyntheticEvent` in the readonly-params lint allow-list.

## Testing

- [x] `yarn typecheck` passes
- [x] `yarn test` passes
- [x] `yarn lint` passes
- [x] New tests added for new functionality