### PR TITLE
feat(#365): add canvas shell to lib-game-rendering

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -382,7 +382,10 @@
       "name": "@vers/game-rendering",
       "version": "0.0.0",
       "dependencies": {
+        "@react-spring/rafz": "catalog:",
+        "@react-three/fiber": "catalog:",
         "react": "catalog:",
+        "three": "catalog:",
         "zustand": "catalog:",
       },
       "devDependencies": {
@@ -393,6 +396,7 @@
         "@types/node": "catalog:",
         "@types/react": "catalog:",
         "@types/react-dom": "catalog:",
+        "@types/three": "catalog:",
         "@zgeoff/bun-test-extended": "catalog:",
         "happy-dom": "catalog:",
         "react-dom": "catalog:",
@@ -696,6 +700,7 @@
     "@pulumi/pulumi": "3.250.0",
     "@react-email/components": "0.0.33",
     "@react-hookz/web": "25.1.0",
+    "@react-spring/rafz": "10.1.2",
     "@react-spring/three": "10.1.2",
     "@react-three/fiber": "9.6.1",
     "@react-three/test-renderer": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
       "@pulumi/pulumi": "3.250.0",
       "@react-email/components": "0.0.33",
       "@react-hookz/web": "25.1.0",
+      "@react-spring/rafz": "10.1.2",
       "@react-spring/three": "10.1.2",
       "@react-three/fiber": "9.6.1",
       "@react-three/test-renderer": "9.1.0",

--- a/projects/lib-game-rendering/package.json
+++ b/projects/lib-game-rendering/package.json
@@ -11,7 +11,10 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@react-spring/rafz": "catalog:",
+    "@react-three/fiber": "catalog:",
     "react": "catalog:",
+    "three": "catalog:",
     "zustand": "catalog:"
   },
   "devDependencies": {
@@ -22,6 +25,7 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
+    "@types/three": "catalog:",
     "@zgeoff/bun-test-extended": "catalog:",
     "happy-dom": "catalog:",
     "react-dom": "catalog:",

--- a/projects/lib-game-rendering/src/create-game-loop.test.ts
+++ b/projects/lib-game-rendering/src/create-game-loop.test.ts
@@ -1,0 +1,95 @@
+import { expect, test } from 'bun:test';
+import { createGameLoop } from './create-game-loop';
+
+test('it runs a registered callback with the driven delta and elapsed time', () => {
+  const gameLoop = createGameLoop();
+  const calls: Array<readonly [number, number]> = [];
+
+  gameLoop.registerGameLoopCallback((delta, elapsed) => {
+    calls.push([delta, elapsed]);
+  });
+
+  gameLoop.runGameLoopCallbacks(0.016, 1.2);
+
+  expect(calls).toStrictEqual([[0.016, 1.2]]);
+});
+
+test('it runs callbacks in registration order', () => {
+  const gameLoop = createGameLoop();
+  const order: Array<number> = [];
+
+  gameLoop.registerGameLoopCallback(() => {
+    order.push(1);
+  });
+
+  gameLoop.registerGameLoopCallback(() => {
+    order.push(2);
+  });
+
+  gameLoop.registerGameLoopCallback(() => {
+    order.push(3);
+  });
+
+  gameLoop.runGameLoopCallbacks(0, 0);
+
+  expect(order).toStrictEqual([1, 2, 3]);
+});
+
+test('it stops running a callback once it unregisters', () => {
+  const gameLoop = createGameLoop();
+  const calls: Array<number> = [];
+
+  const unregister = gameLoop.registerGameLoopCallback(() => {
+    calls.push(1);
+  });
+
+  unregister();
+  gameLoop.runGameLoopCallbacks(0, 0);
+
+  expect(calls).toStrictEqual([]);
+});
+
+test('it leaves the other callbacks running after one unregisters', () => {
+  const gameLoop = createGameLoop();
+  const order: Array<number> = [];
+
+  const unregisterFirst = gameLoop.registerGameLoopCallback(() => {
+    order.push(1);
+  });
+
+  gameLoop.registerGameLoopCallback(() => {
+    order.push(2);
+  });
+
+  unregisterFirst();
+  gameLoop.runGameLoopCallbacks(0, 0);
+
+  expect(order).toStrictEqual([2]);
+});
+
+test('it tolerates unregistering the same callback twice', () => {
+  const gameLoop = createGameLoop();
+  const unregister = gameLoop.registerGameLoopCallback(() => {});
+
+  unregister();
+
+  expect(unregister).not.toThrow();
+});
+
+test('it keeps callback instances from separate game loops independent', () => {
+  const first = createGameLoop();
+  const second = createGameLoop();
+  const calls: Array<string> = [];
+
+  first.registerGameLoopCallback(() => {
+    calls.push('first');
+  });
+
+  second.registerGameLoopCallback(() => {
+    calls.push('second');
+  });
+
+  first.runGameLoopCallbacks(0, 0);
+
+  expect(calls).toStrictEqual(['first']);
+});

--- a/projects/lib-game-rendering/src/create-game-loop.ts
+++ b/projects/lib-game-rendering/src/create-game-loop.ts
@@ -3,8 +3,8 @@ import type { GameLoopCallback } from './types';
 /**
  * Builds an isolated game-loop registry: registered handlers run in the order they were
  * registered, driven only by whoever calls `runGameLoopCallbacks`. The package's real loop uses
- * one shared instance (see the `gameLoop` singleton); this factory lets tests build their own,
- * isolated from one another and from the singleton.
+ * one shared instance built from this factory; calling it again gives tests their own registry,
+ * isolated from that shared instance and from one another.
  */
 export function createGameLoop() {
   const handlers: Array<GameLoopCallback> = [];

--- a/projects/lib-game-rendering/src/create-game-loop.ts
+++ b/projects/lib-game-rendering/src/create-game-loop.ts
@@ -1,0 +1,31 @@
+import type { GameLoopCallback } from './types';
+
+/**
+ * Builds an isolated game-loop registry: registered handlers run in the order they were
+ * registered, driven only by whoever calls `runGameLoopCallbacks`. The package's real loop uses
+ * one shared instance (see the `gameLoop` singleton); this factory lets tests build their own,
+ * isolated from one another and from the singleton.
+ */
+export function createGameLoop() {
+  const handlers: Array<GameLoopCallback> = [];
+
+  const registerGameLoopCallback = (handler: GameLoopCallback): (() => void) => {
+    handlers.push(handler);
+
+    return () => {
+      const index = handlers.indexOf(handler);
+
+      if (index !== -1) {
+        handlers.splice(index, 1);
+      }
+    };
+  };
+
+  const runGameLoopCallbacks = (delta: number, elapsed: number): void => {
+    for (const handler of handlers) {
+      handler(delta, elapsed);
+    }
+  };
+
+  return { registerGameLoopCallback, runGameLoopCallbacks };
+}

--- a/projects/lib-game-rendering/src/create-tunnel.test.tsx
+++ b/projects/lib-game-rendering/src/create-tunnel.test.tsx
@@ -1,0 +1,116 @@
+import { expect, test } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import { createTunnel } from './create-tunnel';
+
+interface UnmountSceneProps {
+  readonly showIn: boolean;
+  readonly tunnel: ReturnType<typeof createTunnel>;
+}
+
+function UnmountScene(props: Readonly<UnmountSceneProps>) {
+  return (
+    <>
+      {props.showIn && (
+        <props.tunnel.In>
+          <span>hello</span>
+        </props.tunnel.In>
+      )}
+      <props.tunnel.Out />
+    </>
+  );
+}
+
+interface LabelSceneProps {
+  readonly label: string;
+  readonly tunnel: ReturnType<typeof createTunnel>;
+}
+
+function LabelScene(props: Readonly<LabelSceneProps>) {
+  return (
+    <>
+      <props.tunnel.In>
+        <span>{props.label}</span>
+      </props.tunnel.In>
+      <props.tunnel.Out />
+    </>
+  );
+}
+
+test('it renders nothing out when no in is mounted', () => {
+  const tunnel = createTunnel();
+  const rendered = render(<tunnel.Out />);
+
+  expect(rendered.container).toBeEmptyDOMElement();
+});
+
+test('it renders an in child through out', () => {
+  const tunnel = createTunnel();
+
+  render(
+    <>
+      <tunnel.In>
+        <span>hello</span>
+      </tunnel.In>
+      <tunnel.Out />
+    </>,
+  );
+
+  expect(screen.getByText('hello')).toBeInTheDocument();
+});
+
+test('it renders multiple ins through out in mount order', () => {
+  const tunnel = createTunnel();
+
+  const rendered = render(
+    <>
+      <tunnel.In>
+        <span>first</span>
+      </tunnel.In>
+      <tunnel.In>
+        <span>second</span>
+      </tunnel.In>
+      <tunnel.Out />
+    </>,
+  );
+
+  expect(rendered.container.textContent).toBe('firstsecond');
+});
+
+test('it removes an in child from out on unmount', () => {
+  const tunnel = createTunnel();
+  const rendered = render(<UnmountScene showIn tunnel={tunnel} />);
+
+  expect(screen.getByText('hello')).toBeInTheDocument();
+
+  rendered.rerender(<UnmountScene showIn={false} tunnel={tunnel} />);
+
+  expect(screen.queryByText('hello')).not.toBeInTheDocument();
+});
+
+test('it updates out when an in child changes on re-render', () => {
+  const tunnel = createTunnel();
+  const rendered = render(<LabelScene label="first" tunnel={tunnel} />);
+
+  expect(screen.getByText('first')).toBeInTheDocument();
+
+  rendered.rerender(<LabelScene label="second" tunnel={tunnel} />);
+
+  expect(screen.queryByText('first')).not.toBeInTheDocument();
+  expect(screen.getByText('second')).toBeInTheDocument();
+});
+
+test('it keeps two tunnels from the same factory independent', () => {
+  const first = createTunnel();
+  const second = createTunnel();
+
+  render(
+    <>
+      <first.In>
+        <span>only in first</span>
+      </first.In>
+      <second.Out />
+    </>,
+  );
+
+  expect(screen.queryByText('only in first')).not.toBeInTheDocument();
+});

--- a/projects/lib-game-rendering/src/create-tunnel.tsx
+++ b/projects/lib-game-rendering/src/create-tunnel.tsx
@@ -14,9 +14,9 @@ interface TunnelInProps {
 /**
  * Builds an isolated `In`/`Out` pair for piping React children out of one subtree and rendering
  * them in another: `In` registers its children under a stable id, `Out` renders every current
- * entry in the order its `In` first mounted. Multiple `In`s may be mounted at once; a fresh call
- * to `createTunnel` gives an independent channel, so this is safe to call more than once — the
- * package's shared scene→DOM channel (see `sceneTunnel`) is just one instance of it.
+ * entry in the order its `In` first mounted. Multiple `In`s may be mounted at once; each call
+ * gives an independent channel, so this is safe to call more than once — the package's shared
+ * scene→DOM channel is just one instance of it.
  */
 export function createTunnel(): {
   readonly In: (props: Readonly<TunnelInProps>) => null;

--- a/projects/lib-game-rendering/src/create-tunnel.tsx
+++ b/projects/lib-game-rendering/src/create-tunnel.tsx
@@ -1,0 +1,71 @@
+import { Fragment, useEffect, useId } from 'react';
+import type { ReactNode } from 'react';
+import { create } from 'zustand';
+
+interface TunnelState {
+  readonly order: ReadonlyArray<string>;
+  readonly entries: ReadonlyMap<string, ReactNode>;
+}
+
+interface TunnelInProps {
+  readonly children: ReactNode;
+}
+
+/**
+ * Builds an isolated `In`/`Out` pair for piping React children out of one subtree and rendering
+ * them in another: `In` registers its children under a stable id, `Out` renders every current
+ * entry in the order its `In` first mounted. Multiple `In`s may be mounted at once; a fresh call
+ * to `createTunnel` gives an independent channel, so this is safe to call more than once — the
+ * package's shared scene→DOM channel (see `sceneTunnel`) is just one instance of it.
+ */
+export function createTunnel(): {
+  readonly In: (props: Readonly<TunnelInProps>) => null;
+  readonly Out: () => ReactNode;
+} {
+  const useTunnelStore = create<TunnelState>(() => ({
+    order: [],
+    entries: new Map(),
+  }));
+
+  const In = (props: Readonly<TunnelInProps>): null => {
+    const id = useId();
+
+    // refreshes this entry's content on every render, without touching its position in `order`
+    useEffect(() => {
+      useTunnelStore.setState((state) => ({
+        order: state.order.includes(id) ? state.order : [...state.order, id],
+        entries: new Map(state.entries).set(id, props.children),
+      }));
+    });
+
+    // removes this entry once, on unmount — kept separate from the effect above so re-renders
+    // never reorder `order`
+    useEffect(
+      () => () => {
+        useTunnelStore.setState((state) => {
+          const entries = new Map(state.entries);
+
+          entries.delete(id);
+
+          return { order: state.order.filter((entryID) => entryID !== id), entries };
+        });
+      },
+      [id],
+    );
+
+    return null;
+  };
+
+  const Out = (): ReactNode => {
+    const order = useTunnelStore((state) => state.order);
+    const entries = useTunnelStore((state) => state.entries);
+
+    if (order.length === 0) {
+      return null;
+    }
+
+    return order.map((id) => <Fragment key={id}>{entries.get(id)}</Fragment>);
+  };
+
+  return { In, Out };
+}

--- a/projects/lib-game-rendering/src/game-canvas.tsx
+++ b/projects/lib-game-rendering/src/game-canvas.tsx
@@ -1,0 +1,42 @@
+import { Canvas } from '@react-three/fiber';
+import type { ReactNode } from 'react';
+import { WebGPURenderer } from 'three/webgpu';
+import type { WebGPURendererParameters } from 'three/webgpu';
+import { GameLoopDriver } from './game-loop-driver';
+import { presentationToFrameloop } from './presentation-to-frameloop';
+import { useSceneStateStore } from './use-scene-state-store';
+
+interface GameCanvasProps {
+  children?: ReactNode;
+  forceWebGL?: boolean;
+}
+
+/**
+ * The persistent, scene-agnostic canvas: one WebGPU (WebGL-fallback) context for the whole app.
+ * Frameloop tracks the scene-state store's presentation, so a hidden scene suspends rendering
+ * entirely instead of paying GPU cost off-screen. Construction happens inside the `gl` callback,
+ * which R3F only invokes client-side, so importing this module is safe under SSR.
+ */
+export function GameCanvas(props: Readonly<GameCanvasProps>): ReactNode {
+  const forceWebGL = props.forceWebGL ?? false;
+  const frameloop = useSceneStateStore((state) => presentationToFrameloop(state.presentation));
+
+  return (
+    <Canvas
+      frameloop={frameloop}
+      gl={async (defaultProps) => {
+        const parameters = { ...defaultProps, forceWebGL };
+
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- R3F's default gl props declare their own minimal OffscreenCanvas shim, which structurally conflicts with three's DOM-lib-typed WebGPURendererParameters; both describe the same real canvas at runtime
+        const renderer = new WebGPURenderer(parameters as WebGPURendererParameters);
+
+        await renderer.init();
+
+        return renderer;
+      }}
+    >
+      <GameLoopDriver />
+      {props.children}
+    </Canvas>
+  );
+}

--- a/projects/lib-game-rendering/src/game-loop-driver.tsx
+++ b/projects/lib-game-rendering/src/game-loop-driver.tsx
@@ -11,9 +11,9 @@ if (raf.frameLoop !== 'demand') {
 }
 
 /**
- * Mounted once inside the persistent canvas by `GameCanvas`. Each driven frame it steps the
- * react-spring rafz clock via `raf.advance`, then runs every callback registered through
- * `registerGameLoopCallback`, in that order.
+ * Mounted once inside the persistent canvas. Each driven frame it steps the react-spring rafz
+ * clock via `raf.advance`, then runs every callback registered against the package's shared
+ * game-loop instance, in that order.
  */
 export function GameLoopDriver(): null {
   useFrame((state, delta) => {

--- a/projects/lib-game-rendering/src/game-loop-driver.tsx
+++ b/projects/lib-game-rendering/src/game-loop-driver.tsx
@@ -1,0 +1,25 @@
+import { raf } from '@react-spring/rafz';
+import { useFrame } from '@react-three/fiber';
+import { gameLoop } from './game-loop';
+
+// this module owns the rafz clock: `raf.advance` is called only here, and `raf.frameLoop` is
+// set only here, once, at module init — springs step exclusively through this driver's
+// `useFrame`, deterministically, and freeze correctly whenever the canvas's frameloop is
+// `never`. Nothing else in this package (or a consumer) may call either.
+if (raf.frameLoop !== 'demand') {
+  raf.frameLoop = 'demand';
+}
+
+/**
+ * Mounted once inside the persistent canvas by `GameCanvas`. Each driven frame it steps the
+ * react-spring rafz clock via `raf.advance`, then runs every callback registered through
+ * `registerGameLoopCallback`, in that order.
+ */
+export function GameLoopDriver(): null {
+  useFrame((state, delta) => {
+    raf.advance();
+    gameLoop.runGameLoopCallbacks(delta, state.clock.elapsedTime);
+  });
+
+  return null;
+}

--- a/projects/lib-game-rendering/src/game-loop.ts
+++ b/projects/lib-game-rendering/src/game-loop.ts
@@ -1,0 +1,3 @@
+import { createGameLoop } from './create-game-loop';
+
+export const gameLoop = createGameLoop();

--- a/projects/lib-game-rendering/src/index.ts
+++ b/projects/lib-game-rendering/src/index.ts
@@ -1,4 +1,5 @@
 export { isSceneSwap } from './is-scene-swap';
+export { presentationToFrameloop } from './presentation-to-frameloop';
 export { resolveSceneState } from './resolve-scene-state';
 export { setSceneState } from './set-scene-state';
 export { useSceneState } from './use-scene-state';

--- a/projects/lib-game-rendering/src/index.ts
+++ b/projects/lib-game-rendering/src/index.ts
@@ -3,10 +3,14 @@ export { GameCanvas } from './game-canvas';
 export { isSceneSwap } from './is-scene-swap';
 export { presentationToFrameloop } from './presentation-to-frameloop';
 export { registerGameLoopCallback } from './register-game-loop-callback';
+export { registerSatellite } from './register-satellite';
+export { removeSatellite } from './remove-satellite';
 export { resolveSceneState } from './resolve-scene-state';
+export { SatelliteHost } from './satellite-host';
 export { sceneTunnel } from './scene-tunnel';
 export { setSceneState } from './set-scene-state';
 export { useRenderer } from './use-renderer';
+export { useSatellite } from './use-satellite';
 export { useSceneState } from './use-scene-state';
 
 export type * from './types';

--- a/projects/lib-game-rendering/src/index.ts
+++ b/projects/lib-game-rendering/src/index.ts
@@ -1,8 +1,10 @@
+export { GameCanvas } from './game-canvas';
 export { isSceneSwap } from './is-scene-swap';
 export { presentationToFrameloop } from './presentation-to-frameloop';
 export { registerGameLoopCallback } from './register-game-loop-callback';
 export { resolveSceneState } from './resolve-scene-state';
 export { setSceneState } from './set-scene-state';
+export { useRenderer } from './use-renderer';
 export { useSceneState } from './use-scene-state';
 
 export type * from './types';

--- a/projects/lib-game-rendering/src/index.ts
+++ b/projects/lib-game-rendering/src/index.ts
@@ -1,8 +1,10 @@
+export { createTunnel } from './create-tunnel';
 export { GameCanvas } from './game-canvas';
 export { isSceneSwap } from './is-scene-swap';
 export { presentationToFrameloop } from './presentation-to-frameloop';
 export { registerGameLoopCallback } from './register-game-loop-callback';
 export { resolveSceneState } from './resolve-scene-state';
+export { sceneTunnel } from './scene-tunnel';
 export { setSceneState } from './set-scene-state';
 export { useRenderer } from './use-renderer';
 export { useSceneState } from './use-scene-state';

--- a/projects/lib-game-rendering/src/index.ts
+++ b/projects/lib-game-rendering/src/index.ts
@@ -1,5 +1,6 @@
 export { isSceneSwap } from './is-scene-swap';
 export { presentationToFrameloop } from './presentation-to-frameloop';
+export { registerGameLoopCallback } from './register-game-loop-callback';
 export { resolveSceneState } from './resolve-scene-state';
 export { setSceneState } from './set-scene-state';
 export { useSceneState } from './use-scene-state';

--- a/projects/lib-game-rendering/src/presentation-to-frameloop.test.ts
+++ b/projects/lib-game-rendering/src/presentation-to-frameloop.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from 'bun:test';
+import { presentationToFrameloop } from './presentation-to-frameloop';
+
+test('it stops the frameloop for a hidden presentation', () => {
+  expect(presentationToFrameloop('hidden')).toBe('never');
+});
+
+test('it keeps the frameloop always-on for a focus presentation', () => {
+  expect(presentationToFrameloop('focus')).toBe('always');
+});
+
+test('it keeps the frameloop always-on for an ambient presentation', () => {
+  expect(presentationToFrameloop('ambient')).toBe('always');
+});

--- a/projects/lib-game-rendering/src/presentation-to-frameloop.ts
+++ b/projects/lib-game-rendering/src/presentation-to-frameloop.ts
@@ -1,0 +1,9 @@
+import type { Presentation } from './types';
+
+/**
+ * Maps scene presentation to the canvas's frameloop mode: a hidden scene suspends rendering
+ * entirely (zero GPU cost off-screen), while focus and ambient scenes render every frame.
+ */
+export function presentationToFrameloop(presentation: Presentation): 'always' | 'never' {
+  return presentation === 'hidden' ? 'never' : 'always';
+}

--- a/projects/lib-game-rendering/src/register-game-loop-callback.ts
+++ b/projects/lib-game-rendering/src/register-game-loop-callback.ts
@@ -1,0 +1,11 @@
+import { gameLoop } from './game-loop';
+import type { GameLoopCallback } from './types';
+
+/**
+ * Registers `handler` to run every driven frame, in registration order, until the returned
+ * function is called. Frames are driven only by the canvas's game-loop driver, so this never
+ * fires while the scene's frameloop is `never`.
+ */
+export function registerGameLoopCallback(handler: GameLoopCallback): () => void {
+  return gameLoop.registerGameLoopCallback(handler);
+}

--- a/projects/lib-game-rendering/src/register-satellite.test.ts
+++ b/projects/lib-game-rendering/src/register-satellite.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from 'bun:test';
+import { registerSatellite } from './register-satellite';
+import { useSatelliteStore } from './use-satellite-store';
+
+test('it adds a satellite entry under its id', () => {
+  registerSatellite('avatar', { element: 'viewer', keepAlive: false });
+
+  expect(useSatelliteStore.getState().satellites.get('avatar')).toStrictEqual({
+    element: 'viewer',
+    keepAlive: false,
+  });
+});
+
+test('it replaces an existing entry registered under the same id', () => {
+  registerSatellite('avatar', { element: 'first', keepAlive: false });
+  registerSatellite('avatar', { element: 'second', keepAlive: true });
+
+  expect(useSatelliteStore.getState().satellites.get('avatar')).toStrictEqual({
+    element: 'second',
+    keepAlive: true,
+  });
+});
+
+test('it leaves other entries untouched when registering a new id', () => {
+  registerSatellite('avatar', { element: 'viewer', keepAlive: false });
+  registerSatellite('item', { element: 'inspector', keepAlive: false });
+
+  expect(useSatelliteStore.getState().satellites.get('avatar')).toStrictEqual({
+    element: 'viewer',
+    keepAlive: false,
+  });
+});

--- a/projects/lib-game-rendering/src/register-satellite.ts
+++ b/projects/lib-game-rendering/src/register-satellite.ts
@@ -1,0 +1,12 @@
+import type { SatelliteEntry } from './types';
+import { useSatelliteStore } from './use-satellite-store';
+
+/**
+ * Registers a satellite element under `id`, replacing any existing entry registered under the
+ * same id.
+ */
+export function registerSatellite(id: string, entry: Readonly<SatelliteEntry>): void {
+  useSatelliteStore.setState((state) => ({
+    satellites: new Map(state.satellites).set(id, entry),
+  }));
+}

--- a/projects/lib-game-rendering/src/remove-satellite.test.ts
+++ b/projects/lib-game-rendering/src/remove-satellite.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from 'bun:test';
+import { registerSatellite } from './register-satellite';
+import { removeSatellite } from './remove-satellite';
+import { useSatelliteStore } from './use-satellite-store';
+
+test('it removes a registered satellite entry', () => {
+  registerSatellite('avatar', { element: 'viewer', keepAlive: false });
+
+  removeSatellite('avatar');
+
+  expect(useSatelliteStore.getState().satellites.has('avatar')).toBeFalse();
+});
+
+test('it leaves other entries untouched', () => {
+  registerSatellite('avatar', { element: 'viewer', keepAlive: false });
+  registerSatellite('item', { element: 'inspector', keepAlive: false });
+
+  removeSatellite('avatar');
+
+  expect(useSatelliteStore.getState().satellites.has('item')).toBeTrue();
+});
+
+test('it does nothing when the id was never registered', () => {
+  expect(() => {
+    removeSatellite('missing');
+  }).not.toThrow();
+});

--- a/projects/lib-game-rendering/src/remove-satellite.ts
+++ b/projects/lib-game-rendering/src/remove-satellite.ts
@@ -1,0 +1,18 @@
+import { useSatelliteStore } from './use-satellite-store';
+
+/**
+ * Removes the satellite entry registered under `id`, if one exists.
+ */
+export function removeSatellite(id: string): void {
+  useSatelliteStore.setState((state) => {
+    if (!state.satellites.has(id)) {
+      return state;
+    }
+
+    const satellites = new Map(state.satellites);
+
+    satellites.delete(id);
+
+    return { satellites };
+  });
+}

--- a/projects/lib-game-rendering/src/satellite-host.test.tsx
+++ b/projects/lib-game-rendering/src/satellite-host.test.tsx
@@ -1,0 +1,20 @@
+import { expect, test } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import { registerSatellite } from './register-satellite';
+import { SatelliteHost } from './satellite-host';
+
+test('it renders nothing when no satellites are registered', () => {
+  const rendered = render(<SatelliteHost />);
+
+  expect(rendered.container).toBeEmptyDOMElement();
+});
+
+test('it renders every registered satellite element', () => {
+  registerSatellite('avatar', { element: <span>avatar viewer</span>, keepAlive: false });
+  registerSatellite('item', { element: <span>item inspector</span>, keepAlive: false });
+
+  render(<SatelliteHost />);
+
+  expect(screen.getByText('avatar viewer')).toBeInTheDocument();
+  expect(screen.getByText('item inspector')).toBeInTheDocument();
+});

--- a/projects/lib-game-rendering/src/satellite-host.tsx
+++ b/projects/lib-game-rendering/src/satellite-host.tsx
@@ -1,0 +1,18 @@
+import { Fragment } from 'react';
+import type { ReactNode } from 'react';
+import { useSatelliteStore } from './use-satellite-store';
+
+/**
+ * Renders every currently registered satellite element, keyed by its registration id.
+ */
+export function SatelliteHost(): ReactNode {
+  const satellites = useSatelliteStore((state) => state.satellites);
+
+  if (satellites.size === 0) {
+    return null;
+  }
+
+  return [...satellites.entries()].map(([id, entry]) => (
+    <Fragment key={id}>{entry.element}</Fragment>
+  ));
+}

--- a/projects/lib-game-rendering/src/scene-tunnel.ts
+++ b/projects/lib-game-rendering/src/scene-tunnel.ts
@@ -1,0 +1,7 @@
+import { createTunnel } from './create-tunnel';
+
+/**
+ * The sanctioned scene → DOM channel: scene code renders into `sceneTunnel.In`, and the game
+ * layout renders `sceneTunnel.Out` wherever that content belongs in the DOM tree.
+ */
+export const sceneTunnel = createTunnel();

--- a/projects/lib-game-rendering/src/types.ts
+++ b/projects/lib-game-rendering/src/types.ts
@@ -11,3 +11,5 @@ export interface SceneState {
   readonly presentation: Presentation;
   readonly scene: SceneKey;
 }
+
+export type GameLoopCallback = (delta: number, elapsed: number) => void;

--- a/projects/lib-game-rendering/src/types.ts
+++ b/projects/lib-game-rendering/src/types.ts
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react';
+
 export type SceneKey = 'respite' | 'worldmap';
 
 export type Presentation = 'ambient' | 'focus' | 'hidden';
@@ -13,3 +15,8 @@ export interface SceneState {
 }
 
 export type GameLoopCallback = (delta: number, elapsed: number) => void;
+
+export interface SatelliteEntry {
+  readonly element: ReactNode;
+  readonly keepAlive: boolean;
+}

--- a/projects/lib-game-rendering/src/use-renderer.ts
+++ b/projects/lib-game-rendering/src/use-renderer.ts
@@ -4,14 +4,14 @@ import type { WebGPURenderer } from 'three/webgpu';
 /**
  * The sanctioned accessor for the active renderer. Scene code reads the renderer through this
  * hook instead of `state.gl` directly: R3F's own types pin `state.gl` to `THREE.WebGLRenderer`,
- * but `GameCanvas` always constructs a `WebGPURenderer` (WebGL is its own internal fallback via
- * `forceWebGL`), so every read needs the same cast — kept here so a renderer swap touches only
- * this one file.
+ * but the persistent canvas always constructs a `WebGPURenderer` (WebGL is its own internal
+ * fallback via `forceWebGL`), so every read needs the same cast — kept here so a renderer swap
+ * touches only this one file.
  */
 export function useRenderer(): WebGPURenderer {
   return useThree(
     (state) =>
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- R3F's state.gl type is pinned to WebGLRenderer; GameCanvas always constructs WebGPURenderer (see game-canvas.tsx)
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- R3F's state.gl type is pinned to WebGLRenderer, but the persistent canvas always constructs a WebGPURenderer
       state.gl as unknown as WebGPURenderer,
   );
 }

--- a/projects/lib-game-rendering/src/use-renderer.ts
+++ b/projects/lib-game-rendering/src/use-renderer.ts
@@ -1,0 +1,17 @@
+import { useThree } from '@react-three/fiber';
+import type { WebGPURenderer } from 'three/webgpu';
+
+/**
+ * The sanctioned accessor for the active renderer. Scene code reads the renderer through this
+ * hook instead of `state.gl` directly: R3F's own types pin `state.gl` to `THREE.WebGLRenderer`,
+ * but `GameCanvas` always constructs a `WebGPURenderer` (WebGL is its own internal fallback via
+ * `forceWebGL`), so every read needs the same cast — kept here so a renderer swap touches only
+ * this one file.
+ */
+export function useRenderer(): WebGPURenderer {
+  return useThree(
+    (state) =>
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- R3F's state.gl type is pinned to WebGLRenderer; GameCanvas always constructs WebGPURenderer (see game-canvas.tsx)
+      state.gl as unknown as WebGPURenderer,
+  );
+}

--- a/projects/lib-game-rendering/src/use-satellite-store.ts
+++ b/projects/lib-game-rendering/src/use-satellite-store.ts
@@ -1,0 +1,10 @@
+import { create } from 'zustand';
+import type { SatelliteEntry } from './types';
+
+interface SatelliteStoreState {
+  readonly satellites: ReadonlyMap<string, SatelliteEntry>;
+}
+
+export const useSatelliteStore = create<SatelliteStoreState>(() => ({
+  satellites: new Map(),
+}));

--- a/projects/lib-game-rendering/src/use-satellite.test.tsx
+++ b/projects/lib-game-rendering/src/use-satellite.test.tsx
@@ -1,0 +1,51 @@
+import { expect, test } from 'bun:test';
+import { render } from '@testing-library/react';
+import { SatelliteHost } from './satellite-host';
+import { useSatellite } from './use-satellite';
+
+interface OwnerProps {
+  readonly keepAlive?: boolean;
+}
+
+function Owner(props: Readonly<OwnerProps>) {
+  useSatellite('viewer', <span>viewer content</span>, props.keepAlive);
+
+  return null;
+}
+
+test('it registers its satellite element while mounted', () => {
+  const rendered = render(
+    <>
+      <Owner />
+      <SatelliteHost />
+    </>,
+  );
+
+  expect(rendered.getByText('viewer content')).toBeInTheDocument();
+});
+
+test('it removes a non-keepAlive satellite when its owner unmounts', () => {
+  const rendered = render(
+    <>
+      <Owner />
+      <SatelliteHost />
+    </>,
+  );
+
+  rendered.rerender(<SatelliteHost />);
+
+  expect(rendered.queryByText('viewer content')).not.toBeInTheDocument();
+});
+
+test('it leaves a keepAlive satellite registered after its owner unmounts', () => {
+  const rendered = render(
+    <>
+      <Owner keepAlive />
+      <SatelliteHost />
+    </>,
+  );
+
+  rendered.rerender(<SatelliteHost />);
+
+  expect(rendered.queryByText('viewer content')).toBeInTheDocument();
+});

--- a/projects/lib-game-rendering/src/use-satellite.ts
+++ b/projects/lib-game-rendering/src/use-satellite.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import type { ReactNode } from 'react';
+import { registerSatellite } from './register-satellite';
+import { removeSatellite } from './remove-satellite';
+
+/**
+ * Registers `element` as a satellite under `id` for the lifetime of the calling component.
+ * `keepAlive` entries survive the owner's unmount until something else calls `removeSatellite`;
+ * non-keepAlive entries (the default) are removed automatically when the owner unmounts.
+ */
+export function useSatellite(id: string, element: ReactNode, keepAlive = false): void {
+  useEffect(() => {
+    registerSatellite(id, { element, keepAlive });
+  });
+
+  useEffect(
+    () => () => {
+      if (!keepAlive) {
+        removeSatellite(id);
+      }
+    },
+    [id, keepAlive],
+  );
+}

--- a/projects/lib-game-rendering/test-setup.ts
+++ b/projects/lib-game-rendering/test-setup.ts
@@ -1,6 +1,7 @@
 import { afterEach, expect, mock } from 'bun:test';
 import { GlobalRegistrator } from '@happy-dom/global-registrator';
 import * as jestDOMMatchers from '@testing-library/jest-dom/matchers';
+import { useSatelliteStore } from './src/use-satellite-store';
 import { useSceneStateStore } from './src/use-scene-state-store';
 
 GlobalRegistrator.register();
@@ -10,11 +11,12 @@ expect.extend(jestDOMMatchers);
 // dynamic import: RTL reads `document` at import time, so it must load after registration
 const reactTestingLibrary = await import('@testing-library/react');
 
-// the store is a module singleton; bun runs every test file in one process with no isolation,
-// so a test that mutates it would otherwise leak into the next file's reads
+// these stores are module singletons; bun runs every test file in one process with no
+// isolation, so a test that mutates one would otherwise leak into the next file's reads
 afterEach(() => {
   reactTestingLibrary.cleanup();
   mock.restore();
 
   useSceneStateStore.setState(useSceneStateStore.getInitialState(), true);
+  useSatelliteStore.setState(useSatelliteStore.getInitialState(), true);
 });


### PR DESCRIPTION
Closes #365

Adds the canvas-shell deliverable to `@vers/game-rendering`: a persistent `GameCanvas` (async WebGPU renderer with WebGL fallback), a game-loop scheduler that owns react-spring's rafz clock, a scene-to-DOM tunnel, and a satellite registry for out-of-canvas mounts.

- `GameCanvas` mounts an r3f `Canvas` with an async WebGPURenderer `gl` callback (forceWebGL fallback), a reactive frameloop from scene-state presentation, and an auto-mounted game-loop driver; SSR-safe
- `presentationToFrameloop` maps scene-state presentation to r3f's frameloop mode
- `createGameLoop`/`gameLoop`/`registerGameLoopCallback`: the driver solely owns rafz's demand-mode clock, calling `raf.advance()`
- `useRenderer` is the sanctioned accessor for `state.gl`
- In-house `createTunnel` In/Out pair plus a shared `sceneTunnel` instance
- Minimal satellite registry (`useSatelliteStore`, `registerSatellite`/`removeSatellite`, `useSatellite`, `SatelliteHost`) with keepAlive semantics
- New deps: three, @react-three/fiber, @react-spring/rafz (10.1.2, matching @react-spring/three)

Canvas/driver carry no unit tests (no WebGL/WebGPU under bun test) — e2e coverage is issue #366.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
