### PR TITLE
chore(#244): burn down service-lib baseline(#236) lint directives

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -144,6 +144,8 @@
           { "from": "package", "name": "JWTPayload", "package": "jose" },
           { "from": "package", "name": "SubmissionResult", "package": "@conform-to/dom" },
           { "from": "package", "name": "XXHashAPI", "package": "xxhash-wasm" },
+          { "from": "package", "name": "Context", "package": "hono" },
+          { "from": "package", "name": "PostgresError", "package": "postgres" },
           // idle-core's live domain objects are mutable handles: entities and
           // the simulation own internal state that tick/lifecycle code drives
           // through mutation methods (receiveDamage, setState, scheduleEvent),

--- a/projects/lib-service-runtime/src/base-env-schema.ts
+++ b/projects/lib-service-runtime/src/base-env-schema.ts
@@ -3,10 +3,8 @@ import * as z from 'zod';
 /** Environment variables every service validates at boot, before any service-specific ones. */
 export const BASE_ENV_SCHEMA = z.object({
   LOG_LEVEL: z.enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace']).default('info'),
-  // oxlint-disable-next-line typescript/no-deprecated -- baseline(#236)
-  OTEL_EXPORTER_OTLP_ENDPOINT: z.string().url().optional(),
+  OTEL_EXPORTER_OTLP_ENDPOINT: z.url().optional(),
   PORT: z.coerce.number().int().positive().default(3000),
-  // oxlint-disable-next-line typescript/no-deprecated -- baseline(#236)
-  SENTRY_DSN: z.string().url().optional(),
+  SENTRY_DSN: z.url().optional(),
   SERVICE_AUTH_PUBLIC_KEY: z.string().min(1),
 });

--- a/projects/lib-service-runtime/src/create-service.test.ts
+++ b/projects/lib-service-runtime/src/create-service.test.ts
@@ -9,6 +9,17 @@ import { createServiceKeyPair } from './test-utils/create-service-key-pair';
 import { createServiceToken } from './test-utils/create-service-token';
 import type { ServiceContext } from './types';
 
+const OPENAPI_RESPONSES_SHAPE = z.record(z.string(), z.unknown());
+
+const OPENAPI_PATH_ITEM_SHAPE = z.object({
+  get: z.object({ responses: OPENAPI_RESPONSES_SHAPE }).optional(),
+});
+
+/** The slice of a generated OpenAPI document the `/spec.json` test inspects. */
+const OPENAPI_DOCUMENT_SHAPE = z.object({
+  paths: z.record(z.string(), OPENAPI_PATH_ITEM_SHAPE),
+});
+
 function buildTestContract() {
   return {
     getThing: authedRoute
@@ -392,10 +403,9 @@ test('it serves /spec.json declaring the 401 response for the authed route', asy
 
   expect(response.status).toBe(200);
 
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- baseline(#236)
-  const document = (await response.json()) as {
-    paths: Record<string, { get?: { responses: Record<string, unknown> } }>;
-  };
+  const responseBody = await response.json();
+
+  const document = OPENAPI_DOCUMENT_SHAPE.parse(responseBody);
 
   expect(Object.keys(document.paths)).not.toBeEmpty();
   expect(document.paths['/things']?.get?.responses).toContainKey('401');

--- a/projects/lib-service-runtime/src/create-service.ts
+++ b/projects/lib-service-runtime/src/create-service.ts
@@ -51,8 +51,7 @@ export async function createService<TEnvShape extends z.ZodRawShape = Record<nev
 
   const publicKey = await jose.importSPKI(env.SERVICE_AUTH_PUBLIC_KEY, TOKEN_ALGORITHM);
 
-  // oxlint-disable-next-line typescript/strict-boolean-expressions -- baseline(#236)
-  if (env.SENTRY_DSN) {
+  if (env.SENTRY_DSN !== undefined) {
     const sentry = await import('@sentry/bun');
 
     sentry.init({ dsn: env.SENTRY_DSN });
@@ -63,8 +62,7 @@ export async function createService<TEnvShape extends z.ZodRawShape = Record<nev
 
   const app = new Elysia();
 
-  // oxlint-disable-next-line typescript/strict-boolean-expressions -- baseline(#236)
-  if (env.OTEL_EXPORTER_OTLP_ENDPOINT) {
+  if (env.OTEL_EXPORTER_OTLP_ENDPOINT !== undefined) {
     const [{ opentelemetry }, { OTLPTraceExporter }] = await Promise.all([
       import('@elysiajs/opentelemetry'),
       import('@opentelemetry/exporter-trace-otlp-proto'),

--- a/projects/lib-service-runtime/src/parse-service-token.ts
+++ b/projects/lib-service-runtime/src/parse-service-token.ts
@@ -23,8 +23,7 @@ export async function parseServiceToken(
 ): Promise<ServiceTokenResolution> {
   const authorization = request.headers.get('authorization');
 
-  // oxlint-disable-next-line typescript/strict-boolean-expressions -- baseline(#236)
-  if (!authorization?.startsWith('Bearer ')) {
+  if (authorization === null || !authorization.startsWith('Bearer ')) {
     return { failure: 'invalid-service-token' };
   }
 

--- a/projects/lib-service-runtime/src/test-utils/create-service-token.ts
+++ b/projects/lib-service-runtime/src/test-utils/create-service-token.ts
@@ -11,8 +11,7 @@ interface CreateServiceTokenOptions {
 
 /** Signs a short-lived s2s token carrying the shared claim vocabulary, for tests to send as `Authorization: Bearer <token>`. */
 export function createServiceToken(options: CreateServiceTokenOptions): Promise<string> {
-  // oxlint-disable-next-line typescript/strict-boolean-expressions -- baseline(#236)
-  const claims = options.actingUserId ? { sub: options.actingUserId } : {};
+  const claims = options.actingUserId === undefined ? {} : { sub: options.actingUserId };
 
   const jwt = new jose.SignJWT(claims)
     .setProtectedHeader({ alg: TOKEN_ALGORITHM })

--- a/projects/lib-service-test-utils/src/create-postgres-container.ts
+++ b/projects/lib-service-test-utils/src/create-postgres-container.ts
@@ -6,21 +6,22 @@ import type { StartedPostgreSqlContainer } from '@testcontainers/postgresql';
  *
  * @returns - The started postgres container.
  */
-export async function createPostgresContainer(): Promise<StartedPostgreSqlContainer> {
-  // oxlint-disable-next-line typescript/return-await -- baseline(#236)
-  return await new PostgreSqlContainer('postgres:16.2-alpine3.19')
-    .withDatabase('test_template')
-    .withUsername('test')
-    .withPassword('test')
+export function createPostgresContainer(): Promise<StartedPostgreSqlContainer> {
+  return (
+    new PostgreSqlContainer('postgres:16.2-alpine3.19')
+      .withDatabase('test_template')
+      .withUsername('test')
+      .withPassword('test')
 
-    // use a memory disk for perf
-    .withTmpFs({ '/var/lib/pg/data': 'rw' })
-    .withEnvironment({
-      PGDATA: '/var/lib/pg/data',
-    })
-    .withExposedPorts({ container: 5432, host: 32_999 })
+      // use a memory disk for perf
+      .withTmpFs({ '/var/lib/pg/data': 'rw' })
+      .withEnvironment({
+        PGDATA: '/var/lib/pg/data',
+      })
+      .withExposedPorts({ container: 5432, host: 32_999 })
 
-    // allow reusing our container across tests
-    .withReuse()
-    .start();
+      // allow reusing our container across tests
+      .withReuse()
+      .start()
+  );
 }

--- a/projects/lib-service-utils/src/middleware/create-auth-middleware.test.ts
+++ b/projects/lib-service-utils/src/middleware/create-auth-middleware.test.ts
@@ -3,6 +3,7 @@ import { createTestJWT } from '@vers/service-test-utils';
 import type { Context } from 'hono';
 import { Hono } from 'hono';
 import * as jose from 'jose';
+import type { AuthContextVariables } from './create-auth-middleware';
 import { createAuthMiddleware } from './create-auth-middleware';
 
 const TEST_TOKEN_PAYLOAD = {
@@ -52,25 +53,22 @@ KQIDAQAB
 `;
 
 interface TestConfig {
-  isAuthRequired?: boolean;
+  readonly isAuthRequired?: boolean;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 async function setupTest(config: TestConfig = {}) {
   const app = new Hono();
 
   // a fresh spy per test: bun runs the file in one process and `mock.restore()` reverts spies
   // without clearing their call history, so a shared module-level spy would accrue calls
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-  const handlerSpy = mock<(ctx: Context) => Promise<Response>>((ctx: Context) =>
-    Promise.resolve(
-      ctx.json({
-        // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-        payload: ctx.get('jwtPayload'),
-        // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-        userID: ctx.get('userID'),
-      }),
-    ),
+  const handlerSpy = mock<(ctx: Context<{ Variables: AuthContextVariables }>) => Promise<Response>>(
+    (ctx) =>
+      Promise.resolve(
+        ctx.json({
+          payload: ctx.get('jwtPayload'),
+          userID: ctx.get('userID'),
+        }),
+      ),
   );
 
   const authMiddleware = createAuthMiddleware({

--- a/projects/lib-service-utils/src/middleware/create-auth-middleware.ts
+++ b/projects/lib-service-utils/src/middleware/create-auth-middleware.ts
@@ -1,17 +1,23 @@
 import type { Context, Next } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { createTokenVerifier } from '../utils/create-token-verifier';
-import type { TokenVerifierConfig } from '../utils/create-token-verifier';
+import type { RelevantJWTPayload, TokenVerifierConfig } from '../utils/create-token-verifier';
 import { getTokenFromHeader } from '../utils/get-token-from-header';
 
 interface AuthMiddlewareConfig {
-  isAuthRequired?: boolean;
-  tokenVerifierConfig: TokenVerifierConfig;
+  readonly isAuthRequired?: boolean;
+  readonly tokenVerifierConfig: TokenVerifierConfig;
+}
+
+/** Context variables `createAuthMiddleware` sets once a token verifies. */
+export interface AuthContextVariables {
+  jwtPayload: RelevantJWTPayload;
+  token: string;
+  userID: string;
 }
 
 // this is adapted from the generic jwt middleware for hono
 // ref: https://github.com/honojs/hono/blob/d091c6a180887d69715abcd84ea88a123c876305/src/middleware/jwt/index.test.ts
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function createAuthMiddleware(config: AuthMiddlewareConfig) {
   const verifyToken = createTokenVerifier({
     audience: config.tokenVerifierConfig.audience,
@@ -19,21 +25,18 @@ export function createAuthMiddleware(config: AuthMiddlewareConfig) {
     spkiKey: config.tokenVerifierConfig.spkiKey,
   });
 
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-  return async (ctx: Context, next: Next) => {
+  return async (ctx: Context<{ Variables: AuthContextVariables }>, next: Next) => {
     const authHeader = ctx.req.raw.headers.get('Authorization');
 
     // if we don't explicitly require auth then we're safe to pass through
     // when no auth header is present
-    // oxlint-disable-next-line typescript/strict-boolean-expressions -- baseline(#236)
-    if (!authHeader && !config.isAuthRequired) {
+    if (authHeader === null && config.isAuthRequired !== true) {
       await next();
 
       return;
     }
 
-    // oxlint-disable-next-line typescript/strict-boolean-expressions -- baseline(#236)
-    if (!authHeader) {
+    if (authHeader === null) {
       const errorDescription = 'no authorization included in request';
 
       throw new HTTPException(401, {
@@ -48,8 +51,7 @@ export function createAuthMiddleware(config: AuthMiddlewareConfig) {
 
     const token = getTokenFromHeader(authHeader);
 
-    // oxlint-disable-next-line typescript/strict-boolean-expressions -- baseline(#236)
-    if (!token) {
+    if (token === null) {
       const errorDescription = 'invalid authorization header structure';
 
       throw new HTTPException(401, {
@@ -86,13 +88,12 @@ export function createAuthMiddleware(config: AuthMiddlewareConfig) {
 }
 
 interface ErrorParts {
-  ctx: Context;
-  description: string;
-  error: string;
-  statusText?: string;
+  readonly ctx: Context;
+  readonly description: string;
+  readonly error: string;
+  readonly statusText?: string;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 function createUnauthorizedResponse(error: ErrorParts) {
   return new Response('Unauthorized', {
     headers: {

--- a/projects/lib-service-utils/src/middleware/create-logger-middleware.ts
+++ b/projects/lib-service-utils/src/middleware/create-logger-middleware.ts
@@ -8,7 +8,6 @@ interface ContextVariables {
 
 export function createLoggerMiddleware(logger: Logger): MiddlewareHandler {
   return async function loggerMiddleware(
-    // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
     ctx: Context<{ Variables: ContextVariables }>,
     next: Next,
   ) {

--- a/projects/lib-service-utils/src/middleware/remote-address-middleware.test.ts
+++ b/projects/lib-service-utils/src/middleware/remote-address-middleware.test.ts
@@ -1,11 +1,10 @@
 import { expect, mock, test } from 'bun:test';
 import type { Context } from 'hono';
 import { Hono } from 'hono';
+import type { RemoteAddressEnv } from './remote-address-middleware';
 import { remoteAddressMiddleware } from './remote-address-middleware';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-const testHandlerSpy = mock<(ctx: Context) => Promise<Response>>((ctx: Context) =>
-  // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
+const testHandlerSpy = mock<(ctx: Context<RemoteAddressEnv>) => Promise<Response>>((ctx) =>
   Promise.resolve(ctx.json({ ipAddress: ctx.get('ipAddress') })),
 );
 

--- a/projects/lib-service-utils/src/middleware/remote-address-middleware.ts
+++ b/projects/lib-service-utils/src/middleware/remote-address-middleware.ts
@@ -1,7 +1,7 @@
 import type { HttpBindings } from '@hono/node-server';
 import type { Context, Next } from 'hono';
 
-interface Env {
+export interface RemoteAddressEnv {
   Bindings: {
     server?: HttpBindings;
   };
@@ -20,8 +20,7 @@ interface Env {
  * case of an empty string. Otherwise we should ALWAYS have an IP address set in
  * development and production environments.
  */
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-export async function remoteAddressMiddleware(ctx: Context<Env>, next: Next) {
+export async function remoteAddressMiddleware(ctx: Context<RemoteAddressEnv>, next: Next) {
   const ipAddress =
     ctx.req.header('fly-client-ip') ??
     ctx.req.header('x-forwarded-for')?.split(',')[0] ??

--- a/projects/lib-service-utils/src/utils/create-logger.ts
+++ b/projects/lib-service-utils/src/utils/create-logger.ts
@@ -2,12 +2,11 @@ import type { Logger } from 'pino';
 import pino from 'pino';
 
 export interface CreateLoggerOptions {
-  level: string;
-  pretty?: boolean;
-  sentryDSN?: string;
+  readonly level: string;
+  readonly pretty?: boolean;
+  readonly sentryDSN?: string;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function createLogger(options: CreateLoggerOptions): Logger {
   const sentryTransport: pino.TransportTargetOptions = {
     options: {
@@ -35,23 +34,18 @@ export function createLogger(options: CreateLoggerOptions): Logger {
 
   const targets: Array<pino.TransportTargetOptions> = [];
 
-  // oxlint-disable-next-line typescript/strict-boolean-expressions -- baseline(#236)
-  if (options.pretty) {
+  if (options.pretty === true) {
     targets.push(prettyTransport);
   } else {
     targets.push(defaultTransport);
   }
 
-  // oxlint-disable-next-line typescript/strict-boolean-expressions -- baseline(#236)
-  if (options.sentryDSN) {
+  if (options.sentryDSN !== undefined) {
     targets.push(sentryTransport);
   }
 
-  // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-  const transport: pino.DestinationStream = pino.transport({
+  return pino({
     level: options.level,
-    targets,
+    transport: { targets },
   });
-
-  return pino(transport);
 }

--- a/projects/lib-service-utils/src/utils/create-token-verifier.ts
+++ b/projects/lib-service-utils/src/utils/create-token-verifier.ts
@@ -2,17 +2,16 @@ import * as jose from 'jose';
 import invariant from 'tiny-invariant';
 
 export interface TokenVerifierConfig {
-  audience: string;
-  issuer: string;
-  spkiKey: string;
+  readonly audience: string;
+  readonly issuer: string;
+  readonly spkiKey: string;
 }
 
-interface RelevantJWTPayload {
-  iss: string | undefined;
-  sub: string;
+export interface RelevantJWTPayload {
+  readonly iss: string | undefined;
+  readonly sub: string;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function createTokenVerifier(config: TokenVerifierConfig) {
   return async (token: string): Promise<RelevantJWTPayload> => {
     const publicKey = await jose.importSPKI(config.spkiKey, 'RS256');

--- a/projects/lib-service-utils/src/utils/get-token-from-header.ts
+++ b/projects/lib-service-utils/src/utils/get-token-from-header.ts
@@ -1,6 +1,5 @@
 export function getTokenFromHeader(header: null | string | undefined): null | string {
-  // oxlint-disable-next-line typescript/strict-boolean-expressions -- baseline(#236)
-  if (!header) {
+  if (header === null || header === undefined || header.length === 0) {
     return null;
   }
 

--- a/projects/lib-service-utils/src/utils/is-unique-constraint-error.ts
+++ b/projects/lib-service-utils/src/utils/is-unique-constraint-error.ts
@@ -1,6 +1,5 @@
 import type postgres from 'postgres';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function isUniqueConstraintError(error: postgres.PostgresError, constraintName: string) {
   return error.code === '23505' && error.constraint_name === constraintName;
 }


### PR DESCRIPTION
Part of #244. Clears all 29 `baseline(#236)` directives across `lib-service-utils` (20), `lib-service-runtime` (7), and `lib-service-test-utils` (1), fixing the underlying violations rather than suppressing them.

- Own config/options/context types made `readonly` (`AuthMiddlewareConfig`, `ErrorParts`, `CreateLoggerOptions`, `TokenVerifierConfig`, `TestConfig`); hono's `Context` and `postgres`'s `PostgresError` go on the `prefer-readonly` allow list as framework/library handles with no readonly form.
- Explicit null/undefined/boolean comparisons replace truthy checks in the auth/logger middleware and service-runtime env checks.
- Hono `Context` typed with its `Variables` shape (new exported `AuthContextVariables`, `RemoteAddressEnv`) so `ctx.get(...)` resolves concretely instead of `any`.
- `z.string().url()` → `z.url()` (zod v4, drops `no-deprecated`).
- The `/spec.json` test parses the response through a small zod shape instead of an unsafe `as` assertion.
- `createPostgresContainer` drops its unnecessary `async`/`await` (not inside a `try`/`catch`).
- `create-logger.ts` switches from a manual `pino.transport()` call (whose overloaded generic resolved to `any` under the type-aware linter, despite a clean `tsc`) to the idiomatic `pino({ level, transport })` form — this also fixes `level` previously being silently dropped by `pino.transport()`.

No tailored directives remain in these three packages.

## Testing

- [x] typecheck passes (service-utils, service-runtime, service-test-utils, and dependent service-avatar/session/user/verification + web)
- [x] test passes (service-utils 26, service-runtime 16, service-test-utils 32 with postgres, plus dependent service suites)
- [x] lint passes (whole tree, zero unused directives)
