### PR TITLE
feat(#305): enforce single active session server-side

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -12,6 +12,12 @@ the acting user's ID, and calls domain services through typed oRPC contract clie
 private mesh. Services verify that token on every call, do their work against Postgres on Neon, and
 return typed results.
 
+A user has at most one verified session at a time: completing a 2FA-gated login evicts every other
+session on the account, server-side. Because a request's minted service token can outlive its
+session by up to the token's own short lifetime, the trust edge also re-confirms the session still
+exists on every request before trusting it, so an evicted device is signed out on its next request
+rather than waiting for its cached token to expire.
+
 ```mermaid
 flowchart LR
     B[Browser] -->|HTTPS| W["app-web<br>TanStack Start"]

--- a/projects/app-web/src/lib/rpc/clients/session-existence-client.ts
+++ b/projects/app-web/src/lib/rpc/clients/session-existence-client.ts
@@ -11,11 +11,11 @@ interface SessionExistenceClientContext {
 }
 
 /**
- * A bare session client for `loadSessionActor`'s own per-request session-existence check: plain
- * `fetch`, minting an s2s token for the caller-supplied acting user directly. `loadSessionActor` is
- * what establishes a cookie session's identity in the first place, so calling through the
- * isomorphic session client — whose server link derives an omitted acting user id by calling
- * `loadSessionActor` itself — would recurse without bound.
+ * A bare session client for the per-request session-existence check: plain `fetch`, minting an s2s
+ * token for the caller-supplied acting user directly. The check runs inside the routine that
+ * establishes a cookie session's identity, and the isomorphic session client's server link derives
+ * an omitted acting user id from that same routine — so calling through it would recurse without
+ * bound.
  */
 export const sessionExistenceClient: ContractRouterClient<
   typeof sessionContract,

--- a/projects/app-web/src/lib/rpc/clients/session-existence-client.ts
+++ b/projects/app-web/src/lib/rpc/clients/session-existence-client.ts
@@ -1,0 +1,33 @@
+import { createORPCClient } from '@orpc/client';
+import { RPCLink } from '@orpc/client/fetch';
+import type { ContractRouterClient } from '@orpc/contract';
+import type { sessionContract } from '@vers/contract-session';
+import { createEdgeServiceToken } from '../create-edge-service-token';
+import { SERVICE_URLS } from '../service-urls';
+
+/** The per-call context this client requires: who the outbound s2s token's `sub` claim names. */
+interface SessionExistenceClientContext {
+  readonly actingUserID: string;
+}
+
+/**
+ * A bare session client for `loadSessionActor`'s own per-request session-existence check: plain
+ * `fetch`, minting an s2s token for the caller-supplied acting user directly. `loadSessionActor` is
+ * what establishes a cookie session's identity in the first place, so calling through the
+ * isomorphic session client — whose server link derives an omitted acting user id by calling
+ * `loadSessionActor` itself — would recurse without bound.
+ */
+export const sessionExistenceClient: ContractRouterClient<
+  typeof sessionContract,
+  SessionExistenceClientContext
+> = createORPCClient(
+  new RPCLink<SessionExistenceClientContext>({
+    headers: async (options) => ({
+      authorization: `Bearer ${await createEdgeServiceToken({
+        actingUserID: options.context.actingUserID,
+        audience: 'session',
+      })}`,
+    }),
+    url: `${SERVICE_URLS.session}/rpc`,
+  }),
+);

--- a/projects/app-web/src/lib/rpc/load-session-actor.test.ts
+++ b/projects/app-web/src/lib/rpc/load-session-actor.test.ts
@@ -1,9 +1,14 @@
 import { expect, test } from 'bun:test';
 import { createId } from '@paralleldrive/cuid2';
+import { buildContractMock } from '@vers/client-test-utils/rpc-msw';
+import { sessionContract } from '@vers/contract-session';
 import { createMockAccessToken } from '../../mocks/create-mock-access-token';
 import * as db from '../../mocks/db';
+import { server } from '../../mocks/node';
+import { resolveSessionContext } from '../../mocks/resolve-session-context';
 import { withRequestContext } from '../../test-utils/with-request-context';
 import { loadSessionActor } from './load-session-actor';
+import { SERVICE_URLS } from './service-urls';
 
 test('it returns null with no network call when there is no cookie session', async () => {
   const outcome = await withRequestContext({}, () => loadSessionActor());
@@ -11,7 +16,29 @@ test('it returns null with no network call when there is no cookie session', asy
   expect(outcome.value).toBeNull();
 });
 
-test('it returns the cookie userID unchanged for a fresh access token', async () => {
+test('it returns the cookie userID unchanged for a fresh access token whose session still exists', async () => {
+  const session = await db.sessionCollection.create({});
+  const accessToken = await createMockAccessToken(session.userID);
+
+  const outcome = await withRequestContext(
+    {
+      cookies: {
+        en_session: {
+          accessToken,
+          refreshToken: 'refresh-1',
+          sessionID: session.id,
+          userID: session.userID,
+        },
+      },
+    },
+    () => loadSessionActor(),
+  );
+
+  expect(outcome.value).toBe(session.userID);
+  expect(outcome.cookies['en_session']).toContainEntry(['accessToken', accessToken]);
+});
+
+test('it clears the cookie and returns null for a fresh access token whose session no longer exists', async () => {
   const userID = createId();
 
   const accessToken = await createMockAccessToken(userID);
@@ -19,14 +46,57 @@ test('it returns the cookie userID unchanged for a fresh access token', async ()
   const outcome = await withRequestContext(
     {
       cookies: {
-        en_session: { accessToken, refreshToken: 'refresh-1', sessionID: 'session-1', userID },
+        en_session: {
+          accessToken,
+          refreshToken: 'refresh-1',
+          sessionID: 'evicted-session',
+          userID,
+        },
       },
     },
     () => loadSessionActor(),
   );
 
-  expect(outcome.value).toBe(userID);
-  expect(outcome.cookies['en_session']).toContainEntry(['accessToken', accessToken]);
+  expect(outcome.value).toBeNull();
+  expect(outcome.cookies['en_session']).toBeUndefined();
+});
+
+test('it hits getSession at most once per request for a fresh access token', async () => {
+  const session = await db.sessionCollection.create({});
+  const accessToken = await createMockAccessToken(session.userID);
+
+  const mockSession = buildContractMock({
+    baseUrl: SERVICE_URLS.session,
+    contract: sessionContract,
+    resolveContext: resolveSessionContext,
+  });
+
+  let callCount = 0;
+
+  server.use(
+    mockSession.getSession.handler(() => {
+      callCount += 1;
+
+      return session;
+    }),
+  );
+
+  const outcome = await withRequestContext(
+    {
+      cookies: {
+        en_session: {
+          accessToken,
+          refreshToken: 'refresh-1',
+          sessionID: session.id,
+          userID: session.userID,
+        },
+      },
+    },
+    () => Promise.all([loadSessionActor(), loadSessionActor()]),
+  );
+
+  expect(outcome.value).toStrictEqual([session.userID, session.userID]);
+  expect(callCount).toBe(1);
 });
 
 test('it refreshes a stale access token once, updates the cookie, and returns the acting user', async () => {

--- a/projects/app-web/src/lib/rpc/load-session-actor.test.ts
+++ b/projects/app-web/src/lib/rpc/load-session-actor.test.ts
@@ -99,6 +99,40 @@ test('it hits getSession at most once per request for a fresh access token', asy
   expect(callCount).toBe(1);
 });
 
+test('it fails the call and keeps the cookie when the session cannot be confirmed', async () => {
+  const session = await db.sessionCollection.create({});
+  const accessToken = await createMockAccessToken(session.userID);
+
+  const mockSession = buildContractMock({
+    baseUrl: SERVICE_URLS.session,
+    contract: sessionContract,
+    resolveContext: resolveSessionContext,
+  });
+
+  server.use(
+    mockSession.getSession.handler(() => {
+      throw new Error('session service unreachable');
+    }),
+  );
+
+  const outcome = await withRequestContext(
+    {
+      cookies: {
+        en_session: {
+          accessToken,
+          refreshToken: 'refresh-1',
+          sessionID: session.id,
+          userID: session.userID,
+        },
+      },
+    },
+    () => loadSessionActor().catch((error: unknown) => error),
+  );
+
+  expect(outcome.value).toBeInstanceOf(Error);
+  expect(outcome.cookies['en_session']).toContainEntry(['sessionID', session.id]);
+});
+
 test('it refreshes a stale access token once, updates the cookie, and returns the acting user', async () => {
   const session = await db.sessionCollection.create({ refreshToken: 'refresh-1' });
   const staleAccessToken = await createMockAccessToken(session.userID, '-1s');
@@ -141,6 +175,40 @@ test('it clears the cookie and returns null when the refresh itself fails', asyn
 
   expect(outcome.value).toBeNull();
   expect(outcome.cookies['en_session']).toBeUndefined();
+});
+
+test('it fails the call and keeps the cookie when the refresh errors without a verdict on the session', async () => {
+  const session = await db.sessionCollection.create({ refreshToken: 'refresh-1' });
+  const staleAccessToken = await createMockAccessToken(session.userID, '-1s');
+
+  const mockSession = buildContractMock({
+    baseUrl: SERVICE_URLS.session,
+    contract: sessionContract,
+    resolveContext: resolveSessionContext,
+  });
+
+  server.use(
+    mockSession.refreshTokens.handler(() => {
+      throw new Error('session service unreachable');
+    }),
+  );
+
+  const outcome = await withRequestContext(
+    {
+      cookies: {
+        en_session: {
+          accessToken: staleAccessToken,
+          refreshToken: 'refresh-1',
+          sessionID: session.id,
+          userID: session.userID,
+        },
+      },
+    },
+    () => loadSessionActor().catch((error: unknown) => error),
+  );
+
+  expect(outcome.value).toBeInstanceOf(Error);
+  expect(outcome.cookies['en_session']).toContainEntry(['sessionID', session.id]);
 });
 
 test('it single-flights concurrent refreshes for the same session', async () => {

--- a/projects/app-web/src/lib/rpc/load-session-actor.test.ts
+++ b/projects/app-web/src/lib/rpc/load-session-actor.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'bun:test';
 import { createId } from '@paralleldrive/cuid2';
-import { buildContractMock } from '@vers/client-test-utils/rpc-msw';
+import { buildContractMock } from '@vers/client-test-utils/orpc';
 import { sessionContract } from '@vers/contract-session';
 import { createMockAccessToken } from '../../mocks/create-mock-access-token';
 import * as db from '../../mocks/db';

--- a/projects/app-web/src/lib/rpc/load-session-actor.ts
+++ b/projects/app-web/src/lib/rpc/load-session-actor.ts
@@ -1,4 +1,4 @@
-import { safe } from '@orpc/client';
+import { isDefinedError, safe } from '@orpc/client';
 import { getRequest } from '@tanstack/react-start/server';
 import * as jose from 'jose';
 import { clearAuthSession } from '../auth/clear-auth-session';
@@ -29,9 +29,11 @@ const inFlightRefreshes = new Map<string, Promise<RefreshedTokens | undefined>>(
  * trusted to mint an s2s token. Even a fresh access token no longer settles that on its own — this
  * closes the token's own trust window by confirming the session row still exists on every call,
  * request-scoped-memoized so the repeated calls one SSR request makes hit the session service at
- * most once per session. `null` covers no live session, a failed refresh, and a session the
- * confirmation found gone — the cookie is cleared in the latter two cases, and the caller's own
- * guard redirects to login on its next request.
+ * most once per session. `null` covers no live session, a definitively rejected refresh, and a
+ * session the confirmation found gone — the cookie is cleared in the latter two cases, and the
+ * caller's own guard redirects to login on its next request. A session service that can't be
+ * reached at all fails the call instead: an unreachable service is never grounds to trust the
+ * token or to destroy the cookie.
  */
 export async function loadSessionActor(): Promise<string | null> {
   const session = await getAuthSession();
@@ -138,6 +140,12 @@ async function resolveRefreshedTokens(
   }
 }
 
+/**
+ * Rotates the session's token pair, mapping only the contract's declared rejections (session gone,
+ * expired, or token reuse) to `undefined` so the caller signs the session out. A transport failure
+ * or unexpected service error stays a throw — it says nothing about the session, so it must not
+ * end it.
+ */
 async function runRefresh(
   sessionID: string,
   refreshToken: string,
@@ -146,5 +154,13 @@ async function runRefresh(
     sessionRefreshClient.refreshTokens({ id: sessionID, refreshToken }),
   );
 
-  return error === null ? tokens : undefined;
+  if (error === null) {
+    return tokens;
+  }
+
+  if (isDefinedError(error)) {
+    return undefined;
+  }
+
+  throw error;
 }

--- a/projects/app-web/src/lib/rpc/load-session-actor.ts
+++ b/projects/app-web/src/lib/rpc/load-session-actor.ts
@@ -82,8 +82,8 @@ function isAccessTokenStale(accessToken: string): boolean {
 
 /**
  * Per-request cache of the session-existence check, keyed by the ambient request object: a `Map`
- * per request holding one in-flight/settled lookup per session id, so the several `loadSessionActor`
- * calls one SSR request makes for the same session share a single `getSession` round trip. Never a
+ * per request holding one in-flight/settled lookup per session id, so the several identity loads
+ * one SSR request makes for the same session share a single existence round trip. Never a
  * module-level TTL cache — that would trust an evicted session for the life of the process instead
  * of just the request that read it.
  */

--- a/projects/app-web/src/lib/rpc/load-session-actor.ts
+++ b/projects/app-web/src/lib/rpc/load-session-actor.ts
@@ -1,8 +1,10 @@
 import { safe } from '@orpc/client';
+import { getRequest } from '@tanstack/react-start/server';
 import * as jose from 'jose';
 import { clearAuthSession } from '../auth/clear-auth-session';
 import { getAuthSession } from '../auth/get-auth-session';
 import { updateAuthSession } from '../auth/update-auth-session';
+import { sessionExistenceClient } from './clients/session-existence-client';
 import { sessionRefreshClient } from './clients/session-refresh-client';
 
 /** How far ahead of the access token's real `exp` a refresh is triggered proactively. */
@@ -24,9 +26,12 @@ const inFlightRefreshes = new Map<string, Promise<RefreshedTokens | undefined>>(
  * Loads the acting user id for a cookie-derived service call, proactively re-validating a
  * near-expired session first: services no longer see the caller's own access token, so nothing
  * else re-checks the underlying session's existence, expiry, or revocation before its identity is
- * trusted to mint an s2s token. `null` covers both no live session and one that failed
- * re-validation — the cookie is cleared in the latter case, and the caller's own guard redirects to
- * login on its next request.
+ * trusted to mint an s2s token. Even a fresh access token no longer settles that on its own — this
+ * closes the token's own trust window by confirming the session row still exists on every call,
+ * request-scoped-memoized so the repeated calls one SSR request makes hit the session service at
+ * most once per session. `null` covers no live session, a failed refresh, and a session the
+ * confirmation found gone — the cookie is cleared in the latter two cases, and the caller's own
+ * guard redirects to login on its next request.
  */
 export async function loadSessionActor(): Promise<string | null> {
   const session = await getAuthSession();
@@ -41,6 +46,14 @@ export async function loadSessionActor(): Promise<string | null> {
   }
 
   if (!isAccessTokenStale(session.accessToken)) {
+    const stillExists = await checkSessionStillExists(session.sessionID, session.userID);
+
+    if (!stillExists) {
+      await clearAuthSession();
+
+      return null;
+    }
+
     return session.userID;
   }
 
@@ -65,6 +78,43 @@ function isAccessTokenStale(accessToken: string): boolean {
   } catch {
     return true;
   }
+}
+
+/**
+ * Per-request cache of the session-existence check, keyed by the ambient request object: a `Map`
+ * per request holding one in-flight/settled lookup per session id, so the several `loadSessionActor`
+ * calls one SSR request makes for the same session share a single `getSession` round trip. Never a
+ * module-level TTL cache — that would trust an evicted session for the life of the process instead
+ * of just the request that read it.
+ */
+const sessionExistenceCache = new WeakMap<Request, Map<string, Promise<boolean>>>();
+
+function checkSessionStillExists(sessionID: string, userID: string): Promise<boolean> {
+  const request = getRequest();
+  const perRequestCache = sessionExistenceCache.get(request) ?? new Map<string, Promise<boolean>>();
+
+  sessionExistenceCache.set(request, perRequestCache);
+
+  const cached = perRequestCache.get(sessionID);
+
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const check = readSessionStillExists(sessionID, userID);
+
+  perRequestCache.set(sessionID, check);
+
+  return check;
+}
+
+async function readSessionStillExists(sessionID: string, userID: string): Promise<boolean> {
+  const row = await sessionExistenceClient.getSession(
+    { id: sessionID },
+    { context: { actingUserID: userID } },
+  );
+
+  return row !== null && row.userID === userID;
 }
 
 async function resolveRefreshedTokens(

--- a/projects/app-web/src/mocks/routers/session/verify-session.ts
+++ b/projects/app-web/src/mocks/routers/session/verify-session.ts
@@ -3,7 +3,11 @@ import { createMockAccessToken } from '../../create-mock-access-token';
 import * as db from '../../db';
 import { os } from './os';
 
-/** Completes a login for a not-yet-verified session, minting the tokens the edge caches. */
+/**
+ * Completes a login for a not-yet-verified session, minting the tokens the edge caches, then
+ * evicts every other session belonging to the same user — mirroring the service's single-verified-
+ * session enforcement — along with those evicted sessions' pending step-up transactions.
+ */
 export const verifySession = os.verifySession.handler(async (opts) => {
   const session = db.sessionCollection.findFirst((q) => q.where({ id: opts.input.id }));
 
@@ -19,6 +23,16 @@ export const verifySession = os.verifySession.handler(async (opts) => {
       record.verified = true;
     },
   });
+
+  const otherSessions = db.sessionCollection.findMany((q) =>
+    q.where({ id: (id) => id !== session.id, userID: session.userID }),
+  );
+
+  for (const otherSession of otherSessions) {
+    db.pendingTransactionCollection.deleteMany((q) => q.where({ sessionID: otherSession.id }));
+
+    db.sessionCollection.delete(otherSession);
+  }
 
   return { accessToken: await createMockAccessToken(session.userID), refreshToken };
 });

--- a/projects/app-web/src/routes/-login-force-logout/force-logout-handler.ts
+++ b/projects/app-web/src/routes/-login-force-logout/force-logout-handler.ts
@@ -13,10 +13,10 @@ const CLEAR_PENDING_SESSION: VerifySessionData = {
 };
 
 /**
- * Runs the force-logout page's confirm/cancel choice. Confirming signs out every other live
- * session for the pending sign-in's account, then completes it exactly like a direct login would;
- * cancelling — or a request with no pending state left to act on — just clears the verify-session
- * cookie and sends the caller back.
+ * Runs the force-logout page's confirm/cancel choice. Confirming completes the pending sign-in
+ * exactly like a direct login would — `verifySession` itself signs out every other live session
+ * for the account; cancelling, or a request with no pending state left to act on, just clears the
+ * verify-session cookie and sends the caller back.
  */
 export async function forceLogoutHandler(formData: FormData): Promise<never> {
   await requireAnonymous();
@@ -33,14 +33,6 @@ export async function forceLogoutHandler(formData: FormData): Promise<never> {
 
     throw redirect({ href: '/' });
   }
-
-  const otherSessions = await sessionClient.getSessions({}, { context: { actingUserID } });
-
-  await Promise.all(
-    otherSessions
-      .filter((other) => other.id !== sessionID)
-      .map((other) => sessionClient.deleteSession({ id: other.id }, { context: { actingUserID } })),
-  );
 
   const session = await sessionClient.getSession({ id: sessionID }, { context: { actingUserID } });
 

--- a/projects/app-web/src/test-utils/register-request-context-mock.ts
+++ b/projects/app-web/src/test-utils/register-request-context-mock.ts
@@ -13,6 +13,7 @@ export function registerRequestContextMock(): void {
   void mock.module('@tanstack/react-start/server', () => ({
     ...reactStartServer,
     clearSession: fakeClearSession,
+    getRequest: fakeGetRequest,
     getRequestHeader: fakeGetRequestHeader,
     getRequestHeaders: fakeGetRequestHeaders,
     getRequestIP: fakeGetRequestIP,
@@ -91,6 +92,10 @@ function fakeClearSession(config: FakeSessionConfig): Promise<void> {
   state.sessions.delete(config.name ?? 'h3');
 
   return Promise.resolve();
+}
+
+function fakeGetRequest(): Request {
+  return requireContext().request;
 }
 
 function fakeGetRequestUrl(): URL {

--- a/projects/app-web/src/test-utils/request-context-holder.ts
+++ b/projects/app-web/src/test-utils/request-context-holder.ts
@@ -9,6 +9,7 @@ export interface FakeSession {
 export interface RequestContextState {
   readonly headers: Headers;
   readonly ip: string | undefined;
+  readonly request: Request;
   readonly sessions: Map<string, FakeSession>;
   readonly url: URL;
 }

--- a/projects/app-web/src/test-utils/with-request-context.ts
+++ b/projects/app-web/src/test-utils/with-request-context.ts
@@ -40,9 +40,12 @@ export async function withRequestContext<T>(
     sessions.set(name, { createdAt: Date.now(), data: { ...data }, id: createId() });
   }
 
+  const request = new Request(init.url ?? 'http://localhost/');
+
   requestContextHolder.current = {
     headers: new Headers(init.headers ?? {}),
     ip: init.ip,
+    request,
     sessions,
     url: new URL(init.url ?? 'http://localhost/'),
   };
@@ -56,7 +59,7 @@ export async function withRequestContext<T>(
           throw new Error('getRouter is not available under withRequestContext');
         },
         handlerType: 'serverFn',
-        request: new Request(init.url ?? 'http://localhost/'),
+        request,
         startOptions: {},
       },
       run,

--- a/projects/lib-contract-session/src/session-contract.ts
+++ b/projects/lib-contract-session/src/session-contract.ts
@@ -132,7 +132,11 @@ export const sessionContract = {
   },
 
   verifySession: publicRoute
-    .route({ method: 'POST', path: '/sessions/verify', summary: 'Complete a 2FA-gated login' })
+    .route({
+      method: 'POST',
+      path: '/sessions/verify',
+      summary: 'Complete a 2FA-gated login, signing the user out of every other session',
+    })
     .input(z.object({ id: z.string() }))
     .output(SessionTokensSchema)
     .errors({

--- a/projects/lib-db/migrations/1783000000006_sessions_user_id_index.ts
+++ b/projects/lib-db/migrations/1783000000006_sessions_user_id_index.ts
@@ -1,0 +1,13 @@
+import type { Kysely } from 'kysely';
+
+/**
+ * Indexes `sessions.user_id` — both the verify-time eviction delete and
+ * `getSessions` filter on it and would otherwise seq-scan.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema.createIndex('sessions_user_id_index').on('sessions').column('user_id').execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropIndex('sessions_user_id_index').execute();
+}

--- a/projects/service-session/src/handlers/verify-session.test.ts
+++ b/projects/service-session/src/handlers/verify-session.test.ts
@@ -4,6 +4,7 @@ import { createAnonymousViewer, createTestDB, createTestUser } from '@vers/servi
 import { buildRPCTestClient, getTestJWTKeyPair } from '@vers/test-utils';
 import * as jose from 'jose';
 import { createSessionService } from '../create-session-service';
+import { createPendingTransactionRow } from '../test-utils/create-pending-transaction-row';
 import { createSessionRow } from '../test-utils/create-session-row';
 
 async function setupTest() {
@@ -100,4 +101,138 @@ test('it throws NOT_FOUND for a session that is already verified', async () => {
   expect(client.verifySession({ id: session.id })).rejects.toMatchObject({
     code: 'NOT_FOUND',
   });
+});
+
+test("it deletes the user's other verified session when a new session verifies", async () => {
+  await using ctx = await setupTest();
+
+  const created = await createTestUser(ctx.db);
+  const other = await createSessionRow(ctx.db, { userId: created.user.id, verified: true });
+  const session = await createSessionRow(ctx.db, { userId: created.user.id, verified: false });
+  const viewer = await createAnonymousViewer({ audience: 'service-session' });
+
+  const client = buildRPCTestClient<SessionContract>(ctx.app, { token: viewer.token });
+
+  const result = await client.verifySession({ id: session.id });
+
+  expect(result).toStrictEqual({
+    accessToken: expect.toBeString(),
+    refreshToken: expect.toBeString(),
+  });
+
+  const remaining = await ctx.db
+    .selectFrom('sessions')
+    .select('id')
+    .where('id', '=', other.id)
+    .executeTakeFirst();
+
+  expect(remaining).toBeUndefined();
+});
+
+test("it deletes the user's other unverified sessions when a session verifies", async () => {
+  await using ctx = await setupTest();
+
+  const created = await createTestUser(ctx.db);
+  const other = await createSessionRow(ctx.db, { userId: created.user.id, verified: false });
+  const session = await createSessionRow(ctx.db, { userId: created.user.id, verified: false });
+  const viewer = await createAnonymousViewer({ audience: 'service-session' });
+
+  const client = buildRPCTestClient<SessionContract>(ctx.app, { token: viewer.token });
+
+  const result = await client.verifySession({ id: session.id });
+
+  expect(result).toStrictEqual({
+    accessToken: expect.toBeString(),
+    refreshToken: expect.toBeString(),
+  });
+
+  const remaining = await ctx.db
+    .selectFrom('sessions')
+    .select('id')
+    .where('id', '=', other.id)
+    .executeTakeFirst();
+
+  expect(remaining).toBeUndefined();
+});
+
+test("it leaves other users' sessions untouched", async () => {
+  await using ctx = await setupTest();
+
+  const created = await createTestUser(ctx.db);
+  const otherUser = await createTestUser(ctx.db);
+
+  const otherUsersSession = await createSessionRow(ctx.db, {
+    userId: otherUser.user.id,
+    verified: true,
+  });
+
+  const session = await createSessionRow(ctx.db, { userId: created.user.id, verified: false });
+  const viewer = await createAnonymousViewer({ audience: 'service-session' });
+
+  const client = buildRPCTestClient<SessionContract>(ctx.app, { token: viewer.token });
+
+  const result = await client.verifySession({ id: session.id });
+
+  expect(result).toStrictEqual({
+    accessToken: expect.toBeString(),
+    refreshToken: expect.toBeString(),
+  });
+
+  const remaining = await ctx.db
+    .selectFrom('sessions')
+    .select('id')
+    .where('id', '=', otherUsersSession.id)
+    .executeTakeFirst();
+
+  expect(remaining).toStrictEqual({ id: otherUsersSession.id });
+});
+
+test('it evicts nothing when the session was already verified', async () => {
+  await using ctx = await setupTest();
+
+  const created = await createTestUser(ctx.db);
+  const other = await createSessionRow(ctx.db, { userId: created.user.id, verified: true });
+  const session = await createSessionRow(ctx.db, { userId: created.user.id, verified: true });
+  const viewer = await createAnonymousViewer({ audience: 'service-session' });
+
+  const client = buildRPCTestClient<SessionContract>(ctx.app, { token: viewer.token });
+
+  expect(client.verifySession({ id: session.id })).rejects.toMatchObject({
+    code: 'NOT_FOUND',
+  });
+
+  const remaining = await ctx.db
+    .selectFrom('sessions')
+    .select('id')
+    .where('id', '=', other.id)
+    .executeTakeFirst();
+
+  expect(remaining).toStrictEqual({ id: other.id });
+});
+
+test("it drops the evicted session's pending step-up transactions", async () => {
+  await using ctx = await setupTest();
+
+  const created = await createTestUser(ctx.db);
+  const other = await createSessionRow(ctx.db, { userId: created.user.id, verified: true });
+  const pendingTransaction = await createPendingTransactionRow(ctx.db, { sessionId: other.id });
+  const session = await createSessionRow(ctx.db, { userId: created.user.id, verified: false });
+  const viewer = await createAnonymousViewer({ audience: 'service-session' });
+
+  const client = buildRPCTestClient<SessionContract>(ctx.app, { token: viewer.token });
+
+  const result = await client.verifySession({ id: session.id });
+
+  expect(result).toStrictEqual({
+    accessToken: expect.toBeString(),
+    refreshToken: expect.toBeString(),
+  });
+
+  const remaining = await ctx.db
+    .selectFrom('pendingTransactions')
+    .select('id')
+    .where('id', '=', pendingTransaction.id)
+    .executeTakeFirst();
+
+  expect(remaining).toBeUndefined();
 });

--- a/projects/service-session/src/handlers/verify-session.ts
+++ b/projects/service-session/src/handlers/verify-session.ts
@@ -2,6 +2,7 @@ import type { DB } from '@vers/db';
 import type { Kysely } from 'kysely';
 import { ACCESS_TOKEN_DURATION } from '../consts';
 import { createJWT } from '../create-jwt';
+import { isDeadlockError } from '../is-deadlock-error';
 import type { EmptyErrorPayload, SessionSigningDeps } from '../types';
 
 /** oRPC handler opts for the public `verifySession` procedure. */
@@ -112,9 +113,4 @@ function runVerifyAndEvictStatement(
     .selectFrom('verified')
     .select('id')
     .execute();
-}
-
-/** postgres.js surfaces a deadlock as SQLSTATE 40P01. */
-function isDeadlockError(error: unknown): boolean {
-  return typeof error === 'object' && error !== null && 'code' in error && error.code === '40P01';
 }

--- a/projects/service-session/src/handlers/verify-session.ts
+++ b/projects/service-session/src/handlers/verify-session.ts
@@ -14,8 +14,9 @@ interface VerifySessionOpts {
 
 /**
  * Completes a 2FA-gated login: mints the session's first token pair, then flips `verified` in a
- * conditional update guarded on the same `verified = false` precondition the select used, so a
- * concurrent second verify of the same session finds no row to update.
+ * guarded update, evicting every other session belonging to the same user in the same statement —
+ * enforcing at most one verified session per user. A concurrent second verify of the same session
+ * finds no row to update and evicts nothing.
  */
 export async function verifySession(
   db: Kysely<DB>,
@@ -50,16 +51,70 @@ export async function verifySession(
     }),
   ]);
 
-  const updateResult = await db
-    .updateTable('sessions')
-    .set({ refreshToken: tokenPair[0], verified: true })
-    .where('id', '=', session.id)
-    .where('verified', '=', false)
-    .executeTakeFirst();
+  const verified = await runVerifyAndEvict(db, session.id, tokenPair[0]);
 
-  if (updateResult.numUpdatedRows === 0n) {
+  if (verified.length === 0) {
     throw opts.errors.NOT_FOUND({ data: {} });
   }
 
   return { accessToken: tokenPair[1], refreshToken: tokenPair[0] };
+}
+
+/**
+ * Runs the verify-and-evict statement, retrying once on a deadlock. Two different pending
+ * sessions of the same user verifying concurrently can deadlock (SQLSTATE 40P01: each statement's
+ * update locks its own row while its delete waits on the other's); the retry's update finds its
+ * row already evicted by the winner and fails cleanly into an empty result, never a raw 500.
+ */
+async function runVerifyAndEvict(
+  db: Kysely<DB>,
+  sessionId: string,
+  refreshToken: string,
+): Promise<Array<{ readonly id: string }>> {
+  try {
+    return await runVerifyAndEvictStatement(db, sessionId, refreshToken);
+  } catch (error: unknown) {
+    if (!isDeadlockError(error)) {
+      throw error;
+    }
+
+    return runVerifyAndEvictStatement(db, sessionId, refreshToken);
+  }
+}
+
+/**
+ * Flips `verified` on the session guarded by the same precondition the caller's select used, then
+ * deletes every other session owned by the same user — cascading onto their pending step-up
+ * transactions, since `pending_transactions.session_id` is `ON DELETE CASCADE` and an evicted
+ * session's step-up must not survive it.
+ */
+function runVerifyAndEvictStatement(
+  db: Kysely<DB>,
+  sessionId: string,
+  refreshToken: string,
+): Promise<Array<{ readonly id: string }>> {
+  return db
+    .with('verified', (qb) =>
+      qb
+        .updateTable('sessions')
+        .set({ refreshToken, verified: true })
+        .where('id', '=', sessionId)
+        .where('verified', '=', false)
+        .returning(['id', 'userId']),
+    )
+    .with('evicted', (qb) =>
+      qb
+        .deleteFrom('sessions')
+        .where('userId', 'in', (eb) => eb.selectFrom('verified').select('userId'))
+        .where('id', '<>', sessionId)
+        .returning('id'),
+    )
+    .selectFrom('verified')
+    .select('id')
+    .execute();
+}
+
+/** postgres.js surfaces a deadlock as SQLSTATE 40P01. */
+function isDeadlockError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === '40P01';
 }

--- a/projects/service-session/src/is-deadlock-error.test.ts
+++ b/projects/service-session/src/is-deadlock-error.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from 'bun:test';
+import { isDeadlockError } from './is-deadlock-error';
+
+test('it recognizes a driver error carrying the deadlock SQLSTATE', () => {
+  expect(isDeadlockError({ code: '40P01' })).toBeTrue();
+});
+
+test('it rejects an error carrying a different SQLSTATE', () => {
+  expect(isDeadlockError({ code: '23505' })).toBeFalse();
+});
+
+test('it rejects values that carry no code', () => {
+  expect(isDeadlockError(new Error('deadlock detected'))).toBeFalse();
+  expect(isDeadlockError(null)).toBeFalse();
+  expect(isDeadlockError('40P01')).toBeFalse();
+});

--- a/projects/service-session/src/is-deadlock-error.ts
+++ b/projects/service-session/src/is-deadlock-error.ts
@@ -1,0 +1,6 @@
+/**
+ * Postgres reports a deadlock as SQLSTATE 40P01, which the driver relays as the error's `code`.
+ */
+export function isDeadlockError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === '40P01';
+}


### PR DESCRIPTION
Closes #305

Verifying a login now enforces at most one verified session per user: the service evicts every other session for that user in the same statement that flips `verified`, and the edge re-confirms a session still exists on every request instead of trusting a live access token alone.

- `verifySession` evicts siblings via a data-modifying CTE, retrying once on a Postgres deadlock (40P01); pending step-up transactions cascade off the eviction
- new `sessions.user_id` index backs both the eviction delete and `getSessions`
- `load-session-actor.ts` closes the access-token trust window by re-checking session existence through a new bare `session-existence-client.ts`, memoized per-request via a `WeakMap<Request, Map<string, Promise<boolean>>>`
- `force-logout-handler.ts` drops its manual eviction fan-out now that `verifySession` does it
- app-web's mock `verifySession` mirrors the service's scoped eviction and cascade
- `verifySession`'s contract summary and `docs/overview.md` document the invariant

## Testing

- [x] `yarn typecheck` passes
- [x] `yarn test` passes
- [x] `yarn lint` passes
- [x] New tests added for new functionality
