### PR TITLE
refactor(app-web): rename resolve-session-actor to load-session-actor

### DIFF
--- a/projects/app-web/src/lib/proxy/send-rpc-request.ts
+++ b/projects/app-web/src/lib/proxy/send-rpc-request.ts
@@ -1,5 +1,5 @@
 import { createEdgeServiceToken } from '../rpc/create-edge-service-token';
-import { resolveSessionActor } from '../rpc/resolve-session-actor';
+import { loadSessionActor } from '../rpc/load-session-actor';
 import type { ServiceName } from '../rpc/service-urls';
 import { SERVICE_URLS } from '../rpc/service-urls';
 
@@ -25,7 +25,7 @@ export async function sendRPCRequest(request: Request, service: ServiceName): Pr
 
   const headers = new Headers(request.headers);
 
-  const actingUserID = await resolveSessionActor();
+  const actingUserID = await loadSessionActor();
 
   const token = await createEdgeServiceToken({ actingUserID, audience: service });
 

--- a/projects/app-web/src/lib/rpc/build-service-link.ts
+++ b/projects/app-web/src/lib/rpc/build-service-link.ts
@@ -1,7 +1,7 @@
 import { RPCLink } from '@orpc/client/fetch';
 import { createIsomorphicFn } from '@tanstack/react-start';
 import { createEdgeServiceToken } from './create-edge-service-token';
-import { resolveSessionActor } from './resolve-session-actor';
+import { loadSessionActor } from './load-session-actor';
 import type { ServiceName } from './service-urls';
 import { SERVICE_URLS } from './service-urls';
 
@@ -30,7 +30,7 @@ export function buildServiceLink(service: ServiceName): RPCLink<ServiceLinkConte
           headers: async (options) => {
             const actingUserID =
               options.context.actingUserID === undefined
-                ? await resolveSessionActor()
+                ? await loadSessionActor()
                 : options.context.actingUserID;
 
             const token = await createEdgeServiceToken({ actingUserID, audience: service });

--- a/projects/app-web/src/lib/rpc/load-session-actor.test.ts
+++ b/projects/app-web/src/lib/rpc/load-session-actor.test.ts
@@ -3,10 +3,10 @@ import { createId } from '@paralleldrive/cuid2';
 import { createMockAccessToken } from '../../mocks/create-mock-access-token';
 import * as db from '../../mocks/db';
 import { withRequestContext } from '../../test-utils/with-request-context';
-import { resolveSessionActor } from './resolve-session-actor';
+import { loadSessionActor } from './load-session-actor';
 
 test('it returns null with no network call when there is no cookie session', async () => {
-  const outcome = await withRequestContext({}, () => resolveSessionActor());
+  const outcome = await withRequestContext({}, () => loadSessionActor());
 
   expect(outcome.value).toBeNull();
 });
@@ -22,7 +22,7 @@ test('it returns the cookie userID unchanged for a fresh access token', async ()
         en_session: { accessToken, refreshToken: 'refresh-1', sessionID: 'session-1', userID },
       },
     },
-    () => resolveSessionActor(),
+    () => loadSessionActor(),
   );
 
   expect(outcome.value).toBe(userID);
@@ -44,7 +44,7 @@ test('it refreshes a stale access token once, updates the cookie, and returns th
         },
       },
     },
-    () => resolveSessionActor(),
+    () => loadSessionActor(),
   );
 
   expect(outcome.value).toBe(session.userID);
@@ -66,7 +66,7 @@ test('it clears the cookie and returns null when the refresh itself fails', asyn
         },
       },
     },
-    () => resolveSessionActor(),
+    () => loadSessionActor(),
   );
 
   expect(outcome.value).toBeNull();
@@ -87,7 +87,7 @@ test('it single-flights concurrent refreshes for the same session', async () => 
   };
 
   const outcome = await withRequestContext({ cookies }, () =>
-    Promise.all([resolveSessionActor(), resolveSessionActor()]),
+    Promise.all([loadSessionActor(), loadSessionActor()]),
   );
 
   expect(outcome.value).toStrictEqual([session.userID, session.userID]);

--- a/projects/app-web/src/lib/rpc/load-session-actor.ts
+++ b/projects/app-web/src/lib/rpc/load-session-actor.ts
@@ -21,14 +21,14 @@ interface RefreshedTokens {
 const inFlightRefreshes = new Map<string, Promise<RefreshedTokens | undefined>>();
 
 /**
- * Resolves the acting user id for a cookie-derived service call, proactively re-validating a
+ * Loads the acting user id for a cookie-derived service call, proactively re-validating a
  * near-expired session first: services no longer see the caller's own access token, so nothing
  * else re-checks the underlying session's existence, expiry, or revocation before its identity is
  * trusted to mint an s2s token. `null` covers both no live session and one that failed
  * re-validation — the cookie is cleared in the latter case, and the caller's own guard redirects to
  * login on its next request.
  */
-export async function resolveSessionActor(): Promise<string | null> {
+export async function loadSessionActor(): Promise<string | null> {
   const session = await getAuthSession();
 
   if (


### PR DESCRIPTION
Renames the edge session-actor helper from `resolveSessionActor` to `loadSessionActor`. The function is effectful — it proactively refreshes tokens and rotates the `en_session` cookie — so the pure-producer `resolve` prefix under-advertised its side effects; `load` signals the I/O per the AGENTS naming taxonomy. Follow-up to the #343 review (#319).

Pure rename, no behavior change: file + symbol + JSDoc verb + call sites (`build-service-link`, `send-rpc-request`).

## Checks
typecheck, test (237), boundaries, format:check, lint — all green locally.