### PR TITLE
spike(#300): tanstack-form testability against the #314 pattern

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -57,6 +57,8 @@
         "@react-three/fiber": "9.1.0",
         "@sentry/node": "9.5.0",
         "@sentry/react": "9.5.0",
+        "@tanstack/react-form": "1.33.0",
+        "@tanstack/react-form-start": "1.33.0",
         "@tanstack/react-query": "5.101.2",
         "@tanstack/react-router": "1.170.17",
         "@tanstack/react-router-ssr-query": "1.167.1",
@@ -1563,9 +1565,19 @@
 
     "@swc/types": ["@swc/types@0.1.27", "", { "dependencies": { "@swc/counter": "^0.1.3" } }, "sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg=="],
 
+    "@tanstack/devtools-event-client": ["@tanstack/devtools-event-client@0.4.4", "", { "bin": { "intent": "./bin/intent.js" } }, "sha512-6T5Yop/793YI+H+5J8Hsyj4kCih9sl4t3ElLgKioW5hk3ocn+ZdSJ94tT7vL7uabxSugWYBZlOTMPzEw2puvQw=="],
+
+    "@tanstack/form-core": ["@tanstack/form-core@1.33.0", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.1", "@tanstack/pacer-lite": "^0.1.1", "@tanstack/store": "^0.11.0" } }, "sha512-AV4Pw9Dk4orFsuPBcDssfWMJFs+yMYBae7zZ4oTqrCf4ftNGQKxvrQRZeqKHG6A4TkiLeSvf2kzIjcVkrW7E6w=="],
+
     "@tanstack/history": ["@tanstack/history@1.162.0", "", {}, "sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA=="],
 
+    "@tanstack/pacer-lite": ["@tanstack/pacer-lite@0.1.1", "", {}, "sha512-y/xtNPNt/YeyoVxE/JCx+T7yjEzpezmbb+toK8DDD1P4m7Kzs5YR956+7OKexG3f8aXgC3rLZl7b1V+yNUSy5w=="],
+
     "@tanstack/query-core": ["@tanstack/query-core@5.101.2", "", {}, "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw=="],
+
+    "@tanstack/react-form": ["@tanstack/react-form@1.33.0", "", { "dependencies": { "@tanstack/form-core": "1.33.0", "@tanstack/react-store": "^0.11.0" }, "peerDependencies": { "react": "^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-unaee+VS4MvKo+s1dmgGUXI4902VeAhuaUbKsQbhFe3MceOpB3JpAUGCDpyzjQPXVFkFY0COKfLrUNX2XZYW4g=="],
+
+    "@tanstack/react-form-start": ["@tanstack/react-form-start@1.33.0", "", { "dependencies": { "@tanstack/react-form": "1.33.0", "decode-formdata": "^0.9.0", "devalue": "^5.3.2" }, "peerDependencies": { "@tanstack/react-start": "^1.134.9", "react": "^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@tanstack/react-start"] }, "sha512-pIz0ndtIwR0iFhZXzvbzEDnFlLSxVjLtVjyxQ2HEV78cH4oxH2JDxT9VqeiVZLYUGBsUsv+j2CFQV8plxNPCcw=="],
 
     "@tanstack/react-query": ["@tanstack/react-query@5.101.2", "", { "dependencies": { "@tanstack/query-core": "5.101.2" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg=="],
 
@@ -1581,7 +1593,7 @@
 
     "@tanstack/react-start-server": ["@tanstack/react-start-server@1.167.21", "", { "dependencies": { "@tanstack/react-router": "1.170.17", "@tanstack/router-core": "1.171.14", "@tanstack/start-server-core": "1.169.16" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-puJ7eFxaLuDzeM/tiLDJaXCA4uK+PZnEOoIC73zipsFqx865MGzrRS/GSZxeVxjavC5iHU+ZwC+rgI0qYSol1A=="],
 
-    "@tanstack/react-store": ["@tanstack/react-store@0.9.3", "", { "dependencies": { "@tanstack/store": "0.9.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg=="],
+    "@tanstack/react-store": ["@tanstack/react-store@0.11.0", "", { "dependencies": { "@tanstack/store": "0.11.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-tX4YXh3PDkmpvGQWkWqKpzs/MSqbtuwY9dWdWhtV9Q50PmO+jOkUKIWIX4G85dwt7lxdHLXsiaEKPdKmC8F41w=="],
 
     "@tanstack/router-cli": ["@tanstack/router-cli@1.167.18", "", { "dependencies": { "@tanstack/router-generator": "1.167.18", "chokidar": "^5.0.0", "yargs": "^17.7.2" }, "bin": { "tsr": "bin/tsr.cjs" } }, "sha512-R3DwK6uZY1x97EC/CsjGY/xCVUXmeZZhlaaFf+EYgJ4gb5ozxZ5mmDh304g+Q9Lw/oWt5azDJXL8TPZiTAwHzQ=="],
 
@@ -1605,7 +1617,7 @@
 
     "@tanstack/start-storage-context": ["@tanstack/start-storage-context@1.167.16", "", { "dependencies": { "@tanstack/router-core": "1.171.14" } }, "sha512-zTegxlij4BC1DbCrC6rsVlMOQVMzOuG5IllacZEkrUdhiFwMIMYpk0VWGH+d0ucx5RBkmv8e8GNX3AOVBWclfg=="],
 
-    "@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
+    "@tanstack/store": ["@tanstack/store@0.11.0", "", {}, "sha512-WlzzCt3xi0G6pCAJu1U+2jiECwabETDpQDi3hfkFZvJii9AuZqEKbOiVarX1/bWhTNjU486yQtJCCasi/0q+Cw=="],
 
     "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.162.0", "", {}, "sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA=="],
 
@@ -2257,6 +2269,8 @@
 
     "decamelize": ["decamelize@1.2.0", "", {}, "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="],
 
+    "decode-formdata": ["decode-formdata@0.9.0", "", {}, "sha512-q5uwOjR3Um5YD+ZWPOF/1sGHVW9A5rCrRwITQChRXlmPkxDFBqCm4jNTIVdGHNH9OnR+V9MoZVgRhsFb+ARbUw=="],
+
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
 
     "decode-uri-component": ["decode-uri-component@0.4.1", "", {}, "sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ=="],
@@ -2290,6 +2304,8 @@
     "detect-gpu": ["detect-gpu@5.0.70", "", { "dependencies": { "webgl-constants": "^1.1.1" } }, "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w=="],
 
     "detect-libc": ["detect-libc@1.0.3", "", { "bin": { "detect-libc": "./bin/detect-libc.js" } }, "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="],
+
+    "devalue": ["devalue@5.8.1", "", {}, "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw=="],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
@@ -3931,6 +3947,8 @@
 
     "@sentry/react/@sentry/core": ["@sentry/core@9.5.0", "", {}, "sha512-NMqyFdyg26ECAfnibAPKT8vvAt4zXp4R7dYtQnwJKhEJEVkgAshcNYeJ2D95ZLMVOqlqhTtTPnw1vqf+v9ePZg=="],
 
+    "@tanstack/react-router/@tanstack/react-store": ["@tanstack/react-store@0.9.3", "", { "dependencies": { "@tanstack/store": "0.9.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg=="],
+
     "@tanstack/router-cli/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
     "@tanstack/router-generator/jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
@@ -4418,6 +4436,8 @@
     "@sentry/opentelemetry/@opentelemetry/sdk-trace-base/@opentelemetry/resources": ["@opentelemetry/resources@1.30.1", "", { "dependencies": { "@opentelemetry/core": "1.30.1", "@opentelemetry/semantic-conventions": "1.28.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA=="],
 
     "@sentry/opentelemetry/@opentelemetry/sdk-trace-base/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
+
+    "@tanstack/react-router/@tanstack/react-store/@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
 
     "@tanstack/router-cli/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 

--- a/projects/app-web/package.json
+++ b/projects/app-web/package.json
@@ -24,6 +24,8 @@
     "@react-three/fiber": "9.1.0",
     "@sentry/node": "9.5.0",
     "@sentry/react": "9.5.0",
+    "@tanstack/react-form": "1.33.0",
+    "@tanstack/react-form-start": "1.33.0",
     "@tanstack/react-query": "5.101.2",
     "@tanstack/react-router": "1.170.17",
     "@tanstack/react-router-ssr-query": "1.167.1",

--- a/projects/app-web/src/lib/forms/tf-reference-form.test.tsx
+++ b/projects/app-web/src/lib/forms/tf-reference-form.test.tsx
@@ -1,0 +1,87 @@
+import { expect, test } from 'bun:test';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { buildDeferred } from '../../test-utils/build-deferred';
+import { renderWithRouter } from '../../test-utils/render-with-router';
+import type { TFAction } from './tf-reference-form';
+import { TFReferenceForm } from './tf-reference-form';
+
+test('it maps a fabricated form-level result onto a form error with no submit', async () => {
+  renderWithRouter(<TFReferenceForm serverState={{ form: ['Invalid email or password'] }} />);
+
+  const alert = await screen.findByRole('alert');
+
+  expect(alert).toHaveTextContent('Invalid email or password');
+});
+
+test('it maps a fabricated field result onto that field with no submit', async () => {
+  renderWithRouter(
+    <TFReferenceForm serverState={{ fields: { email: ['That email is taken'] } }} />,
+  );
+
+  const fieldError = await screen.findByText('That email is taken');
+
+  expect(fieldError).toBeInTheDocument();
+});
+
+function rejectWithResponse(): Promise<Response> {
+  return Promise.resolve(new Response(null, { status: 400 }));
+}
+
+test('it maps a returned Response onto a generic form error', async () => {
+  const user = userEvent.setup();
+
+  renderWithRouter(<TFReferenceForm action={rejectWithResponse} />);
+
+  const emailInput = await screen.findByPlaceholderText('Email');
+
+  await user.type(emailInput, 'player@vers.test');
+  await user.type(screen.getByPlaceholderText('Password'), 'password123');
+  await user.click(screen.getByRole('button', { name: 'Sign in' }));
+
+  await waitFor(() => {
+    expect(screen.getByRole('alert')).toHaveTextContent('Something went wrong. Please try again.');
+  });
+});
+
+test('it shows no error after a redirect resolves the submission', async () => {
+  const user = userEvent.setup();
+
+  renderWithRouter(<TFReferenceForm />);
+
+  const emailInput = await screen.findByPlaceholderText('Email');
+
+  await user.type(emailInput, 'player@vers.test');
+  await user.type(screen.getByPlaceholderText('Password'), 'password123');
+  await user.click(screen.getByRole('button', { name: 'Sign in' }));
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: 'Sign in' })).not.toBeDisabled();
+  });
+
+  expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+});
+
+test('it disables the submit button while the action is in flight', async () => {
+  const user = userEvent.setup();
+  const deferred = buildDeferred<'redirect'>();
+  const gatedAction: TFAction = () => deferred.promise;
+
+  renderWithRouter(<TFReferenceForm action={gatedAction} />);
+
+  const emailInput = await screen.findByPlaceholderText('Email');
+
+  await user.type(emailInput, 'player@vers.test');
+  await user.type(screen.getByPlaceholderText('Password'), 'password123');
+  await user.click(screen.getByRole('button', { name: 'Sign in' }));
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeDisabled();
+  });
+
+  await deferred.release('redirect');
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: 'Sign in' })).not.toBeDisabled();
+  });
+});

--- a/projects/app-web/src/lib/forms/tf-reference-form.tsx
+++ b/projects/app-web/src/lib/forms/tf-reference-form.tsx
@@ -1,0 +1,169 @@
+import { useForm } from '@tanstack/react-form';
+import { mergeForm, useTransform } from '@tanstack/react-form-start';
+import { Field, StatusButton, Text } from '@vers/design-system';
+import { useState } from 'react';
+import { z } from 'zod';
+
+const ReferenceSchema = z.object({
+  email: z.email('Enter a valid email'),
+  password: z.string().min(8, 'Password is too short'),
+});
+
+interface ServerErrors {
+  readonly fields?: Readonly<Record<string, ReadonlyArray<string>>>;
+  readonly form?: ReadonlyArray<string>;
+}
+
+interface FormActionInput {
+  readonly data: FormData;
+}
+
+export type TFAction = (input: FormActionInput) => Promise<ServerErrors | 'redirect' | Response>;
+
+interface TFReferenceFormProps {
+  readonly action?: TFAction;
+  readonly serverState?: ServerErrors;
+}
+
+const GENERIC_SUBMIT_ERROR = 'Something went wrong. Please try again.';
+
+export function TFReferenceForm(props: Readonly<TFReferenceFormProps>) {
+  const action = props.action ?? noopAction;
+
+  const [dispatchedErrors, setDispatchedErrors] = useState<ServerErrors | undefined>(undefined);
+  const serverState = dispatchedErrors ?? props.serverState;
+
+  const form = useForm({
+    defaultValues: { email: '', password: '' },
+    transform: useTransform(
+      (baseForm) => mergeForm(baseForm, toFormState(serverState)),
+      [serverState],
+    ),
+    validators: { onSubmit: ReferenceSchema },
+    async onSubmit(ctx) {
+      const data = new FormData();
+
+      data.set('email', ctx.value.email);
+      data.set('password', ctx.value.password);
+
+      const result = await action({ data });
+
+      if (result === 'redirect') {
+        return;
+      }
+
+      if (result instanceof Response) {
+        setDispatchedErrors({ form: [GENERIC_SUBMIT_ERROR] });
+
+        return;
+      }
+
+      setDispatchedErrors(result);
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        void form.handleSubmit();
+      }}
+    >
+      <form.Field name="email">
+        {(field) => (
+          <Field
+            errors={field.state.meta.errors.filter((error) => typeof error === 'string')}
+            inputProps={{
+              name: field.name,
+              onBlur: field.handleBlur,
+              onChange: (event) => {
+                field.handleChange(event.target.value);
+              },
+              placeholder: 'Email',
+              type: 'email',
+              value: field.state.value,
+            }}
+            labelProps={{ children: 'Email', htmlFor: field.name }}
+          />
+        )}
+      </form.Field>
+      <form.Field name="password">
+        {(field) => (
+          <Field
+            errors={field.state.meta.errors.filter((error) => typeof error === 'string')}
+            inputProps={{
+              name: field.name,
+              onBlur: field.handleBlur,
+              onChange: (event) => {
+                field.handleChange(event.target.value);
+              },
+              placeholder: 'Password',
+              type: 'password',
+              value: field.state.value,
+            }}
+            labelProps={{ children: 'Password', htmlFor: field.name }}
+          />
+        )}
+      </form.Field>
+      <form.Subscribe selector={(state) => [state.errorMap.onServer, state.isSubmitting] as const}>
+        {([serverError, isSubmitting]) => {
+          const message = pickFormMessage(serverError);
+
+          return (
+            <>
+              {message !== undefined && <Text role="alert">{message}</Text>}
+              <StatusButton
+                disabled={isSubmitting}
+                status={isSubmitting ? StatusButton.Status.Pending : StatusButton.Status.Idle}
+                type="submit"
+                variant="primary"
+              >
+                Sign in
+              </StatusButton>
+            </>
+          );
+        }}
+      </form.Subscribe>
+    </form>
+  );
+}
+
+function noopAction(): Promise<'redirect'> {
+  return Promise.resolve('redirect');
+}
+
+function toFormState(errors: ServerErrors | undefined) {
+  if (errors === undefined) {
+    return {};
+  }
+
+  const fields: Record<string, Array<string>> = {};
+
+  for (const [name, messages] of Object.entries(errors.fields ?? {})) {
+    fields[name] = [...messages];
+  }
+
+  return { errorMap: { onServer: { fields, form: [...(errors.form ?? [])] } } };
+}
+
+/**
+ * TanStack Form represents a form-level `onServer` error as a bare `string[]` after a submit but as
+ * a `{ form, fields }` object when merged in through `mergeForm` at mount. Reading either shape
+ * takes this normalization the library does not do itself.
+ */
+function pickFormMessage(serverError: unknown): string | undefined {
+  if (Array.isArray(serverError)) {
+    return serverError.find((error) => typeof error === 'string');
+  }
+
+  if (
+    serverError !== null &&
+    typeof serverError === 'object' &&
+    'form' in serverError &&
+    Array.isArray(serverError.form)
+  ) {
+    return serverError.form.find((error) => typeof error === 'string');
+  }
+
+  return undefined;
+}

--- a/projects/app-web/src/test-utils/build-deferred.test.ts
+++ b/projects/app-web/src/test-utils/build-deferred.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from 'bun:test';
+import { buildDeferred } from './build-deferred';
+
+test('it leaves the promise pending until released', async () => {
+  const deferred = buildDeferred<string>();
+  const pendingMarker = Symbol('pending');
+
+  const beforeRelease = await Promise.race([deferred.promise, Promise.resolve(pendingMarker)]);
+
+  expect(beforeRelease).toBe(pendingMarker);
+
+  await deferred.release('done');
+
+  const afterRelease = await deferred.promise;
+
+  expect(afterRelease).toBe('done');
+});
+
+test('it resolves the promise with the released value', async () => {
+  const deferred = buildDeferred<number>();
+
+  await deferred.release(42);
+
+  const value = await deferred.promise;
+
+  expect(value).toBe(42);
+});

--- a/projects/app-web/src/test-utils/build-deferred.ts
+++ b/projects/app-web/src/test-utils/build-deferred.ts
@@ -1,0 +1,25 @@
+import { act } from '@testing-library/react';
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  readonly release: (value: T) => Promise<void>;
+}
+
+/**
+ * A promise a test controls: `promise` stays pending until `release`. `release` resolves it inside
+ * `act`, so state a React consumer updates from the promise's own continuation — a microtask outside
+ * React's batching that `waitFor` races — is settled before the next assertion.
+ */
+export function buildDeferred<T>(): Deferred<T> {
+  const gate = Promise.withResolvers<T>();
+
+  return {
+    promise: gate.promise,
+    release: (value) =>
+      act(async () => {
+        gate.resolve(value);
+
+        await gate.promise;
+      }),
+  };
+}


### PR DESCRIPTION
## Description

Spike checking whether TanStack Form's testing model shakes out as cleanly as the adopted Conform work (#314). Ports #314's reference island and its five result→UI scenarios onto TanStack Form 1.33 — throwaway, for review, not for merge.

- Adds `@tanstack/react-form` + `@tanstack/react-form-start` 1.33.0 (peer aligns with app-web's `@tanstack/react-start` 1.168.27 — no churn).
- Client-dispatch island wired like a migrated form: server errors seed through `mergeForm`/`useTransform` and an injected action, mirroring #314's fabricated-`lastResult` model.
- All five branches (fabricated form/field error with no submit, `Response`, redirect, in-flight) assert in RTL with no server boundary.
- `pickFormMessage` normalizes TanStack Form's non-uniform `onServer` error shape — `{form,fields}` object on mount-merge vs bare `string[]` post-submit. The one durable tax versus Conform's uniform `SubmissionResult`.
- The documented typed path needs the Start adapter's `useTransform`; inlining it type-checks worse.

## Testing

- [x] `yarn typecheck` passes
- [x] `yarn test` passes
- [x] `yarn lint` passes
- [x] New tests added for new functionality

## Context

Verdict: testability is not a blocker for TanStack Form — it hits #314's bar. Tradeoff is the error-shape normalizer + value-first FormData assembly vs Conform's FormData-native uniform result. Do not merge; delete the branch once the direction is settled.