### PR TITLE
refactor: consolidate scene-lane colors into a design-system module

### DIFF
--- a/projects/app-web/src/routes/-avatar/avatar-viewer.tsx
+++ b/projects/app-web/src/routes/-avatar/avatar-viewer.tsx
@@ -1,4 +1,5 @@
 import { Canvas, useFrame } from '@react-three/fiber';
+import { sceneColors } from '@vers/design-system';
 import { css } from '@vers/styled-system/css';
 import { useRef } from 'react';
 import type { Mesh } from 'three';
@@ -44,7 +45,7 @@ function PlaceholderAvatar() {
   return (
     <mesh ref={meshRef}>
       <capsuleGeometry args={[0.6, 1.2, 4, 8]} />
-      <meshStandardMaterial color="#D8A56E" flatShading />
+      <meshStandardMaterial color={sceneColors.avatarPlaceholder} flatShading />
     </mesh>
   );
 }

--- a/projects/app-web/src/routes/-game/respite-scene.tsx
+++ b/projects/app-web/src/routes/-game/respite-scene.tsx
@@ -1,13 +1,11 @@
 import { extend } from '@react-three/fiber';
+import { sceneColors } from '@vers/design-system';
 import { useLayoutEffect, useRef } from 'react';
 import type { InstancedMesh } from 'three';
 import { Color, Object3D } from 'three';
 import { MeshBasicNodeMaterial } from 'three/webgpu';
 
-const GROUND_COLOR = '#3d424d';
 const GROUND_SIZE = 40;
-
-const BLOCK_COLOR = '#8fa0c2';
 
 // a handful of flat-topped blocks standing in for buildings: [x, height, z]
 const BLOCKS: ReadonlyArray<readonly [number, number, number]> = [
@@ -21,7 +19,7 @@ const BLOCKS: ReadonlyArray<readonly [number, number, number]> = [
 
 const RespiteMaterial = extend(MeshBasicNodeMaterial);
 
-const blockColor = new Color(BLOCK_COLOR);
+const blockColor = new Color(sceneColors.respiteBlock);
 const dummy = new Object3D();
 
 /**
@@ -58,7 +56,7 @@ export function RespiteScene() {
     <>
       <mesh position={[0, -0.01, 0]} rotation={[-Math.PI / 2, 0, 0]}>
         <planeGeometry args={[GROUND_SIZE, GROUND_SIZE]} />
-        <RespiteMaterial color={GROUND_COLOR} />
+        <RespiteMaterial color={sceneColors.ground} />
       </mesh>
 
       <instancedMesh ref={blocksRef} args={[undefined, undefined, BLOCKS.length]}>

--- a/projects/lib-aether-client/src/components-three/aether-edges.tsx
+++ b/projects/lib-aether-client/src/components-three/aether-edges.tsx
@@ -1,5 +1,6 @@
 import { extend } from '@react-three/fiber';
 import type { AetherEdge } from '@vers/aether-core';
+import { sceneColors } from '@vers/design-system';
 import { useLayoutEffect, useRef } from 'react';
 import type { BufferGeometry } from 'three';
 import { BufferAttribute } from 'three';
@@ -10,7 +11,7 @@ interface AetherEdgesProps {
   readonly edges: ReadonlyArray<AetherEdge>;
 }
 
-const COLOR = '#64748b';
+const COLOR = sceneColors.worldmapEdge;
 const POSITION_COMPONENTS_PER_EDGE = 6;
 const VERTEX_SIZE = 3;
 

--- a/projects/lib-aether-client/src/components-three/aether-nodes.tsx
+++ b/projects/lib-aether-client/src/components-three/aether-nodes.tsx
@@ -1,6 +1,7 @@
 import { extend, useFrame } from '@react-three/fiber';
 import type { ThreeEvent } from '@react-three/fiber';
 import type { AetherNode } from '@vers/aether-core';
+import { sceneColors } from '@vers/design-system';
 import { useLayoutEffect, useRef } from 'react';
 import type { InstancedMesh } from 'three';
 import { Color, Matrix4 } from 'three';
@@ -17,8 +18,8 @@ interface AetherNodesProps {
 const RADIUS = 0.8;
 const NODE_SEGMENTS = 24;
 
-const BASE_COLOR = new Color('#cbd5e1');
-const SELECTED_COLOR = new Color('#7dd3fc');
+const BASE_COLOR = new Color(sceneColors.nodeBase);
+const SELECTED_COLOR = new Color(sceneColors.nodeSelected);
 
 const AetherNodeMaterial = extend(MeshStandardNodeMaterial);
 

--- a/projects/lib-aether-client/src/components-three/floor.tsx
+++ b/projects/lib-aether-client/src/components-three/floor.tsx
@@ -1,11 +1,12 @@
 import { extend } from '@react-three/fiber';
+import { sceneColors } from '@vers/design-system';
 import { Euler, Vector3 } from 'three';
 import { MeshBasicNodeMaterial } from 'three/webgpu';
 
 const rotation = new Euler(-Math.PI / 2, 0, 0);
 const position = new Vector3(0, -0.1, 0);
 
-const color = '#3d424d';
+const color = sceneColors.ground;
 const size = 10_000;
 
 const FloorMaterial = extend(MeshBasicNodeMaterial);

--- a/projects/lib-aether-client/src/components-three/fog.tsx
+++ b/projects/lib-aether-client/src/components-three/fog.tsx
@@ -1,3 +1,4 @@
+import { sceneColors } from '@vers/design-system';
 import { useIsDevCameraActive } from '../state/use-is-dev-camera-active';
 
 export function Fog() {
@@ -7,5 +8,5 @@ export function Fog() {
     return null;
   }
 
-  return <fog args={[0x000000, 20, 200]} attach="fog" />;
+  return <fog args={[sceneColors.fog, 20, 200]} attach="fog" />;
 }

--- a/projects/lib-design-system/src/index.ts
+++ b/projects/lib-design-system/src/index.ts
@@ -11,3 +11,4 @@ export { Spinner } from './components/spinner/spinner';
 export { StatusButton } from './components/status-button/status-button';
 export { Text } from './components/text/text';
 export type { PolymorphicComponentProps } from './types';
+export { sceneColors } from './scene-colors';

--- a/projects/lib-design-system/src/scene-colors.ts
+++ b/projects/lib-design-system/src/scene-colors.ts
@@ -1,0 +1,14 @@
+/**
+ * Colors for the three.js scene lane, which cannot consume Panda tokens: materials take raw
+ * color values, so every 3D color lives here instead of inline in scene code. Values are
+ * hand-derived from the semantic token palette and must move with any re-skin.
+ */
+export const sceneColors = {
+  avatarPlaceholder: '#D8A56E',
+  fog: '#000000',
+  ground: '#3d424d',
+  nodeBase: '#cbd5e1',
+  nodeSelected: '#7dd3fc',
+  respiteBlock: '#8fa0c2',
+  worldmapEdge: '#64748b',
+} as const;


### PR DESCRIPTION
## Description

Moves every hardcoded 3D color (worldmap nodes/edges/floor/fog, respite ground/blocks, avatar placeholder) into one `sceneColors` module in lib-design-system — three.js materials can't consume Panda tokens, so this is the single place the scene lane's palette lives, hand-derived from the token palette. Codegen-from-tokens replacement is tracked separately.

## Testing

- [x] typecheck, test (aether-client + web), format — green

## Context

Retro follow-up from #84's delivery. Left unmerged for review.