### PR TITLE
test(app-web-e2e): guard against an unlinked or inert stylesheet

### DIFF
--- a/projects/app-web-e2e/src/game-smoke.spec.ts
+++ b/projects/app-web-e2e/src/game-smoke.spec.ts
@@ -31,6 +31,21 @@ test('it renders respite, avatar, and explore for a signed-in caller without con
   await expect(page.getByText(/Destiny Awaits a Vessel|Respite/)).toBeVisible();
   await expect(page.locator('canvas')).toBeVisible();
 
+  // guard against the app shipping without its generated stylesheet: at least one sheet must be
+  // linked, preflight must have applied (body margin reset), and the preset's global token
+  // variables must resolve
+  const styleProbe = await page.evaluate(() => ({
+    bodyMargin: getComputedStyle(document.body).margin,
+    fontBodyVar: getComputedStyle(document.documentElement)
+      .getPropertyValue('--global-font-body')
+      .trim(),
+    sheetCount: document.styleSheets.length,
+  }));
+
+  expect(styleProbe.sheetCount).toBeGreaterThan(0);
+  expect(styleProbe.bodyMargin).toBe('0px');
+  expect(styleProbe.fontBodyVar).not.toBe('');
+
   await page.goto('/avatar');
 
   // mock-backend data persists across runs against the same dev server, so the account may or


### PR DESCRIPTION
## Description

Adds a style probe to the game smoke spec so the app can never again ship without its generated stylesheet (the pre-#386 state): asserts at least one stylesheet is linked, preflight applied (body margin reset to 0), and the preset's global token variables resolve.

## Testing

- [x] `bun run e2e` — 6/6 passing locally

## Context

Retro follow-up from #84's delivery: every existing gate asserted DOM structure and console cleanliness, none asserted styling reality.