### PR TITLE
docs(agents): require triaging new issues onto the delivery board

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,6 +201,13 @@ implementing that algorithm — forcing list verbs onto textbook terms hides the
 - Pin exact versions — no `^`/`~` ranges. (`bun add` saves exact automatically via `exact = true` in
   bunfig.toml — the rule applies to hand-written edits.)
 
+## Issue hygiene
+
+Triage a GitHub issue the moment it's opened, not in a later pass: assign the delivery-phase
+milestone, apply the area, type, and priority labels, record blocking edges against the issues it
+depends on, add it to the delivery board, and set its board status. An open issue that isn't on the
+board with a milestone and status is a defect.
+
 ## Type-only modules
 
 A module whose exports are all types or interfaces is a defect: those exports belong in the

--- a/agents/project.md
+++ b/agents/project.md
@@ -1,3 +1,10 @@
+## Issue hygiene
+
+Triage a GitHub issue the moment it's opened, not in a later pass: assign the delivery-phase
+milestone, apply the area, type, and priority labels, record blocking edges against the issues it
+depends on, add it to the delivery board, and set its board status. An open issue that isn't on the
+board with a milestone and status is a defect.
+
 ## Type-only modules
 
 A module whose exports are all types or interfaces is a defect: those exports belong in the


### PR DESCRIPTION
## Description

Add an issue-hygiene rule to `agents/project.md` (and regenerate `AGENTS.md`): every new GitHub issue gets triaged onto the delivery board at creation — milestone, labels, blocking edges, board status.

- Behavior-focused and tool-agnostic: states the expectation, not how to do it, so it stays valid as the board tooling evolves.

## Testing

- [x] `bun run format:check` passes
- [x] `AGENTS.md` regenerated from the partial via `bun run build:agents`