### PR TITLE
chore: gitignore .worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ tmp
 /out-tsc
 .test-results
 
+# git worktrees
+.worktrees
+
 # dependencies
 node_modules
 


### PR DESCRIPTION
## Description

Ignore the `.worktrees/` directory. AGENTS.md tells agents to do all work in worktrees under `.worktrees/`, so it's local scratch that should never be committed — right now it shows as untracked noise in every `git status`.

## Testing

- [ ] N/A — gitignore-only change