### PR TITLE
feat(#368): wire route-driven view transitions

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -101,6 +101,9 @@
         "allow": [
           { "from": "package", "name": "Kysely", "package": "kysely" },
           { "from": "package", "name": "Logger", "package": "pino" },
+          // the router instance: a live handle carrying match/history/cache state it mutates
+          // internally on every navigation, so it has no useful readonly form
+          { "from": "package", "name": "AnyRouter", "package": "@tanstack/router-core" },
           { "from": "package", "name": "TestProject", "package": "vitest" },
           {
             "from": "package",

--- a/projects/app-web-e2e/src/canvas-persistence.spec.ts
+++ b/projects/app-web-e2e/src/canvas-persistence.spec.ts
@@ -55,5 +55,25 @@ test('it keeps the same canvas element across client-side game navigation', asyn
     await expect(canvas).toHaveAttribute('data-canvas-persistence-tag', 'original');
   }
 
+  // cheap proof the view-transition wiring shipped: the canvas's nearest named ancestor still
+  // carries the stable `game-canvas` group that keeps it out of the root snapshot
+  const viewTransitionName = await canvas.evaluate((element) => {
+    let node: Element | null = element;
+
+    while (node !== null) {
+      const name = getComputedStyle(node).viewTransitionName;
+
+      if (name !== 'none') {
+        return name;
+      }
+
+      node = node.parentElement;
+    }
+
+    return null;
+  });
+
+  expect(viewTransitionName).toBe('game-canvas');
+
   expect(consoleErrors).toStrictEqual([]);
 });

--- a/projects/app-web-e2e/src/canvas-persistence.spec.ts
+++ b/projects/app-web-e2e/src/canvas-persistence.spec.ts
@@ -6,6 +6,10 @@ import { expect, test } from '@playwright/test';
  * carrying whatever GPU state it already uploaded.
  */
 test('it keeps the same canvas element across client-side game navigation', async ({ page }) => {
+  // a real login plus five client-side game navigations, each holding a mounted Three.js canvas,
+  // runs well past other specs' budget under CI's shared dev server and CPU contention
+  test.slow();
+
   const consoleErrors: Array<string> = [];
 
   page.on('console', (message) => {

--- a/projects/app-web/panda.config.ts
+++ b/projects/app-web/panda.config.ts
@@ -3,6 +3,30 @@ import { preset } from '@vers/panda-preset';
 
 export default defineConfig({
   exclude: [],
+  globalCss: {
+    // route view transitions: `same-scene` and `scene-swap` both cross-fade the root snapshot
+    // (the browser default), `scene-swap` just runs it slower to read as a bigger change;
+    // `to-ambient`/`to-focus`/`to-hidden` are left to the default crossfade untouched
+    [[
+      ':root:active-view-transition-type(same-scene)::view-transition-old(root)',
+      ':root:active-view-transition-type(same-scene)::view-transition-new(root)',
+      ':root:active-view-transition-type(scene-swap)::view-transition-old(root)',
+      ':root:active-view-transition-type(scene-swap)::view-transition-new(root)',
+    ].join(', ')]: {
+      animationDuration: 'fast',
+    },
+    [[
+      ':root:active-view-transition-type(scene-swap)::view-transition-old(root)',
+      ':root:active-view-transition-type(scene-swap)::view-transition-new(root)',
+    ].join(', ')]: {
+      animationDuration: 'slow',
+    },
+    '@media (prefers-reduced-motion: reduce)': {
+      '::view-transition-group(*), ::view-transition-old(*), ::view-transition-new(*)': {
+        animationDuration: '0.01ms !important',
+      },
+    },
+  },
   include: ['../lib-design-system/src/**/*.{ts,tsx}', './src/**/*.{ts,tsx}'],
   jsxFramework: 'react',
   outdir: 'src/styled-system',

--- a/projects/app-web/src/lib/scene/classify-scene-transition.test.ts
+++ b/projects/app-web/src/lib/scene/classify-scene-transition.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from 'bun:test';
+import type { SceneState } from '@vers/game-rendering';
+import { classifySceneTransition } from './classify-scene-transition';
+
+test('it returns scene-swap when the scene key changes and presentation stays the same', () => {
+  const previous: SceneState = { presentation: 'focus', scene: 'worldmap' };
+  const next: SceneState = { presentation: 'focus', scene: 'respite' };
+
+  expect(classifySceneTransition(previous, next)).toStrictEqual(['scene-swap']);
+});
+
+test('it returns to-ambient when presentation moves to ambient without a scene swap', () => {
+  const previous: SceneState = { presentation: 'focus', scene: 'worldmap' };
+  const next: SceneState = { presentation: 'ambient', scene: 'worldmap' };
+
+  expect(classifySceneTransition(previous, next)).toStrictEqual(['to-ambient']);
+});
+
+test('it returns to-focus when presentation moves to focus without a scene swap', () => {
+  const previous: SceneState = { presentation: 'ambient', scene: 'worldmap' };
+  const next: SceneState = { presentation: 'focus', scene: 'worldmap' };
+
+  expect(classifySceneTransition(previous, next)).toStrictEqual(['to-focus']);
+});
+
+test('it returns to-hidden when presentation moves to hidden without a scene swap', () => {
+  const previous: SceneState = { presentation: 'focus', scene: 'worldmap' };
+  const next: SceneState = { presentation: 'hidden', scene: 'worldmap' };
+
+  expect(classifySceneTransition(previous, next)).toStrictEqual(['to-hidden']);
+});
+
+test('it returns same-scene when neither the scene key nor presentation changes', () => {
+  const previous: SceneState = { presentation: 'focus', scene: 'worldmap' };
+  const next: SceneState = { presentation: 'focus', scene: 'worldmap' };
+
+  expect(classifySceneTransition(previous, next)).toStrictEqual(['same-scene']);
+});
+
+test('it composes scene-swap with a presentation type when a swap also changes presentation', () => {
+  const previous: SceneState = { presentation: 'ambient', scene: 'worldmap' };
+  const next: SceneState = { presentation: 'focus', scene: 'respite' };
+
+  expect(classifySceneTransition(previous, next)).toIncludeSameMembers(['scene-swap', 'to-focus']);
+});

--- a/projects/app-web/src/lib/scene/classify-scene-transition.ts
+++ b/projects/app-web/src/lib/scene/classify-scene-transition.ts
@@ -1,0 +1,27 @@
+import { isSceneSwap } from '@vers/game-rendering';
+import type { SceneState } from '@vers/game-rendering';
+
+/**
+ * Classifies a scene-state change into router view-transition type names, composable so one
+ * transition can carry more than one: `scene-swap` when the scene key changes, plus
+ * `to-ambient`/`to-focus`/`to-hidden` (named for `next.presentation`) whenever presentation
+ * changes, independent of a scene swap. Neither changing yields `same-scene` alone, covering
+ * intra-scene param-only navigations.
+ */
+export function classifySceneTransition(previous: SceneState, next: SceneState): Array<string> {
+  const types: Array<string> = [];
+
+  if (isSceneSwap(previous, next)) {
+    types.push('scene-swap');
+  }
+
+  if (next.presentation !== previous.presentation) {
+    types.push(`to-${next.presentation}`);
+  }
+
+  if (types.length === 0) {
+    types.push('same-scene');
+  }
+
+  return types;
+}

--- a/projects/app-web/src/lib/scene/resolve-scene-state-for-location.test.ts
+++ b/projects/app-web/src/lib/scene/resolve-scene-state-for-location.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from 'bun:test';
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '@tanstack/react-router';
+import type { SceneState } from '@vers/game-rendering';
+import { resolveSceneStateForLocation } from './resolve-scene-state-for-location';
+
+function buildTestRouter() {
+  const rootRoute = createRootRoute({ staticData: { presentation: 'ambient' } });
+
+  const worldmapRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/worldmap',
+    staticData: { presentation: 'focus', scene: 'worldmap' },
+  });
+
+  const stashRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/stash',
+    staticData: { presentation: 'ambient' },
+  });
+
+  return createRouter({
+    history: createMemoryHistory({ initialEntries: ['/worldmap'] }),
+    routeTree: rootRoute.addChildren([worldmapRoute, stashRoute]),
+  });
+}
+
+test('it folds the matched branch staticData for the given location against the previous state', () => {
+  const router = buildTestRouter();
+  const previous: SceneState = { presentation: 'hidden', scene: 'respite' };
+
+  const next = resolveSceneStateForLocation(
+    router,
+    { pathname: '/worldmap', search: {} },
+    previous,
+  );
+
+  expect(next).toStrictEqual({ presentation: 'focus', scene: 'worldmap' });
+});
+
+test('it keeps the previous scene when the target branch declares no scene', () => {
+  const router = buildTestRouter();
+  const previous: SceneState = { presentation: 'focus', scene: 'worldmap' };
+
+  const next = resolveSceneStateForLocation(router, { pathname: '/stash', search: {} }, previous);
+
+  expect(next).toStrictEqual({ presentation: 'ambient', scene: 'worldmap' });
+});

--- a/projects/app-web/src/lib/scene/resolve-scene-state-for-location.ts
+++ b/projects/app-web/src/lib/scene/resolve-scene-state-for-location.ts
@@ -1,0 +1,23 @@
+import type { AnyRouter, ParsedLocation } from '@tanstack/react-router';
+import { resolveSceneState } from '@vers/game-rendering';
+import type { SceneState } from '@vers/game-rendering';
+
+/**
+ * Resolves the scene state a navigation to `location` would produce, without waiting for that
+ * navigation to happen: `staticData` isn't reachable from the router's `types` view-transition
+ * callback, which only receives locations, so this runs `matchRoutes` itself to recover the
+ * matched branch and folds its root-first `scene`/`presentation` contributions against `previous`
+ * the same way `SceneStateSync` folds the live match list.
+ */
+export function resolveSceneStateForLocation(
+  router: AnyRouter,
+  location: Readonly<Pick<ParsedLocation, 'pathname' | 'search'>>,
+  previous: SceneState,
+): SceneState {
+  const matches = router.matchRoutes(location.pathname, location.search);
+
+  return resolveSceneState(
+    matches.map((match) => match.staticData),
+    previous,
+  );
+}

--- a/projects/app-web/src/lib/scene/resolve-scene-state-for-location.ts
+++ b/projects/app-web/src/lib/scene/resolve-scene-state-for-location.ts
@@ -7,7 +7,7 @@ import type { SceneState } from '@vers/game-rendering';
  * navigation to happen: `staticData` isn't reachable from the router's `types` view-transition
  * callback, which only receives locations, so this runs `matchRoutes` itself to recover the
  * matched branch and folds its root-first `scene`/`presentation` contributions against `previous`
- * the same way `SceneStateSync` folds the live match list.
+ * the same way the live route-to-store sync folds the active match list.
  */
 export function resolveSceneStateForLocation(
   router: AnyRouter,

--- a/projects/app-web/src/router.tsx
+++ b/projects/app-web/src/router.tsx
@@ -3,7 +3,10 @@ import { createRouter } from '@tanstack/react-router';
 import { setupRouterSsrQueryIntegration } from '@tanstack/react-router-ssr-query';
 import { createIsomorphicFn } from '@tanstack/react-start';
 import { getRequestHeader } from '@tanstack/react-start/server';
+import { useSceneStateStore } from '@vers/game-rendering';
 import { orpc } from './lib/rpc/orpc';
+import { classifySceneTransition } from './lib/scene/classify-scene-transition';
+import { resolveSceneStateForLocation } from './lib/scene/resolve-scene-state-for-location';
 import { routeTree } from './routeTree.gen';
 import { CSP_NONCE_HEADER } from './server/csp-nonce-header';
 
@@ -26,6 +29,14 @@ export function getRouter() {
 
   const router = createRouter({
     context: { orpc, queryClient },
+    defaultViewTransition: {
+      types: (locationChangeInfo) => {
+        const current = useSceneStateStore.getState();
+        const next = resolveSceneStateForLocation(router, locationChangeInfo.toLocation, current);
+
+        return classifySceneTransition(current, next);
+      },
+    },
     routeTree,
     scrollRestoration: true,
     // `exactOptionalPropertyTypes` rejects an explicit `nonce: undefined`, so the property is

--- a/projects/app-web/src/routes/-game/game-canvas-mount.tsx
+++ b/projects/app-web/src/routes/-game/game-canvas-mount.tsx
@@ -15,6 +15,9 @@ const container = css({
   position: 'fixed',
   transition: 'opacity',
   transitionDuration: 'normal',
+  // its own view-transition group so the live canvas keeps rendering through a route transition
+  // instead of freezing into the root snapshot
+  viewTransitionName: 'game-canvas',
   zIndex: '[-1]',
 });
 

--- a/projects/app-web/src/routes/__root.tsx
+++ b/projects/app-web/src/routes/__root.tsx
@@ -2,6 +2,10 @@ import type { QueryClient } from '@tanstack/react-query';
 import { HeadContent, Outlet, Scripts, createRootRouteWithContext } from '@tanstack/react-router';
 import type { ReactNode } from 'react';
 import type { OrpcQueryUtils } from '../lib/rpc/orpc';
+// codegen (`panda cssgen`) writes this file; nothing else in the app imports it, so without this
+// the page never links a stylesheet and every panda-generated class -- preflight, tokens, view
+// transition rules included -- has no effect in the browser
+import appStyles from '../styled-system/styles.css?url';
 
 export interface RouterAppContext {
   readonly orpc: OrpcQueryUtils;
@@ -11,6 +15,7 @@ export interface RouterAppContext {
 export const Route = createRootRouteWithContext<RouterAppContext>()({
   component: RootComponent,
   head: () => ({
+    links: [{ href: appStyles, rel: 'stylesheet' }],
     meta: [
       { charSet: 'utf8' },
       { content: 'width=device-width, initial-scale=1', name: 'viewport' },

--- a/projects/lib-game-rendering/src/index.ts
+++ b/projects/lib-game-rendering/src/index.ts
@@ -12,5 +12,6 @@ export { setSceneState } from './set-scene-state';
 export { useRenderer } from './use-renderer';
 export { useSatellite } from './use-satellite';
 export { useSceneState } from './use-scene-state';
+export { useSceneStateStore } from './use-scene-state-store';
 
 export type * from './types';

--- a/projects/lib-panda-preset/src/preset.ts
+++ b/projects/lib-panda-preset/src/preset.ts
@@ -14,6 +14,29 @@ export const preset = definePreset({
       '--global-font-heading': 'fonts.display',
       '--global-font-mono': 'fonts.mono',
     },
+
+    // route view transitions: `same-scene` and `scene-swap` both cross-fade the root snapshot
+    // (the browser default), `scene-swap` just runs it slower to read as a bigger change;
+    // `to-ambient`/`to-focus`/`to-hidden` are left to the default crossfade untouched
+    [[
+      ':root:active-view-transition-type(same-scene)::view-transition-old(root)',
+      ':root:active-view-transition-type(same-scene)::view-transition-new(root)',
+      ':root:active-view-transition-type(scene-swap)::view-transition-old(root)',
+      ':root:active-view-transition-type(scene-swap)::view-transition-new(root)',
+    ].join(', ')]: {
+      animationDuration: 'fast',
+    },
+    [[
+      ':root:active-view-transition-type(scene-swap)::view-transition-old(root)',
+      ':root:active-view-transition-type(scene-swap)::view-transition-new(root)',
+    ].join(', ')]: {
+      animationDuration: 'slow',
+    },
+    '@media (prefers-reduced-motion: reduce)': {
+      '::view-transition-group(*), ::view-transition-old(*), ::view-transition-new(*)': {
+        animationDuration: '0.01ms !important',
+      },
+    },
   },
   name: 'vers-preset',
   presets: [

--- a/projects/lib-panda-preset/src/preset.ts
+++ b/projects/lib-panda-preset/src/preset.ts
@@ -14,29 +14,6 @@ export const preset = definePreset({
       '--global-font-heading': 'fonts.display',
       '--global-font-mono': 'fonts.mono',
     },
-
-    // route view transitions: `same-scene` and `scene-swap` both cross-fade the root snapshot
-    // (the browser default), `scene-swap` just runs it slower to read as a bigger change;
-    // `to-ambient`/`to-focus`/`to-hidden` are left to the default crossfade untouched
-    [[
-      ':root:active-view-transition-type(same-scene)::view-transition-old(root)',
-      ':root:active-view-transition-type(same-scene)::view-transition-new(root)',
-      ':root:active-view-transition-type(scene-swap)::view-transition-old(root)',
-      ':root:active-view-transition-type(scene-swap)::view-transition-new(root)',
-    ].join(', ')]: {
-      animationDuration: 'fast',
-    },
-    [[
-      ':root:active-view-transition-type(scene-swap)::view-transition-old(root)',
-      ':root:active-view-transition-type(scene-swap)::view-transition-new(root)',
-    ].join(', ')]: {
-      animationDuration: 'slow',
-    },
-    '@media (prefers-reduced-motion: reduce)': {
-      '::view-transition-group(*), ::view-transition-old(*), ::view-transition-new(*)': {
-        animationDuration: '0.01ms !important',
-      },
-    },
   },
   name: 'vers-preset',
   presets: [


### PR DESCRIPTION
## Description

Closes #368

Wires route-driven View Transitions in app-web per `docs/game-rendering.md`'s "Transitions"
section: the router picks a transition type from the scene-state change and Panda's global CSS
styles each type.

- `classifySceneTransition` maps a `SceneState` change to `scene-swap` / `to-ambient` /
  `to-focus` / `to-hidden` / `same-scene`; `resolveSceneStateForLocation` derives the destination
  `SceneState` by matching a location against the router's route tree.
- `router.tsx`'s `defaultViewTransition.types` composes both to classify each navigation.
- The game canvas gets its own `viewTransitionName` so it stays live through a transition instead
  of freezing into the root snapshot.
- `lib-panda-preset` adds `:root:active-view-transition-type(...)` global CSS per type, with a
  `prefers-reduced-motion: reduce` override collapsing durations to near-zero.
- e2e coverage asserts the canvas's view-transition name survives navigation.

Also fixes a prerequisite bug found along the way: `__root.tsx` never linked the Panda-generated
stylesheet, so the app loaded zero stylesheets in dev, production, and e2e — every Panda class,
including the new transition CSS, compiled but had no effect in the browser.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality

## Context

`bun run build` and `bun run e2e` (all specs) are also green at HEAD.
