### PR TITLE
fix(app-web): restore signed-in e2e smoke via real login

### DIFF
--- a/projects/app-web-e2e/src/home-smoke.spec.ts
+++ b/projects/app-web-e2e/src/home-smoke.spec.ts
@@ -28,14 +28,26 @@ test('it serves the anonymous home page server-rendered and hydrates the session
 
 test('it serves the signed-in home page server-rendered and hydrates the session badge', async ({
   page,
-  request,
 }) => {
-  await page.setExtraHTTPHeaders({ authorization: 'Bearer dev-session' });
+  await page.setExtraHTTPHeaders({ 'x-forwarded-for': '127.0.0.1' });
 
-  const rawResponse = await request.get('/', {
-    headers: { authorization: 'Bearer dev-session' },
-  });
+  await page.goto('/login');
+  await page.waitForLoadState('networkidle');
 
+  await page.getByLabel('Email').fill('demo@vers.test');
+  await page.getByLabel('Password').fill('password123');
+
+  // the honeypot rejects any submission under 1.5s old as bot-paced — real typing naturally
+  // clears it, a scripted fill+click doesn't
+  await page.waitForTimeout(1600);
+
+  await page.getByRole('button', { exact: true, name: 'Login' }).click();
+
+  await page.waitForURL((url) => !url.pathname.startsWith('/login'));
+
+  // the raw SSR body, read through the page's own cookie jar — the bare `request` fixture keeps a
+  // separate jar and would render anonymous
+  const rawResponse = await page.request.get('/');
   const rawBody = await rawResponse.text();
 
   expect(rawBody).toContain('data-testid="home-signed-in"');

--- a/projects/app-web/src/mocks/db/create-demo-seed.ts
+++ b/projects/app-web/src/mocks/db/create-demo-seed.ts
@@ -1,48 +1,27 @@
 import { createId } from '@paralleldrive/cuid2';
-import { sessionCollection } from './session-collection';
 import { userCollection } from './user-collection';
 
-/** The demo session id every mock-backed dev run can sign in with (`Authorization: Bearer <id>`). */
-export const DEMO_SESSION_ID = 'dev-session';
-
 /**
- * The e2e game-flow account's own login, so its real sign-in never hits the force-logout
- * confirmation that `DEMO_SESSION_ID`'s live session would trigger.
+ * The e2e game-flow account's login. Each signed-in spec logs in as its own account so their
+ * sessions never collide across a shared dev server.
  */
 export const GAME_DEMO_EMAIL = 'e2e-game@vers.test';
 export const GAME_DEMO_PASSWORD = 'password123';
 
 /**
- * Seeds the demo signed-in identity: a user plus a live session, giving the auth-state-aware
- * server render a real "signed in" path to prove without a login flow existing yet. Also seeds a
- * second account with no pre-existing session, for e2e specs that need a real login round trip —
- * signing in as the first account instead would hit the force-logout confirmation, since it
- * already has a live session.
+ * Seeds the demo accounts with no pre-existing session: every signed-in spec establishes its own
+ * session through a real login round trip.
  */
 export async function createDemoSeed(): Promise<void> {
-  const demoUserID = createId();
-
   await userCollection.create({
     createdAt: new Date(),
     email: 'demo@vers.test',
-    id: demoUserID,
+    id: createId(),
     name: 'Demo Account',
     password: 'password123',
     seed: 0,
     updatedAt: new Date(),
     username: 'demo',
-  });
-
-  await sessionCollection.create({
-    createdAt: new Date(),
-    expiresAt: new Date(Date.now() + 1000 * 60 * 60 * 24 * 30),
-    id: DEMO_SESSION_ID,
-    ipAddress: '127.0.0.1',
-    previousRefreshToken: null,
-    refreshToken: DEMO_SESSION_ID,
-    updatedAt: new Date(),
-    userID: demoUserID,
-    verified: true,
   });
 
   await userCollection.create({


### PR DESCRIPTION
The `Bearer dev-session` header affordance was dropped when the edge moved to minting an s2s token from the sealed session cookie alone (#319/#343). The home-smoke signed-in test still authenticated through that header, so it rendered anonymous — masked by the e2e turbo cache until a cache miss (the recently-fixed `DOTENV_APP_WEB_E2E` secret exposed it).

- Remove the stale seeded demo session + `DEMO_SESSION_ID`; identity is single-sourced on the cookie now.
- Signed-in home test logs in as demo@vers.test through the real login flow, like game-smoke.
- Reads the raw SSR body via the page's own cookie jar (`page.request`), not the bare `request` fixture.

Verified locally: home-smoke 2/2 pass, app-web unit 237/0, typecheck + lint clean.

## Testing

- [x] typecheck / lint / unit pass
- [x] `home-smoke.spec.ts` passes locally (both tests)