### PR TITLE
test(#370): tidy satellite test cleanup and stack doc comment

### DIFF
--- a/projects/app-web/src/routes/-game/satellite-stack.test.tsx
+++ b/projects/app-web/src/routes/-game/satellite-stack.test.tsx
@@ -1,10 +1,14 @@
-import { expect, test } from 'bun:test';
+import { expect, onTestFinished, test } from 'bun:test';
 import { render } from '@testing-library/react';
-import { registerSatellite } from '@vers/game-rendering';
+import { registerSatellite, removeSatellite } from '@vers/game-rendering';
 import { SatelliteStack } from './satellite-stack';
 
 test('it renders every registered satellite inside its fixed card stack', () => {
   registerSatellite('avatar-viewer', { element: <span>viewer content</span>, keepAlive: false });
+
+  onTestFinished(() => {
+    removeSatellite('avatar-viewer');
+  });
 
   const rendered = render(<SatelliteStack />);
 

--- a/projects/app-web/src/routes/-game/satellite-stack.tsx
+++ b/projects/app-web/src/routes/-game/satellite-stack.tsx
@@ -11,9 +11,8 @@ const stack = css({
 });
 
 /**
- * Positions every registered satellite (`useSatellite`) as a card stack fixed to the
- * bottom-right of the viewport, above the persistent canvas and clear of the top-anchored
- * `GameNav`.
+ * Positions every registered satellite widget as a card stack fixed to the bottom-right of the
+ * viewport, above the persistent canvas and clear of the top-anchored nav.
  */
 export function SatelliteStack() {
   return (


### PR DESCRIPTION
## Description

Follow-up applying #389's review findings that missed the merge: the satellite-stack test now removes its registered entry via `onTestFinished` (global-state-restoration convention), and the stack's doc comment no longer names other declarations.

## Testing

- [x] `bun test` (app-web package) passes