### PR TITLE
chore(#244): burn down styling baseline(#236) lint directives

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -142,6 +142,12 @@
           { "from": "package", "name": "ReactNode", "package": "react" },
           { "from": "package", "name": "SyntheticEvent", "package": "react" },
           { "from": "package", "name": "ElementType", "package": "react" },
+          { "from": "package", "name": "ChangeEvent", "package": "react" },
+          {
+            "from": "package",
+            "name": ["SVGProps", "InputHTMLAttributes", "LabelHTMLAttributes", "HTMLAttributes"],
+            "package": "react"
+          },
           { "from": "package", "name": "ZodError", "package": "zod" },
           { "from": "package", "name": "JWTPayload", "package": "jose" },
           { "from": "package", "name": "SubmissionResult", "package": "@conform-to/dom" },

--- a/projects/lib-design-system/src/components/background-pattern/background-pattern.tsx
+++ b/projects/lib-design-system/src/components/background-pattern/background-pattern.tsx
@@ -1,9 +1,4 @@
-interface BackgroundPatternProps extends React.SVGProps<SVGSVGElement> {
-  className?: string;
-}
-
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-export function BackgroundPattern(props: BackgroundPatternProps) {
+export function BackgroundPattern(props: React.SVGProps<SVGSVGElement>) {
   return (
     <svg
       {...props}

--- a/projects/lib-design-system/src/components/brand/brand.tsx
+++ b/projects/lib-design-system/src/components/brand/brand.tsx
@@ -33,8 +33,7 @@ const brand = cva({
   },
 });
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-export function Brand(props: Props) {
+export function Brand(props: Readonly<Props>) {
   return (
     <h1
       className={cx(

--- a/projects/lib-design-system/src/components/button/button.stories.tsx
+++ b/projects/lib-design-system/src/components/button/button.stories.tsx
@@ -80,8 +80,7 @@ interface RowProps {
   children: React.ReactNode;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-function Row(props: RowProps) {
+function Row(props: Readonly<RowProps>) {
   return (
     <Box display="flex" flexDirection="row" gap="2">
       {props.children}

--- a/projects/lib-design-system/src/components/button/button.tsx
+++ b/projects/lib-design-system/src/components/button/button.tsx
@@ -164,8 +164,7 @@ export type Props<C extends React.ElementType = 'button'> = PolymorphicComponent
   ButtonProps
 >;
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-export function Button<C extends React.ElementType>(props: Props<C>) {
+export function Button<C extends React.ElementType>(props: Readonly<Props<C>>) {
   const { as, className, fullWidth, size, variant, ...restProps } = props;
 
   const Element = as ?? 'button';

--- a/projects/lib-design-system/src/components/checkbox-field/checkbox-field.tsx
+++ b/projects/lib-design-system/src/components/checkbox-field/checkbox-field.tsx
@@ -5,9 +5,9 @@ import * as React from 'react';
 import { Icon } from '../icon/icon';
 
 interface Props {
-  checkboxProps: React.ComponentProps<'input'> & { key?: React.Key };
-  errors: Array<string>;
-  labelProps: React.ComponentProps<'label'>;
+  checkboxProps: React.InputHTMLAttributes<HTMLInputElement> & { key?: React.Key };
+  errors: ReadonlyArray<string>;
+  labelProps: React.LabelHTMLAttributes<HTMLLabelElement>;
 }
 
 const checkboxFieldRecipe = sva({
@@ -63,8 +63,7 @@ const checkboxFieldRecipe = sva({
   slots: ['root', 'checkbox', 'control', 'indicator', 'icon', 'label', 'errorText'],
 });
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-export function CheckboxField(props: Props) {
+export function CheckboxField(props: Readonly<Props>) {
   const [firstError] = props.errors;
   const onClick = props.checkboxProps.onClick;
   const styles = checkboxFieldRecipe();
@@ -77,8 +76,11 @@ export function CheckboxField(props: Props) {
         defaultChecked={props.checkboxProps.defaultChecked}
         disabled={props.checkboxProps.disabled}
         form={props.checkboxProps.form}
-        // oxlint-disable-next-line typescript/strict-boolean-expressions -- baseline(#236)
-        ids={props.checkboxProps.id ? { hiddenInput: props.checkboxProps.id } : undefined}
+        ids={
+          props.checkboxProps.id !== undefined && props.checkboxProps.id !== ''
+            ? { hiddenInput: props.checkboxProps.id }
+            : undefined
+        }
         invalid={props.errors.length > 0}
         name={props.checkboxProps.name}
         required={props.checkboxProps.required}

--- a/projects/lib-design-system/src/components/field/field.test.tsx
+++ b/projects/lib-design-system/src/components/field/field.test.tsx
@@ -14,7 +14,6 @@ test('it renders a label and an input', () => {
 });
 
 test('it handles input changes', async () => {
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
   const handleChange = mock<(event: ChangeEvent<HTMLInputElement>) => void>();
   const user = userEvent.setup();
 
@@ -28,14 +27,9 @@ test('it handles input changes', async () => {
 
   await user.type(screen.getByLabelText('Email'), 'test@example.com');
 
-  expect(handleChange).toHaveBeenCalledWith(
-    expect.objectContaining({
-      // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
-      target: expect.objectContaining({
-        value: 'test@example.com',
-      }),
-    }),
-  );
+  const [lastCall] = handleChange.mock.calls.slice(-1);
+
+  expect(lastCall?.[0].target.value).toBe('test@example.com');
 });
 
 test('it displays error messages', () => {

--- a/projects/lib-design-system/src/components/field/field.tsx
+++ b/projects/lib-design-system/src/components/field/field.tsx
@@ -4,9 +4,9 @@ import * as React from 'react';
 
 interface Props {
   className?: string;
-  errors: Array<string>;
-  inputProps: React.ComponentProps<'input'> & { key?: React.Key };
-  labelProps: React.ComponentProps<'label'>;
+  errors: ReadonlyArray<string>;
+  inputProps: React.InputHTMLAttributes<HTMLInputElement> & { key?: React.Key };
+  labelProps: React.LabelHTMLAttributes<HTMLLabelElement>;
 }
 
 const fieldRecipe = sva({
@@ -54,8 +54,7 @@ const fieldRecipe = sva({
   slots: ['root', 'label', 'input', 'errorText'],
 });
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-export function Field(props: Props) {
+export function Field(props: Readonly<Props>) {
   // the field context owns error wiring; callers' aria attributes are dropped
   // so they can't point at error elements that render elsewhere.
   const {

--- a/projects/lib-design-system/src/components/heading/heading.tsx
+++ b/projects/lib-design-system/src/components/heading/heading.tsx
@@ -25,8 +25,7 @@ const heading = cva({
   },
 });
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-export function Heading(props: Props) {
+export function Heading(props: Readonly<Props>) {
   const Element = `h${props.level}` as const;
 
   return (

--- a/projects/lib-design-system/src/components/otp-field/otp-field.tsx
+++ b/projects/lib-design-system/src/components/otp-field/otp-field.tsx
@@ -5,8 +5,8 @@ import * as React from 'react';
 
 interface Props {
   className?: string;
-  errors: Array<string>;
-  inputProps: React.ComponentProps<'input'> & {
+  errors: ReadonlyArray<string>;
+  inputProps: React.InputHTMLAttributes<HTMLInputElement> & {
     key?: React.Key;
     mode?: 'alphanumeric' | 'numeric';
   };
@@ -73,8 +73,7 @@ const otpFieldRecipe = sva({
   slots: ['root', 'control', 'group', 'input', 'separator', 'errorText'],
 });
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-export function OTPField(props: Props) {
+export function OTPField(props: Readonly<Props>) {
   const { autoFocus, defaultValue, id, key, mode, name, ...hiddenInputProps } = props.inputProps;
   const [firstError] = props.errors;
   const styles = otpFieldRecipe();
@@ -84,10 +83,9 @@ export function OTPField(props: Props) {
       <PinInput.Root
         // oxlint-disable-next-line jsx-a11y/no-autofocus -- opt-in per form; code entry is the page's sole action
         autoFocus={autoFocus}
-        // oxlint-disable-next-line typescript/no-misused-spread -- baseline(#236)
+        // oxlint-disable-next-line typescript/no-misused-spread -- unicorn/prefer-spread bans the Array.from() alternative; spread is also the Unicode-code-point-safe way to split the code into per-digit characters
         defaultValue={typeof defaultValue === 'string' ? [...defaultValue] : undefined}
-        // oxlint-disable-next-line typescript/strict-boolean-expressions -- baseline(#236)
-        ids={id ? { hiddenInput: id } : undefined}
+        ids={id !== undefined && id !== '' ? { hiddenInput: id } : undefined}
         invalid={props.errors.length > 0}
         name={name}
         placeholder=""

--- a/projects/lib-design-system/src/components/single-line-code/single-line-code.tsx
+++ b/projects/lib-design-system/src/components/single-line-code/single-line-code.tsx
@@ -2,8 +2,6 @@ import { css, cx } from '@vers/styled-system/css';
 import * as React from 'react';
 import { Icon } from '../icon/icon';
 
-export type Props = React.ComponentProps<'code'>;
-
 const container = css({
   alignItems: 'center',
   backgroundColor: 'neutral.900',
@@ -42,8 +40,7 @@ const copyButton = css({
   transitionTimingFunction: 'out',
 });
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-export function SingleLineCode(props: Props) {
+export function SingleLineCode(props: React.HTMLAttributes<HTMLElement>) {
   const { className, ...rest } = props;
 
   const codeRef = React.useRef<HTMLElement>(null);

--- a/projects/lib-design-system/src/components/spinner/spinner.tsx
+++ b/projects/lib-design-system/src/components/spinner/spinner.tsx
@@ -38,8 +38,7 @@ export type Props = RecipeVariantProps<typeof wrapper> & {
   color?: string;
 };
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-export function Spinner(props: Props) {
+export function Spinner(props: Readonly<Props>) {
   return (
     <output className={wrapper({ ...(props.size !== undefined && { size: props.size }) })}>
       <svg className={container} fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">

--- a/projects/lib-design-system/src/components/status-button/status-button.stories.tsx
+++ b/projects/lib-design-system/src/components/status-button/status-button.stories.tsx
@@ -27,12 +27,11 @@ export function Default() {
 }
 
 interface EmulateSubmitConfig {
-  success: boolean;
+  readonly success: boolean;
 }
 
 // hacky hook to give us a simulatedish submit flow that cycles the
 // status button states from idle -> pending -> success.
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
 function useEmulateSubmit(config: EmulateSubmitConfig) {
   const [submitting, setSubmitting] = useState(false);
   const [status, setStatus] = useState(StatusButton.Status.Idle);
@@ -50,7 +49,7 @@ function useEmulateSubmit(config: EmulateSubmitConfig) {
   // 2 second delay, set the status to success
   useEffect(() => {
     if (!submitting) {
-      return;
+      return () => {};
     }
 
     setStatus(StatusButton.Status.Pending);
@@ -63,8 +62,9 @@ function useEmulateSubmit(config: EmulateSubmitConfig) {
       setStatus(finalStatus);
     }, 2000);
 
-    // oxlint-disable-next-line typescript/consistent-return, typescript/no-confusing-void-expression -- baseline(#236)
-    return () => clearTimeout(timeout);
+    return () => {
+      clearTimeout(timeout);
+    };
   }, [submitting, setSubmitting, config.success]);
 
   return { handleSubmit, resetStatus, status };

--- a/projects/lib-design-system/src/components/status-button/status-button.tsx
+++ b/projects/lib-design-system/src/components/status-button/status-button.tsx
@@ -62,8 +62,8 @@ const hideButtonContent = css({
   transitionTimingFunction: 'in-out',
 });
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-export function StatusButton(props: Props) {
+// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- the polymorphic props type composes through Omit<>, which resolves to a concrete DOM attribute type with no readonly form and no allow-list match once the element type argument is fixed
+export function StatusButton(props: Readonly<Props>) {
   const { children, ...restProps } = props;
 
   // we debounce this state so that we can show our success or error states

--- a/projects/lib-design-system/src/components/text/text.tsx
+++ b/projects/lib-design-system/src/components/text/text.tsx
@@ -34,8 +34,7 @@ const text = cva({
 });
 
 export function Text<C extends React.ElementType = 'p'>(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- baseline(#236)
-  props: PolymorphicComponentProps<C, TextProps>,
+  props: Readonly<PolymorphicComponentProps<C, TextProps>>,
 ) {
   const { align, as, bold, className, ...restProps } = props;
 

--- a/projects/lib-panda-preset/src/preset.ts
+++ b/projects/lib-panda-preset/src/preset.ts
@@ -154,11 +154,9 @@ export const preset = definePreset({
       },
       marginX: {
         className: 'mx',
-        transform(value) {
+        transform(value: string) {
           return {
-            // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
             marginLeft: value,
-            // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
             marginRight: value,
           };
         },
@@ -166,11 +164,9 @@ export const preset = definePreset({
       },
       marginY: {
         className: 'my',
-        transform(value) {
+        transform(value: string) {
           return {
-            // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
             marginBottom: value,
-            // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
             marginTop: value,
           };
         },
@@ -178,11 +174,9 @@ export const preset = definePreset({
       },
       paddingX: {
         className: 'px',
-        transform(value) {
+        transform(value: string) {
           return {
-            // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
             paddingLeft: value,
-            // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
             paddingRight: value,
           };
         },
@@ -190,11 +184,9 @@ export const preset = definePreset({
       },
       paddingY: {
         className: 'py',
-        transform(value) {
+        transform(value: string) {
           return {
-            // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
             paddingBottom: value,
-            // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
             paddingTop: value,
           };
         },
@@ -202,9 +194,8 @@ export const preset = definePreset({
       },
       rounded: {
         className: 'rounded',
-        transform(value) {
+        transform(value: string) {
           return {
-            // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
             borderRadius: value,
           };
         },
@@ -212,11 +203,9 @@ export const preset = definePreset({
       },
       roundedBottom: {
         className: 'rounded-b',
-        transform(value) {
+        transform(value: string) {
           return {
-            // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
             borderBottomLeftRadius: value,
-            // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
             borderBottomRightRadius: value,
           };
         },
@@ -224,11 +213,9 @@ export const preset = definePreset({
       },
       roundedTop: {
         className: 'rounded-t',
-        transform(value) {
+        transform(value: string) {
           return {
-            // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
             borderTopLeftRadius: value,
-            // oxlint-disable-next-line typescript/no-unsafe-assignment -- baseline(#236)
             borderTopRightRadius: value,
           };
         },


### PR DESCRIPTION
## Description

Clears all 32 `baseline(#236)` directives in lib-design-system (19) and lib-panda-preset (13) by fixing the underlying violations. Part of #244.

- React component props switch to `Readonly<Props>`; `React.ComponentProps<'tag'>` swaps for the concrete `*HTMLAttributes` interface so the readonly-parameter-types allow list matches nominally (extended with `SVGProps`, `InputHTMLAttributes`, `LabelHTMLAttributes`, `HTMLAttributes`, `ChangeEvent`).
- panda-preset's utility `transform` callbacks annotate `value: string` instead of the library's untyped `any`.
- A field test asserts on the mock's captured call args instead of a nested `expect.objectContaining`.
- Optional `id` props get explicit `undefined`/empty-string checks instead of truthy coercion.
- `useEffect` cleanups use statement-body arrows; the idle-cycle effect returns a no-op cleanup on its early-exit path instead of mixing a bare `return` with a value `return`.

Two tailored (non-baseline) directives remain: `StatusButton`'s props type resolves `Button`'s polymorphic `Omit<>` machinery to a concrete DOM attribute type that loses the allow list's nominal match; and `otp-field.tsx` documents a genuine conflict between `unicorn/prefer-spread` and `typescript/no-misused-spread` over spreading a string (spread wins — it's also the Unicode-safe way to split the code into digits).

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality

## Context

Reference implementation: PR #344 (`chore/244-idle-core-lint`), which did the same for lib-idle-core.