### PR TITLE
docs: document ha flag for bugsink first deploy

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -126,8 +126,9 @@ rm s2s.key s2s.pub session.key
 ```
 
 Stand up the error tracker. The first deploy is by hand; CI redeploys it on later config changes.
-The admin credentials live on the `bugsink` item in the `vers` 1Password vault — the same item that
-later carries the MCP token:
+`--ha=false` keeps the app to one machine — Fly otherwise creates a pair on first deploy. The admin
+credentials live on the `bugsink` item in the `vers` 1Password vault — the same item that later
+carries the MCP token:
 
 ```sh
 fly apps create vers-bugsink --org vers
@@ -146,7 +147,7 @@ fly secrets set -a vers-bugsink \
   DATABASE_URL="<the bugsink database's pooled connection URL>" \
   CREATE_SUPERUSER="me@$DOMAIN:$BUGSINK_ADMIN_PASSWORD"
 
-fly deploy --config projects/app-bugsink/fly.toml
+fly deploy --config projects/app-bugsink/fly.toml --ha=false
 fly secrets unset CREATE_SUPERUSER -a vers-bugsink
 ```
 


### PR DESCRIPTION
## Description

Adds `--ha=false` to the bugsink first-deploy command in the provisioning runbook — Fly otherwise creates two machines for a new app, and the error tracker needs one. Matches how the instance was actually provisioned.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality