### PR TITLE
chore(#244): burn down idle-core baseline(#236) lint directives

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -142,18 +142,36 @@
           { "from": "package", "name": "ZodError", "package": "zod" },
           { "from": "package", "name": "JWTPayload", "package": "jose" },
           { "from": "package", "name": "SubmissionResult", "package": "@conform-to/dom" },
-          // not handles but intentionally never readonly: idle-core's tick
-          // and lifecycle handlers mutate these entities in place for
-          // performance, so no readonly form of them exists to consume
+          { "from": "package", "name": "XXHashAPI", "package": "xxhash-wasm" },
+          // idle-core's live domain objects are mutable handles: entities and
+          // the simulation own internal state that tick/lifecycle code drives
+          // through mutation methods (receiveDamage, setState, scheduleEvent),
+          // and the *Data seeds are mutated in place during setup -- none has a
+          // readonly form a caller can consume, so they are exempted by type
           {
             "from": "file",
-            "name": ["ActivityData", "ActivityAppState", "AetherNodeActivityData"],
+            "name": ["ActivityData", "ActivityAppState", "AetherNodeActivityData", "Activity"],
             "path": "../lib-idle-core/src/types/activity.ts"
           },
           {
             "from": "file",
-            "name": "AvatarData",
+            "name": ["AvatarData", "EnemyData", "Avatar", "Enemy", "EnemyGroup"],
             "path": "../lib-idle-core/src/types/entities.ts"
+          },
+          {
+            "from": "file",
+            "name": ["Simulation", "SimulationContext"],
+            "path": "../lib-idle-core/src/types/simulation.ts"
+          },
+          {
+            "from": "file",
+            "name": "CombatExecutor",
+            "path": "../lib-idle-core/src/types/combat.ts"
+          },
+          {
+            "from": "file",
+            "name": ["Behaviour", "AvatarBehaviour", "EnemyBehaviour"],
+            "path": "../lib-idle-core/src/types/behaviour.ts"
           }
         ]
       }

--- a/projects/lib-idle-client/src/state/set-avatar.ts
+++ b/projects/lib-idle-client/src/state/set-avatar.ts
@@ -1,7 +1,6 @@
 import type { AvatarAppState } from '@vers/idle-core';
 import { useAvatarStore } from './use-avatar-store';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function setAvatar(avatar?: AvatarAppState) {
   useAvatarStore.setState(() => ({ avatar: avatar ?? null }));
 }

--- a/projects/lib-idle-client/src/worker/run-simulation.ts
+++ b/projects/lib-idle-client/src/worker/run-simulation.ts
@@ -1,7 +1,6 @@
 import type { Simulation } from '@vers/idle-core';
 import { ActivityCheckpointType } from '@vers/idle-core';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export async function runSimulation(simulation: Simulation, timestep: number) {
   if (simulation.activity) {
     const checkpoint = await simulation.run(timestep);

--- a/projects/lib-idle-client/src/worker/simulation.ts
+++ b/projects/lib-idle-client/src/worker/simulation.ts
@@ -6,7 +6,6 @@ export function getSimulation(): null | Simulation {
   return simulation;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function setSimulation(newSimulation: null | Simulation) {
   simulation = newSimulation;
 }

--- a/projects/lib-idle-core/src/behaviours/avatar-weapon-attack/create-avatar-attack-event.test.ts
+++ b/projects/lib-idle-core/src/behaviours/avatar-weapon-attack/create-avatar-attack-event.test.ts
@@ -14,8 +14,7 @@ test('it creates an avatar attack event', () => {
   const event = createAvatarAttackEvent(avatar, time);
 
   expect(event).toStrictEqual({
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    id: expect.any(String),
+    id: expect.toBeString(),
     source: avatar.id,
     time,
     type: CombatEventType.AvatarAttack,

--- a/projects/lib-idle-core/src/behaviours/avatar-weapon-attack/create-avatar-attack-event.ts
+++ b/projects/lib-idle-core/src/behaviours/avatar-weapon-attack/create-avatar-attack-event.ts
@@ -2,7 +2,6 @@ import { createId } from '@paralleldrive/cuid2';
 import type { Avatar, AvatarAttackEvent } from '../../types';
 import { CombatEventType } from '../../types';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function createAvatarAttackEvent(entity: Avatar, time: number): AvatarAttackEvent {
   const event: AvatarAttackEvent = {
     id: createId(),

--- a/projects/lib-idle-core/src/behaviours/avatar-weapon-attack/create.ts
+++ b/projects/lib-idle-core/src/behaviours/avatar-weapon-attack/create.ts
@@ -12,7 +12,6 @@ import { getNextAttackTime } from './get-next-attack-time';
 import { handleTick } from './handle-tick';
 import { predicate } from './predicate';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function create(entity: Avatar): AvatarWeaponAttackBehaviour {
   let state = getInitialState();
 
@@ -43,12 +42,12 @@ export function create(entity: Avatar): AvatarWeaponAttackBehaviour {
 
     // handlers
     handlers: {
-      // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-      [LifecycleEvent.OnTick]: (tickEntity: Avatar, executor: CombatExecutor) =>
-        // oxlint-disable-next-line typescript/no-confusing-void-expression -- baseline(#236)
-        handleTick(tickEntity, behaviour, executor),
-      // oxlint-disable-next-line typescript/no-confusing-void-expression -- baseline(#236)
-      [LifecycleEvent.Reset]: () => handleReset(),
+      [LifecycleEvent.OnTick]: (tickEntity: Avatar, executor: CombatExecutor) => {
+        handleTick(tickEntity, behaviour, executor);
+      },
+      [LifecycleEvent.Reset]: () => {
+        handleReset();
+      },
     },
     predicate,
 

--- a/projects/lib-idle-core/src/behaviours/avatar-weapon-attack/get-attack-interval-ms.ts
+++ b/projects/lib-idle-core/src/behaviours/avatar-weapon-attack/get-attack-interval-ms.ts
@@ -1,7 +1,6 @@
 import invariant from 'tiny-invariant';
 import type { Avatar } from '../../types';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function getAttackIntervalMS(entity: Avatar): number {
   invariant(entity.mainHandEquipment, 'no weapon equipped');
 

--- a/projects/lib-idle-core/src/behaviours/avatar-weapon-attack/get-next-attack-time.ts
+++ b/projects/lib-idle-core/src/behaviours/avatar-weapon-attack/get-next-attack-time.ts
@@ -1,7 +1,6 @@
 import type { Avatar, AvatarWeaponAttackBehaviourState } from '../../types';
 import { getAttackIntervalMS } from './get-attack-interval-ms';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function getNextAttackTime(entity: Avatar, state: AvatarWeaponAttackBehaviourState): number {
   return state.lastAttackTime + getAttackIntervalMS(entity);
 }

--- a/projects/lib-idle-core/src/behaviours/avatar-weapon-attack/handle-tick.ts
+++ b/projects/lib-idle-core/src/behaviours/avatar-weapon-attack/handle-tick.ts
@@ -6,11 +6,9 @@ import { getNextAttackTime } from './get-next-attack-time';
 import { isAttackReady } from './is-attack-ready';
 
 export function handleTick(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   entity: Avatar,
   // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- this behaviour's state is mutated in place via setState during the tick loop
   behaviour: AvatarWeaponAttackBehaviour,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   executor: CombatExecutor,
 ): void {
   const label = createLogLabel('avatar', entity.id);

--- a/projects/lib-idle-core/src/behaviours/avatar-weapon-attack/is-attack-ready.ts
+++ b/projects/lib-idle-core/src/behaviours/avatar-weapon-attack/is-attack-ready.ts
@@ -2,11 +2,8 @@ import type { Avatar, AvatarWeaponAttackBehaviourState, CombatExecutor } from '.
 import { getNextAttackTime } from './get-next-attack-time';
 
 export function isAttackReady(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   entity: Avatar,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   state: AvatarWeaponAttackBehaviourState,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   executor: CombatExecutor,
 ): boolean {
   if (!entity.isAlive) {

--- a/projects/lib-idle-core/src/behaviours/avatar-weapon-attack/predicate.ts
+++ b/projects/lib-idle-core/src/behaviours/avatar-weapon-attack/predicate.ts
@@ -1,6 +1,5 @@
 import type { Avatar } from '../../types';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function predicate(entity: Avatar): boolean {
   // TODO: verify main hand is actually a weapon
   return entity.mainHandEquipment !== null;

--- a/projects/lib-idle-core/src/behaviours/enemy-primary-attack/create-enemy-attack-event.test.ts
+++ b/projects/lib-idle-core/src/behaviours/enemy-primary-attack/create-enemy-attack-event.test.ts
@@ -14,8 +14,7 @@ test('it creates an enemy attack event', () => {
   const event = createEnemyAttackEvent(enemy, time);
 
   expect(event).toStrictEqual({
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    id: expect.any(String),
+    id: expect.toBeString(),
     source: enemy.id,
     time,
     type: CombatEventType.EnemyAttack,

--- a/projects/lib-idle-core/src/behaviours/enemy-primary-attack/create-enemy-attack-event.ts
+++ b/projects/lib-idle-core/src/behaviours/enemy-primary-attack/create-enemy-attack-event.ts
@@ -2,7 +2,6 @@ import { createId } from '@paralleldrive/cuid2';
 import type { Enemy, EnemyAttackEvent } from '../../types';
 import { CombatEventType } from '../../types';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function createEnemyAttackEvent(entity: Enemy, time: number): EnemyAttackEvent {
   const event: EnemyAttackEvent = {
     id: createId(),

--- a/projects/lib-idle-core/src/behaviours/enemy-primary-attack/create.ts
+++ b/projects/lib-idle-core/src/behaviours/enemy-primary-attack/create.ts
@@ -12,7 +12,6 @@ import { getNextAttackTime } from './get-next-attack-time';
 import { handleTick } from './handle-tick';
 import { predicate } from './predicate';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function create(entity: Enemy): EnemyPrimaryAttackBehaviour {
   let state = getInitialState();
 
@@ -43,12 +42,12 @@ export function create(entity: Enemy): EnemyPrimaryAttackBehaviour {
 
     // handlers
     handlers: {
-      // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-      [LifecycleEvent.OnTick]: (tickEntity: Enemy, executor: CombatExecutor) =>
-        // oxlint-disable-next-line typescript/no-confusing-void-expression -- baseline(#236)
-        handleTick(tickEntity, behaviour, executor),
-      // oxlint-disable-next-line typescript/no-confusing-void-expression -- baseline(#236)
-      [LifecycleEvent.Reset]: () => handleReset(),
+      [LifecycleEvent.OnTick]: (tickEntity: Enemy, executor: CombatExecutor) => {
+        handleTick(tickEntity, behaviour, executor);
+      },
+      [LifecycleEvent.Reset]: () => {
+        handleReset();
+      },
     },
     predicate,
 

--- a/projects/lib-idle-core/src/behaviours/enemy-primary-attack/get-attack-interval-ms.ts
+++ b/projects/lib-idle-core/src/behaviours/enemy-primary-attack/get-attack-interval-ms.ts
@@ -1,6 +1,5 @@
 import type { Enemy } from '../../types';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function getAttackIntervalMS(entity: Enemy): number {
   return Math.round(1000 / entity.primaryAttack.speed);
 }

--- a/projects/lib-idle-core/src/behaviours/enemy-primary-attack/get-next-attack-time.ts
+++ b/projects/lib-idle-core/src/behaviours/enemy-primary-attack/get-next-attack-time.ts
@@ -1,7 +1,6 @@
 import type { Enemy, EnemyPrimaryAttackBehaviourState } from '../../types';
 import { getAttackIntervalMS } from './get-attack-interval-ms';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function getNextAttackTime(entity: Enemy, state: EnemyPrimaryAttackBehaviourState): number {
   return state.lastAttackTime + getAttackIntervalMS(entity);
 }

--- a/projects/lib-idle-core/src/behaviours/enemy-primary-attack/handle-tick.ts
+++ b/projects/lib-idle-core/src/behaviours/enemy-primary-attack/handle-tick.ts
@@ -6,11 +6,9 @@ import { getNextAttackTime } from './get-next-attack-time';
 import { isAttackReady } from './is-attack-ready';
 
 export function handleTick(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   entity: Enemy,
   // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- this behaviour's state is mutated in place via setState during the tick loop
   behaviour: EnemyPrimaryAttackBehaviour,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   executor: CombatExecutor,
 ): void {
   const label = createLogLabel('enemy', entity.id);

--- a/projects/lib-idle-core/src/behaviours/enemy-primary-attack/is-attack-ready.ts
+++ b/projects/lib-idle-core/src/behaviours/enemy-primary-attack/is-attack-ready.ts
@@ -2,11 +2,8 @@ import type { CombatExecutor, Enemy, EnemyPrimaryAttackBehaviourState } from '..
 import { getNextAttackTime } from './get-next-attack-time';
 
 export function isAttackReady(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   entity: Enemy,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   state: EnemyPrimaryAttackBehaviourState,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   executor: CombatExecutor,
 ): boolean {
   if (!entity.isAlive) {

--- a/projects/lib-idle-core/src/behaviours/enemy-primary-attack/predicate.ts
+++ b/projects/lib-idle-core/src/behaviours/enemy-primary-attack/predicate.ts
@@ -1,6 +1,5 @@
 import type { Enemy } from '../../types';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function predicate(entity: Enemy): boolean {
   return Boolean(entity.primaryAttack);
 }

--- a/projects/lib-idle-core/src/core/create-activity.test.ts
+++ b/projects/lib-idle-core/src/core/create-activity.test.ts
@@ -23,7 +23,6 @@ test('it creates an activity with a fixed size for each group', () => {
     groupSize: 3,
   });
 
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   expect(activity.enemyGroups).toSatisfyAll((group: EnemyGroup) => group.enemies.length === 3);
 });
 
@@ -36,18 +35,13 @@ test('it returns the expected activity state for a client app', () => {
 
   expect(state).toStrictEqual({
     currentEnemyGroup: {
-      // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-      enemies: expect.any(Array),
-      // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-      id: expect.any(String),
+      enemies: expect.toBeArray(),
+      id: expect.toBeString(),
     },
     elapsed: 0,
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    enemiesRemaining: expect.any(Number),
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    enemyGroups: expect.any(Array),
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    enemyGroupsRemaining: expect.any(Number),
+    enemiesRemaining: expect.toBeNumber(),
+    enemyGroups: expect.toBeArray(),
+    enemyGroupsRemaining: expect.toBeNumber(),
     id: activity.id,
     name: activity.name,
   });

--- a/projects/lib-idle-core/src/core/create-activity.ts
+++ b/projects/lib-idle-core/src/core/create-activity.ts
@@ -8,15 +8,13 @@ import type {
 import { getEnemyGroups } from './utils/get-enemy-groups';
 
 interface ActivityConfig {
-  groupCount?: number;
-  groupSize?: number;
+  readonly groupCount?: number;
+  readonly groupSize?: number;
 }
 
 export function createActivity(
   data: ActivityData,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   ctx: SimulationContext,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   config: ActivityConfig = {},
 ): Activity {
   let elapsed = 0;

--- a/projects/lib-idle-core/src/core/create-combat-executor.ts
+++ b/projects/lib-idle-core/src/core/create-combat-executor.ts
@@ -10,11 +10,8 @@ import type {
 import { handleEvent } from './handle-event';
 
 export function createCombatExecutor(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- activity is mutated in place via elapseTime during the tick loop
   activity: Activity,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- avatar is mutated in place via reset during the tick loop
   avatar: Avatar,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   ctx: SimulationContext,
 ): CombatExecutor {
   let elapsed = 0;
@@ -24,7 +21,6 @@ export function createCombatExecutor(
     elapsed,
   });
 
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   const scheduleEvent = (event: CombatEvent) => {
     scheduledEvents.push(event);
   };
@@ -34,7 +30,6 @@ export function createCombatExecutor(
 
     scheduledEvents.sort(sortEvents);
 
-    // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
     scheduledEvents.forEach((event: CombatEvent) => {
       handleEvent(event, avatar, activity, ctx);
     });
@@ -64,8 +59,10 @@ export function createCombatExecutor(
     elapsed += delta;
 
     avatar.handleTick(executor, ctx);
-    // oxlint-disable-next-line typescript/no-confusing-void-expression -- baseline(#236)
-    activity.currentEnemyGroup?.enemies.map((enemy) => enemy.handleTick(executor, ctx));
+
+    activity.currentEnemyGroup?.enemies.forEach((enemy) => {
+      enemy.handleTick(executor, ctx);
+    });
 
     processEvents();
 

--- a/projects/lib-idle-core/src/core/create-simulation.test.ts
+++ b/projects/lib-idle-core/src/core/create-simulation.test.ts
@@ -131,10 +131,8 @@ test('it runs an activity and returns checkpoints', async () => {
   const firstCheckpoint = await simulation.run(100);
 
   expect(firstCheckpoint).toStrictEqual({
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    hash: expect.any(String),
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    seed: expect.any(Number),
+    hash: expect.toBeString(),
+    seed: expect.toBeNumber(),
     time: 0,
     type: ActivityCheckpointType.Started,
   });
@@ -142,12 +140,9 @@ test('it runs an activity and returns checkpoints', async () => {
   const secondCheckpoint = await simulation.run(10_000);
 
   expect(secondCheckpoint).toStrictEqual({
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    hash: expect.any(String),
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    nextSeed: expect.any(Number),
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    time: expect.any(Number),
+    hash: expect.toBeString(),
+    nextSeed: expect.toBeNumber(),
+    time: expect.toBeNumber(),
     type: ActivityCheckpointType.Progress,
   });
 

--- a/projects/lib-idle-core/src/core/create-simulation.ts
+++ b/projects/lib-idle-core/src/core/create-simulation.ts
@@ -22,7 +22,6 @@ import { createCombatExecutor } from './create-combat-executor';
 import { simulateActivity } from './simulate-activity';
 import { getAppState } from './utils/get-app-state';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function createSimulation(hasher: XXHashAPI): Simulation {
   let _rng = createRNG(0);
   let _avatar: Avatar | null = null;
@@ -30,7 +29,7 @@ export function createSimulation(hasher: XXHashAPI): Simulation {
   let _activity: Activity | null = null;
   let _combat: CombatExecutor | null = null;
   let _generator: ActivityCheckpointGenerator | null = null;
-  let _done: boolean | undefined;
+  let _done = false;
   let _elapsed = 0;
 
   const ctx: SimulationContext = {
@@ -93,7 +92,6 @@ export function createSimulation(hasher: XXHashAPI): Simulation {
   const stopActivity = async () => {
     _activity = null;
 
-    // oxlint-disable-next-line typescript/strict-boolean-expressions -- baseline(#236)
     if (!_done) {
       // @ts-expect-error - we're not passing a return value during cleanup
       await _generator?.return();
@@ -128,16 +126,12 @@ export function createSimulation(hasher: XXHashAPI): Simulation {
       return null;
     }
 
-    // oxlint-disable-next-line typescript/strict-boolean-expressions -- baseline(#236)
-    invariant(_generator, 'generator is required');
-
     const prevState = getAppState(state);
 
     const next = await _generator.next(timestep);
 
-    _done = next.done;
+    _done = next.done ?? false;
 
-    // oxlint-disable-next-line typescript/strict-boolean-expressions -- baseline(#236)
     if (_done) {
       _generator = null;
     }
@@ -188,8 +182,9 @@ export function createSimulation(hasher: XXHashAPI): Simulation {
     getAppState: () => getAppState(state),
     restartActivity,
     run,
-    // oxlint-disable-next-line typescript/no-misused-promises, typescript/strict-void-return -- baseline(#236)
-    startActivity,
+    startActivity: (avatarData: AvatarData, activityData: ActivityData) => {
+      void startActivity(avatarData, activityData);
+    },
     stopActivity,
   };
 }

--- a/projects/lib-idle-core/src/core/handle-avatar-attack.ts
+++ b/projects/lib-idle-core/src/core/handle-avatar-attack.ts
@@ -2,7 +2,6 @@ import type { Activity, Avatar, AvatarAttackEvent } from '../types';
 import { createLogLabel } from '../utils/create-log-label';
 import { logger } from '../utils/logger';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function handleAvatarAttack(_event: AvatarAttackEvent, avatar: Avatar, activity: Activity) {
   const label = createLogLabel('avatar', avatar.id);
 

--- a/projects/lib-idle-core/src/core/handle-enemy-attack.ts
+++ b/projects/lib-idle-core/src/core/handle-enemy-attack.ts
@@ -2,14 +2,12 @@ import type { Activity, Avatar, EnemyAttackEvent } from '../types';
 import { createLogLabel } from '../utils/create-log-label';
 import { logger } from '../utils/logger';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- avatar is mutated in place via receiveDamage during the tick loop
 export function handleEnemyAttack(event: EnemyAttackEvent, avatar: Avatar, activity: Activity) {
   const enemy = activity.currentEnemyGroup?.enemies.find(
     (candidate) => candidate.id === event.source,
   );
 
-  // oxlint-disable-next-line typescript/strict-boolean-expressions -- baseline(#236)
-  if (enemy?.isAlive && avatar.isAlive) {
+  if (enemy?.isAlive === true && avatar.isAlive) {
     const label = createLogLabel('enemy', event.source);
 
     const damage = enemy.calcAttackDamage();

--- a/projects/lib-idle-core/src/core/handle-event.ts
+++ b/projects/lib-idle-core/src/core/handle-event.ts
@@ -5,11 +5,8 @@ import { handleEnemyAttack } from './handle-enemy-attack';
 
 export function handleEvent<T extends CombatEventType>(
   event: Extract<CombatEvent, { type: T }>,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   avatar: Avatar,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   activity: Activity,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   ctx: SimulationContext,
 ) {
   EVENT_HANDLER_FN[event.type](event, avatar, activity, ctx);
@@ -18,11 +15,8 @@ export function handleEvent<T extends CombatEventType>(
 type EventHandlerMap = {
   [Type in CombatEventType]: (
     event: Extract<CombatEvent, { type: Type }>,
-    // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
     avatar: Avatar,
-    // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
     activity: Activity,
-    // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
     ctx: SimulationContext,
   ) => void;
 };

--- a/projects/lib-idle-core/src/core/run-simulation.test.ts
+++ b/projects/lib-idle-core/src/core/run-simulation.test.ts
@@ -128,11 +128,9 @@ test('it stops at the specified seed if provided', async () => {
   const [finalCheckpoint] = result.checkpoints.slice(-1);
 
   expect(finalCheckpoint).toStrictEqual({
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    hash: expect.any(String),
+    hash: expect.toBeString(),
     nextSeed: config.stopAtSeed,
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    time: expect.any(Number),
+    time: expect.toBeNumber(),
     type: ActivityCheckpointType.Completed,
   });
 });
@@ -165,12 +163,9 @@ test('it aborts on failure if failure action is set to abort', async () => {
   const lastCheckpoint = result.checkpoints.at(-1);
 
   expect(lastCheckpoint).toStrictEqual({
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    hash: expect.any(String),
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    nextSeed: expect.any(Number),
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    time: expect.any(Number),
+    hash: expect.toBeString(),
+    nextSeed: expect.toBeNumber(),
+    time: expect.toBeNumber(),
     type: ActivityCheckpointType.Failed,
   });
 });

--- a/projects/lib-idle-core/src/core/run-simulation.ts
+++ b/projects/lib-idle-core/src/core/run-simulation.ts
@@ -16,8 +16,8 @@ import { createSimulation } from './create-simulation';
  * verifying client progress.
  */
 interface SimulationConfig {
-  duration: number;
-  stopAtSeed?: number;
+  readonly duration: number;
+  readonly stopAtSeed?: number;
 }
 
 interface SimulationOutput {
@@ -30,7 +30,6 @@ const SERVER_SIMULATION_INTERVAL = 100;
 export async function runSimulation(
   activity: ActivityData,
   avatar: AvatarData,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   config: SimulationConfig,
 ): Promise<SimulationOutput> {
   const hasher = await xxhash();

--- a/projects/lib-idle-core/src/core/simulate-activity.test.ts
+++ b/projects/lib-idle-core/src/core/simulate-activity.test.ts
@@ -35,8 +35,7 @@ test('it immediately generates a started checkpoint', async () => {
   const firstCheckpoint = firstResult.value;
 
   expect(firstCheckpoint).toStrictEqual({
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    hash: expect.any(String),
+    hash: expect.toBeString(),
     seed: 999_999_999,
     time: 0,
     type: ActivityCheckpointType.Started,
@@ -88,22 +87,16 @@ test('it generates enemy group killed checkpoints', async () => {
   await generator.next(1000);
 
   expect(secondCheckpoint).toStrictEqual({
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    hash: expect.any(String),
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    nextSeed: expect.any(Number),
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    time: expect.any(Number),
+    hash: expect.toBeString(),
+    nextSeed: expect.toBeNumber(),
+    time: expect.toBeNumber(),
     type: ActivityCheckpointType.Progress,
   });
 
   expect(thirdCheckpoint).toStrictEqual({
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    hash: expect.any(String),
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    nextSeed: expect.any(Number),
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    time: expect.any(Number),
+    hash: expect.toBeString(),
+    nextSeed: expect.toBeNumber(),
+    time: expect.toBeNumber(),
     type: ActivityCheckpointType.Progress,
   });
 });
@@ -130,20 +123,16 @@ test('it generates a failed checkpoint when the avatar dies', async () => {
 
   let result = await generator.next(1000);
 
-  // oxlint-disable-next-line typescript/strict-boolean-expressions -- baseline(#236)
-  while (!result.done) {
+  while (result.done !== true) {
     result = await generator.next(1000);
   }
 
   const checkpoint = result.value;
 
   expect(checkpoint).toStrictEqual({
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    hash: expect.any(String),
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    nextSeed: expect.any(Number),
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    time: expect.any(Number),
+    hash: expect.toBeString(),
+    nextSeed: expect.toBeNumber(),
+    time: expect.toBeNumber(),
     type: ActivityCheckpointType.Failed,
   });
 });
@@ -181,20 +170,16 @@ test('it returns a completed checkpoint when all enemies are defeated', async ()
 
   let result = await generator.next(1000);
 
-  // oxlint-disable-next-line typescript/strict-boolean-expressions -- baseline(#236)
-  while (!result.done) {
+  while (result.done !== true) {
     result = await generator.next(1000);
   }
 
   const checkpoint = result.value;
 
   expect(checkpoint).toStrictEqual({
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    hash: expect.any(String),
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    nextSeed: expect.any(Number),
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    time: expect.any(Number),
+    hash: expect.toBeString(),
+    nextSeed: expect.toBeNumber(),
+    time: expect.toBeNumber(),
     type: ActivityCheckpointType.Completed,
   });
 });

--- a/projects/lib-idle-core/src/core/simulate-activity.ts
+++ b/projects/lib-idle-core/src/core/simulate-activity.ts
@@ -1,4 +1,3 @@
-import invariant from 'tiny-invariant';
 import type {
   Activity,
   ActivityCheckpointGenerator,
@@ -12,20 +11,13 @@ import { createFailedCheckpoint } from './utils/create-failed-checkpoint';
 import { createProgressCheckpoint } from './utils/create-progress-checkpoint';
 import { createStartedCheckpoint } from './utils/create-started-checkpoint';
 
-// oxlint-disable-next-line typescript/require-await -- baseline(#236)
+// oxlint-disable-next-line typescript/require-await -- callers drive this generator with awaited next()/return() calls, so it must satisfy the AsyncGenerator contract even though its own body has no await
 export async function* simulateActivity(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- executor is mutated in place via run/reset during the tick loop
   executor: CombatExecutor,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- activity is mutated in place via moveToNextEnemyGroup during the tick loop
   activity: Activity,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   avatar: Avatar,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   ctx: SimulationContext,
 ): ActivityCheckpointGenerator {
-  // oxlint-disable-next-line typescript/strict-boolean-expressions -- baseline(#236)
-  invariant(activity, 'activity is required');
-
   const timestep = yield createStartedCheckpoint(ctx);
 
   const label = `[activity:${activity.type}]`;

--- a/projects/lib-idle-core/src/core/utils/create-completed-checkpoint.test.ts
+++ b/projects/lib-idle-core/src/core/utils/create-completed-checkpoint.test.ts
@@ -10,10 +10,8 @@ test('it creates a completed checkpoint', () => {
   const checkpoint = createCompletedCheckpoint(2500, ctx);
 
   expect(checkpoint).toStrictEqual({
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    hash: expect.any(String),
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    nextSeed: expect.any(Number),
+    hash: expect.toBeString(),
+    nextSeed: expect.toBeNumber(),
     time: 2500,
     type: ActivityCheckpointType.Completed,
   });

--- a/projects/lib-idle-core/src/core/utils/create-completed-checkpoint.ts
+++ b/projects/lib-idle-core/src/core/utils/create-completed-checkpoint.ts
@@ -4,7 +4,6 @@ import { hashObject } from '../../utils/hash-object';
 
 export function createCompletedCheckpoint(
   elapsed: number,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   ctx: SimulationContext,
 ): ActivityCompletedCheckpoint {
   const result: Omit<ActivityCompletedCheckpoint, 'hash'> = {

--- a/projects/lib-idle-core/src/core/utils/create-enemy-group.ts
+++ b/projects/lib-idle-core/src/core/utils/create-enemy-group.ts
@@ -4,7 +4,6 @@ import { getRandomEnemies } from './get-random-enemies';
 
 export function createEnemyGroup(
   activity: ActivityData,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   ctx: SimulationContext,
   enemyCount: number,
 ): EnemyGroup {

--- a/projects/lib-idle-core/src/core/utils/create-event-sorter.ts
+++ b/projects/lib-idle-core/src/core/utils/create-event-sorter.ts
@@ -2,9 +2,7 @@ import type { Avatar, CombatEvent } from '../../types';
 
 // returns a fn that sorts events by time then by event source,
 // preferring the avatar's events first
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function createEventSorter(avatar: Avatar) {
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   return (a: CombatEvent, b: CombatEvent) => {
     const timeDiff = a.time - b.time;
 

--- a/projects/lib-idle-core/src/core/utils/create-failed-checkpoint.test.ts
+++ b/projects/lib-idle-core/src/core/utils/create-failed-checkpoint.test.ts
@@ -16,10 +16,8 @@ test('it creates a failed checkpoint', () => {
   const checkpoint = createFailedCheckpoint(activity, ctx);
 
   expect(checkpoint).toStrictEqual({
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    hash: expect.any(String),
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    nextSeed: expect.any(Number),
+    hash: expect.toBeString(),
+    nextSeed: expect.toBeNumber(),
     time: 2500,
     type: ActivityCheckpointType.Failed,
   });

--- a/projects/lib-idle-core/src/core/utils/create-failed-checkpoint.ts
+++ b/projects/lib-idle-core/src/core/utils/create-failed-checkpoint.ts
@@ -3,9 +3,7 @@ import { ActivityCheckpointType } from '../../types';
 import { hashObject } from '../../utils/hash-object';
 
 export function createFailedCheckpoint(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   activity: Activity,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   ctx: SimulationContext,
 ): ActivityFailedCheckpoint {
   const result: Omit<ActivityFailedCheckpoint, 'hash'> = {

--- a/projects/lib-idle-core/src/core/utils/create-progress-checkpoint.test.ts
+++ b/projects/lib-idle-core/src/core/utils/create-progress-checkpoint.test.ts
@@ -16,10 +16,8 @@ test('it creates a progress checkpoint', () => {
   const checkpoint = createProgressCheckpoint(activity, ctx);
 
   expect(checkpoint).toStrictEqual({
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    hash: expect.any(String),
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    nextSeed: expect.any(Number),
+    hash: expect.toBeString(),
+    nextSeed: expect.toBeNumber(),
     time: 2500,
     type: ActivityCheckpointType.Progress,
   });

--- a/projects/lib-idle-core/src/core/utils/create-progress-checkpoint.ts
+++ b/projects/lib-idle-core/src/core/utils/create-progress-checkpoint.ts
@@ -3,9 +3,7 @@ import { ActivityCheckpointType } from '../../types';
 import { hashObject } from '../../utils/hash-object';
 
 export function createProgressCheckpoint(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   activity: Activity,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   ctx: SimulationContext,
 ): ActivityProgressCheckpoint {
   const data: Omit<ActivityProgressCheckpoint, 'hash'> = {

--- a/projects/lib-idle-core/src/core/utils/create-started-checkpoint.test.ts
+++ b/projects/lib-idle-core/src/core/utils/create-started-checkpoint.test.ts
@@ -9,8 +9,7 @@ test('it creates a started checkpoint', () => {
   const checkpoint = createStartedCheckpoint(ctx);
 
   expect(checkpoint).toStrictEqual({
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    hash: expect.any(String),
+    hash: expect.toBeString(),
     seed: ctx.rng.seed,
     time: 0,
     type: ActivityCheckpointType.Started,

--- a/projects/lib-idle-core/src/core/utils/create-started-checkpoint.ts
+++ b/projects/lib-idle-core/src/core/utils/create-started-checkpoint.ts
@@ -2,7 +2,6 @@ import type { ActivityStartedCheckpoint, SimulationContext } from '../../types';
 import { ActivityCheckpointType } from '../../types';
 import { hashObject } from '../../utils/hash-object';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function createStartedCheckpoint(ctx: SimulationContext): ActivityStartedCheckpoint {
   const result: Omit<ActivityStartedCheckpoint, 'hash'> = {
     seed: ctx.rng.seed,

--- a/projects/lib-idle-core/src/core/utils/get-app-state.ts
+++ b/projects/lib-idle-core/src/core/utils/get-app-state.ts
@@ -1,6 +1,5 @@
 import type { SimulationAppState, SimulationState } from '../../types';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function getAppState(state: SimulationState): SimulationAppState {
   const combat = state.combat?.getAppState();
   const activity = state.activity?.getAppState();

--- a/projects/lib-idle-core/src/core/utils/get-enemy-groups.test.ts
+++ b/projects/lib-idle-core/src/core/utils/get-enemy-groups.test.ts
@@ -10,7 +10,6 @@ test('it returns groups of the specified size', () => {
 
   const groups = getEnemyGroups(activity, ctx, { groupSize: 3 });
 
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   expect(groups).toSatisfyAll((group: EnemyGroup) => group.enemies.length === 3);
 });
 

--- a/projects/lib-idle-core/src/core/utils/get-enemy-groups.ts
+++ b/projects/lib-idle-core/src/core/utils/get-enemy-groups.ts
@@ -6,15 +6,13 @@ const MIN_ENEMIES = 3;
 const MAX_ENEMIES = 6;
 
 interface ActivityConfig {
-  groupCount?: number;
-  groupSize?: number;
+  readonly groupCount?: number;
+  readonly groupSize?: number;
 }
 
 export function getEnemyGroups(
   activity: ActivityData,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   ctx: SimulationContext,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   config: ActivityConfig,
 ): Array<EnemyGroup> {
   const enemyGroupCount = config.groupCount ?? getRandomEnemyGroupCount(ctx);

--- a/projects/lib-idle-core/src/core/utils/get-random-enemies.ts
+++ b/projects/lib-idle-core/src/core/utils/get-random-enemies.ts
@@ -4,7 +4,6 @@ import type { ActivityData, Enemy, SimulationContext } from '../../types';
 export function getRandomEnemies(
   activity: ActivityData,
   count: number,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   ctx: SimulationContext,
 ): Array<Enemy> {
   if (activity.enemies.length === 1) {

--- a/projects/lib-idle-core/src/core/utils/get-random-enemy-group-count.ts
+++ b/projects/lib-idle-core/src/core/utils/get-random-enemy-group-count.ts
@@ -3,7 +3,6 @@ import type { SimulationContext } from '../../types';
 const MIN_ENEMY_GROUPS = 3;
 const MAX_ENEMY_GROUPS = 6;
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function getRandomEnemyGroupCount(ctx: SimulationContext): number {
   return ctx.rng.getInt(MIN_ENEMY_GROUPS, MAX_ENEMY_GROUPS);
 }

--- a/projects/lib-idle-core/src/entities/create-avatar.test.ts
+++ b/projects/lib-idle-core/src/entities/create-avatar.test.ts
@@ -205,8 +205,7 @@ test('it returns the expected avatar state for a client app', () => {
   expect(state).toStrictEqual({
     behaviours: {
       avatarWeaponAttack: {
-        // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-        lastAttackTime: expect.any(Number),
+        lastAttackTime: expect.toBeNumber(),
       },
     },
     class: data.class,
@@ -215,12 +214,9 @@ test('it returns the expected avatar state for a client app', () => {
     level: avatar.level,
     life: avatar.life,
     mainHandAttack: {
-      // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-      maxDamage: expect.any(Number),
-      // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-      minDamage: expect.any(Number),
-      // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-      speed: expect.any(Number),
+      maxDamage: expect.toBeNumber(),
+      minDamage: expect.toBeNumber(),
+      speed: expect.toBeNumber(),
     },
     maxLife: avatar.life,
     name: data.name,

--- a/projects/lib-idle-core/src/entities/create-avatar.ts
+++ b/projects/lib-idle-core/src/entities/create-avatar.ts
@@ -21,10 +21,9 @@ import { handleReceiveAvatarDamage } from './utils/handle-receive-avatar-damage'
 const DEFAULT_BEHAVIOUR_FACTORIES = [createAvatarWeaponAttackBehaviour];
 
 interface ResetConfig {
-  soft?: boolean;
+  readonly soft?: boolean;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function createAvatar(data: AvatarData, ctx: SimulationContext): Avatar {
   const label = createLogLabel('avatar', data.id);
 
@@ -68,7 +67,6 @@ export function createAvatar(data: AvatarData, ctx: SimulationContext): Avatar {
 
   let behaviours: Array<AvatarBehaviour> = [];
 
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   const handleTick = (combatExecutor: CombatExecutor): void => {
     for (const behaviour of behaviours) {
       const handler = behaviour.handlers[LifecycleEvent.OnTick];
@@ -77,7 +75,6 @@ export function createAvatar(data: AvatarData, ctx: SimulationContext): Avatar {
     }
   };
 
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   const addBehaviour = (behaviour: AvatarBehaviour): void => {
     behaviours.push(behaviour);
   };
@@ -86,10 +83,8 @@ export function createAvatar(data: AvatarData, ctx: SimulationContext): Avatar {
     behaviours = behaviours.filter((behaviour) => behaviour.id !== id);
   };
 
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   const reset = (config: ResetConfig = {}): void => {
-    // oxlint-disable-next-line typescript/strict-boolean-expressions -- baseline(#236)
-    if (!config.soft) {
+    if (config.soft !== true) {
       state = getInitialState(data);
     }
 
@@ -142,8 +137,9 @@ export function createAvatar(data: AvatarData, ctx: SimulationContext): Avatar {
     // create behaviours & register them if they're applicable
     .map((createBehaviour) => createBehaviour(avatar))
     .filter((behaviour) => behaviour.predicate(avatar))
-    // oxlint-disable-next-line typescript/no-confusing-void-expression -- baseline(#236)
-    .map((behaviour) => addBehaviour(behaviour));
+    .forEach((behaviour) => {
+      addBehaviour(behaviour);
+    });
 
   return avatar;
 }
@@ -158,7 +154,6 @@ export function getInitialState(data: AvatarData): AvatarState {
 
 // type safe util for adding our behaviour state to our serializable state
 function addBehaviourState<K extends BehaviourID>(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   state: AvatarBehaviourAppState,
   id: K,
   value: AvatarBehaviourAppState[K],

--- a/projects/lib-idle-core/src/entities/create-enemy.test.ts
+++ b/projects/lib-idle-core/src/entities/create-enemy.test.ts
@@ -136,8 +136,7 @@ test('it returns the expected enemy state for a client app', () => {
   expect(state).toStrictEqual({
     behaviours: {
       enemyPrimaryAttack: {
-        // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-        lastAttackTime: expect.any(Number),
+        lastAttackTime: expect.toBeNumber(),
       },
     },
     id: enemy.id,
@@ -147,12 +146,9 @@ test('it returns the expected enemy state for a client app', () => {
     maxLife: enemy.life,
     name: enemy.name,
     primaryAttack: {
-      // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-      maxDamage: expect.any(Number),
-      // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-      minDamage: expect.any(Number),
-      // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-      speed: expect.any(Number),
+      maxDamage: expect.toBeNumber(),
+      minDamage: expect.toBeNumber(),
+      speed: expect.toBeNumber(),
     },
     status: EntityStatus.Alive,
   });

--- a/projects/lib-idle-core/src/entities/create-enemy.ts
+++ b/projects/lib-idle-core/src/entities/create-enemy.ts
@@ -21,7 +21,6 @@ import { handleReceiveEnemyDamage } from './utils/handle-receive-enemy-damage';
 
 const DEFAULT_BEHAVIOUR_FACTORIES = [createEnemyPrimaryAttackBehaviour];
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function createEnemy(data: EnemyData, ctx: SimulationContext): Enemy {
   const id = createId();
   const label = createLogLabel('enemy', id);
@@ -54,7 +53,6 @@ export function createEnemy(data: EnemyData, ctx: SimulationContext): Enemy {
 
   let behaviours: Array<EnemyBehaviour> = [];
 
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   const handleTick = (combatExecutor: CombatExecutor): void => {
     for (const behaviour of behaviours) {
       const handler = behaviour.handlers[LifecycleEvent.OnTick];
@@ -63,7 +61,6 @@ export function createEnemy(data: EnemyData, ctx: SimulationContext): Enemy {
     }
   };
 
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   const addBehaviour = (behaviour: EnemyBehaviour): void => {
     behaviours.push(behaviour);
   };
@@ -114,13 +111,13 @@ export function createEnemy(data: EnemyData, ctx: SimulationContext): Enemy {
     // create behaviours & register them if they're applicable
     .map((createBehaviour) => createBehaviour(enemy))
     .filter((behaviour) => behaviour.predicate(enemy))
-    // oxlint-disable-next-line typescript/no-confusing-void-expression -- baseline(#236)
-    .map((behaviour) => addBehaviour(behaviour));
+    .forEach((behaviour) => {
+      addBehaviour(behaviour);
+    });
 
   return enemy;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function getInitialState(data: EnemyData): EnemyState {
   return {
     life: data.life,
@@ -131,7 +128,6 @@ export function getInitialState(data: EnemyData): EnemyState {
 
 // type safe util for adding our behaviour state to our serializable state
 function addBehaviourState<K extends BehaviourID>(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   state: EnemyBehaviourAppState,
   id: K,
   value: EnemyBehaviourAppState[K],

--- a/projects/lib-idle-core/src/entities/utils/calc-avatar-attack-damage.ts
+++ b/projects/lib-idle-core/src/entities/utils/calc-avatar-attack-damage.ts
@@ -1,6 +1,5 @@
 import type { Avatar, SimulationContext } from '../../types';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function calcAvatarAttackDamage(avatar: Avatar, ctx: SimulationContext): number {
   if (!avatar.mainHandEquipment) {
     return 0;

--- a/projects/lib-idle-core/src/entities/utils/calc-enemy-attack-damage.ts
+++ b/projects/lib-idle-core/src/entities/utils/calc-enemy-attack-damage.ts
@@ -1,6 +1,5 @@
 import type { Enemy, SimulationContext } from '../../types';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function calcEnemyAttackDamage(enemy: Enemy, ctx: SimulationContext): number {
   return ctx.rng.getInt(enemy.primaryAttack.minDamage, enemy.primaryAttack.maxDamage);
 }

--- a/projects/lib-idle-core/src/entities/utils/handle-receive-avatar-damage.ts
+++ b/projects/lib-idle-core/src/entities/utils/handle-receive-avatar-damage.ts
@@ -1,7 +1,6 @@
 import { EntityStatus } from '../../types';
 import type { Avatar } from '../../types';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- entities are mutated in place by the tick loop
 export function handleReceiveAvatarDamage(amount: number, entity: Avatar): void {
   // prevent negative life
   const newLife = Math.max(entity.life - amount, 0);

--- a/projects/lib-idle-core/src/entities/utils/handle-receive-enemy-damage.ts
+++ b/projects/lib-idle-core/src/entities/utils/handle-receive-enemy-damage.ts
@@ -1,7 +1,6 @@
 import { EntityStatus } from '../../types';
 import type { Enemy } from '../../types';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- entities are mutated in place by the tick loop
 export function handleReceiveEnemyDamage(amount: number, entity: Enemy): void {
   // prevent negative life
   const newLife = Math.max(entity.life - amount, 0);

--- a/projects/lib-idle-core/src/test-utils/create-mock-activity-data.test.ts
+++ b/projects/lib-idle-core/src/test-utils/create-mock-activity-data.test.ts
@@ -20,11 +20,9 @@ test('it creates activity data with expected properties', () => {
       },
     ],
     failureAction: ActivityFailureAction.Retry,
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    id: expect.any(String),
+    id: expect.toBeString(),
     name: 'Aether Node',
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    seed: expect.any(Number),
+    seed: expect.toBeNumber(),
     type: ActivityType.AetherNode,
   });
 });

--- a/projects/lib-idle-core/src/test-utils/create-mock-activity-data.ts
+++ b/projects/lib-idle-core/src/test-utils/create-mock-activity-data.ts
@@ -3,7 +3,7 @@ import type { ActivityData } from '../types';
 import { ActivityFailureAction, ActivityType } from '../types';
 import { createMockEnemyData } from './create-mock-enemy-data';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
+// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- a Partial of the mutable activity seed, whose nested enemies array has no readonly form; spread into the returned seed, never mutated
 export function createMockActivityData(overrides: Partial<ActivityData> = {}): ActivityData {
   const activity: ActivityData = {
     enemies: [createMockEnemyData()],

--- a/projects/lib-idle-core/src/test-utils/create-mock-avatar-data.test.ts
+++ b/projects/lib-idle-core/src/test-utils/create-mock-avatar-data.test.ts
@@ -8,15 +8,13 @@ test('it creates avatar data with expected properties', () => {
 
   expect(avatar).toStrictEqual({
     class: Class.Brute,
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    id: expect.any(String),
+    id: expect.toBeString(),
     level: 1,
     life: 200,
     name: 'Test Avatar',
     paperdoll: {
       [EquipmentSlot.MainHand]: {
-        // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-        id: expect.any(String),
+        id: expect.toBeString(),
         maxDamage: 20,
         minDamage: 10,
         name: 'Bloodthirst Blade, Bastard Sword',

--- a/projects/lib-idle-core/src/test-utils/create-mock-avatar-data.ts
+++ b/projects/lib-idle-core/src/test-utils/create-mock-avatar-data.ts
@@ -3,7 +3,7 @@ import { Class } from '@vers/data';
 import type { AvatarData } from '../types';
 import { EquipmentSlot } from '../types';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
+// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- a Partial of the mutable avatar seed, whose nested paperdoll has no readonly form; spread into the returned seed, never mutated
 export function createMockAvatarData(overrides: Partial<AvatarData> = {}): AvatarData {
   const avatar: AvatarData = {
     class: Class.Brute,

--- a/projects/lib-idle-core/src/test-utils/create-mock-enemy-data.ts
+++ b/projects/lib-idle-core/src/test-utils/create-mock-enemy-data.ts
@@ -1,6 +1,5 @@
 import type { EnemyData } from '../types';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function createMockEnemyData(overrides: Partial<EnemyData> = {}): EnemyData {
   const enemy: EnemyData = {
     level: 1,

--- a/projects/lib-idle-core/src/test-utils/create-mock-simulation-context.test.ts
+++ b/projects/lib-idle-core/src/test-utils/create-mock-simulation-context.test.ts
@@ -7,10 +7,8 @@ test('it creates a simulation context with expected properties', () => {
 
   expect(ctx).toStrictEqual({
     elapsed: 0,
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    hasher: expect.any(Object),
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    rng: expect.any(Object),
+    hasher: expect.toBeObject(),
+    rng: expect.toBeObject(),
   });
 });
 
@@ -24,8 +22,7 @@ test('it creates a simulation context with custom properties', () => {
 
   expect(ctx).toStrictEqual({
     elapsed: 100,
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    hasher: expect.any(Object),
+    hasher: expect.toBeObject(),
     rng,
   });
 });

--- a/projects/lib-idle-core/src/test-utils/create-mock-simulation-context.ts
+++ b/projects/lib-idle-core/src/test-utils/create-mock-simulation-context.ts
@@ -6,7 +6,7 @@ const hasher = await xxhash();
 
 type Overrides = Omit<Partial<SimulationContext>, 'hasher'>;
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
+// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- a Partial of the mutable simulation context, whose rng handle has no readonly form; spread into the returned context, never mutated
 export function createMockSimulationContext(overrides: Overrides = {}): SimulationContext {
   const ctx: SimulationContext = {
     elapsed: 0,

--- a/projects/lib-idle-core/src/types/activity.ts
+++ b/projects/lib-idle-core/src/types/activity.ts
@@ -59,9 +59,9 @@ export type ActivityCheckpointGenerator = AsyncGenerator<
 >;
 
 interface IActivityCheckpoint {
-  hash: string;
-  time: number;
-  type: ActivityCheckpointType;
+  readonly hash: string;
+  readonly time: number;
+  readonly type: ActivityCheckpointType;
 }
 
 export enum ActivityCheckpointType {
@@ -72,23 +72,23 @@ export enum ActivityCheckpointType {
 }
 
 export interface ActivityStartedCheckpoint extends IActivityCheckpoint {
-  seed: number;
-  type: ActivityCheckpointType.Started;
+  readonly seed: number;
+  readonly type: ActivityCheckpointType.Started;
 }
 
 export interface ActivityFailedCheckpoint extends IActivityCheckpoint {
-  nextSeed: number;
-  type: ActivityCheckpointType.Failed;
+  readonly nextSeed: number;
+  readonly type: ActivityCheckpointType.Failed;
 }
 
 export interface ActivityCompletedCheckpoint extends IActivityCheckpoint {
-  nextSeed: number;
-  type: ActivityCheckpointType.Completed;
+  readonly nextSeed: number;
+  readonly type: ActivityCheckpointType.Completed;
 }
 
 export interface ActivityProgressCheckpoint extends IActivityCheckpoint {
-  nextSeed: number;
-  type: ActivityCheckpointType.Progress;
+  readonly nextSeed: number;
+  readonly type: ActivityCheckpointType.Progress;
 }
 
 export type ActivityCheckpoint =

--- a/projects/lib-idle-core/src/types/behaviour.ts
+++ b/projects/lib-idle-core/src/types/behaviour.ts
@@ -7,7 +7,7 @@ import type {
   SimulationContext,
 } from '../types';
 
-export type BehaviourState<T> = Record<string, unknown> & T;
+export type BehaviourState<T> = Readonly<Record<string, unknown>> & T;
 
 export interface IBehaviour<
   T extends Entity,
@@ -33,14 +33,11 @@ export interface IBehaviour<
   setState: (setStateFn: SetEntityStateFn<S>) => void;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export type LifecycleHandler<T extends Entity> = (entity: T, ctx: SimulationContext) => void;
 
 export type CombatLifecycleHandler<T extends Entity> = (
   entity: T,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   combatExecutor: CombatExecutor,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   ctx: SimulationContext,
 ) => void;
 

--- a/projects/lib-idle-core/src/types/combat.ts
+++ b/projects/lib-idle-core/src/types/combat.ts
@@ -10,15 +10,14 @@ export interface CombatExecutor {
   getAppState: () => CombatExecutorAppState;
   reset: () => void;
   run: (delta: number) => void;
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   scheduleEvent: (event: CombatEvent) => void;
 }
 
 interface ICombatEvent {
-  id: string;
-  source: string;
-  time: number;
-  type: CombatEventType;
+  readonly id: string;
+  readonly source: string;
+  readonly time: number;
+  readonly type: CombatEventType;
 }
 
 export enum CombatEventType {
@@ -27,11 +26,11 @@ export enum CombatEventType {
 }
 
 export interface AvatarAttackEvent extends ICombatEvent {
-  type: CombatEventType.AvatarAttack;
+  readonly type: CombatEventType.AvatarAttack;
 }
 
 export interface EnemyAttackEvent extends ICombatEvent {
-  type: CombatEventType.EnemyAttack;
+  readonly type: CombatEventType.EnemyAttack;
 }
 
 export type CombatEvent = AvatarAttackEvent | EnemyAttackEvent;

--- a/projects/lib-idle-core/src/types/entities.ts
+++ b/projects/lib-idle-core/src/types/entities.ts
@@ -27,7 +27,6 @@ export interface EnemyData {
   primaryAttack: AttackData;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export type HandleTickFn = (combatExecutor: CombatExecutor) => void;
 
 interface IEntity<State extends object, EntityAppState extends object> {
@@ -42,10 +41,9 @@ interface IEntity<State extends object, EntityAppState extends object> {
   get status(): EntityStatus;
 
   // core
-  // oxlint-disable-next-line typescript/method-signature-style, typescript/prefer-readonly-parameter-types -- subtypes narrow the behaviour param; method syntax keeps the bivariant check that permits it; baseline(#236)
+  // oxlint-disable-next-line typescript/method-signature-style -- subtypes narrow the behaviour param; method syntax keeps the bivariant check that permits it
   addBehaviour(behaviour: Behaviour): void;
   getAppState: () => EntityAppState;
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   handleTick: (combatExecutor: CombatExecutor, ctx: SimulationContext) => void;
   removeBehaviour: (id: BehaviourID) => void;
   setState: (setStateFn: SetEntityStateFn<State>) => void;
@@ -57,7 +55,7 @@ interface IEntity<State extends object, EntityAppState extends object> {
 export type Entity = Avatar | Enemy;
 
 interface ResetConfig {
-  soft?: boolean;
+  readonly soft?: boolean;
 }
 
 export interface AvatarState {
@@ -91,12 +89,11 @@ export interface Avatar extends IEntity<AvatarState, AvatarAppState> {
   get mainHandEquipment(): EquipmentWeapon | null;
 
   // core
-  // oxlint-disable-next-line typescript/method-signature-style, typescript/prefer-readonly-parameter-types -- narrows the behaviour param; method syntax keeps the bivariant check that permits it; baseline(#236)
+  // oxlint-disable-next-line typescript/method-signature-style -- narrows the behaviour param; method syntax keeps the bivariant check that permits it
   addBehaviour(behaviour: AvatarBehaviour): void;
 
   // utils
   calcAttackDamage: () => number;
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   reset: (config?: ResetConfig) => void;
 }
 
@@ -131,7 +128,7 @@ export interface Enemy extends IEntity<EnemyState, EnemyAppState> {
   get primaryAttack(): AttackData;
 
   // core
-  // oxlint-disable-next-line typescript/method-signature-style, typescript/prefer-readonly-parameter-types -- narrows the behaviour param; method syntax keeps the bivariant check that permits it; baseline(#236)
+  // oxlint-disable-next-line typescript/method-signature-style -- narrows the behaviour param; method syntax keeps the bivariant check that permits it
   addBehaviour(behaviour: EnemyBehaviour): void;
 
   // utils
@@ -149,9 +146,9 @@ export enum EntityType {
 }
 
 export interface AttackData {
-  maxDamage: number;
-  minDamage: number;
-  speed: number;
+  readonly maxDamage: number;
+  readonly minDamage: number;
+  readonly speed: number;
 }
 
 export interface EnemyGroupAppState {

--- a/projects/lib-idle-core/src/types/index.ts
+++ b/projects/lib-idle-core/src/types/index.ts
@@ -1,9 +1,7 @@
 export * from './activity';
 export * from './behaviour';
 export * from './combat';
-// oxlint-disable-next-line typescript/consistent-type-exports -- baseline(#236)
-export * from './core';
+export type * from './core';
 export * from './entities';
 export * from './equipment';
-// oxlint-disable-next-line typescript/consistent-type-exports -- baseline(#236)
-export * from './simulation';
+export type * from './simulation';

--- a/projects/lib-idle-core/src/types/simulation.ts
+++ b/projects/lib-idle-core/src/types/simulation.ts
@@ -46,5 +46,4 @@ export interface SimulationContext {
   rng: RNG;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export type SimulationListener = (state: SimulationState) => void;

--- a/projects/lib-idle-core/src/utils/hash-object.ts
+++ b/projects/lib-idle-core/src/utils/hash-object.ts
@@ -1,6 +1,5 @@
 import type { XXHashAPI } from 'xxhash-wasm';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function hashObject(hasher: XXHashAPI, object: object): string {
   return hasher.h64ToString(JSON.stringify(object));
 }

--- a/projects/lib-idle-core/src/utils/is-completed-checkpoint.ts
+++ b/projects/lib-idle-core/src/utils/is-completed-checkpoint.ts
@@ -2,7 +2,6 @@ import type { ActivityCheckpoint, ActivityCompletedCheckpoint } from '../types';
 import { ActivityCheckpointType } from '../types';
 
 export function isCompletedCheckpoint(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   checkpoint: ActivityCheckpoint,
 ): checkpoint is ActivityCompletedCheckpoint {
   return checkpoint.type === ActivityCheckpointType.Completed;

--- a/projects/lib-idle-core/src/utils/is-failed-checkpoint.ts
+++ b/projects/lib-idle-core/src/utils/is-failed-checkpoint.ts
@@ -2,7 +2,6 @@ import type { ActivityCheckpoint, ActivityFailedCheckpoint } from '../types';
 import { ActivityCheckpointType } from '../types';
 
 export function isFailedCheckpoint(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   checkpoint: ActivityCheckpoint,
 ): checkpoint is ActivityFailedCheckpoint {
   return checkpoint.type === ActivityCheckpointType.Failed;

--- a/projects/lib-idle-core/src/utils/is-progress-checkpoint.ts
+++ b/projects/lib-idle-core/src/utils/is-progress-checkpoint.ts
@@ -2,7 +2,6 @@ import type { ActivityCheckpoint, ActivityProgressCheckpoint } from '../types';
 import { ActivityCheckpointType } from '../types';
 
 export function isProgressCheckpoint(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   checkpoint: ActivityCheckpoint,
 ): checkpoint is ActivityProgressCheckpoint {
   return checkpoint.type === ActivityCheckpointType.Progress;

--- a/projects/lib-idle-core/src/utils/is-started-checkpoint.ts
+++ b/projects/lib-idle-core/src/utils/is-started-checkpoint.ts
@@ -2,7 +2,6 @@ import type { ActivityCheckpoint, ActivityStartedCheckpoint } from '../types';
 import { ActivityCheckpointType } from '../types';
 
 export function isStartedCheckpoint(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   checkpoint: ActivityCheckpoint,
 ): checkpoint is ActivityStartedCheckpoint {
   return checkpoint.type === ActivityCheckpointType.Started;

--- a/projects/lib-idle-core/src/utils/logger.ts
+++ b/projects/lib-idle-core/src/utils/logger.ts
@@ -2,8 +2,12 @@
 const isDebugEnabled = false;
 
 export const logger = {
-  // oxlint-disable-next-line typescript/no-confusing-void-expression -- baseline(#236)
-  debug: (message: string) => isDebugEnabled && console.log(message),
-  // oxlint-disable-next-line typescript/no-confusing-void-expression -- baseline(#236)
-  info: (message: string) => console.log(message),
+  debug: (message: string) => {
+    if (isDebugEnabled) {
+      console.log(message);
+    }
+  },
+  info: (message: string) => {
+    console.log(message);
+  },
 };


### PR DESCRIPTION
Part of #244. Clears all 159 `baseline(#236)` directives in `lib-idle-core` (whole tree 290 → 128), fixing the underlying violations rather than suppressing them.

- Value types made `readonly` (checkpoints, combat events, `AttackData`, reset/config shapes, `BehaviourState`); the mutable domain handles (`Avatar`, `Enemy`, `Activity`, `Simulation`, `CombatExecutor`, behaviours, `*Data` seeds) go on the `prefer-readonly` allow list — they expose mutation methods with no readonly form.
- `expect.any(...)` → typed jest-extended matchers (`toBeString`/`toBeNumber`/`toBeArray`/`toBeObject`).
- Statement-body arrows and side-effecting `.map` → `.forEach`; explicit boolean comparisons; two redundant `invariant`s dropped; `export type *` for type-only modules; fire-and-forget `startActivity` void-wrapped.
- Five tailored directives remain (two tick-loop behaviour-state mutations, three mock-factory `Partial<seed>` overrides).
- Drops three `idle-client` directives the allow-list/readonly changes made redundant.

## Testing

- [x] typecheck passes (idle-core, idle-client, app-web)
- [x] test passes (idle-core 118, idle-client 33)
- [x] lint passes (zero unused directives)