### PR TITLE
feat(#207): restore fly deployment for the rebuilt stack

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,11 +55,8 @@ jobs:
           restore-keys: |
             turbo-${{ runner.os }}-
 
-      - name: Setup Docker image cache
-        uses: ScribeMD/docker-cache@fb28c93772363301b8d0a6072ce850224b73f74e # 0.5.0
-        id: docker-cache
-        with:
-          key: docker-${{ runner.os }}-${{ github.sha }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Boundaries
         run: bun run boundaries
@@ -121,6 +118,16 @@ jobs:
           echo "${affected}" >> "${GITHUB_OUTPUT}"
           echo "${delimiter}" >> "${GITHUB_OUTPUT}"
 
+      # affected images are pushed to Fly's registry here and deployed by digest in
+      # the `deploy` job, so a bad-tests run never ships (deploy gates on success)
+      - name: Log in to Fly registry
+        if: ${{ !cancelled() }}
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: registry.fly.io
+          username: x
+          password: ${{ secrets.FLY_API_TOKEN }}
+
       - name: Build Avatar Service Image
         if:
           ${{ !cancelled() && contains(steps.record-affected-projects.outputs.affected-projects,
@@ -129,8 +136,10 @@ jobs:
         with:
           context: .
           file: projects/service-avatar/Dockerfile
-          tags: vers/service-avatar:latest
-          push: false
+          tags: registry.fly.io/vers-service-avatar:${{ github.sha }}
+          push: true
+          cache-from: type=gha,scope=service-avatar
+          cache-to: type=gha,scope=service-avatar,mode=max
 
       - name: Build Session Service Image
         if:
@@ -140,8 +149,10 @@ jobs:
         with:
           context: .
           file: projects/service-session/Dockerfile
-          tags: vers/service-session:latest
-          push: false
+          tags: registry.fly.io/vers-service-session:${{ github.sha }}
+          push: true
+          cache-from: type=gha,scope=service-session
+          cache-to: type=gha,scope=service-session,mode=max
 
       - name: Build User Service Image
         if:
@@ -151,8 +162,10 @@ jobs:
         with:
           context: .
           file: projects/service-user/Dockerfile
-          tags: vers/service-user:latest
-          push: false
+          tags: registry.fly.io/vers-service-user:${{ github.sha }}
+          push: true
+          cache-from: type=gha,scope=service-user
+          cache-to: type=gha,scope=service-user,mode=max
 
       - name: Build Verification Service Image
         if:
@@ -162,8 +175,10 @@ jobs:
         with:
           context: .
           file: projects/service-verification/Dockerfile
-          tags: vers/service-verification:latest
-          push: false
+          tags: registry.fly.io/vers-service-verification:${{ github.sha }}
+          push: true
+          cache-from: type=gha,scope=service-verification
+          cache-to: type=gha,scope=service-verification,mode=max
 
       - name: Build Web App Image
         if:
@@ -173,5 +188,71 @@ jobs:
         with:
           context: .
           file: projects/app-web/Dockerfile
-          tags: vers/app-web:latest
-          push: false
+          tags: registry.fly.io/vers-app-web:${{ github.sha }}
+          push: true
+          cache-from: type=gha,scope=app-web
+          cache-to: type=gha,scope=app-web,mode=max
+
+  deploy:
+    name: Deploy
+    needs: checks
+    # deploy only a fully green build; each leg self-gates on being affected. Runs
+    # after `checks`, so the migration step there has already applied to Neon.
+    if: ${{ needs.checks.result == 'success' }}
+    runs-on: ubuntu-latest
+    strategy:
+      # one app's rollout failing must not abandon the others
+      fail-fast: false
+      matrix:
+        include:
+          - app: vers-service-avatar
+            pkg: '@vers/service-avatar'
+            dir: service-avatar
+          - app: vers-service-session
+            pkg: '@vers/service-session'
+            dir: service-session
+          - app: vers-service-user
+            pkg: '@vers/service-user'
+            dir: service-user
+          - app: vers-service-verification
+            pkg: '@vers/service-verification'
+            dir: service-verification
+          - app: vers-app-web
+            pkg: '@vers/web'
+            dir: app-web
+    env:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@dfdfedc86b296f5e5384f755a18bf400409a15d0 # v1.4
+
+      # bluegreen (per each app's fly.toml) gates cutover on the /health check, so a
+      # machine that fails to boot or serve blocks the release instead of shipping.
+      # The image was already pushed to Fly's registry by the build steps above.
+      - name: Deploy ${{ matrix.app }}
+        if: ${{ contains(needs.checks.outputs.affected-projects, format('<{0}>', matrix.pkg)) }}
+        run: >
+          flyctl deploy --app ${{ matrix.app }} --config projects/${{ matrix.dir }}/fly.toml --image
+          registry.fly.io/${{ matrix.app }}:${{ github.sha }}
+
+      # private services can't be reached from CI — their bluegreen health gate is the
+      # smoke test. app-web is public, so verify it end-to-end after cutover.
+      - name: Smoke check app-web
+        if:
+          ${{ matrix.app == 'vers-app-web' && contains(needs.checks.outputs.affected-projects,
+          '<@vers/web>') }}
+        run: |
+          for attempt in $(seq 1 10); do
+            code="$(curl -fsS -o /dev/null -w '%{http_code}' https://vers-app-web.fly.dev/health || true)"
+            if [ "${code}" = "200" ]; then
+              echo "app-web healthy"
+              exit 0
+            fi
+            echo "attempt ${attempt}: /health returned ${code:-no-response}"
+            sleep 5
+          done
+          echo "app-web /health never returned 200 after deploy"
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,7 +240,7 @@ tags. CI's changed-project detection is `turbo run --affected`.
 
 TypeScript is 7.0.2 (catalog). TS7 has no `baseUrl` and no classic Compiler API, and there is no
 path-alias convention here — write imports relative to the importing file. Node is 24.18.0 in CI and
-`app-web` (its runtime image and `engines` field); the four services compile to a Bun binary on
+`app-web` (its runtime image and `engines` field); the domain services compile to a Bun binary on
 `alpine`. Panda 2.0's floor and the ES2024 `lib` target both need Node 24.
 
 ## Boundaries
@@ -315,7 +315,7 @@ layers read a BuildKit cache mount (`--mount=type=cache,target=/root/.bun/instal
 reuse the package cache.
 
 `service-avatar`, `service-session`, `service-user`, and `service-verification` compile to a single
-executable in three stages:
+executable in stages:
 
 1. **pruner** — as above.
 2. **builder** — a full `bun install`, then
@@ -324,8 +324,8 @@ executable in three stages:
 3. **runtime** — `alpine` with `libgcc` and `libstdc++` and the binary alone: no `node_modules`, no
    source. The busybox shell keeps `fly ssh console` usable.
 
-`app-web` bundles an SSR server across five stages: **pruner**; **installer** (full `bun install`
-for the build tooling); **builder** (its `codegen`/`typegen`/`build` scripts directly, plus
+`app-web` bundles an SSR server in stages: **pruner**; **installer** (full `bun install` for the
+build tooling); **builder** (its `codegen`/`typegen`/`build` scripts directly, plus
 `tsconfig.base.json` from outside any package); **prod-deps**
 (`bun install --production --linker=hoisted`, whose flat `node_modules` lets the bundle resolve
 external imports like `pino` from one location); and a `node:24.18.0-alpine` **runtime** holding

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,9 +239,9 @@ project's `workspace:*` deps). Per-project `turbo.json` files exist only to decl
 tags. CI's changed-project detection is `turbo run --affected`.
 
 TypeScript is 7.0.2 (catalog). TS7 has no `baseUrl` and no classic Compiler API, and there is no
-path-alias convention here — write imports relative to the importing file. Node is 24.18.0
-everywhere (CI, every service's Dockerfile, app-web's `engines` field) — panda 2.0's floor and the
-ES2024 `lib` target both need it.
+path-alias convention here — write imports relative to the importing file. Node is 24.18.0 in CI and
+`app-web` (its runtime image and `engines` field); the four services compile to a Bun binary on
+`alpine`. Panda 2.0's floor and the ES2024 `lib` target both need Node 24.
 
 ## Boundaries
 
@@ -308,21 +308,30 @@ CSS values that aren't theme tokens need the bracket escape hatch (`cursor: '[po
 
 ## Docker
 
-Each server deployable (`app-web`; `service-avatar`, `service-session`, `service-user`,
-`service-verification`) has a multi-stage Dockerfile around `turbo prune <pkg> --docker`;
-`app-design-reference` ships as a plain static-nginx image:
+Every server Dockerfile is multi-stage around `turbo prune <pkg> --docker`, whose **pruner** stage
+runs a standalone `turbo` binary to cut the workspace to the target's dependency graph: `out/json`
+(manifests only, for layer caching), `out/full` (source), a pruned `out/bun.lock`. `bun install`
+layers read a BuildKit cache mount (`--mount=type=cache,target=/root/.bun/install/cache`), so builds
+reuse the package cache.
 
-1. **pruner** — a standalone `turbo` binary prunes to the target's dependency graph: `out/json`
-   (manifests only, for layer caching), `out/full` (source), a pruned `out/bun.lock`.
-2. **installer** — full `bun install` against `out/json` for build-time tooling.
-3. **builder** — copies `out/full` plus `scripts/build-esbuild.ts` and `tsconfig.base.json` (outside
-   any package, so prune doesn't carry them), then runs the project's `build` script.
-4. **prod-deps** — `bun install --production --linker=hoisted`. Hoisting is essential: a bundle
-   inlines source from several packages, and its external imports (`pino`, …) must resolve from the
-   bundle's own location — only a flat `node_modules` serves them all.
-5. **runtime** — `node:24.18.0-alpine` with the prod-deps `node_modules` and built output only.
+`service-avatar`, `service-session`, `service-user`, and `service-verification` compile to a single
+executable in three stages:
 
-app-web's builder runs its `codegen`/`typegen`/`build` scripts directly, not `turbo run build`.
+1. **pruner** — as above.
+2. **builder** — a full `bun install`, then
+   `bun build src/serve.ts --compile --target=bun-linux-x64-musl` inlines every dependency (the
+   services carry no native addons) into one binary.
+3. **runtime** — `alpine` with `libgcc` and `libstdc++` and the binary alone: no `node_modules`, no
+   source. The busybox shell keeps `fly ssh console` usable.
+
+`app-web` bundles an SSR server across five stages: **pruner**; **installer** (full `bun install`
+for the build tooling); **builder** (its `codegen`/`typegen`/`build` scripts directly, plus
+`tsconfig.base.json` from outside any package); **prod-deps**
+(`bun install --production --linker=hoisted`, whose flat `node_modules` lets the bundle resolve
+external imports like `pino` from one location); and a `node:24.18.0-alpine` **runtime** holding
+`node_modules`, `server.mjs`, and `dist`.
+
+`app-design-reference` ships as a plain static-nginx image.
 
 ## Testing (bun test, 0-isolation)
 

--- a/agents/project.md
+++ b/agents/project.md
@@ -36,9 +36,9 @@ project's `workspace:*` deps). Per-project `turbo.json` files exist only to decl
 tags. CI's changed-project detection is `turbo run --affected`.
 
 TypeScript is 7.0.2 (catalog). TS7 has no `baseUrl` and no classic Compiler API, and there is no
-path-alias convention here — write imports relative to the importing file. Node is 24.18.0
-everywhere (CI, every service's Dockerfile, app-web's `engines` field) — panda 2.0's floor and the
-ES2024 `lib` target both need it.
+path-alias convention here — write imports relative to the importing file. Node is 24.18.0 in CI and
+`app-web` (its runtime image and `engines` field); the four services compile to a Bun binary on
+`alpine`. Panda 2.0's floor and the ES2024 `lib` target both need Node 24.
 
 ## Boundaries
 
@@ -105,21 +105,30 @@ CSS values that aren't theme tokens need the bracket escape hatch (`cursor: '[po
 
 ## Docker
 
-Each server deployable (`app-web`; `service-avatar`, `service-session`, `service-user`,
-`service-verification`) has a multi-stage Dockerfile around `turbo prune <pkg> --docker`;
-`app-design-reference` ships as a plain static-nginx image:
+Every server Dockerfile is multi-stage around `turbo prune <pkg> --docker`, whose **pruner** stage
+runs a standalone `turbo` binary to cut the workspace to the target's dependency graph: `out/json`
+(manifests only, for layer caching), `out/full` (source), a pruned `out/bun.lock`. `bun install`
+layers read a BuildKit cache mount (`--mount=type=cache,target=/root/.bun/install/cache`), so builds
+reuse the package cache.
 
-1. **pruner** — a standalone `turbo` binary prunes to the target's dependency graph: `out/json`
-   (manifests only, for layer caching), `out/full` (source), a pruned `out/bun.lock`.
-2. **installer** — full `bun install` against `out/json` for build-time tooling.
-3. **builder** — copies `out/full` plus `scripts/build-esbuild.ts` and `tsconfig.base.json` (outside
-   any package, so prune doesn't carry them), then runs the project's `build` script.
-4. **prod-deps** — `bun install --production --linker=hoisted`. Hoisting is essential: a bundle
-   inlines source from several packages, and its external imports (`pino`, …) must resolve from the
-   bundle's own location — only a flat `node_modules` serves them all.
-5. **runtime** — `node:24.18.0-alpine` with the prod-deps `node_modules` and built output only.
+`service-avatar`, `service-session`, `service-user`, and `service-verification` compile to a single
+executable in three stages:
 
-app-web's builder runs its `codegen`/`typegen`/`build` scripts directly, not `turbo run build`.
+1. **pruner** — as above.
+2. **builder** — a full `bun install`, then
+   `bun build src/serve.ts --compile --target=bun-linux-x64-musl` inlines every dependency (the
+   services carry no native addons) into one binary.
+3. **runtime** — `alpine` with `libgcc` and `libstdc++` and the binary alone: no `node_modules`, no
+   source. The busybox shell keeps `fly ssh console` usable.
+
+`app-web` bundles an SSR server across five stages: **pruner**; **installer** (full `bun install`
+for the build tooling); **builder** (its `codegen`/`typegen`/`build` scripts directly, plus
+`tsconfig.base.json` from outside any package); **prod-deps**
+(`bun install --production --linker=hoisted`, whose flat `node_modules` lets the bundle resolve
+external imports like `pino` from one location); and a `node:24.18.0-alpine` **runtime** holding
+`node_modules`, `server.mjs`, and `dist`.
+
+`app-design-reference` ships as a plain static-nginx image.
 
 ## Testing (bun test, 0-isolation)
 

--- a/agents/project.md
+++ b/agents/project.md
@@ -37,7 +37,7 @@ tags. CI's changed-project detection is `turbo run --affected`.
 
 TypeScript is 7.0.2 (catalog). TS7 has no `baseUrl` and no classic Compiler API, and there is no
 path-alias convention here — write imports relative to the importing file. Node is 24.18.0 in CI and
-`app-web` (its runtime image and `engines` field); the four services compile to a Bun binary on
+`app-web` (its runtime image and `engines` field); the domain services compile to a Bun binary on
 `alpine`. Panda 2.0's floor and the ES2024 `lib` target both need Node 24.
 
 ## Boundaries
@@ -112,7 +112,7 @@ layers read a BuildKit cache mount (`--mount=type=cache,target=/root/.bun/instal
 reuse the package cache.
 
 `service-avatar`, `service-session`, `service-user`, and `service-verification` compile to a single
-executable in three stages:
+executable in stages:
 
 1. **pruner** — as above.
 2. **builder** — a full `bun install`, then
@@ -121,8 +121,8 @@ executable in three stages:
 3. **runtime** — `alpine` with `libgcc` and `libstdc++` and the binary alone: no `node_modules`, no
    source. The busybox shell keeps `fly ssh console` usable.
 
-`app-web` bundles an SSR server across five stages: **pruner**; **installer** (full `bun install`
-for the build tooling); **builder** (its `codegen`/`typegen`/`build` scripts directly, plus
+`app-web` bundles an SSR server in stages: **pruner**; **installer** (full `bun install` for the
+build tooling); **builder** (its `codegen`/`typegen`/`build` scripts directly, plus
 `tsconfig.base.json` from outside any package); **prod-deps**
 (`bun install --production --linker=hoisted`, whose flat `node_modules` lets the bundle resolve
 external imports like `pino` from one location); and a `node:24.18.0-alpine` **runtime** holding

--- a/docs/000-overview.md
+++ b/docs/000-overview.md
@@ -1,8 +1,8 @@
 # Overview
 
 Vers is a browser idle game on a microservice backend: a deterministic simulation runs on the
-client, the server verifies its results by replay, and everything deploys from one repo as a single
-atomic release.
+client, the server verifies its results by replay, and everything [deploys](./004-deployment.md)
+from one repo as a single atomic release.
 
 ## Request path
 

--- a/docs/004-deployment.md
+++ b/docs/004-deployment.md
@@ -4,7 +4,7 @@ Where the stack runs, how a merge reaches production, and how to re-provision it
 
 ## Topology
 
-Five apps run on Fly.io in the `syd` region. `app-web` holds the only public address. The four
+The stack runs on Fly.io in the `syd` region. `app-web` holds the only public address. The domain
 services — `service-avatar`, `service-session`, `service-user`, `service-verification` — are
 private, reachable only across the organization's 6PN WireGuard mesh. Postgres is a Neon project
 (see [database](./003-database.md)); no app runs its own database.

--- a/docs/004-deployment.md
+++ b/docs/004-deployment.md
@@ -1,0 +1,119 @@
+# Deployment
+
+Where the stack runs, how a merge reaches production, and how to re-provision it from nothing.
+
+## Topology
+
+Five apps run on Fly.io in the `syd` region. `app-web` holds the only public address. The four
+services — `service-avatar`, `service-session`, `service-user`, `service-verification` — are
+private, reachable only across the organization's 6PN WireGuard mesh. Postgres is a Neon project
+(see [database](./003-database.md)); no app runs its own database.
+
+Every app scales to zero. `auto_stop_machines = 'suspend'` parks an idle machine with its memory
+snapshot for sub-second wake. `app-web` keeps one machine warm (`min_machines_running = 1`) so a
+visitor never waits on a cold start; a service wakes on its first request.
+
+## Networking
+
+`app-web` reaches a service at `http://<app>.flycast` — a private address that load-balances across
+the service's machines and wakes a suspended one on demand. These URLs live in `app-web`'s
+`fly.toml` `[env]`. A service is allocated no public IP, so nothing outside the mesh can reach it,
+and mesh traffic is already encrypted, so services set `force_https = false`.
+
+## Secrets
+
+Non-sensitive config (service URLs, `NODE_ENV`, log level) lives in each `fly.toml` or Dockerfile.
+Secrets are set with `fly secrets set` and never committed.
+
+| App                                                      | Secrets                                             |
+| -------------------------------------------------------- | --------------------------------------------------- |
+| `service-avatar`, `service-user`, `service-verification` | `DATABASE_URL`, `SERVICE_AUTH_PUBLIC_KEY`           |
+| `service-session`                                        | the above + `API_IDENTIFIER`, `JWT_SIGNING_PRIVKEY` |
+| `app-web`                                                | `SESSION_SECRET`, `COOKIE_DOMAIN`                   |
+
+`SERVICE_AUTH_PUBLIC_KEY` is the Ed25519 SPKI public key a service verifies inbound calls with.
+`JWT_SIGNING_PRIVKEY` is the RS256 PKCS8 private key `service-session` signs user tokens with, under
+issuer and audience `API_IDENTIFIER`. `SESSION_SECRET` seals `app-web`'s cookies. `SENTRY_DSN` and
+`OTEL_EXPORTER_OTLP_ENDPOINT` are optional on any app.
+
+## Release
+
+A push to `main` runs `.github/workflows/main.yml`. Once the checks pass, the pipeline migrates and
+rolls out:
+
+1. Neon migrations apply once — several services share the one database, so migration never runs per
+   service.
+2. Each affected app's image builds and pushes to `registry.fly.io/<app>:<sha>`.
+3. `flyctl deploy --image` ships each affected app with the `bluegreen` strategy: a new machine must
+   pass its `/health` check before traffic cuts over, so a broken boot blocks the release.
+4. `app-web`'s public `/health` is polled as an end-to-end check. A service, being private, is
+   verified by its bluegreen health gate alone.
+
+Only a fully green run deploys, and only affected apps.
+
+## Provision from nothing
+
+Requires `flyctl` authenticated to the `vers` org, the Neon pooled `DATABASE_URL`, and the domain in
+`$DOMAIN`.
+
+Create the apps:
+
+```sh
+for app in app-web service-avatar service-session service-user service-verification; do
+  fly apps create "vers-$app" --org vers
+done
+```
+
+Give `app-web` public addresses; give each service a private Flycast address and no public IP:
+
+```sh
+fly ips allocate-v4 --shared -a vers-app-web
+fly ips allocate-v6 -a vers-app-web
+for svc in avatar session user verification; do
+  fly ips allocate-v6 --private -a "vers-service-$svc"
+done
+```
+
+Mint the CI deploy token and store it for the workflow:
+
+```sh
+fly tokens create deploy --name github-ci | gh secret set FLY_API_TOKEN
+```
+
+Generate the keys and set each app's secrets:
+
+```sh
+openssl genpkey -algorithm ed25519 -out s2s.key
+openssl pkey -in s2s.key -pubout -out s2s.pub
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out session.key
+
+for svc in avatar user verification; do
+  fly secrets set -a "vers-service-$svc" \
+    DATABASE_URL="$DATABASE_URL" \
+    SERVICE_AUTH_PUBLIC_KEY="$(cat s2s.pub)"
+done
+
+fly secrets set -a vers-service-session \
+  DATABASE_URL="$DATABASE_URL" \
+  SERVICE_AUTH_PUBLIC_KEY="$(cat s2s.pub)" \
+  API_IDENTIFIER=vers-api \
+  JWT_SIGNING_PRIVKEY="$(cat session.key)"
+
+fly secrets set -a vers-app-web \
+  SESSION_SECRET="$(openssl rand -base64 32)" \
+  COOKIE_DOMAIN="$DOMAIN"
+
+rm s2s.key s2s.pub session.key
+```
+
+The next push to `main` fills the machines.
+
+## Teardown
+
+```sh
+for app in app-web service-avatar service-session service-user service-verification; do
+  fly apps destroy "vers-$app" --yes
+done
+```
+
+Destroying an app releases its IPs and secrets. The Neon project and the domain outlive it.

--- a/projects/app-web/Dockerfile
+++ b/projects/app-web/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 FROM base AS pruner
 
 # a standalone turbo binary — no workspace install needed to run prune
-RUN bun add --global turbo@2.10.0
+RUN --mount=type=cache,target=/root/.bun/install/cache bun add --global turbo@2.10.0
 
 COPY . .
 
@@ -21,7 +21,7 @@ FROM base AS installer
 COPY --from=pruner /app/out/json/ .
 COPY --from=pruner /app/out/bun.lock ./bun.lock
 
-RUN bun install --frozen-lockfile
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install --frozen-lockfile
 
 # --- build the client + SSR server bundle ---
 FROM installer AS builder
@@ -53,7 +53,7 @@ FROM base AS prod-deps
 COPY --from=pruner /app/out/json/ .
 COPY --from=pruner /app/out/bun.lock ./bun.lock
 
-RUN bun install --frozen-lockfile --production --linker=hoisted --ignore-scripts
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install --frozen-lockfile --production --linker=hoisted --ignore-scripts
 
 # --- runtime ---
 FROM node:${NODE_VERSION}-alpine
@@ -64,10 +64,10 @@ WORKDIR /app
 
 ENV NODE_ENV="production"
 
-COPY --from=prod-deps /app/node_modules ./node_modules
-COPY --from=builder /app/projects/app-web/package.json ./package.json
-COPY --from=builder /app/projects/app-web/server.mjs ./server.mjs
-COPY --from=builder /app/projects/app-web/dist ./dist
+COPY --link --from=prod-deps /app/node_modules ./node_modules
+COPY --link --from=builder /app/projects/app-web/package.json ./package.json
+COPY --link --from=builder /app/projects/app-web/server.mjs ./server.mjs
+COPY --link --from=builder /app/projects/app-web/dist ./dist
 
 EXPOSE 3000
 CMD [ "server.mjs" ]

--- a/projects/app-web/fly.toml
+++ b/projects/app-web/fly.toml
@@ -1,3 +1,5 @@
+# Public edge app: the only deployable with a public IP. It reaches the backend
+# services over the private 6PN mesh at their `.flycast` addresses (see [env]).
 app = 'vers-app-web'
 primary_region = 'syd'
 
@@ -6,12 +8,34 @@ primary_region = 'syd'
 [http_service]
 internal_port = 3000
 force_https = true
-auto_stop_machines = 'stop'
-auto_start_machines = false
+auto_stop_machines = 'suspend'
+auto_start_machines = true
+# keep one machine warm so the user-facing SSR app never pays a cold start
 min_machines_running = 1
 processes = ['app']
+
+[http_service.concurrency]
+type = 'requests'
+soft_limit = 200
+hard_limit = 250
+
+[[http_service.checks]]
+method = 'GET'
+path = '/health'
+interval = '15s'
+timeout = '2s'
+grace_period = '10s'
+
+[env]
+AVATAR_SERVICE_URL = 'http://vers-service-avatar.flycast'
+SESSION_SERVICE_URL = 'http://vers-service-session.flycast'
+USER_SERVICE_URL = 'http://vers-service-user.flycast'
+VERIFICATION_SERVICE_URL = 'http://vers-service-verification.flycast'
 
 [[vm]]
 memory = '512mb'
 cpu_kind = 'shared'
 cpus = 1
+
+[deploy]
+strategy = 'bluegreen'

--- a/projects/service-avatar/Dockerfile
+++ b/projects/service-avatar/Dockerfile
@@ -8,31 +8,41 @@ WORKDIR /app
 FROM base AS pruner
 
 # a standalone turbo binary — no workspace install needed to run prune
-RUN bun add --global turbo@2.10.0
+RUN --mount=type=cache,target=/root/.bun/install/cache bun add --global turbo@2.10.0
 
 COPY . .
 
 RUN turbo prune @vers/service-avatar --docker
 
-# --- production-only deps: no bundle step, so no hoisting needed ---
-FROM base AS prod-deps
+# --- compile the service to a single self-contained executable ---
+# the full dependency set is needed here: `bun build --compile` inlines every JS
+# import (workspace source + external deps) into the binary. The services have no
+# native addons, so the result is standalone — no node_modules or source at runtime.
+FROM base AS builder
 
 COPY --from=pruner /app/out/json/ .
 COPY --from=pruner /app/out/bun.lock ./bun.lock
 
-RUN bun install --frozen-lockfile --production
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install --frozen-lockfile
 
-# --- runtime: runs the pruned bun source directly, no bundle ---
-FROM base
-
-# the isolated linker nests a `node_modules` under every workspace package, not just the root, so
-# prod-deps' whole tree comes first; out/full then lays real source over its out/json placeholders
-COPY --from=prod-deps /app/ .
 COPY --from=pruner /app/out/full/ .
 
 WORKDIR /app/projects/service-avatar
 
-USER bun
-EXPOSE 3005
+# musl target matches the alpine runtime below
+RUN bun build src/serve.ts --compile --target=bun-linux-x64-musl --outfile /tmp/server
 
-CMD ["bun", "run", "src/serve.ts"]
+# --- runtime: just the binary on alpine (busybox shell kept for `fly ssh console`) ---
+FROM alpine:3.21
+
+# bun's musl binary links against libgcc and libstdc++
+RUN apk add --no-cache libgcc libstdc++
+
+COPY --from=builder /tmp/server /usr/local/bin/server
+
+ENV NODE_ENV="production"
+
+USER nobody
+EXPOSE 3000
+
+CMD ["server"]

--- a/projects/service-avatar/fly.toml
+++ b/projects/service-avatar/fly.toml
@@ -1,0 +1,35 @@
+# Private backend service: reachable only over the org's 6PN WireGuard mesh via
+# `vers-service-avatar.flycast`. No public IP is allocated (see the deploy runbook),
+# so `force_https` stays off — internal mesh traffic is already encrypted.
+app = 'vers-service-avatar'
+primary_region = 'syd'
+
+[build]
+
+[http_service]
+internal_port = 3000
+force_https = false
+auto_stop_machines = 'suspend'
+auto_start_machines = true
+min_machines_running = 0
+processes = ['app']
+
+[http_service.concurrency]
+type = 'requests'
+soft_limit = 200
+hard_limit = 250
+
+[[http_service.checks]]
+method = 'GET'
+path = '/health'
+interval = '15s'
+timeout = '2s'
+grace_period = '10s'
+
+[[vm]]
+memory = '256mb'
+cpu_kind = 'shared'
+cpus = 1
+
+[deploy]
+strategy = 'bluegreen'

--- a/projects/service-session/Dockerfile
+++ b/projects/service-session/Dockerfile
@@ -8,31 +8,41 @@ WORKDIR /app
 FROM base AS pruner
 
 # a standalone turbo binary — no workspace install needed to run prune
-RUN bun add --global turbo@2.10.0
+RUN --mount=type=cache,target=/root/.bun/install/cache bun add --global turbo@2.10.0
 
 COPY . .
 
 RUN turbo prune @vers/service-session --docker
 
-# --- production-only deps: no bundle step, so no hoisting needed ---
-FROM base AS prod-deps
+# --- compile the service to a single self-contained executable ---
+# the full dependency set is needed here: `bun build --compile` inlines every JS
+# import (workspace source + external deps) into the binary. The services have no
+# native addons, so the result is standalone — no node_modules or source at runtime.
+FROM base AS builder
 
 COPY --from=pruner /app/out/json/ .
 COPY --from=pruner /app/out/bun.lock ./bun.lock
 
-RUN bun install --frozen-lockfile --production
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install --frozen-lockfile
 
-# --- runtime: runs the pruned bun source directly, no bundle ---
-FROM base
-
-# the isolated linker nests a `node_modules` under every workspace package, not just the root, so
-# prod-deps' whole tree comes first; out/full then lays real source over its out/json placeholders
-COPY --from=prod-deps /app/ .
 COPY --from=pruner /app/out/full/ .
 
 WORKDIR /app/projects/service-session
 
-USER bun
-EXPOSE 3002
+# musl target matches the alpine runtime below
+RUN bun build src/serve.ts --compile --target=bun-linux-x64-musl --outfile /tmp/server
 
-CMD ["bun", "run", "src/serve.ts"]
+# --- runtime: just the binary on alpine (busybox shell kept for `fly ssh console`) ---
+FROM alpine:3.21
+
+# bun's musl binary links against libgcc and libstdc++
+RUN apk add --no-cache libgcc libstdc++
+
+COPY --from=builder /tmp/server /usr/local/bin/server
+
+ENV NODE_ENV="production"
+
+USER nobody
+EXPOSE 3000
+
+CMD ["server"]

--- a/projects/service-session/fly.toml
+++ b/projects/service-session/fly.toml
@@ -1,0 +1,35 @@
+# Private backend service: reachable only over the org's 6PN WireGuard mesh via
+# `vers-service-session.flycast`. No public IP is allocated (see the deploy runbook),
+# so `force_https` stays off — internal mesh traffic is already encrypted.
+app = 'vers-service-session'
+primary_region = 'syd'
+
+[build]
+
+[http_service]
+internal_port = 3000
+force_https = false
+auto_stop_machines = 'suspend'
+auto_start_machines = true
+min_machines_running = 0
+processes = ['app']
+
+[http_service.concurrency]
+type = 'requests'
+soft_limit = 200
+hard_limit = 250
+
+[[http_service.checks]]
+method = 'GET'
+path = '/health'
+interval = '15s'
+timeout = '2s'
+grace_period = '10s'
+
+[[vm]]
+memory = '256mb'
+cpu_kind = 'shared'
+cpus = 1
+
+[deploy]
+strategy = 'bluegreen'

--- a/projects/service-user/Dockerfile
+++ b/projects/service-user/Dockerfile
@@ -8,31 +8,41 @@ WORKDIR /app
 FROM base AS pruner
 
 # a standalone turbo binary — no workspace install needed to run prune
-RUN bun add --global turbo@2.10.0
+RUN --mount=type=cache,target=/root/.bun/install/cache bun add --global turbo@2.10.0
 
 COPY . .
 
 RUN turbo prune @vers/service-user --docker
 
-# --- production-only deps: no bundle step, so no hoisting needed ---
-FROM base AS prod-deps
+# --- compile the service to a single self-contained executable ---
+# the full dependency set is needed here: `bun build --compile` inlines every JS
+# import (workspace source + external deps) into the binary. The services have no
+# native addons, so the result is standalone — no node_modules or source at runtime.
+FROM base AS builder
 
 COPY --from=pruner /app/out/json/ .
 COPY --from=pruner /app/out/bun.lock ./bun.lock
 
-RUN bun install --frozen-lockfile --production
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install --frozen-lockfile
 
-# --- runtime: runs the pruned bun source directly, no bundle ---
-FROM base
-
-# the isolated linker nests a `node_modules` under every workspace package, not just the root, so
-# prod-deps' whole tree comes first; out/full then lays real source over its out/json placeholders
-COPY --from=prod-deps /app/ .
 COPY --from=pruner /app/out/full/ .
 
 WORKDIR /app/projects/service-user
 
-USER bun
-EXPOSE 3003
+# musl target matches the alpine runtime below
+RUN bun build src/serve.ts --compile --target=bun-linux-x64-musl --outfile /tmp/server
 
-CMD ["bun", "run", "src/serve.ts"]
+# --- runtime: just the binary on alpine (busybox shell kept for `fly ssh console`) ---
+FROM alpine:3.21
+
+# bun's musl binary links against libgcc and libstdc++
+RUN apk add --no-cache libgcc libstdc++
+
+COPY --from=builder /tmp/server /usr/local/bin/server
+
+ENV NODE_ENV="production"
+
+USER nobody
+EXPOSE 3000
+
+CMD ["server"]

--- a/projects/service-user/fly.toml
+++ b/projects/service-user/fly.toml
@@ -1,0 +1,35 @@
+# Private backend service: reachable only over the org's 6PN WireGuard mesh via
+# `vers-service-user.flycast`. No public IP is allocated (see the deploy runbook),
+# so `force_https` stays off — internal mesh traffic is already encrypted.
+app = 'vers-service-user'
+primary_region = 'syd'
+
+[build]
+
+[http_service]
+internal_port = 3000
+force_https = false
+auto_stop_machines = 'suspend'
+auto_start_machines = true
+min_machines_running = 0
+processes = ['app']
+
+[http_service.concurrency]
+type = 'requests'
+soft_limit = 200
+hard_limit = 250
+
+[[http_service.checks]]
+method = 'GET'
+path = '/health'
+interval = '15s'
+timeout = '2s'
+grace_period = '10s'
+
+[[vm]]
+memory = '256mb'
+cpu_kind = 'shared'
+cpus = 1
+
+[deploy]
+strategy = 'bluegreen'

--- a/projects/service-verification/Dockerfile
+++ b/projects/service-verification/Dockerfile
@@ -8,31 +8,41 @@ WORKDIR /app
 FROM base AS pruner
 
 # a standalone turbo binary — no workspace install needed to run prune
-RUN bun add --global turbo@2.10.0
+RUN --mount=type=cache,target=/root/.bun/install/cache bun add --global turbo@2.10.0
 
 COPY . .
 
 RUN turbo prune @vers/service-verification --docker
 
-# --- production-only deps: no bundle step, so no hoisting needed ---
-FROM base AS prod-deps
+# --- compile the service to a single self-contained executable ---
+# the full dependency set is needed here: `bun build --compile` inlines every JS
+# import (workspace source + external deps) into the binary. The services have no
+# native addons, so the result is standalone — no node_modules or source at runtime.
+FROM base AS builder
 
 COPY --from=pruner /app/out/json/ .
 COPY --from=pruner /app/out/bun.lock ./bun.lock
 
-RUN bun install --frozen-lockfile --production
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install --frozen-lockfile
 
-# --- runtime: runs the pruned bun source directly, no bundle ---
-FROM base
-
-# the isolated linker nests a `node_modules` under every workspace package, not just the root, so
-# prod-deps' whole tree comes first; out/full then lays real source over its out/json placeholders
-COPY --from=prod-deps /app/ .
 COPY --from=pruner /app/out/full/ .
 
 WORKDIR /app/projects/service-verification
 
-USER bun
-EXPOSE 3004
+# musl target matches the alpine runtime below
+RUN bun build src/serve.ts --compile --target=bun-linux-x64-musl --outfile /tmp/server
 
-CMD ["bun", "run", "src/serve.ts"]
+# --- runtime: just the binary on alpine (busybox shell kept for `fly ssh console`) ---
+FROM alpine:3.21
+
+# bun's musl binary links against libgcc and libstdc++
+RUN apk add --no-cache libgcc libstdc++
+
+COPY --from=builder /tmp/server /usr/local/bin/server
+
+ENV NODE_ENV="production"
+
+USER nobody
+EXPOSE 3000
+
+CMD ["server"]

--- a/projects/service-verification/fly.toml
+++ b/projects/service-verification/fly.toml
@@ -1,0 +1,35 @@
+# Private backend service: reachable only over the org's 6PN WireGuard mesh via
+# `vers-service-verification.flycast`. No public IP is allocated (see the deploy runbook),
+# so `force_https` stays off — internal mesh traffic is already encrypted.
+app = 'vers-service-verification'
+primary_region = 'syd'
+
+[build]
+
+[http_service]
+internal_port = 3000
+force_https = false
+auto_stop_machines = 'suspend'
+auto_start_machines = true
+min_machines_running = 0
+processes = ['app']
+
+[http_service.concurrency]
+type = 'requests'
+soft_limit = 200
+hard_limit = 250
+
+[[http_service.checks]]
+method = 'GET'
+path = '/health'
+interval = '15s'
+timeout = '2s'
+grace_period = '10s'
+
+[[vm]]
+memory = '256mb'
+cpu_kind = 'shared'
+cpus = 1
+
+[deploy]
+strategy = 'bluegreen'


### PR DESCRIPTION
## Description

Closes #207

Restores deployment for the rebuilt stack on Fly.io: five apps in `syd` — public `app-web` plus four private services — with affected-only, health-gated rollouts wired into `main.yml`.

- Services compile to one musl binary on `alpine` via `bun build --compile` (426MB → 160MB, boot-verified); `app-web` keeps its node runtime and gains BuildKit cache mounts.
- Services are private (Flycast, no public IP), reached over the WireGuard mesh; only `app-web` is public. Suspend-based scale-to-zero, `bluegreen` cutover gated on `/health`.
- CI pushes affected images to `registry.fly.io` by SHA, then `flyctl deploy --image` after the migration step; `app-web` adds a public `/health` smoke check.
- Dropped `app-design-reference` from prod; removed the dead `service-api`/`service-email` dirs.
- `docs/004-deployment.md` covers topology, the per-app secrets manifest, and provision/teardown.

## Testing

- [x] `format:check` and AGENTS.md drift pass locally
- [x] Compiled service image boots and serves `/health` (HTTP 200)
- [ ] `typecheck` / `test` / `lint` — deferred to CI (worktree-local codegen bins unavailable)
- [x] No new functionality to test (config, CI, and docs only)

## Context

- Do not merge until the Fly org is provisioned: the five apps created, IPs allocated, and `FLY_API_TOKEN` in repo secrets. `main`'s build steps log in to `registry.fly.io` on every push, so an unprovisioned merge fails. Provisioning, key generation, and secrets are handled out-of-band via `flyctl` (needs the Neon pooled `DATABASE_URL` and the domain).
- The services verify EdDSA service tokens, but no code mints them at the edge yet — `app-web` forwards the user's RS256 token instead. Service calls will 401 until the edge signer is wired; tracked separately.
