### PR TITLE
chore(#244): burn down aether baseline(#236) lint directives

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -135,17 +135,33 @@
               "HTMLFormElement",
               "MessageEvent",
               "SharedWorker",
-              "URL"
+              "URL",
+              "MouseEvent"
             ]
           },
           { "from": "package", "name": "ReactNode", "package": "react" },
           { "from": "package", "name": "SyntheticEvent", "package": "react" },
+          { "from": "package", "name": "ElementType", "package": "react" },
           { "from": "package", "name": "ZodError", "package": "zod" },
           { "from": "package", "name": "JWTPayload", "package": "jose" },
           { "from": "package", "name": "SubmissionResult", "package": "@conform-to/dom" },
           { "from": "package", "name": "XXHashAPI", "package": "xxhash-wasm" },
           { "from": "package", "name": "Context", "package": "hono" },
           { "from": "package", "name": "PostgresError", "package": "postgres" },
+          // stateful factory-return handle: getInt/getSeries/generateNewSeed
+          // close over a mutable seed, so there is no readonly form to consume
+          { "from": "file", "name": "RNG", "path": "../lib-game-utils/src/types.ts" },
+          // three.js scene-graph handles: mutated in place every frame
+          // (position/rotation writes, matrix updates) by design, so no
+          // readonly form of them is useful to a caller
+          {
+            "from": "package",
+            "name": ["Object3D", "Mesh", "PerspectiveCamera"],
+            "package": "three"
+          },
+          // r3f pointer event: intersects a live DOM PointerEvent, which has
+          // no readonly form
+          { "from": "package", "name": "ThreeEvent", "package": "@react-three/fiber" },
           // idle-core's live domain objects are mutable handles: entities and
           // the simulation own internal state that tick/lifecycle code drives
           // through mutation methods (receiveDamage, setState, scheduleEvent),

--- a/projects/lib-aether-client/src/components-three/aether-edge.tsx
+++ b/projects/lib-aether-client/src/components-three/aether-edge.tsx
@@ -6,8 +6,7 @@ interface AetherEdgeProps {
   edge: AetherEdge;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-export function AetherEdge(props: AetherEdgeProps) {
+export function AetherEdge(props: Readonly<AetherEdgeProps>) {
   const points = [
     new Vector3(...getScenePosition(props.edge.start)),
     new Vector3(...getScenePosition(props.edge.end)),

--- a/projects/lib-aether-client/src/components-three/aether-node.tsx
+++ b/projects/lib-aether-client/src/components-three/aether-node.tsx
@@ -14,20 +14,17 @@ interface AetherNodeProps {
 const RADIUS = 0.8;
 const NODE_SEGMENTS = 24;
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-export function AetherNode(props: AetherNodeProps) {
+export function AetherNode(props: Readonly<AetherNodeProps>) {
   const position = getScenePosition(props.node.position);
   const selectedNode = useSelectedNode();
 
   // if the node is selected but we're doing our initial render this is our opportunity
   // to grab a reference to the scene node
   const setSelectedNodeRef = useCallback(
-    // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
     (object3D: Mesh | undefined) => {
       const isSelected = selectedNode.node?.id === props.node.id;
-      const isInitialRender = !selectedNode.object3D && object3D;
+      const isInitialRender = selectedNode.object3D === undefined && object3D !== undefined;
 
-      // oxlint-disable-next-line typescript/strict-boolean-expressions -- baseline(#236)
       if (isSelected && isInitialRender) {
         setSelectedNode(props.node, object3D);
       }
@@ -35,7 +32,6 @@ export function AetherNode(props: AetherNodeProps) {
     [props.node, selectedNode.node?.id, selectedNode.object3D],
   );
 
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   const handleClickNode = (event: ThreeEvent<PointerEvent>) => {
     // TODO(#119): limit node navigation to nodes connected to any completed node
     setSelectedNode(props.node, event.object);
@@ -47,12 +43,15 @@ export function AetherNode(props: AetherNodeProps) {
       position={position}
       // its important we attach our node ID so we can look it up without selecting
       userData={{ id: props.node.id }}
-      // oxlint-disable-next-line typescript/no-confusing-void-expression, typescript/prefer-readonly-parameter-types -- baseline(#236)
-      onPointerDown={(event: ThreeEvent<PointerEvent>) => handleClickNode(event)}
-      // oxlint-disable-next-line typescript/no-confusing-void-expression -- baseline(#236)
-      onPointerEnter={() => setHoveredNode(props.node)}
-      // oxlint-disable-next-line typescript/no-confusing-void-expression -- baseline(#236)
-      onPointerLeave={() => setHoveredNode(null)}
+      onPointerDown={(event: ThreeEvent<PointerEvent>) => {
+        handleClickNode(event);
+      }}
+      onPointerEnter={() => {
+        setHoveredNode(props.node);
+      }}
+      onPointerLeave={() => {
+        setHoveredNode(null);
+      }}
     >
       <circleGeometry args={[RADIUS, NODE_SEGMENTS]} />
       <meshStandardMaterial

--- a/projects/lib-aether-client/src/components-three/isometric-camera.tsx
+++ b/projects/lib-aether-client/src/components-three/isometric-camera.tsx
@@ -40,7 +40,6 @@ export function IsometricCamera() {
     position: getNodeCameraPosition(selectedNode.object3D),
   });
 
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   const setCameraRef = useCallback((cameraInstance: null | PerspectiveCameraImpl) => {
     if (!cameraInstance) {
       return;
@@ -97,7 +96,6 @@ export function IsometricCamera() {
  * @param node - the node to get the camera position for
  * @returns the camera position
  */
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 function getNodeCameraPosition(node: null | Object3D) {
   if (!node) {
     return [0, CAMERA_DISTANCE, 0];

--- a/projects/lib-aether-client/src/components-ui/node-tooltip.tsx
+++ b/projects/lib-aether-client/src/components-ui/node-tooltip.tsx
@@ -12,13 +12,11 @@ interface NodeTooltipProps {
 
 const TOOLTIP_OFFSET = 10;
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-export function NodeTooltip(props: NodeTooltipProps) {
+export function NodeTooltip(props: Readonly<NodeTooltipProps>) {
   const element = useRef<HTMLDivElement | null>(null);
   const node = useHoveredNode();
   const document = useDocument();
 
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   useEventListener(document, 'mousemove', (e: MouseEvent) => {
     if (element.current) {
       const x = e.clientX + TOOLTIP_OFFSET;

--- a/projects/lib-aether-client/src/components-ui/tooltip/tooltip-content.tsx
+++ b/projects/lib-aether-client/src/components-ui/tooltip/tooltip-content.tsx
@@ -3,8 +3,7 @@ interface TooltipContentProps {
   className?: string;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-export function TooltipContent(props: TooltipContentProps) {
+export function TooltipContent(props: Readonly<TooltipContentProps>) {
   const { children, className, ...restProps } = props;
 
   return (

--- a/projects/lib-aether-client/src/components-ui/tooltip/tooltip-header.tsx
+++ b/projects/lib-aether-client/src/components-ui/tooltip/tooltip-header.tsx
@@ -6,8 +6,7 @@ interface TooltipHeaderProps {
   className?: string;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-export function TooltipHeader(props: TooltipHeaderProps) {
+export function TooltipHeader(props: Readonly<TooltipHeaderProps>) {
   const { children, className, ...restProps } = props;
 
   return (

--- a/projects/lib-aether-client/src/state/set-aether-graph.ts
+++ b/projects/lib-aether-client/src/state/set-aether-graph.ts
@@ -1,7 +1,6 @@
 import type { AetherGraph } from '@vers/aether-core';
 import { useAetherGraphStore } from './use-aether-graph-store';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function setAetherGraph(graph: AetherGraph) {
   useAetherGraphStore.setState(graph);
 }

--- a/projects/lib-aether-client/src/state/set-camera.ts
+++ b/projects/lib-aether-client/src/state/set-camera.ts
@@ -1,7 +1,6 @@
 import type { PerspectiveCamera } from 'three';
 import { useCameraStore } from './use-camera-store';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function setCamera(camera: null | PerspectiveCamera) {
   useCameraStore.setState({ camera });
 }

--- a/projects/lib-aether-client/src/state/set-hovered-node.ts
+++ b/projects/lib-aether-client/src/state/set-hovered-node.ts
@@ -1,7 +1,6 @@
 import type { AetherNode } from '@vers/aether-core';
 import { useHoveredNodeStore } from './use-hovered-node-store';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function setHoveredNode(node: AetherNode | null) {
   useHoveredNodeStore.setState({ node });
 }

--- a/projects/lib-aether-client/src/state/set-selected-node.ts
+++ b/projects/lib-aether-client/src/state/set-selected-node.ts
@@ -2,7 +2,6 @@ import type { AetherNode } from '@vers/aether-core';
 import type { Object3D } from 'three';
 import { useSelectedNodeStore } from './use-selected-node-store';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function setSelectedNode(node: AetherNode | null, object3D?: null | Object3D) {
   useSelectedNodeStore.setState({ node, object3D: object3D ?? null });
 }

--- a/projects/lib-aether-client/src/utils/create-style-context.tsx
+++ b/projects/lib-aether-client/src/utils/create-style-context.tsx
@@ -26,7 +26,7 @@ export function createStyleContext<R extends StyleRecipe>(recipe: R) {
       React.ComponentPropsWithoutRef<T> & RecipeVariantProps<R>
     >((props, ref) => {
       const [variantProps, restProps] = recipe.splitVariantProps(props);
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- baseline(#236)
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- calling a value of the generic type R returns its call signature's declared type, not ReturnType<R>; TS can't unify the two for a type parameter
       const slotStyles = recipe(variantProps) as StyleSlotRecipe<R>;
 
       const className =
@@ -51,8 +51,7 @@ export function createStyleContext<R extends StyleRecipe>(recipe: R) {
   };
 
   const withContext = <T extends React.ElementType>(Component: T, slot?: StyleSlot<R>): T => {
-    // oxlint-disable-next-line typescript/strict-boolean-expressions -- baseline(#236)
-    if (!slot) {
+    if (slot === undefined) {
       return Component;
     }
 
@@ -76,17 +75,21 @@ export function createStyleContext<R extends StyleRecipe>(recipe: R) {
 
     StyledComponent.displayName = `Styled${getComponentName(Component)}`;
 
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- baseline(#236)
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- forwardRef's return type is a fixed ForwardRefExoticComponent that can't be expressed in terms of the caller's generic component type
     return StyledComponent as unknown as T;
   };
 
   return { withContext, withProvider };
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-function getComponentName(Component: React.ElementType) {
-  return typeof Component === 'string'
-    ? Component
-    : // oxlint-disable-next-line typescript/prefer-nullish-coalescing, typescript/strict-boolean-expressions -- baseline(#236)
-      Component.displayName || Component.name || 'Component';
+function getComponentName(Component: React.ElementType): string {
+  if (typeof Component === 'string') {
+    return Component;
+  }
+
+  if (Component.displayName !== undefined && Component.displayName !== '') {
+    return Component.displayName;
+  }
+
+  return Component.name === '' ? 'Component' : Component.name;
 }

--- a/projects/lib-aether-client/src/utils/filter-distant-graph.test.ts
+++ b/projects/lib-aether-client/src/utils/filter-distant-graph.test.ts
@@ -53,8 +53,7 @@ test('it filters nodes beyond the maximum distance', () => {
   });
 });
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-function createTestNode(id: string, position: [number, number]): AetherNode {
+function createTestNode(id: string, position: readonly [number, number]): AetherNode {
   return {
     connections: [null, null, null, null],
     difficulty: 0,
@@ -65,8 +64,11 @@ function createTestNode(id: string, position: [number, number]): AetherNode {
   };
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-function createTestEdge(id: string, start: [number, number], end: [number, number]): AetherEdge {
+function createTestEdge(
+  id: string,
+  start: readonly [number, number],
+  end: readonly [number, number],
+): AetherEdge {
   return {
     end,
     id,

--- a/projects/lib-aether-client/src/utils/filter-distant-graph.ts
+++ b/projects/lib-aether-client/src/utils/filter-distant-graph.ts
@@ -1,4 +1,4 @@
-import type { AetherEdgeMap, AetherGraph, AetherNodeMap } from '@vers/aether-core';
+import type { AetherEdge, AetherGraph, AetherNode } from '@vers/aether-core';
 import type { Object3D } from 'three';
 import { Vector3 } from 'three';
 import { getScenePosition } from './get-scene-position';
@@ -11,14 +11,12 @@ const MAX_DISTANCE = 160;
  * our scene size.
  */
 export function filterDistanceGraph(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   selectedNode: null | Object3D,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   graphData: AetherGraph,
 ): AetherGraph {
   const position = selectedNode?.position ?? new Vector3();
 
-  const nodes: AetherNodeMap = {};
+  const nodes: Record<string, AetherNode> = {};
 
   for (const [id, node] of Object.entries(graphData.nodes)) {
     const nodePosition = new Vector3(...getScenePosition(node.position));
@@ -30,7 +28,7 @@ export function filterDistanceGraph(
     }
   }
 
-  const edges: AetherEdgeMap = {};
+  const edges: Record<string, AetherEdge> = {};
 
   for (const [id, edge] of Object.entries(graphData.edges)) {
     const start = new Vector3(...getScenePosition(edge.start));

--- a/projects/lib-aether-client/src/utils/focus-camera-on-position.ts
+++ b/projects/lib-aether-client/src/utils/focus-camera-on-position.ts
@@ -2,8 +2,10 @@ import type { PerspectiveCamera } from 'three';
 import { Vector3 } from 'three';
 import { CAMERA_DISTANCE, ISOMETRIC_OFFSET_X, ISOMETRIC_OFFSET_Z } from '../consts';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-export function focusCameraOnPosition(camera: PerspectiveCamera, position: [number, number]) {
+export function focusCameraOnPosition(
+  camera: PerspectiveCamera,
+  position: readonly [number, number],
+) {
   const [x, y] = position;
 
   const offset = new Vector3();

--- a/projects/lib-aether-client/src/utils/get-scene-position.ts
+++ b/projects/lib-aether-client/src/utils/get-scene-position.ts
@@ -4,8 +4,7 @@ import type { VectorTuple } from '../types';
 /**
  * convert a given x,y position to an x,y,z
  */
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-export function getScenePosition(position: [number, number]): VectorTuple {
+export function getScenePosition(position: readonly [number, number]): VectorTuple {
   const x = position[0] * NODE_POSITION_SCALING_FACTOR;
   const y = position[1] * NODE_POSITION_SCALING_FACTOR;
 

--- a/projects/lib-aether-core/src/decompress-aether-nodes.test.ts
+++ b/projects/lib-aether-core/src/decompress-aether-nodes.test.ts
@@ -5,7 +5,9 @@ import type { CompressedAetherNode } from './types';
 
 test('it decompresses nodes into a complete aether graph', () => {
   // mock our randomization so we can assert we're getting the correct positions
-  spyOn(getRandomizedPosition, 'getRandomizedPosition').mockImplementation((position) => position);
+  spyOn(getRandomizedPosition, 'getRandomizedPosition').mockImplementation((position) => [
+    ...position,
+  ]);
 
   const compressedNodes: Array<CompressedAetherNode> = [
     {

--- a/projects/lib-aether-core/src/decompress-aether-nodes.ts
+++ b/projects/lib-aether-core/src/decompress-aether-nodes.ts
@@ -2,8 +2,7 @@ import { getAetherEdgeMap } from './get-aether-edge-map';
 import { getAetherNodeMap } from './get-aether-node-map';
 import type { AetherGraph, CompressedAetherNode } from './types';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-export function decompressAetherNodes(data: Array<CompressedAetherNode>): AetherGraph {
+export function decompressAetherNodes(data: ReadonlyArray<CompressedAetherNode>): AetherGraph {
   const nodes = getAetherNodeMap(data);
 
   return {

--- a/projects/lib-aether-core/src/generate-graph-nodes.test.ts
+++ b/projects/lib-aether-core/src/generate-graph-nodes.test.ts
@@ -30,20 +30,17 @@ test('it generates a central origin node', () => {
   const nodes = generateGraphNodes(1);
 
   expect(nodes[0]).toStrictEqual({
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    connections: expect.arrayContaining([
-      expect.any(String),
-      expect.any(String),
-      expect.any(String),
-      expect.any(String),
-    ]),
+    connections: [
+      expect.toBeString(),
+      expect.toBeString(),
+      expect.toBeString(),
+      expect.toBeString(),
+    ],
     difficulty: 0,
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    id: expect.any(String),
+    id: expect.toBeString(),
     index: 0,
     position: [0, 0],
-    // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-    seed: expect.any(Number),
+    seed: expect.toBeNumber(),
   });
 });
 

--- a/projects/lib-aether-core/src/generate-graph-nodes.ts
+++ b/projects/lib-aether-core/src/generate-graph-nodes.ts
@@ -2,6 +2,18 @@ import invariant from 'tiny-invariant';
 import { createAetherNode } from './create-aether-node';
 import type { AetherNode } from './types';
 
+type MutableConnections = [null | string, null | string, null | string, null | string];
+
+/**
+ * a node mid-construction: its connections are filled in across two passes
+ * before the graph is frozen into the readonly AetherNode shape callers get.
+ */
+type AetherNodeDraft = Omit<AetherNode, 'connections'> & { connections: MutableConnections };
+
+function toDraftNode(node: AetherNode): AetherNodeDraft {
+  return { ...node, connections: [...node.connections] };
+}
+
 /**
  * Generates a graph of AetherNodes and returns them as an array.
  *
@@ -9,9 +21,9 @@ import type { AetherNode } from './types';
  * @returns A graph of AetherNodes
  */
 export function generateGraphNodes(maxDifficulty: number): Array<AetherNode> {
-  const graph: Array<AetherNode> = [];
+  const graph: Array<AetherNodeDraft> = [];
 
-  const centralNode = createAetherNode(0, 0);
+  const centralNode = toDraftNode(createAetherNode(0, 0));
 
   graph.push(centralNode);
 
@@ -21,15 +33,12 @@ export function generateGraphNodes(maxDifficulty: number): Array<AetherNode> {
     const nodesInLevel = 4 * difficulty;
 
     for (let i = 0; i < nodesInLevel; i++) {
-      graph.push(createAetherNode(i, difficulty));
+      graph.push(toDraftNode(createAetherNode(i, difficulty)));
     }
   }
 
   // set all our connections
   for (const [i, node] of graph.entries()) {
-    // oxlint-disable-next-line typescript/strict-boolean-expressions -- baseline(#236)
-    invariant(node, 'node is required');
-
     const nodesInCurrentLevel = 4 * node.difficulty;
     const nodesInPreviousLevel = nodesInCurrentLevel - 4;
     const nodesInNextLevel = nodesInCurrentLevel + 4;
@@ -141,5 +150,12 @@ export function generateGraphNodes(maxDifficulty: number): Array<AetherNode> {
     node.connections[0] = centralNode.id;
   }
 
-  return graph;
+  return graph.map((node) => ({
+    connections: node.connections,
+    difficulty: node.difficulty,
+    id: node.id,
+    index: node.index,
+    position: node.position,
+    seed: node.seed,
+  }));
 }

--- a/projects/lib-aether-core/src/get-aether-edge-map.ts
+++ b/projects/lib-aether-core/src/get-aether-edge-map.ts
@@ -1,9 +1,8 @@
 import invariant from 'tiny-invariant';
-import type { AetherEdgeMap, AetherNodeMap } from './types';
+import type { AetherEdge, AetherEdgeMap, AetherNodeMap } from './types';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 export function getAetherEdgeMap(aetherNodes: AetherNodeMap): AetherEdgeMap {
-  const edges: AetherEdgeMap = {};
+  const edges: Record<string, AetherEdge> = {};
 
   for (const node of Object.values(aetherNodes)) {
     for (const connection of node.connections) {

--- a/projects/lib-aether-core/src/get-aether-node-map.test.ts
+++ b/projects/lib-aether-core/src/get-aether-node-map.test.ts
@@ -5,7 +5,9 @@ import type { CompressedAetherNode } from './types';
 
 test('it creates a node map from compressed nodes', () => {
   // mock our randomization so we can assert we're getting the correct positions
-  spyOn(getRandomizedPosition, 'getRandomizedPosition').mockImplementation((position) => position);
+  spyOn(getRandomizedPosition, 'getRandomizedPosition').mockImplementation((position) => [
+    ...position,
+  ]);
 
   const compressedNodes: Array<CompressedAetherNode> = [
     {

--- a/projects/lib-aether-core/src/get-aether-node-map.ts
+++ b/projects/lib-aether-core/src/get-aether-node-map.ts
@@ -2,9 +2,10 @@ import { createRNG } from '@vers/game-utils';
 import { getRandomizedPosition } from './get-randomized-position';
 import type { AetherNode, AetherNodeMap, CompressedAetherNode } from './types';
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-export function getAetherNodeMap(compressedNodes: Array<CompressedAetherNode>): AetherNodeMap {
-  const nodes: AetherNodeMap = {};
+export function getAetherNodeMap(
+  compressedNodes: ReadonlyArray<CompressedAetherNode>,
+): AetherNodeMap {
+  const nodes: Record<string, AetherNode> = {};
 
   for (const node of compressedNodes) {
     const rng = createRNG(node.s);

--- a/projects/lib-aether-core/src/get-compressed-aether-graph.ts
+++ b/projects/lib-aether-core/src/get-compressed-aether-graph.ts
@@ -6,8 +6,9 @@ import type { AetherNode, CompressedAetherNode } from './types';
  * @param nodes - The AetherNodes to serialize.
  * @returns An array of CompressedAetherNodes.
  */
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-export function getCompressedAetherGraph(nodes: Array<AetherNode>): Array<CompressedAetherNode> {
+export function getCompressedAetherGraph(
+  nodes: ReadonlyArray<AetherNode>,
+): Array<CompressedAetherNode> {
   return nodes.map((node) => ({
     c: node.connections,
     d: node.difficulty,

--- a/projects/lib-aether-core/src/get-randomized-position.ts
+++ b/projects/lib-aether-core/src/get-randomized-position.ts
@@ -2,8 +2,10 @@ import type { RNG } from '@vers/game-utils';
 
 const JITTER_FACTOR = 200;
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-export function getRandomizedPosition(position: [number, number], rng: RNG): [number, number] {
+export function getRandomizedPosition(
+  position: readonly [number, number],
+  rng: RNG,
+): [number, number] {
   const xOffset = rng.getInt(-JITTER_FACTOR, JITTER_FACTOR) / 1000;
   const yOffset = rng.getInt(-JITTER_FACTOR, JITTER_FACTOR) / 1000;
 

--- a/projects/lib-aether-core/src/index.ts
+++ b/projects/lib-aether-core/src/index.ts
@@ -1,4 +1,3 @@
 export { decompressAetherNodes } from './decompress-aether-nodes';
 
-// oxlint-disable-next-line typescript/consistent-type-exports -- baseline(#236)
-export * from './types';
+export type * from './types';

--- a/projects/lib-aether-core/src/types.ts
+++ b/projects/lib-aether-core/src/types.ts
@@ -1,32 +1,32 @@
 export interface AetherGraph {
-  edges: AetherEdgeMap;
-  nodes: AetherNodeMap;
+  readonly edges: AetherEdgeMap;
+  readonly nodes: AetherNodeMap;
 }
 
-export type AetherEdgeMap = Record<string, AetherEdge>;
+export type AetherEdgeMap = Readonly<Record<string, AetherEdge>>;
 
-export type AetherNodeMap = Record<string, AetherNode>;
+export type AetherNodeMap = Readonly<Record<string, AetherNode>>;
 
 export interface AetherNode {
-  connections: [null | string, null | string, null | string, null | string];
-  difficulty: number;
-  id: string;
-  index: number;
-  position: [number, number];
-  seed: number;
+  readonly connections: readonly [null | string, null | string, null | string, null | string];
+  readonly difficulty: number;
+  readonly id: string;
+  readonly index: number;
+  readonly position: readonly [number, number];
+  readonly seed: number;
 }
 
 export interface AetherEdge {
-  end: [number, number];
-  id: string;
-  start: [number, number];
+  readonly end: readonly [number, number];
+  readonly id: string;
+  readonly start: readonly [number, number];
 }
 
 export interface CompressedAetherNode {
-  c: [null | string, null | string, null | string, null | string];
-  d: number;
-  i: number;
-  id: string;
-  p: [number, number];
-  s: number;
+  readonly c: readonly [null | string, null | string, null | string, null | string];
+  readonly d: number;
+  readonly i: number;
+  readonly id: string;
+  readonly p: readonly [number, number];
+  readonly s: number;
 }

--- a/projects/lib-aether-core/tsconfig.json
+++ b/projects/lib-aether-core/tsconfig.json
@@ -4,6 +4,6 @@
     "types": ["node", "bun", "@zgeoff/bun-test-extended"]
   },
   "files": [],
-  "include": ["src/**/*.ts", "generate-graph.ts"],
+  "include": ["src/**/*.ts", "generate-graph.ts", "test-setup.ts"],
   "exclude": []
 }

--- a/projects/lib-idle-core/src/test-utils/create-mock-simulation-context.ts
+++ b/projects/lib-idle-core/src/test-utils/create-mock-simulation-context.ts
@@ -6,7 +6,6 @@ const hasher = await xxhash();
 
 type Overrides = Omit<Partial<SimulationContext>, 'hasher'>;
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- a Partial of the mutable simulation context, whose rng handle has no readonly form; spread into the returned context, never mutated
 export function createMockSimulationContext(overrides: Overrides = {}): SimulationContext {
   const ctx: SimulationContext = {
     elapsed: 0,


### PR DESCRIPTION
Clears all 39 `baseline(#236)` directives across `lib-aether-core` (10) and `lib-aether-client` (29) by fixing the underlying violations. Stacks on #344 (idle-core), which this branch is built from.

- `AetherNode`/`AetherEdge`/`CompressedAetherNode` made deeply `readonly`; `generateGraphNodes` builds connections through a local mutable draft type so the public shape stays readonly.
- React component props wrapped in `Readonly<Props>`; mutable handles with no readonly form (game-utils' `RNG`, three.js `Object3D`/`Mesh`/`PerspectiveCamera`, r3f's `ThreeEvent`, DOM `MouseEvent`, `React.ElementType`) go on the `prefer-readonly` allow list.
- `expect.any(...)` → typed jest-extended matchers; statement-body arrows for r3f event handlers; explicit boolean comparisons; a redundant `invariant` dropped; `export type *` for the type-only barrel.
- Two tailored directives remain in `create-style-context.tsx`: a generic recipe-call cast (`ReturnType<R>` can't unify with a type parameter's call result) and a `forwardRef` cast (its fixed return type can't be expressed in terms of the caller's generic component type).
- Fixed `lib-aether-core/tsconfig.json`, which omitted `test-setup.ts` and made type-aware lint fail outright.
- Dropped one `lib-idle-core` directive the new `RNG` allow-list entry stranded.

## Testing

- [x] `bun run typecheck` passes (both packages + `app-web`)
- [x] `bun run test` passes (both packages)
- [x] `bun run lint` passes
- [ ] New tests added for new functionality