### PR TITLE
fix(app-web): mint s2s tokens with the service's registered audience

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -25,13 +25,15 @@ and mesh traffic is already encrypted, so services set `force_https = false`.
 Non-sensitive config (service URLs, `NODE_ENV`, log level) lives in each `fly.toml` or Dockerfile.
 Secrets are set with `fly secrets set` and never committed.
 
-| App                                                      | Secrets                                             |
-| -------------------------------------------------------- | --------------------------------------------------- |
-| `service-avatar`, `service-user`, `service-verification` | `DATABASE_URL`, `SERVICE_AUTH_PUBLIC_KEY`           |
-| `service-session`                                        | the above + `API_IDENTIFIER`, `JWT_SIGNING_PRIVKEY` |
-| `app-web`                                                | `SESSION_SECRET`, `COOKIE_DOMAIN`                   |
+| App                                                      | Secrets                                                       |
+| -------------------------------------------------------- | ------------------------------------------------------------- |
+| `service-avatar`, `service-user`, `service-verification` | `DATABASE_URL`, `SERVICE_AUTH_PUBLIC_KEY`                     |
+| `service-session`                                        | the above + `API_IDENTIFIER`, `JWT_SIGNING_PRIVKEY`           |
+| `app-web`                                                | `SESSION_SECRET`, `COOKIE_DOMAIN`, `SERVICE_AUTH_PRIVATE_KEY` |
 
-`SERVICE_AUTH_PUBLIC_KEY` is the Ed25519 SPKI public key a service verifies inbound calls with.
+`SERVICE_AUTH_PUBLIC_KEY` is the Ed25519 SPKI public key a service verifies inbound calls with;
+`SERVICE_AUTH_PRIVATE_KEY` is its PKCS8 private half, which `app-web` signs outbound s2s tokens with
+— every token's `aud` is the target's registered service name (`service-user`).
 `JWT_SIGNING_PRIVKEY` is the RS256 PKCS8 private key `service-session` signs user tokens with, under
 issuer and audience `API_IDENTIFIER`. `SESSION_SECRET` seals `app-web`'s cookies. `SENTRY_DSN` and
 `OTEL_EXPORTER_OTLP_ENDPOINT` are optional on any app.
@@ -104,7 +106,8 @@ fly secrets set -a vers-service-session \
 
 fly secrets set -a vers-app-web \
   SESSION_SECRET="$(openssl rand -base64 32)" \
-  COOKIE_DOMAIN="$DOMAIN"
+  COOKIE_DOMAIN="$DOMAIN" \
+  SERVICE_AUTH_PRIVATE_KEY="$(cat s2s.key)"
 
 rm s2s.key s2s.pub session.key
 ```

--- a/projects/app-web/src/lib/proxy/send-rpc-request.test.ts
+++ b/projects/app-web/src/lib/proxy/send-rpc-request.test.ts
@@ -54,7 +54,7 @@ test('it forwards the method and body for a caller with no cookie session, minti
   const payload = jose.decodeJwt(authorization.replace('Bearer ', ''));
 
   expect(request?.method).toBe('POST');
-  expect(payload).toMatchObject({ aud: 'user', iss: 'vers-edge' });
+  expect(payload).toMatchObject({ aud: 'service-user', iss: 'vers-edge' });
   expect(payload.sub).toBeUndefined();
   expect(body).toBe(JSON.stringify({ email: 'new@vers.test' }));
 });
@@ -105,5 +105,23 @@ test("it mints an s2s token carrying the caller's cookie userID as its subject, 
   const authorization = resolver.mock.calls[0]?.[0].request.headers.get('authorization') ?? '';
   const payload = jose.decodeJwt(authorization.replace('Bearer ', ''));
 
-  expect(payload).toMatchObject({ aud: 'avatar', iss: 'vers-edge', sub: userID });
+  expect(payload).toMatchObject({ aud: 'service-avatar', iss: 'vers-edge', sub: userID });
+});
+
+test('it returns a response whose headers the server can still modify', async () => {
+  server.use(
+    http.get('http://localhost:3003/rpc/getUser', () =>
+      HttpResponse.json({}, { headers: { 'x-upstream': 'kept' } }),
+    ),
+  );
+
+  const outcome = await withRequestContext({}, () =>
+    sendRPCRequest(new Request('http://app.test/api/rpc/user/getUser', { method: 'GET' }), 'user'),
+  );
+
+  expect(outcome.value.headers.get('x-upstream')).toBe('kept');
+
+  expect(() => {
+    outcome.value.headers.delete('x-upstream');
+  }).not.toThrow();
 });

--- a/projects/app-web/src/lib/proxy/send-rpc-request.ts
+++ b/projects/app-web/src/lib/proxy/send-rpc-request.ts
@@ -31,9 +31,24 @@ export async function sendRPCRequest(request: Request, service: ServiceName): Pr
 
   headers.set('authorization', `Bearer ${token}`);
 
-  return fetch(target, {
+  const response = await fetch(target, {
     headers,
     method: request.method,
     ...(hasBody && { body: await request.blob() }),
+  });
+
+  // fetch responses carry immutable headers, which the server framework must still be able to
+  // finalize (merge, drop stale encoding headers) — rewrap into a mutable response. Copy entry by
+  // entry: passing another runtime's Headers instance to the constructor can yield an empty copy.
+  // The body is already decoded, so the upstream encoding headers no longer describe it.
+  const responseHeaders = new Headers([...response.headers]);
+
+  responseHeaders.delete('content-encoding');
+  responseHeaders.delete('content-length');
+
+  return new Response(response.body, {
+    headers: responseHeaders,
+    status: response.status,
+    statusText: response.statusText,
   });
 }

--- a/projects/app-web/src/lib/rpc/create-edge-service-token.test.ts
+++ b/projects/app-web/src/lib/rpc/create-edge-service-token.test.ts
@@ -9,7 +9,7 @@ test('it mints a token carrying the acting user as its subject', async () => {
   const payload = jose.decodeJwt(token);
 
   expect(decoded).toStrictEqual({ alg: 'EdDSA' });
-  expect(payload).toMatchObject({ aud: 'user', iss: 'vers-edge', sub: 'user-1' });
+  expect(payload).toMatchObject({ aud: 'service-user', iss: 'vers-edge', sub: 'user-1' });
   expect(payload.exp).toBeNumber();
 });
 
@@ -19,7 +19,7 @@ test('it mints a subject-less token for an anonymous actor', async () => {
   const payload = jose.decodeJwt(token);
 
   expect(payload.sub).toBeUndefined();
-  expect(payload).toMatchObject({ aud: 'session', iss: 'vers-edge' });
+  expect(payload).toMatchObject({ aud: 'service-session', iss: 'vers-edge' });
 });
 
 test('it signs with a key the matching public key can verify', async () => {

--- a/projects/app-web/src/lib/rpc/create-edge-service-token.ts
+++ b/projects/app-web/src/lib/rpc/create-edge-service-token.ts
@@ -21,10 +21,11 @@ interface CreateEdgeServiceTokenOptions {
 export async function createEdgeServiceToken(
   options: Readonly<CreateEdgeServiceTokenOptions>,
 ): Promise<string> {
+  // services verify `aud` against their registered name, which carries the `service-` prefix
   const jwt = new jose.SignJWT({})
     .setProtectedHeader({ alg: ALGORITHM })
     .setIssuer(ISSUER)
-    .setAudience(options.audience)
+    .setAudience(`service-${options.audience}`)
     .setExpirationTime('60s');
 
   if (options.actingUserID !== null) {


### PR DESCRIPTION
## Description

Every production s2s call failed token verification: services verify `aud` against their registered name (`service-user`), but app-web minted the bare `ServiceName` key (`user`). The resulting plain 401 reaches the oRPC client as an unparseable response, shown as `transport-error` on versidle.com.

- Mint `aud: service-<name>` in the edge token, matching every service's `createService` name.
- Rewrap the RPC proxy's upstream response into a mutable `Response` — fetch responses carry immutable headers and the server crashes with `TypeError: immutable` when finalizing them.
- Copy headers entry-by-entry: constructing `Headers` from another runtime's instance can yield an empty copy.
- Document `SERVICE_AUTH_PRIVATE_KEY` in the deployment runbook's app-web secrets; the provisioning script now sets it before deleting the keypair.

Dev never catches this: the mock backend intercepts all local calls, and each side's tests asserted its own audience.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality

https://claude.ai/code/session_016uigbMXTa7yNGey5HcQcTn