### PR TITLE
fix(aether-client): stabilize dev camera and controls lifecycle

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -403,6 +403,9 @@
               "geometry",
               "far",
               "near",
+              "aspect",
+              "fov",
+              "onUpdate",
               "userData"
             ]
           }

--- a/projects/lib-aether-client/src/components-three/camera-controls.tsx
+++ b/projects/lib-aether-client/src/components-three/camera-controls.tsx
@@ -13,9 +13,6 @@ import {
   Vector4,
 } from 'three';
 
-const MIN_ZOOM = 10;
-const MAX_ZOOM = 30;
-
 // to allow for tree shaking, only import the subset of three.js camera-controls depends on
 // see https://github.com/yomotsu/camera-controls#important
 CameraControlsImpl.install({
@@ -27,25 +24,23 @@ export function CameraControls() {
   const domElement = useThree((state) => state.gl.domElement);
   const controlsRef = useRef<CameraControlsImpl | null>(null);
 
-  controlsRef.current ??= new CameraControlsImpl(camera);
-
-  const controls = controlsRef.current;
-
-  controls.camera = camera;
-  controls.minZoom = MIN_ZOOM;
-  controls.maxZoom = MAX_ZOOM;
-
   useEffect(() => {
+    const controls = new CameraControlsImpl(camera);
+
+    controlsRef.current = controls;
+
     controls.connect(domElement);
 
     return () => {
       controls.disconnect();
       controls.dispose();
+
+      controlsRef.current = null;
     };
-  }, [controls, domElement]);
+  }, [camera, domElement]);
 
   useFrame((_state, delta) => {
-    controls.update(delta);
+    controlsRef.current?.update(delta);
   });
 
   return null;

--- a/projects/lib-aether-client/src/components-three/dev-camera.tsx
+++ b/projects/lib-aether-client/src/components-three/dev-camera.tsx
@@ -23,7 +23,13 @@ export function DevCamera() {
       <CameraControls />
       <perspectiveCamera
         ref={cameraRef}
-        args={[75, aspect, 0.1, 1000]}
+        aspect={aspect}
+        far={1000}
+        fov={75}
+        near={0.1}
+        onUpdate={(camera) => {
+          camera.updateProjectionMatrix();
+        }}
         position={[0, 500, -500]}
         rotation={[-Math.PI / 4, 0, 0]}
       />


### PR DESCRIPTION
## Description

Fixes the three dev-only findings deferred from #363's review:

- The dev camera no longer reconstructs on window resize (props instead of `args`, projection matrix refreshed via `onUpdate`), so the active-camera handle can't go stale mid-session
- `CameraControls` builds and wires its instance in an effect instead of the render body — pure under StrictMode/concurrent re-renders, and recreated cleanly when the camera or canvas changes
- Dropped the inert `MIN_ZOOM`/`MAX_ZOOM` clamps (perspective wheel-dolly never touches `camera.zoom`)
- oxlint's r3f ignore list gains `aspect`/`fov`/`onUpdate` for the new camera props

## Testing

- [x] typecheck, test, lint, format — green

## Context

Retro follow-up from #84's delivery. Left unmerged for review.