### PR TITLE
fix(deploy): right-size deploy strategy per app tier, fix git-less build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -160,15 +160,32 @@ jobs:
 
       # Fly's remote builder builds the image and pushes it inside Fly's network —
       # avoiding a GitHub-runner-to-registry.fly.io blob upload, which 502s on the
-      # large compiled-binary layers. bluegreen (per fly.toml) gates cutover on the
-      # /health check, so a machine that fails to boot blocks the release.
+      # large compiled-binary layers. Each app's strategy (per fly.toml) gates cutover
+      # on the /health check, so a machine that fails to boot blocks the release.
+      #
+      # syd host capacity is intermittently tight: a rollout that can't reserve a
+      # machine fails with "insufficient resources / could not reserve resource". Fly
+      # rolls the failed rollout back, so a retry is clean — capacity frees within
+      # seconds. Retry on any failure; a genuinely broken image fails all three and the
+      # health gate still blocks it.
       - name: Deploy ${{ matrix.app }}
         if: ${{ contains(needs.checks.outputs.affected-projects, format('<{0}>', matrix.pkg)) }}
-        run: >
-          flyctl deploy --remote-only --config projects/${{ matrix.dir }}/fly.toml --dockerfile
-          projects/${{ matrix.dir }}/Dockerfile
+        run: |
+          for attempt in 1 2 3; do
+            if flyctl deploy --remote-only \
+              --config projects/${{ matrix.dir }}/fly.toml \
+              --dockerfile projects/${{ matrix.dir }}/Dockerfile; then
+              exit 0
+            fi
+            if [ "${attempt}" -lt 3 ]; then
+              echo "deploy attempt ${attempt} failed; retrying in $((attempt * 30))s"
+              sleep $((attempt * 30))
+            fi
+          done
+          echo "deploy failed after 3 attempts"
+          exit 1
 
-      # private services can't be reached from CI — their bluegreen health gate is the
+      # private services can't be reached from CI — their rollout health gate is the
       # smoke test. app-web is public, so verify it end-to-end after cutover.
       - name: Smoke check app-web
         if:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -44,10 +44,14 @@ rolls out:
 1. Neon migrations apply once — several services share the one database, so migration never runs per
    service.
 2. Each affected app's image builds and pushes to `registry.fly.io/<app>:<sha>`.
-3. `flyctl deploy --image` ships each affected app with the `bluegreen` strategy: a new machine must
-   pass its `/health` check before traffic cuts over, so a broken boot blocks the release.
+3. `flyctl deploy --image` ships each affected app, retried up to three times against transient
+   `syd` host-capacity refusals. `app-web` uses the `bluegreen` strategy — a full parallel fleet
+   passes `/health` before traffic cuts over atomically — because it is the one public app.
+   Services use `rolling` with `max_unavailable = 1`, updating a machine in place while the other
+   keeps serving; a broken boot fails the health gate and halts the rollout with the old machine
+   still up.
 4. `app-web`'s public `/health` is polled as an end-to-end check. A service, being private, is
-   verified by its bluegreen health gate alone.
+   verified by its rollout health gate alone.
 
 Only a fully green run deploys, and only affected apps.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -46,10 +46,9 @@ rolls out:
 2. Each affected app's image builds and pushes to `registry.fly.io/<app>:<sha>`.
 3. `flyctl deploy --image` ships each affected app, retried up to three times against transient
    `syd` host-capacity refusals. `app-web` uses the `bluegreen` strategy — a full parallel fleet
-   passes `/health` before traffic cuts over atomically — because it is the one public app.
-   Services use `rolling` with `max_unavailable = 1`, updating a machine in place while the other
-   keeps serving; a broken boot fails the health gate and halts the rollout with the old machine
-   still up.
+   passes `/health` before traffic cuts over atomically — because it is the one public app. Services
+   use `rolling` with `max_unavailable = 1`, updating a machine in place while the other keeps
+   serving; a broken boot fails the health gate and halts the rollout with the old machine still up.
 4. `app-web`'s public `/health` is polled as an end-to-end check. A service, being private, is
    verified by its rollout health gate alone.
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "e2e:app-web": "turbo run e2e --filter=@vers/web-e2e",
     "serve:app-web": "dotenvx run -f projects/app-web/.env.development.local -- node ./projects/app-web/server.mjs",
     "---UTILITY": "",
-    "prepare": "lefthook install --force || true"
+    "prepare": "command -v git > /dev/null 2>&1 && lefthook install --force || true"
   },
   "dependencies": {
     "commander": "13.1.0",

--- a/projects/service-avatar/fly.toml
+++ b/projects/service-avatar/fly.toml
@@ -32,4 +32,5 @@ cpu_kind = 'shared'
 cpus = 1
 
 [deploy]
-strategy = 'bluegreen'
+strategy = 'rolling'
+max_unavailable = 1

--- a/projects/service-session/fly.toml
+++ b/projects/service-session/fly.toml
@@ -32,4 +32,5 @@ cpu_kind = 'shared'
 cpus = 1
 
 [deploy]
-strategy = 'bluegreen'
+strategy = 'rolling'
+max_unavailable = 1

--- a/projects/service-user/fly.toml
+++ b/projects/service-user/fly.toml
@@ -32,4 +32,5 @@ cpu_kind = 'shared'
 cpus = 1
 
 [deploy]
-strategy = 'bluegreen'
+strategy = 'rolling'
+max_unavailable = 1

--- a/projects/service-verification/fly.toml
+++ b/projects/service-verification/fly.toml
@@ -32,4 +32,5 @@ cpu_kind = 'shared'
 cpus = 1
 
 [deploy]
-strategy = 'bluegreen'
+strategy = 'rolling'
+max_unavailable = 1


### PR DESCRIPTION
## Description

Reviews the deploy strategy: every app ran `bluegreen`, which boots green machines beside blue and so needs the syd host to hold 2× the footprint — intermittently refused with `could not reserve resource for machine`. Bluegreen is only justified for the one public app.

- app-web stays bluegreen — the sole public SSR app, where atomic cutover (no mixed-version window) and instant rollback earn the doubled fleet
- backend services → `rolling`, `max_unavailable = 1` — internal, mesh-fronted, cold-startable and independently deployed, so they gain nothing from bluegreen; rolling updates in place, so it never needs a second host reservation and is immune to that error by construction
- guard the root `prepare` on `git` being present, so the git-less `bun:slim` builder stops printing `exec: "git": executable file not found` during install (lefthook shells out to git)
- retry the deploy step 3× with backoff as insurance against transient syd host-capacity blips

## Testing

Config/CI-only — no app code changed; workflow YAML parses, `prepare` guard verified in both branches.

## Context

The reservation error is physical-host capacity in syd (org is at 10/100 machines — unrelated), amplified by bluegreen's simultaneous doubling. Rolling sidesteps it entirely for services.