### PR TITLE
refactor(#324): drop unsafe cast at R3F test-renderer identity assertion

### DIFF
--- a/projects/lib-aether-client/src/components-three/aether-node.test.tsx
+++ b/projects/lib-aether-client/src/components-three/aether-node.test.tsx
@@ -1,7 +1,6 @@
 import { expect, test } from 'bun:test';
 import ReactThreeTestRenderer from '@react-three/test-renderer';
 import type { AetherNode as AetherNodeType } from '@vers/aether-core';
-import type { Object3D } from 'three';
 import { useHoveredNodeStore } from '../state/use-hovered-node-store';
 import { useSelectedNodeStore } from '../state/use-selected-node-store';
 import { AetherNode } from './aether-node';
@@ -48,12 +47,9 @@ test('it sets the selected node when the node is clicked and connected to the cu
   const mesh = renderer.scene.children[0]!;
 
   await renderer.fireEvent(mesh, 'pointerDown', {
-    object: mesh,
+    object: mesh.instance,
   });
 
   expect(useSelectedNodeStore.getState().node).toBe(node);
-  // the test renderer types its scene children more loosely than the three Object3D the store
-  // holds, though the runtime identity is the same object
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test-renderer/three type gap (#325)
-  expect(useSelectedNodeStore.getState().object3D).toBe(mesh as unknown as Object3D);
+  expect(useSelectedNodeStore.getState().object3D).toBe(mesh.instance);
 });


### PR DESCRIPTION
## Description

Closes #324

The R3F test renderer wraps scene children in `ReactThreeTestInstance`, whose `.instance` getter is already typed `three.Object3D` — the type our store holds. Fire the pointer event with `mesh.instance` and assert against it, so the `no-unsafe-type-assertion` cast and its disable directive are gone.

- Removes the one such disable in the tree; nothing else references the test-renderer/three type gap.
- The stale disable cited #325 (a closed duplicate of #324).

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes (3 pass, `@vers/aether-client`)
- [x] `bun run lint` passes