### PR TITLE
docs: activity checkpoint store as per-event append-only postgres (drop Emmett)

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -21,6 +21,14 @@ from a Fly Sydney machine; warm queries ~2ms, fresh connections ~55–70ms). Fly
 not equal the 300s suspend window, or a first request after idle pays both cold starts at once — set
 Fly's idle-stop meaningfully longer or shorter when provisioning apps.
 
+## Activity checkpoint store
+
+The activity checkpoint log shares this Postgres. It is an append-only table keyed by
+`(activity_id, version)`, range-partitioned by time, alongside a per-activity head row carrying the
+appended and verified cursors that the resume read and the verification lock target. Retention is a
+`DROP PARTITION` over streams already verified and cold-archived to object storage — a bulk delete
+that avoids row-by-row churn and keeps the hot set bounded no matter how long the game runs.
+
 ## Connection strings
 
 Two hosts per endpoint: **direct** (`ep-<endpoint>.<region>.aws.neon.tech`) and **pooled**

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -16,7 +16,7 @@ return typed results.
 flowchart LR
     B[Browser] -->|HTTPS| W["app-web<br>TanStack Start"]
     W -->|"oRPC + service token<br>(Fly private mesh)"| S["domain services<br>Elysia on Bun"]
-    S -->|Kysely / Emmett| P[("Postgres<br>(Neon)")]
+    S -->|Kysely| P[("Postgres<br>(Neon)")]
 ```
 
 The oRPC link is isomorphic: during SSR the Start server calls services directly; in the browser,
@@ -44,11 +44,12 @@ is playing. Provisioning, connection rules, and where the secrets live: [databas
 
 - **Relational identity data** — users, sessions, verifications, avatars — accessed through Kysely,
   migrated by kysely-ctl in `lib-db`.
-- **Event-store checkpoints** — via Emmett, one stream per activity. The workload is append-heavy
-  checkpoint batches, point reads for "latest progress", and rare full replays — a natural fit for
-  indexed Postgres, with optimistic concurrency (`UNIQUE(stream_id, version)`) backing the
-  checkpoint hash chain. Emmett is backend-agnostic, so a purpose-built event store would be a
-  drop-in swap.
+- **Activity checkpoints** — an append-only table keyed by `(activity_id, version)`, one row per
+  checkpoint batch, range-partitioned by time. The workload is append-heavy submissions, point reads
+  for "latest progress" off a per-activity head row, and full-stream replays during verification — a
+  natural fit for indexed Postgres, with `UNIQUE(activity_id, version)` optimistic concurrency
+  backing the checkpoint hash chain. Verified streams age out on a retention window and cold-archive
+  to object storage, so the hot partitions stay bounded regardless of lifetime volume.
 
 ## Game layer
 
@@ -100,7 +101,6 @@ Backend:
 - API Layer - [oRPC](https://orpc.unnoq.com), contract-first
 - Database - [PostgreSQL](https://postgresql.org) on [Neon](https://neon.tech) via
   [Kysely](https://kysely.dev)
-- Event Store - [Emmett](https://event-driven-io.github.io/emmett/)
 - Authentication - [TOTP](https://github.com/epicweb-dev/totp),
   [jose](https://github.com/panva/jose), `Bun.password` (argon2id)
 - Email - [React Email](https://react.email), [Resend](https://resend.com)


### PR DESCRIPTION
Records the activity checkpoint store as a plain append-only Postgres table on Kysely, replacing the Emmett event-store framing in the architecture docs. Nothing in the tree depends on Emmett, so this is a docs-only decision ahead of the activities-service build.

- One row per checkpoint batch, keyed `(activity_id, version)`, range-partitioned by time; a per-activity head row carries the appended/verified cursors for resume and verification.
- Retention is `DROP PARTITION` over verified, cold-archived streams — bounded hot set, no row-churn.
- Drops Emmett: its event-sourcing ergonomics buy little for a single aggregate whose CAS/ledger/queue paths are hand-rolled anyway, and its fixed schema fought the hash-chain.

## Testing

- [x] Docs-only, no code paths

## Context

Why per-event rows over one-record-per-activity: row count is a non-issue for Postgres — an append-only, point-read-by-index table runs 100M+ rows fine. On Neon (storage $0.35/GB-month) ~250 B/row puts 100M checkpoints at ~$8.75/mo storage before pruning; compute scales to zero. One-record-per-activity would reintroduce JSONB blob-rewrite amplification and MVCC bloat to "save" rows that are nearly free. Stacked on #326 (doc de-numbering); retargets to main once that merges.