### PR TITLE
chore(infra): commit versidle.com zone id to the prod stack config

### DIFF
--- a/projects/infra/Pulumi.prod.yaml
+++ b/projects/infra/Pulumi.prod.yaml
@@ -1,5 +1,4 @@
 config:
-  # Set after adding versidle.com to Cloudflare:
-  #   op run --env-file=.env -- pulumi config set vers-infra:zoneId <zone-id>
   vers-infra:zoneName: versidle.com
   vers-infra:appHostname: vers-app-web.fly.dev
+  vers-infra:zoneId: fc9e4cdc2fff4aee760c7fd1e71ffe27


### PR DESCRIPTION
## Description

Pins the Cloudflare zone id in `projects/infra/Pulumi.prod.yaml` so a fresh `pulumi up` reproduces the DNS records without a manual `pulumi config set`. The zone id is a non-secret public identifier.

## Testing

- [x] DNS records already applied from this config; `versidle.com` + `www` serve HTTP 200 with issued Fly certs