### PR TITLE
chore(#315): adopt oxlint await-hiding rules, hoist flagged awaits

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
         "@vitest/ui": "3.0.8",
         "@zgeoff/bun-test-extended": "0.0.3",
         "@zgeoff/format-codemod": "0.0.5",
-        "@zgeoff/oxlint-config": "0.0.2",
+        "@zgeoff/oxlint-config": "0.0.3",
         "esbuild": "0.25.1",
         "lefthook": "2.1.9",
         "oxfmt": "0.56.0",
@@ -2103,7 +2103,7 @@
 
     "@zgeoff/format-codemod": ["@zgeoff/format-codemod@0.0.5", "", { "dependencies": { "oxc-parser": "0.137.0" }, "bin": { "format-codemod": "dist/cli.js" } }, "sha512-YYyXMc9IPjCgcVGkWsXkrLfFFozpvMDgm1EUAVBuW4TyOxZpkIw4pIyg7SWdOgJ2AX0MANMoaPLC7LQdaWpG4w=="],
 
-    "@zgeoff/oxlint-config": ["@zgeoff/oxlint-config@0.0.2", "", { "dependencies": { "@stylistic/eslint-plugin": "5.10.0" }, "peerDependencies": { "oxlint": ">=1.71.0" } }, "sha512-H/GP7joUR2a5tuiqkjN//UoafqMug4khijcafAE4EI718NTKYd3DoIlbuB84tAG6UIlXWmuJFPp23NxMYheeOg=="],
+    "@zgeoff/oxlint-config": ["@zgeoff/oxlint-config@0.0.3", "", { "dependencies": { "@stylistic/eslint-plugin": "5.10.0" }, "peerDependencies": { "oxlint": ">=1.71.0" } }, "sha512-Kk6WBhjQ6FHpuxT1xTh7oWqbPezoikN9GwM679/nW6geNjdVxFKpBoJjzuGVVLT6BU3/JFHj5caHFrmxDCpx4w=="],
 
     "JSONStream": ["JSONStream@1.3.5", "", { "dependencies": { "jsonparse": "^1.2.0", "through": ">=2.2.7 <3" }, "bin": { "JSONStream": "./bin.js" } }, "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ=="],
 

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@vitest/ui": "3.0.8",
     "@zgeoff/bun-test-extended": "0.0.3",
     "@zgeoff/format-codemod": "0.0.5",
-    "@zgeoff/oxlint-config": "0.0.2",
+    "@zgeoff/oxlint-config": "0.0.3",
     "esbuild": "0.25.1",
     "lefthook": "2.1.9",
     "oxfmt": "0.56.0",

--- a/projects/app-web/src/lib/auth/check-step-up.ts
+++ b/projects/app-web/src/lib/auth/check-step-up.ts
@@ -38,11 +38,12 @@ export async function checkStepUp(opts: Readonly<CheckStepUpOptions>): Promise<C
 
   const sessionID = authSession.sessionID ?? null;
 
-  if (
-    opts.token !== undefined &&
-    (await tryConsumeStepUpToken(opts.action, opts.target, opts.token, sessionID))
-  ) {
-    return { status: 'verified' };
+  if (opts.token !== undefined) {
+    const consumed = await tryConsumeStepUpToken(opts.action, opts.target, opts.token, sessionID);
+
+    if (consumed) {
+      return { status: 'verified' };
+    }
   }
 
   return {

--- a/projects/lib-db/test-setup.ts
+++ b/projects/lib-db/test-setup.ts
@@ -11,7 +11,9 @@ const TEST_TEMPLATE_DB = 'test_template';
 // handoff of the container's connection details needs an env var rather
 // than an in-memory value (`resolveTestDBTarget` reads it back per file)
 if (process.env['TEST_DB_URI'] === undefined) {
-  if (await isTestContainerReachable()) {
+  const containerReachable = await isTestContainerReachable();
+
+  if (containerReachable) {
     process.env['TEST_DB_URI'] = `postgres://test:test@localhost:${TEST_CONTAINER_PORT}`;
     process.env['TEST_TEMPLATE_DB'] = TEST_TEMPLATE_DB;
   } else {

--- a/projects/lib-service-test-utils/src/bun/setup-bun-test-db.ts
+++ b/projects/lib-service-test-utils/src/bun/setup-bun-test-db.ts
@@ -20,7 +20,9 @@ export async function setupBunTestDB(): Promise<void> {
     return;
   }
 
-  if (await isTestContainerReachable()) {
+  const containerReachable = await isTestContainerReachable();
+
+  if (containerReachable) {
     process.env['TEST_DB_URI'] = `postgres://test:test@localhost:${TEST_CONTAINER_PORT}`;
     process.env['TEST_TEMPLATE_DB'] = TEST_TEMPLATE_DB;
 

--- a/projects/service-session/src/handlers/record-failed-attempt.ts
+++ b/projects/service-session/src/handlers/record-failed-attempt.ts
@@ -25,7 +25,9 @@ export async function recordFailedAttempt(
   db: Kysely<DB>,
   opts: RecordFailedAttemptOpts,
 ): Promise<{ attemptsRemaining: number }> {
-  if (await removeIfAtCap(db, opts.input.id)) {
+  const removedAtCap = await removeIfAtCap(db, opts.input.id);
+
+  if (removedAtCap) {
     return { attemptsRemaining: 0 };
   }
 
@@ -44,7 +46,9 @@ export async function recordFailedAttempt(
 
   // a concurrent increment may have moved the row to the cap between the delete-at-cap attempt
   // above and this update; retry the delete once before concluding the row is gone or expired
-  if (await removeIfAtCap(db, opts.input.id)) {
+  const removedOnRetry = await removeIfAtCap(db, opts.input.id);
+
+  if (removedOnRetry) {
     return { attemptsRemaining: 0 };
   }
 


### PR DESCRIPTION
Closes #315

Bump `@zgeoff/oxlint-config` 0.0.2 → 0.0.3, adding `zgeoff/no-await-in-condition` and `zgeoff/no-await-in-logical`, then hoist the five awaits they flag into named consts before their control-flow statement.

- `check-step-up.ts`: split the `&&` chain into a nested `if` so the `opts.token !== undefined` short-circuit still gates the await.
- `record-failed-attempt.ts`: both delete-at-cap checks hoisted (`removedAtCap`, `removedOnRetry`).
- `setup-bun-test-db.ts` / `lib-db/test-setup.ts`: container-reachable check hoisted.

Pure hoist — no behaviour change. The config package is in `minimumReleaseAgeExcludes`, so 0.0.3 installs before the 7-day gate; #292 drops that exclude after this lands.

## Testing
- [x] `bun run typecheck` passes (touched projects)
- [x] `bun run lint` — await-hiding rules clean
- [ ] CI