### PR TITLE
fix(#207): generate workspace-dep codegen in the app-web image

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -325,8 +325,9 @@ executable in stages:
    source. The busybox shell keeps `fly ssh console` usable.
 
 `app-web` bundles an SSR server in stages: **pruner**; **installer** (full `bun install` for the
-build tooling); **builder** (its `codegen`/`typegen`/`build` scripts directly, plus
-`tsconfig.base.json` from outside any package); **prod-deps**
+build tooling); **builder** (`turbo run codegen typegen --filter=@vers/web...` so a workspace dep's
+generated output — `@vers/styled-system`'s panda CSS — exists before its own `build` script runs,
+plus `tsconfig.base.json` from outside any package); **prod-deps**
 (`bun install --production --linker=hoisted`, whose flat `node_modules` lets the bundle resolve
 external imports like `pino` from one location); and a `node:24.18.0-alpine` **runtime** holding
 `node_modules`, `server.mjs`, and `dist`.

--- a/agents/project.md
+++ b/agents/project.md
@@ -122,8 +122,9 @@ executable in stages:
    source. The busybox shell keeps `fly ssh console` usable.
 
 `app-web` bundles an SSR server in stages: **pruner**; **installer** (full `bun install` for the
-build tooling); **builder** (its `codegen`/`typegen`/`build` scripts directly, plus
-`tsconfig.base.json` from outside any package); **prod-deps**
+build tooling); **builder** (`turbo run codegen typegen --filter=@vers/web...` so a workspace dep's
+generated output — `@vers/styled-system`'s panda CSS — exists before its own `build` script runs,
+plus `tsconfig.base.json` from outside any package); **prod-deps**
 (`bun install --production --linker=hoisted`, whose flat `node_modules` lets the bundle resolve
 external imports like `pino` from one location); and a `node:24.18.0-alpine` **runtime** holding
 `node_modules`, `server.mjs`, and `dist`.

--- a/projects/app-web/Dockerfile
+++ b/projects/app-web/Dockerfile
@@ -41,8 +41,7 @@ RUN \
   # without removing dev/test env files, vite loads the wrong one in our prod
   # bundle — doesn't reproduce outside docker, not worth chasing further
   rm -f .env.development .env.test && \
-  bun run codegen && \
-  bun run typegen && \
+  bunx turbo run codegen typegen --filter=@vers/web... && \
   bun run build --mode production && \
   rm -f dist/client/mockServiceWorker.js
 


### PR DESCRIPTION
## Description

app-web's Docker build fails: `Rolldown failed to resolve import "@vers/styled-system/css"`. That package's panda output is generated + gitignored, but the builder ran only app-web's *own* `bun run codegen`, so the dependency's CSS never existed in the image.

- Builder now runs `turbo run codegen typegen --filter=@vers/web...`, generating the deps' output (like `@vers/styled-system`) in dependency order before app-web's `build`.
- Verified: app-web builds and deploys clean via Fly remote builder — public `/health` returns 200.

## Testing

- [x] app-web deployed via `flyctl deploy --remote-only`, machines healthy, `https://vers-app-web.fly.dev/health` → 200
- [x] `format:check` + AGENTS.md drift pass

## Context

Latent since the deploy rebuild — the old CI 502'd on image push before app-web's build was ever exercised. All 5 apps are now deployed.