### PR TITLE
ci: write app-web dotenv secrets with printf, not echo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,9 +30,12 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Dotenv
+        env:
+          DOTENV_APP_WEB_DEV: ${{ secrets.DOTENV_APP_WEB_DEV }}
+          DOTENV_APP_WEB_E2E: ${{ secrets.DOTENV_APP_WEB_E2E }}
         run: |
-          echo "${{ secrets.DOTENV_APP_WEB_DEV }}" > projects/app-web/.env.development.local
-          echo "${{ secrets.DOTENV_APP_WEB_E2E }}" > projects/app-web-e2e/.env
+          printf '%s\n' "$DOTENV_APP_WEB_DEV" > projects/app-web/.env.development.local
+          printf '%s\n' "$DOTENV_APP_WEB_E2E" > projects/app-web-e2e/.env
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,9 +21,12 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Dotenv
+        env:
+          DOTENV_APP_WEB_DEV: ${{ secrets.DOTENV_APP_WEB_DEV }}
+          DOTENV_APP_WEB_E2E: ${{ secrets.DOTENV_APP_WEB_E2E }}
         run: |
-          echo "${{ secrets.DOTENV_APP_WEB_DEV }}" > projects/app-web/.env.development.local
-          echo "${{ secrets.DOTENV_APP_WEB_E2E }}" > projects/app-web-e2e/.env
+          printf '%s\n' "$DOTENV_APP_WEB_DEV" > projects/app-web/.env.development.local
+          printf '%s\n' "$DOTENV_APP_WEB_E2E" > projects/app-web-e2e/.env
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
`echo "${{ secrets.X }}"` inlines the secret into the shell script text, so a secret with double quotes or newlines — the app-web s2s private key is a multiline PEM, required since #319 — ends the echo string early and runs the remaining PEM lines as commands (exit 127). That's why app-web e2e breaks whenever its turbo cache misses and the app actually boots (recent lint-only PRs #346–#348 all hit it).

- Pass both dotenv secrets via `env:` into shell vars, write with `printf '%s\n' "$VAR"` — value never re-parsed by the shell.
- The `DOTENV_APP_WEB_E2E` secret was also rebuilt to include `SERVICE_AUTH_PRIVATE_KEY` (a fresh Ed25519 PKCS8 key; the mocked e2e backend never verifies the signature). Stored in the 1Password `vers` vault.

## Testing

- [x] This PR's own e2e run exercises the new write path + secret.