### PR TITLE
chore(deps): bump @zgeoff/oxlint-config to 0.0.4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -791,7 +791,7 @@
     "@vitest/web-worker": "3.0.9",
     "@zgeoff/bun-test-extended": "0.0.3",
     "@zgeoff/format-codemod": "0.0.5",
-    "@zgeoff/oxlint-config": "0.0.3",
+    "@zgeoff/oxlint-config": "0.0.4",
     "autoprefixer": "10.4.21",
     "babel-plugin-react-compiler": "1.0.0",
     "camera-controls": "3.1.2",
@@ -2307,7 +2307,7 @@
 
     "@zgeoff/format-codemod": ["@zgeoff/format-codemod@0.0.5", "", { "dependencies": { "oxc-parser": "0.137.0" }, "bin": { "format-codemod": "dist/cli.js" } }, "sha512-YYyXMc9IPjCgcVGkWsXkrLfFFozpvMDgm1EUAVBuW4TyOxZpkIw4pIyg7SWdOgJ2AX0MANMoaPLC7LQdaWpG4w=="],
 
-    "@zgeoff/oxlint-config": ["@zgeoff/oxlint-config@0.0.3", "", { "dependencies": { "@stylistic/eslint-plugin": "5.10.0" }, "peerDependencies": { "oxlint": ">=1.71.0" } }, "sha512-Kk6WBhjQ6FHpuxT1xTh7oWqbPezoikN9GwM679/nW6geNjdVxFKpBoJjzuGVVLT6BU3/JFHj5caHFrmxDCpx4w=="],
+    "@zgeoff/oxlint-config": ["@zgeoff/oxlint-config@0.0.4", "", { "dependencies": { "@stylistic/eslint-plugin": "5.10.0" }, "peerDependencies": { "oxlint": ">=1.71.0" } }, "sha512-nWetV+a2ir+aXgFyRwVTzNs5XY4jFWc4CCWkF242VMACLpp7D8f6U3To7TRkWnLnP4D/tmpriaW6OmtzZq3ncQ=="],
 
     "JSONStream": ["JSONStream@1.3.5", "", { "dependencies": { "jsonparse": "^1.2.0", "through": ">=2.2.7 <3" }, "bin": { "JSONStream": "./bin.js" } }, "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ=="],
 

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
       "@vitest/web-worker": "3.0.9",
       "@zgeoff/bun-test-extended": "0.0.3",
       "@zgeoff/format-codemod": "0.0.5",
-      "@zgeoff/oxlint-config": "0.0.3",
+      "@zgeoff/oxlint-config": "0.0.4",
       "autoprefixer": "10.4.21",
       "babel-plugin-react-compiler": "1.0.0",
       "camera-controls": "3.1.2",

--- a/projects/app-web/src/lib/auth/build-auth-session-config.ts
+++ b/projects/app-web/src/lib/auth/build-auth-session-config.ts
@@ -1,13 +1,19 @@
 import type { getSession } from '@tanstack/react-start/server';
 import { readSessionSecret } from './read-session-secret';
 
-/** `getSession`'s config parameter type, without a direct dependency on its owning package. */
+/**
+ * `getSession`'s config parameter type, without a direct dependency on its owning package.
+ */
 export type SessionConfig = Parameters<typeof getSession>[0];
 
-/** A generous ceiling for reads: real expiry is enforced by comparing `data.expires` to now. */
+/**
+ * A generous ceiling for reads: real expiry is enforced by comparing `data.expires` to now.
+ */
 export const AUTH_SESSION_READ_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
 
-/** Builds the `en_session` cookie's session config; `maxAge` governs the emitted `Max-Age`. */
+/**
+ * Builds the `en_session` cookie's session config; `maxAge` governs the emitted `Max-Age`.
+ */
 export function buildAuthSessionConfig(maxAge: number): SessionConfig {
   const domain = process.env['COOKIE_DOMAIN'];
 

--- a/projects/app-web/src/lib/auth/build-honeypot-valid-from.ts
+++ b/projects/app-web/src/lib/auth/build-honeypot-valid-from.ts
@@ -1,7 +1,11 @@
-/** A human takes at least this long to fill in a form; a faster submission is treated as a bot. */
+/**
+ * A human takes at least this long to fill in a form; a faster submission is treated as a bot.
+ */
 const HONEYPOT_MIN_FILL_TIME_MS = 1500;
 
-/** Computes the valid-from timestamp for a freshly rendered form. */
+/**
+ * Computes the valid-from timestamp for a freshly rendered form.
+ */
 export function buildHoneypotValidFrom(): string {
   return String(Date.now() + HONEYPOT_MIN_FILL_TIME_MS);
 }

--- a/projects/app-web/src/lib/auth/build-verify-session-config.ts
+++ b/projects/app-web/src/lib/auth/build-verify-session-config.ts
@@ -1,10 +1,14 @@
 import type { SessionConfig } from './build-auth-session-config';
 import { readSessionSecret } from './read-session-secret';
 
-/** Every in-flight verification flow abandons its state after this long. */
+/**
+ * Every in-flight verification flow abandons its state after this long.
+ */
 const VERIFY_SESSION_MAX_AGE_SECONDS = 60 * 10;
 
-/** Builds the `en_verification` cookie's session config: a fixed 10-minute lifetime. */
+/**
+ * Builds the `en_verification` cookie's session config: a fixed 10-minute lifetime.
+ */
 export function buildVerifySessionConfig(): SessionConfig {
   const domain = process.env['COOKIE_DOMAIN'];
 

--- a/projects/app-web/src/lib/auth/check-step-up.ts
+++ b/projects/app-web/src/lib/auth/check-step-up.ts
@@ -52,7 +52,9 @@ export async function checkStepUp(opts: Readonly<CheckStepUpOptions>): Promise<C
   };
 }
 
-/** Redeems a step-up transaction token exactly once, folding every failure mode into `false`. */
+/**
+ * Redeems a step-up transaction token exactly once, folding every failure mode into `false`.
+ */
 async function tryConsumeStepUpToken(
   action: SecureAction,
   target: string,

--- a/projects/app-web/src/lib/auth/clear-auth-session.ts
+++ b/projects/app-web/src/lib/auth/clear-auth-session.ts
@@ -4,7 +4,9 @@ import {
   buildAuthSessionConfig,
 } from './build-auth-session-config';
 
-/** Clears the auth session, deleting the `en_session` cookie. */
+/**
+ * Clears the auth session, deleting the `en_session` cookie.
+ */
 export async function clearAuthSession(): Promise<void> {
   await clearSession(buildAuthSessionConfig(AUTH_SESSION_READ_MAX_AGE_SECONDS));
 }

--- a/projects/app-web/src/lib/auth/find-step-up-token.ts
+++ b/projects/app-web/src/lib/auth/find-step-up-token.ts
@@ -1,4 +1,6 @@
-/** Reads the step-up transaction token a gated mutation's resubmission carries, if any. */
+/**
+ * Reads the step-up transaction token a gated mutation's resubmission carries, if any.
+ */
 export function findStepUpToken(formData: FormData): string | undefined {
   const raw = formData.get('stepUpToken');
 

--- a/projects/app-web/src/lib/auth/get-login-path-with-redirect.ts
+++ b/projects/app-web/src/lib/auth/get-login-path-with-redirect.ts
@@ -1,10 +1,14 @@
-/** The part of a URL {@link getLoginPathWithRedirect} needs to rebuild the page a guard bounced. */
+/**
+ * The part of a URL {@link getLoginPathWithRedirect} needs to rebuild the page a guard bounced.
+ */
 interface RedirectSource {
   readonly pathname: string;
   readonly search: string;
 }
 
-/** Builds `/login?redirect=<page>`, so a completed login returns the caller to where it left off. */
+/**
+ * Builds `/login?redirect=<page>`, so a completed login returns the caller to where it left off.
+ */
 export function getLoginPathWithRedirect(source: RedirectSource): string {
   const redirectTo = `${source.pathname}${source.search}`;
 

--- a/projects/app-web/src/lib/auth/get-verify-session.ts
+++ b/projects/app-web/src/lib/auth/get-verify-session.ts
@@ -2,7 +2,9 @@ import { getSession } from '@tanstack/react-start/server';
 import { buildVerifySessionConfig } from './build-verify-session-config';
 import type { VerifySessionData } from './types';
 
-/** Reads the caller's in-flight verification state; empty once the 10-minute window lapses. */
+/**
+ * Reads the caller's in-flight verification state; empty once the 10-minute window lapses.
+ */
 export async function getVerifySession(): Promise<VerifySessionData> {
   const session = await getSession<VerifySessionData>(buildVerifySessionConfig());
 

--- a/projects/app-web/src/lib/auth/honeypot-field-names.ts
+++ b/projects/app-web/src/lib/auth/honeypot-field-names.ts
@@ -1,5 +1,9 @@
-/** The hidden field a real caller never fills in; any value here marks the submission as spam. */
+/**
+ * The hidden field a real caller never fills in; any value here marks the submission as spam.
+ */
 export const HONEYPOT_FIELD_NAME = 'name__confirm';
 
-/** Encodes the earliest timestamp (ms epoch) a submission of this render counts as human-paced. */
+/**
+ * Encodes the earliest timestamp (ms epoch) a submission of this render counts as human-paced.
+ */
 export const HONEYPOT_VALID_FROM_FIELD_NAME = 'from__confirm';

--- a/projects/app-web/src/lib/auth/read-session-secret.ts
+++ b/projects/app-web/src/lib/auth/read-session-secret.ts
@@ -1,4 +1,6 @@
-/** The shared signing/encryption key behind both cookie sessions. */
+/**
+ * The shared signing/encryption key behind both cookie sessions.
+ */
 export function readSessionSecret(): string {
   const secret = process.env['SESSION_SECRET'];
 

--- a/projects/app-web/src/lib/auth/require-anonymous.ts
+++ b/projects/app-web/src/lib/auth/require-anonymous.ts
@@ -1,7 +1,9 @@
 import { redirect } from '@tanstack/react-router';
 import { getAuthSession } from './get-auth-session';
 
-/** Gates a route to signed-out callers, bouncing an already-signed-in caller back home. */
+/**
+ * Gates a route to signed-out callers, bouncing an already-signed-in caller back home.
+ */
 export async function requireAnonymous(): Promise<void> {
   const session = await getAuthSession();
 

--- a/projects/app-web/src/lib/auth/spam-error.ts
+++ b/projects/app-web/src/lib/auth/spam-error.ts
@@ -1,4 +1,6 @@
-/** A form submission a honeypot check flagged as spam. */
+/**
+ * A form submission a honeypot check flagged as spam.
+ */
 export class SpamError extends Error {
   public override readonly name = 'SpamError';
 }

--- a/projects/app-web/src/lib/auth/step-up-transaction-token.ts
+++ b/projects/app-web/src/lib/auth/step-up-transaction-token.ts
@@ -3,12 +3,16 @@ import type { SecureAction } from '@vers/contract-session';
 import { SecureActionSchema } from '@vers/contract-session';
 import * as jose from 'jose';
 
-/** How long a minted step-up transaction token stays redeemable. */
+/**
+ * How long a minted step-up transaction token stays redeemable.
+ */
 const TRANSACTION_TOKEN_TTL_MS = 5 * 60 * 1000;
 
 const TRANSACTION_TOKEN_ISSUER = 'vers-web-step-up';
 
-/** Claims a step-up transaction token carries; `jti` is its single-use replay-guard id. */
+/**
+ * Claims a step-up transaction token carries; `jti` is its single-use replay-guard id.
+ */
 interface StepUpTransactionClaims {
   readonly action: SecureAction;
   readonly expiresAt: Date;
@@ -54,7 +58,9 @@ export async function mintStepUpTransactionToken(
   return { expiresAt, jti, token };
 }
 
-/** Verifies a step-up transaction token's signature and expiry, returning its claims. */
+/**
+ * Verifies a step-up transaction token's signature and expiry, returning its claims.
+ */
 export async function verifyStepUpTransactionToken(
   token: string,
 ): Promise<StepUpTransactionClaims> {

--- a/projects/app-web/src/lib/auth/types.ts
+++ b/projects/app-web/src/lib/auth/types.ts
@@ -1,4 +1,6 @@
-/** The `en_session` cookie's stored shape: the caller's live session plus its target expiry. */
+/**
+ * The `en_session` cookie's stored shape: the caller's live session plus its target expiry.
+ */
 export interface AuthSessionData {
   readonly accessToken?: string;
   readonly expires?: string;
@@ -19,5 +21,7 @@ type VerifySessionKey =
   | 'loginLogout#userID'
   | 'onboarding#email';
 
-/** A write with an explicit `undefined` value clears that key. */
+/**
+ * A write with an explicit `undefined` value clears that key.
+ */
 export type VerifySessionData = Partial<Record<VerifySessionKey, string | undefined>>;

--- a/projects/app-web/src/lib/auth/update-verify-session.ts
+++ b/projects/app-web/src/lib/auth/update-verify-session.ts
@@ -2,7 +2,9 @@ import { updateSession } from '@tanstack/react-start/server';
 import { buildVerifySessionConfig } from './build-verify-session-config';
 import type { VerifySessionData } from './types';
 
-/** Writes to the in-flight verification state; an explicit `undefined` value clears that key. */
+/**
+ * Writes to the in-flight verification state; an explicit `undefined` value clears that key.
+ */
 export async function updateVerifySession(update: VerifySessionData): Promise<VerifySessionData> {
   const session = await updateSession<VerifySessionData>(buildVerifySessionConfig(), update);
 

--- a/projects/app-web/src/lib/auth/verify-step-up.ts
+++ b/projects/app-web/src/lib/auth/verify-step-up.ts
@@ -2,7 +2,9 @@ import { createServerFn } from '@tanstack/react-start';
 import { requireAuth } from './require-auth';
 import { VerifyStepUpInputSchema, verifyStepUpHandler } from './verify-step-up-handler';
 
-/** The step-up challenge island's submit action, shared by every gated mutation's inline prompt. */
+/**
+ * The step-up challenge island's submit action, shared by every gated mutation's inline prompt.
+ */
 export const verifyStepUp = createServerFn({ method: 'POST' })
   .validator((input: unknown) => VerifyStepUpInputSchema.parse(input))
   .handler(async (ctx) => {

--- a/projects/app-web/src/lib/idle/send-idle-initialize.ts
+++ b/projects/app-web/src/lib/idle/send-idle-initialize.ts
@@ -1,6 +1,8 @@
 import { createInitializeMessage } from '@vers/idle-client';
 
-/** Sends the one-time message a freshly connected worker needs before it reports simulation state. */
+/**
+ * Sends the one-time message a freshly connected worker needs before it reports simulation state.
+ */
 export function sendIdleInitialize(worker: SharedWorker): void {
   worker.port.postMessage(createInitializeMessage());
 }

--- a/projects/app-web/src/lib/rpc/clients/session-existence-client.ts
+++ b/projects/app-web/src/lib/rpc/clients/session-existence-client.ts
@@ -5,7 +5,9 @@ import type { sessionContract } from '@vers/contract-session';
 import { createEdgeServiceToken } from '../create-edge-service-token';
 import { SERVICE_URLS } from '../service-urls';
 
-/** The per-call context this client requires: who the outbound s2s token's `sub` claim names. */
+/**
+ * The per-call context this client requires: who the outbound s2s token's `sub` claim names.
+ */
 interface SessionExistenceClientContext {
   readonly actingUserID: string;
 }

--- a/projects/app-web/src/lib/rpc/load-session-actor.ts
+++ b/projects/app-web/src/lib/rpc/load-session-actor.ts
@@ -7,7 +7,9 @@ import { updateAuthSession } from '../auth/update-auth-session';
 import { sessionExistenceClient } from './clients/session-existence-client';
 import { sessionRefreshClient } from './clients/session-refresh-client';
 
-/** How far ahead of the access token's real `exp` a refresh is triggered proactively. */
+/**
+ * How far ahead of the access token's real `exp` a refresh is triggered proactively.
+ */
 const REFRESH_SKEW_SECONDS = 30;
 
 interface RefreshedTokens {

--- a/projects/app-web/src/lib/session/get-session-badge-fragment.tsx
+++ b/projects/app-web/src/lib/session/get-session-badge-fragment.tsx
@@ -4,7 +4,9 @@ import type { ReactNode } from 'react';
 import { pickSessionBadgeMessage } from './pick-session-badge-message';
 import { tryReadCurrentUser } from './try-read-current-user';
 
-/** The session-badge fragment's one client slot: a free-form refresh control. */
+/**
+ * The session-badge fragment's one client slot: a free-form refresh control.
+ */
 interface SessionBadgeFragmentProps {
   readonly children?: ReactNode;
 }

--- a/projects/app-web/src/lib/session/try-read-current-user.ts
+++ b/projects/app-web/src/lib/session/try-read-current-user.ts
@@ -3,7 +3,9 @@ import type { UnauthorizedReason } from '@vers/contract-base';
 import type { UserData } from '@vers/contract-user';
 import { userClient } from '../rpc/clients/user-client';
 
-/** The index route's auth-state read, folded into a plain result union — never a thrown error. */
+/**
+ * The index route's auth-state read, folded into a plain result union — never a thrown error.
+ */
 export type CurrentUserResult =
   | { readonly authenticated: false; readonly reason: 'transport-error' | UnauthorizedReason }
   | { readonly authenticated: true; readonly user: UserData };

--- a/projects/app-web/src/lib/validation/confirm-password-schema.ts
+++ b/projects/app-web/src/lib/validation/confirm-password-schema.ts
@@ -1,7 +1,9 @@
 import { PasswordSchema } from '@vers/contract-user';
 import * as z from 'zod';
 
-/** Shared shape for any form collecting a new password twice, requiring the pair to match. */
+/**
+ * Shared shape for any form collecting a new password twice, requiring the pair to match.
+ */
 export const ConfirmPasswordSchema = z
   .object({ confirmPassword: PasswordSchema, password: PasswordSchema })
   .superRefine((value, ctx) => {

--- a/projects/app-web/src/mocks/resolve-session-context.ts
+++ b/projects/app-web/src/mocks/resolve-session-context.ts
@@ -1,6 +1,8 @@
 import * as jose from 'jose';
 
-/** The context every mocked contract handler receives; mirrors the real services' shape. */
+/**
+ * The context every mocked contract handler receives; mirrors the real services' shape.
+ */
 export interface MockContext extends Record<string, unknown> {
   readonly actingUserId: string | null;
 }

--- a/projects/app-web/src/mocks/routers/session/create-session.ts
+++ b/projects/app-web/src/mocks/routers/session/create-session.ts
@@ -2,10 +2,14 @@ import { createId } from '@paralleldrive/cuid2';
 import * as db from '../../db';
 import { os } from './os';
 
-/** Default session lifetime for a login without `rememberMe`, mirroring the session service. */
+/**
+ * Default session lifetime for a login without `rememberMe`, mirroring the session service.
+ */
 const SESSION_DURATION_SHORT = 24 * 60 * 60 * 1000;
 
-/** Session lifetime for a login with `rememberMe`, mirroring the session service. */
+/**
+ * Session lifetime for a login with `rememberMe`, mirroring the session service.
+ */
 const SESSION_DURATION_LONG = 7 * 24 * 60 * 60 * 1000;
 
 export const createSession = os.createSession.handler(async (opts) => {

--- a/projects/app-web/src/mocks/routers/session/step-up/create-pending-transaction.ts
+++ b/projects/app-web/src/mocks/routers/session/step-up/create-pending-transaction.ts
@@ -1,7 +1,9 @@
 import * as db from '../../../db';
 import { os } from '../os';
 
-/** How long a pending step-up transaction stays consumable before it must be restarted. */
+/**
+ * How long a pending step-up transaction stays consumable before it must be restarted.
+ */
 const PENDING_TRANSACTION_TTL_MS = 10 * 60 * 1000;
 
 export const createPendingTransaction = os.stepUp.createPendingTransaction.handler((opts) => {

--- a/projects/app-web/src/mocks/routers/session/step-up/record-failed-attempt.ts
+++ b/projects/app-web/src/mocks/routers/session/step-up/record-failed-attempt.ts
@@ -2,7 +2,9 @@ import * as db from '../../../db';
 import { os } from '../os';
 import { findLivePendingTransaction } from './find-live-pending-transaction';
 
-/** Failed verify attempts a pending transaction tolerates before it's abandoned. */
+/**
+ * Failed verify attempts a pending transaction tolerates before it's abandoned.
+ */
 const MAX_STEP_UP_ATTEMPTS = 5;
 
 /**

--- a/projects/app-web/src/mocks/routers/verification/verify-code.ts
+++ b/projects/app-web/src/mocks/routers/verification/verify-code.ts
@@ -2,7 +2,9 @@ import type { VerificationType } from '@vers/contract-verification';
 import * as db from '../../db';
 import { os } from './os';
 
-/** Verification types whose code is consumed once and the row deleted on a successful verify. */
+/**
+ * Verification types whose code is consumed once and the row deleted on a successful verify.
+ */
 const DELETING_TYPES: ReadonlySet<VerificationType> = new Set(['change-email', 'onboarding']);
 
 export const verifyCode = os.verifyCode.handler((opts) => {

--- a/projects/app-web/src/router.tsx
+++ b/projects/app-web/src/router.tsx
@@ -21,7 +21,9 @@ const getCSPNonce = createIsomorphicFn()
     // no request middleware on the client to have stamped a nonce
   });
 
-/** Builds a fresh router + query client pair for each request (SSR) or the one browser session. */
+/**
+ * Builds a fresh router + query client pair for each request (SSR) or the one browser session.
+ */
 export function getRouter() {
   const queryClient = new QueryClient();
 

--- a/projects/app-web/src/routes/-account-2fa-verify/verify-two-factor-setup.ts
+++ b/projects/app-web/src/routes/-account-2fa-verify/verify-two-factor-setup.ts
@@ -1,7 +1,9 @@
 import { createServerFn } from '@tanstack/react-start';
 import { verifyTwoFactorSetupHandler } from './verify-two-factor-setup-handler';
 
-/** The 2FA-setup verify form's submit action; field-level validation happens once inside the handler. */
+/**
+ * The 2FA-setup verify form's submit action; field-level validation happens once inside the handler.
+ */
 export const verifyTwoFactorSetup = createServerFn({ method: 'POST' })
   .validator((formData: unknown) => {
     if (!(formData instanceof FormData)) {

--- a/projects/app-web/src/routes/-account-change-email/change-email.ts
+++ b/projects/app-web/src/routes/-account-change-email/change-email.ts
@@ -1,7 +1,9 @@
 import { createServerFn } from '@tanstack/react-start';
 import { changeEmailHandler } from './change-email-handler';
 
-/** The change-email form's submit action; field-level validation happens once inside the handler. */
+/**
+ * The change-email form's submit action; field-level validation happens once inside the handler.
+ */
 export const changeEmail = createServerFn({ method: 'POST' })
   .validator((formData: unknown) => {
     if (!(formData instanceof FormData)) {

--- a/projects/app-web/src/routes/-account-change-password/change-password.ts
+++ b/projects/app-web/src/routes/-account-change-password/change-password.ts
@@ -1,7 +1,9 @@
 import { createServerFn } from '@tanstack/react-start';
 import { changePasswordHandler } from './change-password-handler';
 
-/** The change-password form's submit action; field-level validation happens once inside the handler. */
+/**
+ * The change-password form's submit action; field-level validation happens once inside the handler.
+ */
 export const changePassword = createServerFn({ method: 'POST' })
   .validator((formData: unknown) => {
     if (!(formData instanceof FormData)) {

--- a/projects/app-web/src/routes/-account/account-content.tsx
+++ b/projects/app-web/src/routes/-account/account-content.tsx
@@ -7,7 +7,9 @@ interface AccountContentProps {
   readonly user: UserData;
 }
 
-/** The account hub's read-only summary: profile fields plus current 2FA status. */
+/**
+ * The account hub's read-only summary: profile fields plus current 2FA status.
+ */
 export function AccountContent(props: AccountContentProps): ReactElement {
   return (
     <section>

--- a/projects/app-web/src/routes/-account/disable-two-factor-auth.ts
+++ b/projects/app-web/src/routes/-account/disable-two-factor-auth.ts
@@ -1,7 +1,9 @@
 import { createServerFn } from '@tanstack/react-start';
 import { disableTwoFactorAuthHandler } from './disable-two-factor-auth-handler';
 
-/** The account hub's disable-2FA submit action. */
+/**
+ * The account hub's disable-2FA submit action.
+ */
 export const disableTwoFactorAuth = createServerFn({ method: 'POST' })
   .validator((formData: unknown) => {
     if (!(formData instanceof FormData)) {

--- a/projects/app-web/src/routes/-forgot-password/forgot-password-form.tsx
+++ b/projects/app-web/src/routes/-forgot-password/forgot-password-form.tsx
@@ -20,7 +20,9 @@ const pageInfo = css({ marginBottom: '8', textAlign: 'center' });
 
 const formStyles = css({ marginBottom: '6', width: '96' });
 
-/** The forgot-password page's client-interactive form: submits to the forgot-password server function. */
+/**
+ * The forgot-password page's client-interactive form: submits to the forgot-password server function.
+ */
 export function ForgotPasswordForm(props: ForgotPasswordFormProps) {
   const forgotPasswordFn = useServerFn(forgotPassword);
   const submission = useFormSubmit(props.action ?? forgotPasswordFn, props.lastResult);

--- a/projects/app-web/src/routes/-forgot-password/forgot-password.ts
+++ b/projects/app-web/src/routes/-forgot-password/forgot-password.ts
@@ -1,7 +1,9 @@
 import { createServerFn } from '@tanstack/react-start';
 import { forgotPasswordHandler } from './forgot-password-handler';
 
-/** The forgot-password form's submit action; field-level validation happens once inside the handler. */
+/**
+ * The forgot-password form's submit action; field-level validation happens once inside the handler.
+ */
 export const forgotPassword = createServerFn({ method: 'POST' })
   .validator((formData: unknown) => {
     if (!(formData instanceof FormData)) {

--- a/projects/app-web/src/routes/-login-force-logout/force-logout-form.tsx
+++ b/projects/app-web/src/routes/-login-force-logout/force-logout-form.tsx
@@ -26,7 +26,9 @@ const buttonContainer = css({
   width: '96',
 });
 
-/** The force-logout page's confirm/cancel choice; both intents end the request in a redirect. */
+/**
+ * The force-logout page's confirm/cancel choice; both intents end the request in a redirect.
+ */
 export function ForceLogoutForm(props: ForceLogoutFormProps) {
   const forceLogoutFn = useServerFn(forceLogout);
   const submission = useFormSubmit(props.action ?? forceLogoutFn);

--- a/projects/app-web/src/routes/-login-force-logout/force-logout-loader.ts
+++ b/projects/app-web/src/routes/-login-force-logout/force-logout-loader.ts
@@ -2,7 +2,9 @@ import { redirect } from '@tanstack/react-router';
 import { getVerifySession } from '../../lib/auth/get-verify-session';
 import { requireAnonymous } from '../../lib/auth/require-anonymous';
 
-/** Bounces back to `/login` when this page is visited with no pending force-logout to confirm. */
+/**
+ * Bounces back to `/login` when this page is visited with no pending force-logout to confirm.
+ */
 export async function forceLogoutLoader(): Promise<void> {
   await requireAnonymous();
 

--- a/projects/app-web/src/routes/-login-force-logout/force-logout.ts
+++ b/projects/app-web/src/routes/-login-force-logout/force-logout.ts
@@ -1,7 +1,9 @@
 import { createServerFn } from '@tanstack/react-start';
 import { forceLogoutHandler } from './force-logout-handler';
 
-/** The force-logout page's confirm/cancel submit action. */
+/**
+ * The force-logout page's confirm/cancel submit action.
+ */
 export const forceLogout = createServerFn({ method: 'POST' })
   .validator((formData: unknown) => {
     if (!(formData instanceof FormData)) {

--- a/projects/app-web/src/routes/-login/login-form.tsx
+++ b/projects/app-web/src/routes/-login/login-form.tsx
@@ -28,7 +28,9 @@ const formStyles = css({
 
 const submitButton = css({ marginBottom: '2' });
 
-/** The login page's client-interactive form: submits to the login server function and renders its result. */
+/**
+ * The login page's client-interactive form: submits to the login server function and renders its result.
+ */
 export function LoginForm(props: LoginFormProps) {
   const loginFn = useServerFn(login);
   const submission = useFormSubmit(props.action ?? loginFn, props.lastResult);

--- a/projects/app-web/src/routes/-login/login.ts
+++ b/projects/app-web/src/routes/-login/login.ts
@@ -1,7 +1,9 @@
 import { createServerFn } from '@tanstack/react-start';
 import { loginHandler } from './login-handler';
 
-/** The login form's submit action; field-level validation happens once inside the handler. */
+/**
+ * The login form's submit action; field-level validation happens once inside the handler.
+ */
 export const login = createServerFn({ method: 'POST' })
   .validator((formData: unknown) => {
     if (!(formData instanceof FormData)) {

--- a/projects/app-web/src/routes/-logout/run-logout.ts
+++ b/projects/app-web/src/routes/-logout/run-logout.ts
@@ -1,6 +1,8 @@
 import { logout } from '../../lib/auth/logout';
 
-/** Adapts the always-throwing `logout` into the `Response` a route's raw HTTP handler must return. */
+/**
+ * Adapts the always-throwing `logout` into the `Response` a route's raw HTTP handler must return.
+ */
 export async function runLogout(): Promise<Response> {
   try {
     await logout({ deleteSession: true });

--- a/projects/app-web/src/routes/-onboarding/onboarding-form.tsx
+++ b/projects/app-web/src/routes/-onboarding/onboarding-form.tsx
@@ -25,7 +25,9 @@ const formStyles = css({
   width: '96',
 });
 
-/** The onboarding page's client-interactive form: submits to the onboarding server function. */
+/**
+ * The onboarding page's client-interactive form: submits to the onboarding server function.
+ */
 export function OnboardingForm(props: OnboardingFormProps) {
   const onboardingFn = useServerFn(onboarding);
   const submission = useFormSubmit(props.action ?? onboardingFn, props.lastResult);

--- a/projects/app-web/src/routes/-onboarding/onboarding.ts
+++ b/projects/app-web/src/routes/-onboarding/onboarding.ts
@@ -1,7 +1,9 @@
 import { createServerFn } from '@tanstack/react-start';
 import { onboardingHandler } from './onboarding-handler';
 
-/** The onboarding form's submit action; field-level validation happens once inside the handler. */
+/**
+ * The onboarding form's submit action; field-level validation happens once inside the handler.
+ */
 export const onboarding = createServerFn({ method: 'POST' })
   .validator((formData: unknown) => {
     if (!(formData instanceof FormData)) {

--- a/projects/app-web/src/routes/-onboarding/require-onboarding-session.ts
+++ b/projects/app-web/src/routes/-onboarding/require-onboarding-session.ts
@@ -6,7 +6,9 @@ export interface OnboardingSession {
   readonly email: string;
 }
 
-/** Gates the onboarding page on a target verified by signup's onboarding-typed code. */
+/**
+ * Gates the onboarding page on a target verified by signup's onboarding-typed code.
+ */
 export async function requireOnboardingSession(): Promise<OnboardingSession> {
   await requireAnonymous();
 

--- a/projects/app-web/src/routes/-reset-password/require-reset-password-access.ts
+++ b/projects/app-web/src/routes/-reset-password/require-reset-password-access.ts
@@ -6,7 +6,9 @@ export interface ResetPasswordAccess {
   readonly resetToken: string;
 }
 
-/** Gates the reset-password page on the emailed link's `email`/`token` query params. */
+/**
+ * Gates the reset-password page on the emailed link's `email`/`token` query params.
+ */
 export async function requireResetPasswordAccess(
   search: Readonly<Record<string, unknown>>,
 ): Promise<ResetPasswordAccess> {

--- a/projects/app-web/src/routes/-reset-password/reset-password-form.tsx
+++ b/projects/app-web/src/routes/-reset-password/reset-password-form.tsx
@@ -27,7 +27,9 @@ const formStyles = css({
   width: '96',
 });
 
-/** The reset-password page's client-interactive form: submits to the reset-password server function. */
+/**
+ * The reset-password page's client-interactive form: submits to the reset-password server function.
+ */
 export function ResetPasswordForm(props: ResetPasswordFormProps) {
   const resetPasswordFn = useServerFn(resetPassword);
   const submission = useFormSubmit(props.action ?? resetPasswordFn, props.lastResult);

--- a/projects/app-web/src/routes/-reset-password/reset-password.ts
+++ b/projects/app-web/src/routes/-reset-password/reset-password.ts
@@ -1,7 +1,9 @@
 import { createServerFn } from '@tanstack/react-start';
 import { resetPasswordHandler } from './reset-password-handler';
 
-/** The reset-password form's submit action; field-level validation happens once inside the handler. */
+/**
+ * The reset-password form's submit action; field-level validation happens once inside the handler.
+ */
 export const resetPassword = createServerFn({ method: 'POST' })
   .validator((formData: unknown) => {
     if (!(formData instanceof FormData)) {

--- a/projects/app-web/src/routes/-signup/signup-form.tsx
+++ b/projects/app-web/src/routes/-signup/signup-form.tsx
@@ -27,7 +27,9 @@ const formStyles = css({
 
 const submitButton = css({ marginBottom: '2' });
 
-/** The signup page's client-interactive form: submits to the signup server function. */
+/**
+ * The signup page's client-interactive form: submits to the signup server function.
+ */
 export function SignupForm(props: SignupFormProps) {
   const signupFn = useServerFn(signup);
   const submission = useFormSubmit(props.action ?? signupFn, props.lastResult);

--- a/projects/app-web/src/routes/-signup/signup.ts
+++ b/projects/app-web/src/routes/-signup/signup.ts
@@ -1,7 +1,9 @@
 import { createServerFn } from '@tanstack/react-start';
 import { signupHandler } from './signup-handler';
 
-/** The signup form's submit action; field-level validation happens once inside the handler. */
+/**
+ * The signup form's submit action; field-level validation happens once inside the handler.
+ */
 export const signup = createServerFn({ method: 'POST' })
   .validator((formData: unknown) => {
     if (!(formData instanceof FormData)) {

--- a/projects/app-web/src/routes/-verify-otp/run-onboarding.ts
+++ b/projects/app-web/src/routes/-verify-otp/run-onboarding.ts
@@ -2,7 +2,9 @@ import { redirect } from '@tanstack/react-router';
 import { updateVerifySession } from '../../lib/auth/update-verify-session';
 import type { RunVerificationContext } from './types';
 
-/** Records the verified email so the onboarding page's guard can trust it, then sends the caller there. */
+/**
+ * Records the verified email so the onboarding page's guard can trust it, then sends the caller there.
+ */
 export async function runOnboarding(ctx: Readonly<RunVerificationContext>): Promise<never> {
   await updateVerifySession({ 'onboarding#email': ctx.target });
 

--- a/projects/app-web/src/routes/-verify-otp/types.ts
+++ b/projects/app-web/src/routes/-verify-otp/types.ts
@@ -1,4 +1,6 @@
-/** What a verification type's post-verify continuation needs: who/what it verified for. */
+/**
+ * What a verification type's post-verify continuation needs: who/what it verified for.
+ */
 export interface RunVerificationContext {
   readonly redirectTo?: string | undefined;
   readonly target: string;

--- a/projects/app-web/src/routes/-verify-otp/verify-otp-form.tsx
+++ b/projects/app-web/src/routes/-verify-otp/verify-otp-form.tsx
@@ -56,7 +56,9 @@ const formStyles = css({
 
 const otpField = css({ marginBottom: '6' });
 
-/** The verify-otp page's client-interactive form: submits the code and renders the result. */
+/**
+ * The verify-otp page's client-interactive form: submits the code and renders the result.
+ */
 export function VerifyOTPForm(props: VerifyOTPFormProps) {
   const router = useRouter();
   const verifyOTPFn = useServerFn(verifyOTP);

--- a/projects/app-web/src/routes/-verify-otp/verify-otp.ts
+++ b/projects/app-web/src/routes/-verify-otp/verify-otp.ts
@@ -1,7 +1,9 @@
 import { createServerFn } from '@tanstack/react-start';
 import { verifyOTPHandler } from './verify-otp-handler';
 
-/** The verify-otp form's submit action; field-level validation happens once inside the handler. */
+/**
+ * The verify-otp form's submit action; field-level validation happens once inside the handler.
+ */
 export const verifyOTP = createServerFn({ method: 'POST' })
   .validator((formData: unknown) => {
     if (!(formData instanceof FormData)) {

--- a/projects/app-web/src/routes/health.ts
+++ b/projects/app-web/src/routes/health.ts
@@ -1,6 +1,8 @@
 import { createFileRoute } from '@tanstack/react-router';
 
-/** Liveness probe: no auth, no downstream calls, just confirms the server process is up. */
+/**
+ * Liveness probe: no auth, no downstream calls, just confirms the server process is up.
+ */
 export const Route = createFileRoute('/health')({
   server: {
     handlers: {

--- a/projects/app-web/src/routes/reset-password-started.tsx
+++ b/projects/app-web/src/routes/reset-password-started.tsx
@@ -14,7 +14,9 @@ export const Route = createFileRoute('/reset-password-started')({
 
 const pageInfo = css({ marginBottom: '8', textAlign: 'center' });
 
-/** A pure server component: a confirmation page with no client-interactive parts. */
+/**
+ * A pure server component: a confirmation page with no client-interactive parts.
+ */
 function ResetPasswordStarted() {
   return (
     <>

--- a/projects/app-web/src/test-utils/build-form-data.ts
+++ b/projects/app-web/src/test-utils/build-form-data.ts
@@ -1,4 +1,6 @@
-/** Builds a `FormData` from a flat field map, mirroring a form submission's payload. */
+/**
+ * Builds a `FormData` from a flat field map, mirroring a form submission's payload.
+ */
 export function buildFormData(fields: Readonly<Record<string, string>>): FormData {
   const formData = new FormData();
 

--- a/projects/app-web/src/test-utils/idle-worker-handle-holder.ts
+++ b/projects/app-web/src/test-utils/idle-worker-handle-holder.ts
@@ -1,6 +1,8 @@
 import type { ActivityAppState } from '@vers/idle-core';
 
-/** A duck-typed stand-in for `SharedWorker`: only the one channel the app ever writes to. */
+/**
+ * A duck-typed stand-in for `SharedWorker`: only the one channel the app ever writes to.
+ */
 export interface FakeSimulationWorker {
   readonly port: { readonly postMessage: (message: unknown) => void };
 }

--- a/projects/app-web/src/test-utils/render-with-router.tsx
+++ b/projects/app-web/src/test-utils/render-with-router.tsx
@@ -13,7 +13,9 @@ import type { FlagKey } from '@vers/flags';
 import type { ReactElement } from 'react';
 
 interface RenderWithRouterOptions {
-  /** Seeds the `/_game` layout route's context, read via `useRouteContext({ from: '/_game' })`. */
+  /**
+   * Seeds the `/_game` layout route's context, read via `useRouteContext({ from: '/_game' })`.
+   */
   readonly flags?: Readonly<Record<FlagKey, boolean>>;
 }
 

--- a/projects/app-web/src/test-utils/request-context-holder.ts
+++ b/projects/app-web/src/test-utils/request-context-holder.ts
@@ -1,11 +1,15 @@
-/** One faked cookie session: mirrors the shape `@tanstack/react-start/server` itself returns. */
+/**
+ * One faked cookie session: mirrors the shape `@tanstack/react-start/server` itself returns.
+ */
 export interface FakeSession {
   createdAt: number;
   data: Record<string, unknown>;
   id: string;
 }
 
-/** The ambient request state a `withRequestContext` call is currently driving. */
+/**
+ * The ambient request state a `withRequestContext` call is currently driving.
+ */
 export interface RequestContextState {
   readonly headers: Headers;
   readonly ip: string | undefined;

--- a/projects/app-web/src/test-utils/with-request-context.ts
+++ b/projects/app-web/src/test-utils/with-request-context.ts
@@ -4,7 +4,9 @@ import type { FakeSession } from './request-context-holder';
 import { requestContextHolder } from './request-context-holder';
 
 interface RequestContextInit {
-  /** Seeds a named cookie session (keyed by its `SessionConfig.name`) with existing data. */
+  /**
+   * Seeds a named cookie session (keyed by its `SessionConfig.name`) with existing data.
+   */
   readonly cookies?: Readonly<Record<string, Readonly<Record<string, unknown>>>>;
   readonly headers?: Readonly<Record<string, string>>;
   readonly ip?: string;
@@ -12,7 +14,9 @@ interface RequestContextInit {
 }
 
 interface RequestContextOutcome<T> {
-  /** Every named cookie session's data once the driven call finished; missing if it was cleared. */
+  /**
+   * Every named cookie session's data once the driven call finished; missing if it was cleared.
+   */
   readonly cookies: Readonly<Record<string, Record<string, unknown> | undefined>>;
   readonly value: T;
 }

--- a/projects/lib-client-test-utils/src/orpc/build-contract-mock.test.ts
+++ b/projects/lib-client-test-utils/src/orpc/build-contract-mock.test.ts
@@ -26,7 +26,9 @@ const secretContract = {
     .output(z.object({ value: z.string() })),
 };
 
-/** Reads the acting user from a bearer token forwarded on the `Authorization` header. */
+/**
+ * Reads the acting user from a bearer token forwarded on the `Authorization` header.
+ */
 function resolveContext(request: Request): SecretContext {
   const header = request.headers.get('authorization') ?? '';
   const actingUserId = header.startsWith('Bearer ') ? header.slice('Bearer '.length) : null;
@@ -34,7 +36,9 @@ function resolveContext(request: Request): SecretContext {
   return { actingUserId };
 }
 
-/** Runs a client call expected to reject with a defined oRPC error, and returns it. */
+/**
+ * Runs a client call expected to reject with a defined oRPC error, and returns it.
+ */
 async function runRejectingCall(call: () => Promise<unknown>): Promise<ORPCError<string, unknown>> {
   try {
     await call();

--- a/projects/lib-client-test-utils/src/orpc/build-contract-mock.ts
+++ b/projects/lib-client-test-utils/src/orpc/build-contract-mock.ts
@@ -13,7 +13,9 @@ import { http } from 'msw';
 import { RPC_PREFIX } from './rpc-prefix';
 import { toRPCHTTPPath } from './to-rpc-http-path';
 
-/** Arguments passed to a mocked procedure's handler function. */
+/**
+ * Arguments passed to a mocked procedure's handler function.
+ */
 export interface MockProcedureHandlerArgs<
   TInput,
   TContext extends Record<string, unknown>,
@@ -26,7 +28,9 @@ export interface MockProcedureHandlerArgs<
   readonly request: Request;
 }
 
-/** A mocked procedure's output: a static value, or a function computing it per call. */
+/**
+ * A mocked procedure's output: a static value, or a function computing it per call.
+ */
 export type MockProcedureHandler<
   TInput,
   TOutput,
@@ -39,14 +43,18 @@ export type MockProcedureHandler<
       args: MockProcedureHandlerArgs<TInput, TContext, TErrorMap>,
     ) => Promise<Response | TOutput> | Response | TOutput);
 
-/** The leaf the proxy exposes at a contract procedure's path. */
+/**
+ * The leaf the proxy exposes at a contract procedure's path.
+ */
 export interface MockProcedureProxy<
   TInput,
   TOutput,
   TContext extends Record<string, unknown>,
   TErrorMap extends ErrorMap,
 > {
-  /** Registers a narrow MSW handler matching exactly this procedure's RPC URL. */
+  /**
+   * Registers a narrow MSW handler matching exactly this procedure's RPC URL.
+   */
   handler: (mock: MockProcedureHandler<TInput, TOutput, TContext, TErrorMap>) => HttpHandler;
 }
 
@@ -67,7 +75,9 @@ type MockServiceProxyNode<TNode, TContext extends Record<string, unknown>> =
       ? { [K in keyof TNode]: MockServiceProxyNode<TNode[K], TContext> }
       : never;
 
-/** A typed proxy mirroring a contract's procedure tree; every leaf exposes `.handler(mock)`. */
+/**
+ * A typed proxy mirroring a contract's procedure tree; every leaf exposes `.handler(mock)`.
+ */
 export type MockServiceProxy<
   TContract extends AnyContractRouter,
   TContext extends Record<string, unknown>,
@@ -77,13 +87,19 @@ export interface MockServiceOptions<
   TContract extends AnyContractRouter,
   TContext extends Record<string, unknown>,
 > {
-  /** The service's origin, e.g. `http://user.test`; the RPC mount is always `${baseUrl}/rpc`. */
+  /**
+   * The service's origin, e.g. `http://user.test`; the RPC mount is always `${baseUrl}/rpc`.
+   */
   baseUrl: string;
 
-  /** The contract the proxy mirrors; anchors every leaf's input/output/error types. */
+  /**
+   * The contract the proxy mirrors; anchors every leaf's input/output/error types.
+   */
   contract: TContract;
 
-  /** Builds per-call context (e.g. `actingUserId`) from a request's forwarded headers. */
+  /**
+   * Builds per-call context (e.g. `actingUserId`) from a request's forwarded headers.
+   */
   resolveContext: (request: Request) => TContext | Promise<TContext>;
 }
 
@@ -104,7 +120,9 @@ export function buildContractMock<
   return buildProxyNode(options, []) as MockServiceProxy<TContract, TContext>;
 }
 
-/** Arguments a mocked procedure's handler function receives, once its types are erased. */
+/**
+ * Arguments a mocked procedure's handler function receives, once its types are erased.
+ */
 interface LooseMockFnArgs {
   readonly context: Record<string, unknown>;
   readonly errors: unknown;
@@ -113,18 +131,24 @@ interface LooseMockFnArgs {
   readonly request: Request;
 }
 
-/** A mocked procedure's handler function, once its input/output/error/context types are erased. */
+/**
+ * A mocked procedure's handler function, once its input/output/error/context types are erased.
+ */
 // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- generic callback-arg object; members are caller-typed, no deep-readonly satisfies the rule
 type LooseMockFn = (args: LooseMockFnArgs) => unknown;
 
-/** The loosely-typed view of `MockServiceOptions` this module's runtime traversal operates over. */
+/**
+ * The loosely-typed view of `MockServiceOptions` this module's runtime traversal operates over.
+ */
 interface UntypedMockServiceOptions {
   baseUrl: string;
   contract: AnyContractRouter;
   resolveContext: (request: Request) => Promise<Record<string, unknown>> | Record<string, unknown>;
 }
 
-/** Recursively builds the proxy tree, tracking the dot-path walked so far. */
+/**
+ * Recursively builds the proxy tree, tracking the dot-path walked so far.
+ */
 function buildProxyNode<
   TContract extends AnyContractRouter,
   TContext extends Record<string, unknown>,
@@ -147,7 +171,9 @@ function buildProxyNode<
   });
 }
 
-/** Builds the narrow MSW handler for one procedure's `.handler(mock)` call. */
+/**
+ * Builds the narrow MSW handler for one procedure's `.handler(mock)` call.
+ */
 function buildProcedureHandler(
   options: Readonly<UntypedMockServiceOptions>,
   path: ReadonlyArray<string>,
@@ -181,7 +207,9 @@ function buildProcedureHandler(
   });
 }
 
-/** Arguments a single implemented procedure's inner handler receives. */
+/**
+ * Arguments a single implemented procedure's inner handler receives.
+ */
 interface ProcedureImplementerHandlerArgs {
   readonly context: Record<string, unknown>;
   readonly errors: unknown;
@@ -189,7 +217,9 @@ interface ProcedureImplementerHandlerArgs {
   readonly path: ReadonlyArray<string>;
 }
 
-/** The shape `implement(contract)` exposes at a single procedure's path. */
+/**
+ * The shape `implement(contract)` exposes at a single procedure's path.
+ */
 interface ProcedureImplementer {
   // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- generic callback-arg object; members are caller-typed, no deep-readonly satisfies the rule
   handler: (fn: (opts: ProcedureImplementerHandlerArgs) => Promise<unknown>) => AnyRouter;
@@ -232,7 +262,9 @@ function buildMockProcedure(
   });
 }
 
-/** Rebuilds the nested router shape a single implemented procedure needs to sit at its path. */
+/**
+ * Rebuilds the nested router shape a single implemented procedure needs to sit at its path.
+ */
 // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- oRPC AnyRouter is a live router handle; no readonly form
 function buildNestedRouter(path: ReadonlyArray<string>, leaf: AnyRouter): AnyRouter {
   return path.reduceRight<AnyRouter>((accumulator, segment) => ({ [segment]: accumulator }), leaf);

--- a/projects/lib-client-test-utils/src/orpc/build-mock-service.test.ts
+++ b/projects/lib-client-test-utils/src/orpc/build-mock-service.test.ts
@@ -18,7 +18,9 @@ const widgetContract = {
 
 const widgetSchema = z.object({ id: z.string(), name: z.string() });
 
-/** A fresh, per-test in-memory backend the mocked `getWidget` handler reads from. */
+/**
+ * A fresh, per-test in-memory backend the mocked `getWidget` handler reads from.
+ */
 function buildWidgetCollection() {
   return new Collection({ schema: widgetSchema });
 }

--- a/projects/lib-client-test-utils/src/orpc/build-mock-service.ts
+++ b/projects/lib-client-test-utils/src/orpc/build-mock-service.ts
@@ -9,16 +9,24 @@ export interface BuildMockServiceOptions<
   TContract extends AnyContractRouter,
   TContext extends Record<string, unknown>,
 > {
-  /** The service's origin, e.g. `http://user.test`; the RPC mount is always `${baseUrl}/rpc`. */
+  /**
+   * The service's origin, e.g. `http://user.test`; the RPC mount is always `${baseUrl}/rpc`.
+   */
   baseUrl: string;
 
-  /** The contract the router must implement; anchors `router`'s type to the real service shape. */
+  /**
+   * The contract the router must implement; anchors `router`'s type to the real service shape.
+   */
   contract: TContract;
 
-  /** Builds per-call context (e.g. `actingUserId`) from a request's forwarded headers. */
+  /**
+   * Builds per-call context (e.g. `actingUserId`) from a request's forwarded headers.
+   */
   resolveContext: (request: Request) => TContext | Promise<TContext>;
 
-  /** A full `implement(contract)` router; every leaf handled, backend storage is the caller's choice. */
+  /**
+   * A full `implement(contract)` router; every leaf handled, backend storage is the caller's choice.
+   */
   router: Router<TContract, TContext>;
 }
 

--- a/projects/lib-client-test-utils/src/orpc/rpc-prefix.ts
+++ b/projects/lib-client-test-utils/src/orpc/rpc-prefix.ts
@@ -1,2 +1,4 @@
-/** The RPC mount point every service exposes its contract under; see docs/service-contracts.md. */
+/**
+ * The RPC mount point every service exposes its contract under; see docs/service-contracts.md.
+ */
 export const RPC_PREFIX = '/rpc';

--- a/projects/lib-client-test-utils/src/orpc/to-rpc-http-path.ts
+++ b/projects/lib-client-test-utils/src/orpc/to-rpc-http-path.ts
@@ -1,4 +1,6 @@
-/** Renders a procedure's dot-path segments as the URL path oRPC's RPC protocol sends them on. */
+/**
+ * Renders a procedure's dot-path segments as the URL path oRPC's RPC protocol sends them on.
+ */
 export function toRPCHTTPPath(path: ReadonlyArray<string>): string {
   return `/${path.map((segment) => encodeURIComponent(segment)).join('/')}`;
 }

--- a/projects/lib-contract-avatar/src/avatar-class-schema.ts
+++ b/projects/lib-contract-avatar/src/avatar-class-schema.ts
@@ -1,7 +1,9 @@
 import { Class } from '@vers/data';
 import * as z from 'zod';
 
-/** An avatar's class, sourced from the game's canonical class list. */
+/**
+ * An avatar's class, sourced from the game's canonical class list.
+ */
 export const AvatarClassSchema = z.enum(Class);
 
 export type AvatarClass = z.infer<typeof AvatarClassSchema>;

--- a/projects/lib-contract-avatar/src/avatar-contract.ts
+++ b/projects/lib-contract-avatar/src/avatar-contract.ts
@@ -4,7 +4,9 @@ import { AvatarClassSchema } from './avatar-class-schema';
 import { AvatarDataSchema } from './avatar-data-schema';
 import { AvatarNameSchema } from './avatar-name-schema';
 
-/** The avatar service's API: every procedure is authed and owner-scoped by `actingUserId`. */
+/**
+ * The avatar service's API: every procedure is authed and owner-scoped by `actingUserId`.
+ */
 export const avatarContract = {
   createAvatar: authedRoute
     .route({ method: 'POST', path: '/avatars', summary: 'Create an avatar for the caller' })

--- a/projects/lib-contract-avatar/src/avatar-data-schema.ts
+++ b/projects/lib-contract-avatar/src/avatar-data-schema.ts
@@ -1,7 +1,9 @@
 import * as z from 'zod';
 import { AvatarClassSchema } from './avatar-class-schema';
 
-/** An avatar as returned to callers. */
+/**
+ * An avatar as returned to callers.
+ */
 export const AvatarDataSchema = z.object({
   class: AvatarClassSchema,
   createdAt: z.date(),

--- a/projects/lib-contract-avatar/src/avatar-name-schema.ts
+++ b/projects/lib-contract-avatar/src/avatar-name-schema.ts
@@ -1,6 +1,8 @@
 import * as z from 'zod';
 
-/** An avatar's display name. */
+/**
+ * An avatar's display name.
+ */
 export const AvatarNameSchema = z
   .string({ error: 'Name is required' })
   .min(3, { error: 'Name must be at least 3 characters' })

--- a/projects/lib-contract-base/src/authed-route.ts
+++ b/projects/lib-contract-base/src/authed-route.ts
@@ -1,5 +1,7 @@
 import { oc } from '@orpc/contract';
 import { STANDARD_ERRORS } from './standard-errors';
 
-/** Base contract builder for procedures that require an authenticated acting user. */
+/**
+ * Base contract builder for procedures that require an authenticated acting user.
+ */
 export const authedRoute = oc.errors(STANDARD_ERRORS);

--- a/projects/lib-contract-base/src/public-route.ts
+++ b/projects/lib-contract-base/src/public-route.ts
@@ -1,3 +1,5 @@
-/** Base contract builder for procedures callable without an acting user. */
+/**
+ * Base contract builder for procedures callable without an acting user.
+ */
 
 export { oc as publicRoute } from '@orpc/contract';

--- a/projects/lib-contract-base/src/standard-errors.ts
+++ b/projects/lib-contract-base/src/standard-errors.ts
@@ -1,6 +1,8 @@
 import * as z from 'zod';
 
-/** Why a session failed to authenticate; carried in the UNAUTHORIZED error payload. */
+/**
+ * Why a session failed to authenticate; carried in the UNAUTHORIZED error payload.
+ */
 export const UnauthorizedReasonSchema = z.enum(['missing-session', 'expired-session']);
 
 export type UnauthorizedReason = z.infer<typeof UnauthorizedReasonSchema>;

--- a/projects/lib-contract-session/src/pending-transaction-data-schema.ts
+++ b/projects/lib-contract-session/src/pending-transaction-data-schema.ts
@@ -1,7 +1,9 @@
 import * as z from 'zod';
 import { SecureActionSchema } from './secure-action-schema';
 
-/** Durable state behind a step-up transaction; the token itself is minted at the edge. */
+/**
+ * Durable state behind a step-up transaction; the token itself is minted at the edge.
+ */
 export const PendingTransactionDataSchema = z.object({
   action: SecureActionSchema,
   attempts: z.int(),

--- a/projects/lib-contract-session/src/secure-action-schema.ts
+++ b/projects/lib-contract-session/src/secure-action-schema.ts
@@ -1,6 +1,8 @@
 import * as z from 'zod';
 
-/** A step-up-gated action; the pending-transaction and transaction-token subject. */
+/**
+ * A step-up-gated action; the pending-transaction and transaction-token subject.
+ */
 export const SecureActionSchema = z.enum([
   'ChangeEmail',
   'ChangeEmailConfirmation',

--- a/projects/lib-contract-session/src/session-data-schema.ts
+++ b/projects/lib-contract-session/src/session-data-schema.ts
@@ -1,6 +1,8 @@
 import * as z from 'zod';
 
-/** A session as returned to callers; strips `refreshToken` and `previousRefreshToken`. */
+/**
+ * A session as returned to callers; strips `refreshToken` and `previousRefreshToken`.
+ */
 export const SessionDataSchema = z.object({
   createdAt: z.date(),
   expiresAt: z.date(),

--- a/projects/lib-contract-user/src/name-schema.ts
+++ b/projects/lib-contract-user/src/name-schema.ts
@@ -1,6 +1,8 @@
 import * as z from 'zod';
 
-/** A user's display name. */
+/**
+ * A user's display name.
+ */
 export const NameSchema = z
   .string({ error: 'Name is required' })
   .min(3, { error: 'Name is too short' })

--- a/projects/lib-contract-user/src/password-schema.ts
+++ b/projects/lib-contract-user/src/password-schema.ts
@@ -1,6 +1,8 @@
 import * as z from 'zod';
 
-/** A user's plaintext password on signup, password change, or reset. */
+/**
+ * A user's plaintext password on signup, password change, or reset.
+ */
 export const PasswordSchema = z
   .string({ error: 'Password is required' })
   .min(8, { error: 'Password must be 8+ characters' })

--- a/projects/lib-contract-user/src/user-contract.ts
+++ b/projects/lib-contract-user/src/user-contract.ts
@@ -6,7 +6,9 @@ import { UserDataSchema } from './user-data-schema';
 import { UserEmailSchema } from './user-email-schema';
 import { UsernameSchema } from './username-schema';
 
-/** The user service's API: signup, credential checks, and profile mutation. */
+/**
+ * The user service's API: signup, credential checks, and profile mutation.
+ */
 export const userContract = {
   changePassword: authedRoute
     .route({ method: 'POST', path: '/users/me/password', summary: "Change the caller's password" })

--- a/projects/lib-contract-user/src/user-data-schema.ts
+++ b/projects/lib-contract-user/src/user-data-schema.ts
@@ -1,6 +1,8 @@
 import * as z from 'zod';
 
-/** A user as returned to callers; strips `passwordHash` and password-reset fields. */
+/**
+ * A user as returned to callers; strips `passwordHash` and password-reset fields.
+ */
 export const UserDataSchema = z.object({
   createdAt: z.date(),
   email: z.string(),

--- a/projects/lib-contract-user/src/user-email-schema.ts
+++ b/projects/lib-contract-user/src/user-email-schema.ts
@@ -1,6 +1,8 @@
 import * as z from 'zod';
 
-/** A user's email address; normalized to lowercase since users can type it in any case. */
+/**
+ * A user's email address; normalized to lowercase since users can type it in any case.
+ */
 export const UserEmailSchema = z
   .email({
     error: (issue) => (issue.input === undefined ? 'Email is required' : 'Email is invalid'),

--- a/projects/lib-contract-user/src/username-schema.ts
+++ b/projects/lib-contract-user/src/username-schema.ts
@@ -3,7 +3,9 @@ import * as z from 'zod';
 export const USERNAME_MIN_LENGTH = 3;
 export const USERNAME_MAX_LENGTH = 20;
 
-/** A user's handle; normalized to lowercase since users can type it in any case. */
+/**
+ * A user's handle; normalized to lowercase since users can type it in any case.
+ */
 export const UsernameSchema = z
   .string({ error: 'Username is required' })
   .min(USERNAME_MIN_LENGTH, { error: 'Username is too short' })

--- a/projects/lib-contract-verification/src/verification-contract.ts
+++ b/projects/lib-contract-verification/src/verification-contract.ts
@@ -3,7 +3,9 @@ import * as z from 'zod';
 import { VerificationDataSchema } from './verification-data-schema';
 import { VerificationTypeSchema } from './verification-type-schema';
 
-/** The verification service's API: TOTP-backed codes for 2FA, email change, and onboarding. */
+/**
+ * The verification service's API: TOTP-backed codes for 2FA, email change, and onboarding.
+ */
 export const verificationContract = {
   createVerification: publicRoute
     .route({ method: 'POST', path: '/verifications', summary: 'Create a verification code' })

--- a/projects/lib-contract-verification/src/verification-data-schema.ts
+++ b/projects/lib-contract-verification/src/verification-data-schema.ts
@@ -1,7 +1,9 @@
 import * as z from 'zod';
 import { VerificationTypeSchema } from './verification-type-schema';
 
-/** A verification as returned to callers; strips the TOTP secret and its configuration. */
+/**
+ * A verification as returned to callers; strips the TOTP secret and its configuration.
+ */
 export const VerificationDataSchema = z.object({
   id: z.string(),
   target: z.string(),

--- a/projects/lib-contract-verification/src/verification-type-schema.ts
+++ b/projects/lib-contract-verification/src/verification-type-schema.ts
@@ -1,6 +1,8 @@
 import * as z from 'zod';
 
-/** What a verification code is gating: 2FA login/setup, an email change, or onboarding. */
+/**
+ * What a verification code is gating: 2FA login/setup, an email change, or onboarding.
+ */
 export const VerificationTypeSchema = z.enum(['2fa', '2fa-setup', 'change-email', 'onboarding']);
 
 export type VerificationType = z.infer<typeof VerificationTypeSchema>;

--- a/projects/lib-db/src/test-support/resolve-test-db-target.ts
+++ b/projects/lib-db/src/test-support/resolve-test-db-target.ts
@@ -1,4 +1,6 @@
-/** The test container's base connection URI and migrated template database name. */
+/**
+ * The test container's base connection URI and migrated template database name.
+ */
 interface TestDBTarget {
   readonly baseURI: string;
   readonly templateDB: string;

--- a/projects/lib-email/scripts/preview.ts
+++ b/projects/lib-email/scripts/preview.ts
@@ -13,7 +13,9 @@ try {
   process.exit(1);
 }
 
-/** Renders every registered preview to `<name>.html`/`<name>.txt`, plus a linking `index.html`. */
+/**
+ * Renders every registered preview to `<name>.html`/`<name>.txt`, plus a linking `index.html`.
+ */
 async function writePreviews(outDir: string): Promise<void> {
   await mkdir(outDir, { recursive: true });
 
@@ -33,7 +35,9 @@ async function writePreviews(outDir: string): Promise<void> {
   console.log(`Rendered ${previews.length} email previews to ${outDir}`);
 }
 
-/** Builds a static index page linking every rendered preview's html/plain-text pair. */
+/**
+ * Builds a static index page linking every rendered preview's html/plain-text pair.
+ */
 function renderIndexPage(): string {
   const items = previews
     .map(

--- a/projects/lib-flags/src/is-flag-key.ts
+++ b/projects/lib-flags/src/is-flag-key.ts
@@ -1,7 +1,9 @@
 import { FLAGS } from './flags';
 import type { FlagKey } from './types';
 
-/** Narrows an arbitrary string to a registered {@link FlagKey}. */
+/**
+ * Narrows an arbitrary string to a registered {@link FlagKey}.
+ */
 export function isFlagKey(key: string): key is FlagKey {
   return Object.hasOwn(FLAGS, key);
 }

--- a/projects/lib-flags/src/types.ts
+++ b/projects/lib-flags/src/types.ts
@@ -1,9 +1,13 @@
 import type { FLAGS } from './flags';
 
-/** A registered flag's key, drawn from {@link FLAGS}. */
+/**
+ * A registered flag's key, drawn from {@link FLAGS}.
+ */
 export type FlagKey = keyof typeof FLAGS;
 
-/** A flag's static declaration: its safe fallback and what it gates. */
+/**
+ * A flag's static declaration: its safe fallback and what it gates.
+ */
 export interface FlagDefinition {
   readonly defaultValue: boolean;
   readonly description: string;

--- a/projects/lib-service-runtime/src/base-env-schema.ts
+++ b/projects/lib-service-runtime/src/base-env-schema.ts
@@ -1,6 +1,8 @@
 import * as z from 'zod';
 
-/** Environment variables every service validates at boot, before any service-specific ones. */
+/**
+ * Environment variables every service validates at boot, before any service-specific ones.
+ */
 export const BASE_ENV_SCHEMA = z.object({
   LOG_LEVEL: z.enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace']).default('info'),
   OTEL_EXPORTER_OTLP_ENDPOINT: z.url().optional(),

--- a/projects/lib-service-runtime/src/create-logger.ts
+++ b/projects/lib-service-runtime/src/create-logger.ts
@@ -5,7 +5,9 @@ interface CreateLoggerOptions {
   readonly name: string;
 }
 
-/** Builds a service's pino logger: JSON lines to stdout, with `name` bound onto every entry. */
+/**
+ * Builds a service's pino logger: JSON lines to stdout, with `name` bound onto every entry.
+ */
 export function createLogger(options: CreateLoggerOptions): pino.Logger {
   return pino({ level: options.level, name: options.name });
 }

--- a/projects/lib-service-runtime/src/create-service.test.ts
+++ b/projects/lib-service-runtime/src/create-service.test.ts
@@ -16,7 +16,9 @@ const OPENAPI_PATH_ITEM_SHAPE = z.object({
   get: z.object({ responses: OPENAPI_RESPONSES_SHAPE }).optional(),
 });
 
-/** The slice of a generated OpenAPI document the `/spec.json` test inspects. */
+/**
+ * The slice of a generated OpenAPI document the `/spec.json` test inspects.
+ */
 const OPENAPI_DOCUMENT_SHAPE = z.object({
   paths: z.record(z.string(), OPENAPI_PATH_ITEM_SHAPE),
 });
@@ -71,7 +73,9 @@ interface CreateTestServiceTokenOptions {
   readonly privateKey: CryptoKey;
 }
 
-/** Signs a short-lived s2s token carrying the same claim vocabulary a real service token does. */
+/**
+ * Signs a short-lived s2s token carrying the same claim vocabulary a real service token does.
+ */
 function createTestServiceToken(options: Readonly<CreateTestServiceTokenOptions>): Promise<string> {
   const claims = options.actingUserId === undefined ? {} : { sub: options.actingUserId };
 

--- a/projects/lib-service-runtime/src/create-service.ts
+++ b/projects/lib-service-runtime/src/create-service.ts
@@ -113,7 +113,9 @@ export async function createService<TEnvShape extends z.ZodRawShape = Record<nev
   };
 }
 
-/** Parses the base + service-specific environment shape against `process.env`, failing fast. */
+/**
+ * Parses the base + service-specific environment shape against `process.env`, failing fast.
+ */
 function parseServiceEnv<TEnvShape extends z.ZodRawShape>(
   envShape: TEnvShape,
 ): ServiceEnv<TEnvShape> {
@@ -132,7 +134,9 @@ function parseServiceEnv<TEnvShape extends z.ZodRawShape>(
   return { ...base.data, ...extra.data };
 }
 
-/** Generates the service's OpenAPI document from its contract, never its implementation. */
+/**
+ * Generates the service's OpenAPI document from its contract, never its implementation.
+ */
 function buildOpenAPIDocument(
   contract: AnyContractRouter,
   name: string,
@@ -146,7 +150,9 @@ function buildOpenAPIDocument(
   });
 }
 
-/** Reads the incoming request-id, or mints one when the caller didn't supply it. */
+/**
+ * Reads the incoming request-id, or mints one when the caller didn't supply it.
+ */
 function getRequestId(request: Request): string {
   return request.headers.get('x-request-id') ?? crypto.randomUUID();
 }

--- a/projects/lib-service-runtime/src/types.ts
+++ b/projects/lib-service-runtime/src/types.ts
@@ -1,8 +1,12 @@
 import type pino from 'pino';
 
-/** Per-request context available to every procedure handler. */
+/**
+ * Per-request context available to every procedure handler.
+ */
 export interface ServiceContext {
-  /** Acting user named by the verified service token; null for verified anonymous calls. */
+  /**
+   * Acting user named by the verified service token; null for verified anonymous calls.
+   */
   actingUserId: null | string;
   logger: pino.Logger;
   requestId: string;

--- a/projects/lib-service-test-utils/src/bun/composites/create-anonymous-viewer.ts
+++ b/projects/lib-service-test-utils/src/bun/composites/create-anonymous-viewer.ts
@@ -5,7 +5,9 @@ interface CreateAnonymousViewerConfig {
   readonly audience: string;
 }
 
-/** An s2s-authenticated token carrying no acting user, for anonymous-call test cases. */
+/**
+ * An s2s-authenticated token carrying no acting user, for anonymous-call test cases.
+ */
 export async function createAnonymousViewer(
   config: Readonly<CreateAnonymousViewerConfig>,
 ): Promise<{ token: string }> {

--- a/projects/lib-service-test-utils/src/bun/composites/create-viewer.ts
+++ b/projects/lib-service-test-utils/src/bun/composites/create-viewer.ts
@@ -10,7 +10,9 @@ interface CreateViewerConfig {
   readonly user?: Partial<Insertable<Users>>;
 }
 
-/** A persisted, s2s-authenticated acting user: a token and the user it was minted for. */
+/**
+ * A persisted, s2s-authenticated acting user: a token and the user it was minted for.
+ */
 export async function createViewer(
   config: Readonly<CreateViewerConfig>,
 ): Promise<{ token: string; user: Selectable<Users> }> {

--- a/projects/lib-service-test-utils/src/bun/create-database-from-template.ts
+++ b/projects/lib-service-test-utils/src/bun/create-database-from-template.ts
@@ -2,7 +2,9 @@ import { createId } from '@paralleldrive/cuid2';
 import postgres from 'postgres';
 import { resolveTestDBTarget } from './resolve-test-db-target';
 
-/** Creates a new database cloned from the migrated template; returns its connection URL. */
+/**
+ * Creates a new database cloned from the migrated template; returns its connection URL.
+ */
 export async function createDatabaseFromTemplate(): Promise<string> {
   const target = resolveTestDBTarget();
   const admin = postgres(`${target.baseURI}/postgres`);

--- a/projects/lib-service-test-utils/src/bun/create-service-key-pair.ts
+++ b/projects/lib-service-test-utils/src/bun/create-service-key-pair.ts
@@ -2,7 +2,9 @@ import { TOKEN_ALGORITHM } from '@vers/service-auth';
 import type { CryptoKey } from 'jose';
 import * as jose from 'jose';
 
-/** Generates a fresh Ed25519 keypair for tests: the public key in the SPKI PEM shape services expect. */
+/**
+ * Generates a fresh Ed25519 keypair for tests: the public key in the SPKI PEM shape services expect.
+ */
 export async function createServiceKeyPair(): Promise<{
   privateKey: CryptoKey;
   publicKeyPEM: string;

--- a/projects/lib-service-test-utils/src/bun/create-service-token.ts
+++ b/projects/lib-service-test-utils/src/bun/create-service-token.ts
@@ -9,7 +9,9 @@ interface CreateServiceTokenOptions {
   readonly privateKey: CryptoKey;
 }
 
-/** Signs a short-lived s2s token carrying the shared claim vocabulary, for tests to send as `Authorization: Bearer <token>`. */
+/**
+ * Signs a short-lived s2s token carrying the shared claim vocabulary, for tests to send as `Authorization: Bearer <token>`.
+ */
 export function createServiceToken(options: CreateServiceTokenOptions): Promise<string> {
   const claims = options.actingUserId === undefined ? {} : { sub: options.actingUserId };
 

--- a/projects/lib-service-test-utils/src/bun/create-test-db.ts
+++ b/projects/lib-service-test-utils/src/bun/create-test-db.ts
@@ -1,6 +1,8 @@
 import { makeTestDB } from './make-test-db';
 
-/** The repo's default test-DB factory: transaction isolation, with database isolation opt-in. */
+/**
+ * The repo's default test-DB factory: transaction isolation, with database isolation opt-in.
+ */
 export const createTestDB = makeTestDB({
   default: 'transaction',
   enabled: ['transaction', 'database'],

--- a/projects/lib-service-test-utils/src/bun/factories/create-mock-user.ts
+++ b/projects/lib-service-test-utils/src/bun/factories/create-mock-user.ts
@@ -4,7 +4,9 @@ import type { Users } from '@vers/db';
 import { createSeed } from '@vers/game-utils';
 import type { Insertable } from 'kysely';
 
-/** A plain, unpersisted user row with faker-generated defaults. Never requires a parent. */
+/**
+ * A plain, unpersisted user row with faker-generated defaults. Never requires a parent.
+ */
 export function createMockUser(overrides: Partial<Insertable<Users>> = {}): Insertable<Users> {
   const now = new Date();
 

--- a/projects/lib-service-test-utils/src/bun/resolve-test-db-target.ts
+++ b/projects/lib-service-test-utils/src/bun/resolve-test-db-target.ts
@@ -1,4 +1,6 @@
-/** The test container's base connection URI and migrated template database name. */
+/**
+ * The test container's base connection URI and migrated template database name.
+ */
 interface TestDBTarget {
   readonly baseURI: string;
   readonly templateDB: string;

--- a/projects/lib-service-test-utils/src/bun/strategies/create-transaction-test-db.ts
+++ b/projects/lib-service-test-utils/src/bun/strategies/create-transaction-test-db.ts
@@ -25,7 +25,9 @@ export async function createTransactionTestDB(): Promise<TestDBHandle> {
 
 let workerDB: Promise<Kysely<DB>> | undefined;
 
-/** One template clone per test process, memoized: every acquire shares the same underlying database. */
+/**
+ * One template clone per test process, memoized: every acquire shares the same underlying database.
+ */
 function getWorkerDB(): Promise<Kysely<DB>> {
   workerDB ??= buildWorkerDB();
 

--- a/projects/lib-test-utils/src/build-rpc-test-client.test.ts
+++ b/projects/lib-test-utils/src/build-rpc-test-client.test.ts
@@ -40,7 +40,9 @@ function buildTestContract() {
 
 type TestContract = ReturnType<typeof buildTestContract>;
 
-/** An app (in the shape `buildRPCTestClient` requires) whose one procedure reports back the `authorization` header it received. */
+/**
+ * An app (in the shape `buildRPCTestClient` requires) whose one procedure reports back the `authorization` header it received.
+ */
 function buildEchoApp(): { handle: (request: Request) => Promise<Response> } {
   const os = implement(buildTestContract()).$context<{ authorization: null | string }>();
 

--- a/projects/lib-test-utils/src/bun/original-env.ts
+++ b/projects/lib-test-utils/src/bun/original-env.ts
@@ -1,2 +1,4 @@
-/** Each overridden key's value from before its first override, `undefined` when it was unset. */
+/**
+ * Each overridden key's value from before its first override, `undefined` when it was unset.
+ */
 export const originals = new Map<string, string | undefined>();

--- a/projects/lib-test-utils/src/bun/remove-env-overrides.ts
+++ b/projects/lib-test-utils/src/bun/remove-env-overrides.ts
@@ -1,6 +1,8 @@
 import { originals } from './original-env';
 
-/** Removes every override made since the last restore. Wired into the global preload cleanup. */
+/**
+ * Removes every override made since the last restore. Wired into the global preload cleanup.
+ */
 export function removeEnvOverrides(): void {
   for (const [key, value] of originals) {
     if (value === undefined) {

--- a/projects/lib-test-utils/src/collect-conformance-cases.test.ts
+++ b/projects/lib-test-utils/src/collect-conformance-cases.test.ts
@@ -6,7 +6,9 @@ import * as z from 'zod';
 import type { ConformanceCaseApp } from './collect-conformance-cases';
 import { collectConformanceCases } from './collect-conformance-cases';
 
-/** Error vocabulary a fixture authed procedure declares, standing in for the real contract-base one. */
+/**
+ * Error vocabulary a fixture authed procedure declares, standing in for the real contract-base one.
+ */
 const TEST_ERRORS = {
   UNAUTHORIZED: {
     data: z.object({ reason: z.string() }),
@@ -71,7 +73,9 @@ function buildTestContract() {
 
 type TestContract = ReturnType<typeof buildTestContract>;
 
-/** Builds an app whose getThing handler enforces the acting-user check the contract declares. */
+/**
+ * Builds an app whose getThing handler enforces the acting-user check the contract declares.
+ */
 // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- structural map of oRPC contract procedures; framework types with no readonly form
 function buildConformingApp(contract: TestContract): ConformanceCaseApp {
   const os = implement(contract).$context<{ actingUserId: null | string }>();
@@ -90,7 +94,9 @@ function buildConformingApp(contract: TestContract): ConformanceCaseApp {
   return buildRPCApp(new RPCHandler(router));
 }
 
-/** Builds an app whose getThing handler skips the acting-user check, so anonymous calls succeed. */
+/**
+ * Builds an app whose getThing handler skips the acting-user check, so anonymous calls succeed.
+ */
 // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- structural map of oRPC contract procedures; framework types with no readonly form
 function buildBrokenApp(contract: TestContract): ConformanceCaseApp {
   const os = implement(contract).$context<{ actingUserId: null | string }>();

--- a/projects/service-avatar/src/build-router.ts
+++ b/projects/service-avatar/src/build-router.ts
@@ -13,7 +13,9 @@ interface BuildAvatarRouterDeps {
   readonly db: Kysely<DB>;
 }
 
-/** Assembles the avatar service's oRPC router, closing each handler over the shared db client. */
+/**
+ * Assembles the avatar service's oRPC router, closing each handler over the shared db client.
+ */
 export function buildAvatarRouter(deps: BuildAvatarRouterDeps) {
   const os = implement(avatarContract).$context<ServiceContext>();
 

--- a/projects/service-avatar/src/create-avatar-service.ts
+++ b/projects/service-avatar/src/create-avatar-service.ts
@@ -8,11 +8,15 @@ import * as z from 'zod';
 import { buildAvatarRouter } from './build-router';
 
 interface CreateAvatarServiceConfig {
-  /** Injected only in tests, to run the service inside the test's own transaction. */
+  /**
+   * Injected only in tests, to run the service inside the test's own transaction.
+   */
   readonly db?: Kysely<DB>;
 }
 
-/** Boots the avatar service; the production entrypoint and tests both call this as the one shared config. */
+/**
+ * Boots the avatar service; the production entrypoint and tests both call this as the one shared config.
+ */
 export function createAvatarService(
   config: CreateAvatarServiceConfig = {},
 ): Promise<Service<{ DATABASE_URL: z.ZodString }>> {

--- a/projects/service-avatar/src/handlers/create-avatar.ts
+++ b/projects/service-avatar/src/handlers/create-avatar.ts
@@ -5,7 +5,9 @@ import type { Kysely } from 'kysely';
 import type { EmptyErrorPayload, MissingSessionPayload } from '../types';
 import { toAvatarData } from './to-avatar-data';
 
-/** oRPC handler opts for the authed `createAvatar` procedure. */
+/**
+ * oRPC handler opts for the authed `createAvatar` procedure.
+ */
 interface CreateAvatarOpts {
   readonly context: { readonly actingUserId: null | string };
   readonly errors: {
@@ -15,7 +17,9 @@ interface CreateAvatarOpts {
   readonly input: { readonly class: AvatarData['class']; readonly name: string };
 }
 
-/** Creates an avatar owned by the acting user; throws CONFLICT when the name is already taken. */
+/**
+ * Creates an avatar owned by the acting user; throws CONFLICT when the name is already taken.
+ */
 export async function createAvatar(db: Kysely<DB>, opts: CreateAvatarOpts): Promise<AvatarData> {
   if (opts.context.actingUserId === null) {
     throw opts.errors.UNAUTHORIZED({ data: { reason: 'missing-session' } });
@@ -43,7 +47,9 @@ export async function createAvatar(db: Kysely<DB>, opts: CreateAvatarOpts): Prom
   }
 }
 
-/** postgres.js surfaces a unique-constraint violation as SQLSTATE 23505. */
+/**
+ * postgres.js surfaces a unique-constraint violation as SQLSTATE 23505.
+ */
 function isUniqueViolation(error: unknown): boolean {
   return typeof error === 'object' && error !== null && 'code' in error && error.code === '23505';
 }

--- a/projects/service-avatar/src/handlers/get-avatar.ts
+++ b/projects/service-avatar/src/handlers/get-avatar.ts
@@ -4,7 +4,9 @@ import type { Kysely } from 'kysely';
 import type { MissingSessionPayload } from '../types';
 import { toAvatarData } from './to-avatar-data';
 
-/** oRPC handler opts for the authed `getAvatar` procedure. */
+/**
+ * oRPC handler opts for the authed `getAvatar` procedure.
+ */
 interface GetAvatarOpts {
   readonly context: { readonly actingUserId: null | string };
   readonly errors: {
@@ -13,7 +15,9 @@ interface GetAvatarOpts {
   readonly input: { readonly id: string };
 }
 
-/** Returns an avatar owned by the acting user, or null when it doesn't exist or isn't theirs. */
+/**
+ * Returns an avatar owned by the acting user, or null when it doesn't exist or isn't theirs.
+ */
 export async function getAvatar(db: Kysely<DB>, opts: GetAvatarOpts): Promise<AvatarData | null> {
   if (opts.context.actingUserId === null) {
     throw opts.errors.UNAUTHORIZED({ data: { reason: 'missing-session' } });

--- a/projects/service-avatar/src/handlers/get-avatars.ts
+++ b/projects/service-avatar/src/handlers/get-avatars.ts
@@ -4,7 +4,9 @@ import type { Kysely } from 'kysely';
 import type { MissingSessionPayload } from '../types';
 import { toAvatarData } from './to-avatar-data';
 
-/** oRPC handler opts for the authed `getAvatars` procedure. */
+/**
+ * oRPC handler opts for the authed `getAvatars` procedure.
+ */
 interface GetAvatarsOpts {
   readonly context: { readonly actingUserId: null | string };
   readonly errors: {
@@ -12,7 +14,9 @@ interface GetAvatarsOpts {
   };
 }
 
-/** Lists every avatar owned by the acting user. */
+/**
+ * Lists every avatar owned by the acting user.
+ */
 export async function getAvatars(db: Kysely<DB>, opts: GetAvatarsOpts): Promise<Array<AvatarData>> {
   if (opts.context.actingUserId === null) {
     throw opts.errors.UNAUTHORIZED({ data: { reason: 'missing-session' } });

--- a/projects/service-avatar/src/handlers/remove-avatar.ts
+++ b/projects/service-avatar/src/handlers/remove-avatar.ts
@@ -2,7 +2,9 @@ import type { DB } from '@vers/db';
 import type { Kysely } from 'kysely';
 import type { EmptyErrorPayload, MissingSessionPayload } from '../types';
 
-/** oRPC handler opts for the authed `deleteAvatar` procedure. */
+/**
+ * oRPC handler opts for the authed `deleteAvatar` procedure.
+ */
 interface RemoveAvatarOpts {
   readonly context: { readonly actingUserId: null | string };
   readonly errors: {
@@ -12,7 +14,9 @@ interface RemoveAvatarOpts {
   readonly input: { readonly id: string };
 }
 
-/** Removes an avatar owned by the acting user; throws NOT_FOUND when they don't own it. */
+/**
+ * Removes an avatar owned by the acting user; throws NOT_FOUND when they don't own it.
+ */
 export async function removeAvatar(
   db: Kysely<DB>,
   opts: RemoveAvatarOpts,

--- a/projects/service-avatar/src/handlers/to-avatar-data.ts
+++ b/projects/service-avatar/src/handlers/to-avatar-data.ts
@@ -2,7 +2,9 @@ import type { AvatarData } from '@vers/contract-avatar';
 import type { Avatars } from '@vers/db';
 import type { Selectable } from 'kysely';
 
-/** Maps a kysely `avatars` row (camelCase columns) onto the contract's `AvatarData` shape. */
+/**
+ * Maps a kysely `avatars` row (camelCase columns) onto the contract's `AvatarData` shape.
+ */
 export function toAvatarData(row: Readonly<Selectable<Avatars>>): AvatarData {
   return {
     class: row.class,

--- a/projects/service-avatar/src/handlers/update-avatar.ts
+++ b/projects/service-avatar/src/handlers/update-avatar.ts
@@ -2,7 +2,9 @@ import type { DB } from '@vers/db';
 import type { Kysely } from 'kysely';
 import type { EmptyErrorPayload, MissingSessionPayload } from '../types';
 
-/** oRPC handler opts for the authed `updateAvatar` procedure. */
+/**
+ * oRPC handler opts for the authed `updateAvatar` procedure.
+ */
 interface UpdateAvatarOpts {
   readonly context: { readonly actingUserId: null | string };
   readonly errors: {
@@ -12,7 +14,9 @@ interface UpdateAvatarOpts {
   readonly input: { readonly id: string; readonly name: string };
 }
 
-/** Renames an avatar owned by the acting user; throws NOT_FOUND when they don't own it. */
+/**
+ * Renames an avatar owned by the acting user; throws NOT_FOUND when they don't own it.
+ */
 export async function updateAvatar(
   db: Kysely<DB>,
   opts: UpdateAvatarOpts,

--- a/projects/service-avatar/src/types.ts
+++ b/projects/service-avatar/src/types.ts
@@ -1,9 +1,13 @@
-/** Payload shape for an authed procedure's UNAUTHORIZED error when no acting user is present. */
+/**
+ * Payload shape for an authed procedure's UNAUTHORIZED error when no acting user is present.
+ */
 export interface MissingSessionPayload {
   readonly data: { readonly reason: 'missing-session' };
 }
 
-/** Payload shape for a data-less contract error (CONFLICT/NOT_FOUND). */
+/**
+ * Payload shape for a data-less contract error (CONFLICT/NOT_FOUND).
+ */
 export interface EmptyErrorPayload {
   readonly data: Record<never, never>;
 }

--- a/projects/service-session/src/build-router.ts
+++ b/projects/service-session/src/build-router.ts
@@ -22,7 +22,9 @@ interface BuildSessionRouterDeps {
   readonly signingKey: CryptoKey;
 }
 
-/** Assembles the session service's oRPC router, closing each handler over the shared db client. */
+/**
+ * Assembles the session service's oRPC router, closing each handler over the shared db client.
+ */
 export function buildSessionRouter(deps: Readonly<BuildSessionRouterDeps>) {
   const os = implement(sessionContract).$context<ServiceContext>();
 

--- a/projects/service-session/src/consts.ts
+++ b/projects/service-session/src/consts.ts
@@ -1,14 +1,24 @@
-/** How long a minted access token remains valid. */
+/**
+ * How long a minted access token remains valid.
+ */
 export const ACCESS_TOKEN_DURATION = 15 * 60 * 1000; // 15 minutes
 
-/** Default session lifetime for a login without `rememberMe`. */
+/**
+ * Default session lifetime for a login without `rememberMe`.
+ */
 export const SESSION_DURATION_SHORT = 24 * 60 * 60 * 1000; // 24 hours
 
-/** Session lifetime for a login with `rememberMe`. */
+/**
+ * Session lifetime for a login with `rememberMe`.
+ */
 export const SESSION_DURATION_LONG = 7 * 24 * 60 * 60 * 1000; // 7 days
 
-/** A step-up transaction is abandoned after this many failed verification attempts. */
+/**
+ * A step-up transaction is abandoned after this many failed verification attempts.
+ */
 export const MAX_TRANSACTION_ATTEMPTS = 5;
 
-/** How long a pending step-up transaction stays consumable before it's swept as expired. */
+/**
+ * How long a pending step-up transaction stays consumable before it's swept as expired.
+ */
 export const PENDING_TRANSACTION_TTL = 5 * 60 * 1000; // 5 minutes

--- a/projects/service-session/src/create-jwt.ts
+++ b/projects/service-session/src/create-jwt.ts
@@ -8,7 +8,9 @@ interface CreateJWTOpts {
   readonly userID: string;
 }
 
-/** Mints an RS256 JWT for a session's access/refresh token, subject-bound to the owning user. */
+/**
+ * Mints an RS256 JWT for a session's access/refresh token, subject-bound to the owning user.
+ */
 export function createJWT(opts: CreateJWTOpts): Promise<string> {
   return new jose.SignJWT({})
     .setProtectedHeader({ alg: 'RS256' })

--- a/projects/service-session/src/create-session-service.ts
+++ b/projects/service-session/src/create-session-service.ts
@@ -9,7 +9,9 @@ import * as z from 'zod';
 import { buildSessionRouter } from './build-router';
 
 interface CreateSessionServiceConfig {
-  /** Injected only in tests, to run the service inside the test's own transaction. */
+  /**
+   * Injected only in tests, to run the service inside the test's own transaction.
+   */
   readonly db?: Kysely<DB>;
 }
 
@@ -19,7 +21,9 @@ const SESSION_ENV_SHAPE = {
   JWT_SIGNING_PRIVKEY: z.string(),
 };
 
-/** Boots the session service; the production entrypoint and tests both call this as the one shared config. */
+/**
+ * Boots the session service; the production entrypoint and tests both call this as the one shared config.
+ */
 export function createSessionService(
   config: CreateSessionServiceConfig = {},
 ): Promise<Service<typeof SESSION_ENV_SHAPE>> {

--- a/projects/service-session/src/handlers/consume-pending-transaction.ts
+++ b/projects/service-session/src/handlers/consume-pending-transaction.ts
@@ -4,12 +4,16 @@ import type { Kysely } from 'kysely';
 import type { EmptyErrorPayload } from '../types';
 import { toPendingTransactionData } from './to-pending-transaction-data';
 
-/** Payload shape for the `TRANSACTION_MISMATCH` error, naming the first field that didn't match. */
+/**
+ * Payload shape for the `TRANSACTION_MISMATCH` error, naming the first field that didn't match.
+ */
 interface TransactionMismatchPayload {
   readonly data: { readonly field: 'action' | 'ipAddress' | 'sessionID' | 'target' };
 }
 
-/** oRPC handler opts for the public `stepUp.consumePendingTransaction` procedure. */
+/**
+ * oRPC handler opts for the public `stepUp.consumePendingTransaction` procedure.
+ */
 interface ConsumePendingTransactionOpts {
   readonly errors: {
     readonly NOT_FOUND: (payload: EmptyErrorPayload) => Error;

--- a/projects/service-session/src/handlers/consume-transaction-token.ts
+++ b/projects/service-session/src/handlers/consume-transaction-token.ts
@@ -1,7 +1,9 @@
 import type { DB } from '@vers/db';
 import type { Kysely } from 'kysely';
 
-/** oRPC handler opts for the public `stepUp.consumeTransactionToken` procedure. */
+/**
+ * oRPC handler opts for the public `stepUp.consumeTransactionToken` procedure.
+ */
 interface ConsumeTransactionTokenOpts {
   readonly input: { readonly expiresAt: Date; readonly jti: string };
 }

--- a/projects/service-session/src/handlers/create-pending-transaction.ts
+++ b/projects/service-session/src/handlers/create-pending-transaction.ts
@@ -5,7 +5,9 @@ import { PENDING_TRANSACTION_TTL } from '../consts';
 import type { EmptyErrorPayload } from '../types';
 import { toPendingTransactionData } from './to-pending-transaction-data';
 
-/** oRPC handler opts for the public `stepUp.createPendingTransaction` procedure. */
+/**
+ * oRPC handler opts for the public `stepUp.createPendingTransaction` procedure.
+ */
 interface CreatePendingTransactionOpts {
   readonly errors: {
     readonly CONFLICT: (payload: EmptyErrorPayload) => Error;
@@ -54,7 +56,9 @@ export async function createPendingTransaction(
   }
 }
 
-/** postgres.js surfaces a unique-constraint violation as SQLSTATE 23505. */
+/**
+ * postgres.js surfaces a unique-constraint violation as SQLSTATE 23505.
+ */
 function isUniqueViolation(error: unknown): boolean {
   return typeof error === 'object' && error !== null && 'code' in error && error.code === '23505';
 }

--- a/projects/service-session/src/handlers/create-session.ts
+++ b/projects/service-session/src/handlers/create-session.ts
@@ -5,7 +5,9 @@ import type { Kysely } from 'kysely';
 import { SESSION_DURATION_LONG, SESSION_DURATION_SHORT } from '../consts';
 import { toSessionData } from './to-session-data';
 
-/** oRPC handler opts for the public `createSession` procedure. */
+/**
+ * oRPC handler opts for the public `createSession` procedure.
+ */
 interface CreateSessionOpts {
   readonly input: {
     readonly expiresAt?: Date | undefined;
@@ -15,7 +17,9 @@ interface CreateSessionOpts {
   };
 }
 
-/** Creates an unverified session for a login, its expiry set by `rememberMe` unless overridden. */
+/**
+ * Creates an unverified session for a login, its expiry set by `rememberMe` unless overridden.
+ */
 export async function createSession(db: Kysely<DB>, opts: CreateSessionOpts): Promise<SessionData> {
   const sessionDuration =
     opts.input.rememberMe === true ? SESSION_DURATION_LONG : SESSION_DURATION_SHORT;

--- a/projects/service-session/src/handlers/get-pending-transaction.ts
+++ b/projects/service-session/src/handlers/get-pending-transaction.ts
@@ -3,7 +3,9 @@ import type { DB } from '@vers/db';
 import type { Kysely } from 'kysely';
 import { toPendingTransactionData } from './to-pending-transaction-data';
 
-/** oRPC handler opts for the public `stepUp.getPendingTransaction` procedure. */
+/**
+ * oRPC handler opts for the public `stepUp.getPendingTransaction` procedure.
+ */
 interface GetPendingTransactionOpts {
   readonly input: { readonly id: string };
 }

--- a/projects/service-session/src/handlers/get-session.ts
+++ b/projects/service-session/src/handlers/get-session.ts
@@ -4,7 +4,9 @@ import type { Kysely } from 'kysely';
 import type { MissingSessionPayload } from '../types';
 import { toSessionData } from './to-session-data';
 
-/** oRPC handler opts for the authed `getSession` procedure. */
+/**
+ * oRPC handler opts for the authed `getSession` procedure.
+ */
 interface GetSessionOpts {
   readonly context: { readonly actingUserId: null | string };
   readonly errors: {
@@ -13,7 +15,9 @@ interface GetSessionOpts {
   readonly input: { readonly id: string };
 }
 
-/** Returns a session owned by the acting user, or null when it doesn't exist or isn't theirs. */
+/**
+ * Returns a session owned by the acting user, or null when it doesn't exist or isn't theirs.
+ */
 export async function getSession(
   db: Kysely<DB>,
   opts: GetSessionOpts,

--- a/projects/service-session/src/handlers/get-sessions.ts
+++ b/projects/service-session/src/handlers/get-sessions.ts
@@ -4,7 +4,9 @@ import type { Kysely } from 'kysely';
 import type { MissingSessionPayload } from '../types';
 import { toSessionData } from './to-session-data';
 
-/** oRPC handler opts for the authed `getSessions` procedure. */
+/**
+ * oRPC handler opts for the authed `getSessions` procedure.
+ */
 interface GetSessionsOpts {
   readonly context: { readonly actingUserId: null | string };
   readonly errors: {
@@ -12,7 +14,9 @@ interface GetSessionsOpts {
   };
 }
 
-/** Lists every session owned by the acting user. */
+/**
+ * Lists every session owned by the acting user.
+ */
 export async function getSessions(
   db: Kysely<DB>,
   opts: GetSessionsOpts,

--- a/projects/service-session/src/handlers/record-failed-attempt.ts
+++ b/projects/service-session/src/handlers/record-failed-attempt.ts
@@ -4,7 +4,9 @@ import { sql } from 'kysely';
 import { MAX_TRANSACTION_ATTEMPTS } from '../consts';
 import type { EmptyErrorPayload } from '../types';
 
-/** oRPC handler opts for the public `stepUp.recordFailedAttempt` procedure. */
+/**
+ * oRPC handler opts for the public `stepUp.recordFailedAttempt` procedure.
+ */
 interface RecordFailedAttemptOpts {
   readonly errors: {
     readonly NOT_FOUND: (payload: EmptyErrorPayload) => Error;
@@ -55,7 +57,9 @@ export async function recordFailedAttempt(
   throw opts.errors.NOT_FOUND({ data: {} });
 }
 
-/** Deletes the pending transaction if it has reached the second-to-last allowed attempt. */
+/**
+ * Deletes the pending transaction if it has reached the second-to-last allowed attempt.
+ */
 async function removeIfAtCap(db: Kysely<DB>, id: string): Promise<boolean> {
   const result = await db
     .deleteFrom('pendingTransactions')

--- a/projects/service-session/src/handlers/refresh-tokens.ts
+++ b/projects/service-session/src/handlers/refresh-tokens.ts
@@ -4,7 +4,9 @@ import { ACCESS_TOKEN_DURATION, SESSION_DURATION_SHORT } from '../consts';
 import { createJWT } from '../create-jwt';
 import type { EmptyErrorPayload, SessionSigningDeps } from '../types';
 
-/** oRPC handler opts for the public `refreshTokens` procedure. */
+/**
+ * oRPC handler opts for the public `refreshTokens` procedure.
+ */
 interface RefreshTokensOpts {
   readonly errors: {
     readonly NOT_FOUND: (payload: EmptyErrorPayload) => Error;

--- a/projects/service-session/src/handlers/remove-session.ts
+++ b/projects/service-session/src/handlers/remove-session.ts
@@ -2,7 +2,9 @@ import type { DB } from '@vers/db';
 import type { Kysely } from 'kysely';
 import type { MissingSessionPayload } from '../types';
 
-/** oRPC handler opts for the authed `deleteSession` procedure. */
+/**
+ * oRPC handler opts for the authed `deleteSession` procedure.
+ */
 interface RemoveSessionOpts {
   readonly context: { readonly actingUserId: null | string };
   readonly errors: {

--- a/projects/service-session/src/handlers/to-session-data.ts
+++ b/projects/service-session/src/handlers/to-session-data.ts
@@ -2,7 +2,9 @@ import type { SessionData } from '@vers/contract-session';
 import type { Sessions } from '@vers/db';
 import type { Selectable } from 'kysely';
 
-/** Maps a kysely `sessions` row onto the contract's `SessionData` shape, stripping token columns. */
+/**
+ * Maps a kysely `sessions` row onto the contract's `SessionData` shape, stripping token columns.
+ */
 export function toSessionData(row: Readonly<Selectable<Sessions>>): SessionData {
   return {
     createdAt: row.createdAt,

--- a/projects/service-session/src/handlers/verify-session.ts
+++ b/projects/service-session/src/handlers/verify-session.ts
@@ -5,7 +5,9 @@ import { createJWT } from '../create-jwt';
 import { isDeadlockError } from '../is-deadlock-error';
 import type { EmptyErrorPayload, SessionSigningDeps } from '../types';
 
-/** oRPC handler opts for the public `verifySession` procedure. */
+/**
+ * oRPC handler opts for the public `verifySession` procedure.
+ */
 interface VerifySessionOpts {
   readonly errors: {
     readonly NOT_FOUND: (payload: EmptyErrorPayload) => Error;

--- a/projects/service-session/src/types.ts
+++ b/projects/service-session/src/types.ts
@@ -1,16 +1,22 @@
 import type { CryptoKey } from 'jose';
 
-/** Payload shape for an authed procedure's UNAUTHORIZED error when no acting user is present. */
+/**
+ * Payload shape for an authed procedure's UNAUTHORIZED error when no acting user is present.
+ */
 export interface MissingSessionPayload {
   readonly data: { readonly reason: 'missing-session' };
 }
 
-/** Payload shape for a data-less contract error (NOT_FOUND/CONFLICT/SESSION_EXPIRED/...). */
+/**
+ * Payload shape for a data-less contract error (NOT_FOUND/CONFLICT/SESSION_EXPIRED/...).
+ */
 export interface EmptyErrorPayload {
   readonly data: Record<never, never>;
 }
 
-/** Signing dependencies every token-minting handler closes over. */
+/**
+ * Signing dependencies every token-minting handler closes over.
+ */
 export interface SessionSigningDeps {
   readonly apiIdentifier: string;
   readonly signingKey: CryptoKey;

--- a/projects/service-user/src/build-router.ts
+++ b/projects/service-user/src/build-router.ts
@@ -17,7 +17,9 @@ interface BuildUserRouterDeps {
   readonly db: Kysely<DB>;
 }
 
-/** Assembles the user service's oRPC router, closing each handler over the shared db client. */
+/**
+ * Assembles the user service's oRPC router, closing each handler over the shared db client.
+ */
 export function buildUserRouter(deps: BuildUserRouterDeps) {
   const os = implement(userContract).$context<ServiceContext>();
 

--- a/projects/service-user/src/create-user-service.ts
+++ b/projects/service-user/src/create-user-service.ts
@@ -8,11 +8,15 @@ import * as z from 'zod';
 import { buildUserRouter } from './build-router';
 
 interface CreateUserServiceConfig {
-  /** Injected only in tests, to run the service inside the test's own transaction. */
+  /**
+   * Injected only in tests, to run the service inside the test's own transaction.
+   */
   readonly db?: Kysely<DB>;
 }
 
-/** Boots the user service; the production entrypoint and tests both call this as the one shared config. */
+/**
+ * Boots the user service; the production entrypoint and tests both call this as the one shared config.
+ */
 export function createUserService(
   config: CreateUserServiceConfig = {},
 ): Promise<Service<{ DATABASE_URL: z.ZodString }>> {

--- a/projects/service-user/src/handlers/change-password.ts
+++ b/projects/service-user/src/handlers/change-password.ts
@@ -2,7 +2,9 @@ import type { DB } from '@vers/db';
 import type { Kysely } from 'kysely';
 import type { EmptyErrorPayload, MissingSessionPayload } from '../types';
 
-/** oRPC handler opts for the authed `changePassword` procedure. */
+/**
+ * oRPC handler opts for the authed `changePassword` procedure.
+ */
 interface ChangePasswordOpts {
   readonly context: { readonly actingUserId: null | string };
   readonly errors: {
@@ -12,7 +14,9 @@ interface ChangePasswordOpts {
   readonly input: { readonly password: string };
 }
 
-/** Rehashes the acting user's password as argon2id; throws NOT_FOUND when the account is gone. */
+/**
+ * Rehashes the acting user's password as argon2id; throws NOT_FOUND when the account is gone.
+ */
 export async function changePassword(
   db: Kysely<DB>,
   opts: ChangePasswordOpts,

--- a/projects/service-user/src/handlers/create-password-reset-token.ts
+++ b/projects/service-user/src/handlers/create-password-reset-token.ts
@@ -5,7 +5,9 @@ import type { EmptyErrorPayload } from '../types';
 
 const RESET_TOKEN_TTL_MS = 10 * 60 * 1000;
 
-/** oRPC handler opts for the `createPasswordResetToken` procedure. */
+/**
+ * oRPC handler opts for the `createPasswordResetToken` procedure.
+ */
 interface CreatePasswordResetTokenOpts {
   readonly errors: {
     readonly NOT_FOUND: (payload: EmptyErrorPayload) => Error;

--- a/projects/service-user/src/handlers/create-user.ts
+++ b/projects/service-user/src/handlers/create-user.ts
@@ -6,7 +6,9 @@ import type { Kysely } from 'kysely';
 import type { FieldConflictPayload } from '../types';
 import { toUserData } from './to-user-data';
 
-/** oRPC handler opts for the `createUser` procedure. */
+/**
+ * oRPC handler opts for the `createUser` procedure.
+ */
 interface CreateUserOpts {
   readonly errors: {
     readonly CONFLICT: (payload: FieldConflictPayload<'email' | 'username'>) => Error;
@@ -19,7 +21,9 @@ interface CreateUserOpts {
   };
 }
 
-/** Creates a user with an argon2id-hashed password; throws CONFLICT when the email or username is taken. */
+/**
+ * Creates a user with an argon2id-hashed password; throws CONFLICT when the email or username is taken.
+ */
 export async function createUser(db: Kysely<DB>, opts: CreateUserOpts): Promise<UserData> {
   const passwordHash = await Bun.password.hash(opts.input.password, 'argon2id');
 
@@ -49,7 +53,9 @@ export async function createUser(db: Kysely<DB>, opts: CreateUserOpts): Promise<
   }
 }
 
-/** postgres.js surfaces a unique-constraint violation as SQLSTATE 23505, naming the constraint. */
+/**
+ * postgres.js surfaces a unique-constraint violation as SQLSTATE 23505, naming the constraint.
+ */
 function findViolatedField(error: unknown): 'email' | 'username' | undefined {
   if (
     typeof error !== 'object' ||

--- a/projects/service-user/src/handlers/get-current-user.ts
+++ b/projects/service-user/src/handlers/get-current-user.ts
@@ -4,7 +4,9 @@ import type { Kysely } from 'kysely';
 import type { MissingSessionPayload } from '../types';
 import { toUserData } from './to-user-data';
 
-/** oRPC handler opts for the authed `getCurrentUser` procedure. */
+/**
+ * oRPC handler opts for the authed `getCurrentUser` procedure.
+ */
 interface GetCurrentUserOpts {
   readonly context: { readonly actingUserId: null | string };
   readonly errors: {
@@ -12,7 +14,9 @@ interface GetCurrentUserOpts {
   };
 }
 
-/** Returns the acting user's own profile; UNAUTHORIZED both for no session and a deleted account. */
+/**
+ * Returns the acting user's own profile; UNAUTHORIZED both for no session and a deleted account.
+ */
 export async function getCurrentUser(db: Kysely<DB>, opts: GetCurrentUserOpts): Promise<UserData> {
   if (opts.context.actingUserId === null) {
     throw opts.errors.UNAUTHORIZED({ data: { reason: 'missing-session' } });

--- a/projects/service-user/src/handlers/get-user.ts
+++ b/projects/service-user/src/handlers/get-user.ts
@@ -3,12 +3,16 @@ import type { DB } from '@vers/db';
 import type { Kysely } from 'kysely';
 import { toUserData } from './to-user-data';
 
-/** oRPC handler opts for the `getUser` procedure. */
+/**
+ * oRPC handler opts for the `getUser` procedure.
+ */
 interface GetUserOpts {
   readonly input: { readonly email?: string | undefined; readonly id?: string | undefined };
 }
 
-/** Looks up a user matching the provided id or email; null when neither is provided or matches. */
+/**
+ * Looks up a user matching the provided id or email; null when neither is provided or matches.
+ */
 export async function getUser(db: Kysely<DB>, opts: GetUserOpts): Promise<UserData | null> {
   const row = await db
     .selectFrom('users')

--- a/projects/service-user/src/handlers/reset-password.ts
+++ b/projects/service-user/src/handlers/reset-password.ts
@@ -3,7 +3,9 @@ import type { DB } from '@vers/db';
 import type { Kysely } from 'kysely';
 import type { EmptyErrorPayload } from '../types';
 
-/** oRPC handler opts for the `resetPassword` procedure. */
+/**
+ * oRPC handler opts for the `resetPassword` procedure.
+ */
 interface ResetPasswordOpts {
   readonly errors: {
     readonly INVALID_RESET_TOKEN: (payload: EmptyErrorPayload) => Error;

--- a/projects/service-user/src/handlers/to-user-data.ts
+++ b/projects/service-user/src/handlers/to-user-data.ts
@@ -2,7 +2,9 @@ import type { UserData } from '@vers/contract-user';
 import type { Users } from '@vers/db';
 import type { Selectable } from 'kysely';
 
-/** Maps a kysely `users` row onto the contract's `UserData` shape, stripping credential fields. */
+/**
+ * Maps a kysely `users` row onto the contract's `UserData` shape, stripping credential fields.
+ */
 export function toUserData(row: Readonly<Selectable<Users>>): UserData {
   return {
     createdAt: row.createdAt,

--- a/projects/service-user/src/handlers/update-email.ts
+++ b/projects/service-user/src/handlers/update-email.ts
@@ -2,7 +2,9 @@ import type { DB } from '@vers/db';
 import type { Kysely } from 'kysely';
 import type { EmptyErrorPayload, FieldConflictPayload, MissingSessionPayload } from '../types';
 
-/** oRPC handler opts for the authed `updateEmail` procedure. */
+/**
+ * oRPC handler opts for the authed `updateEmail` procedure.
+ */
 interface UpdateEmailOpts {
   readonly context: { readonly actingUserId: null | string };
   readonly errors: {
@@ -114,7 +116,9 @@ async function runGuardedEmailUpdate(
   return result.length > 0;
 }
 
-/** postgres.js surfaces a unique-constraint violation as SQLSTATE 23505, naming the constraint. */
+/**
+ * postgres.js surfaces a unique-constraint violation as SQLSTATE 23505, naming the constraint.
+ */
 function isEmailViolation(error: unknown): boolean {
   return (
     typeof error === 'object' &&

--- a/projects/service-user/src/handlers/update-user.ts
+++ b/projects/service-user/src/handlers/update-user.ts
@@ -2,7 +2,9 @@ import type { DB } from '@vers/db';
 import type { Kysely } from 'kysely';
 import type { EmptyErrorPayload, FieldConflictPayload, MissingSessionPayload } from '../types';
 
-/** oRPC handler opts for the authed `updateUser` procedure. */
+/**
+ * oRPC handler opts for the authed `updateUser` procedure.
+ */
 interface UpdateUserOpts {
   readonly context: { readonly actingUserId: null | string };
   readonly errors: {
@@ -66,7 +68,9 @@ export async function updateUser(
   }
 }
 
-/** postgres.js surfaces a unique-constraint violation as SQLSTATE 23505, naming the constraint. */
+/**
+ * postgres.js surfaces a unique-constraint violation as SQLSTATE 23505, naming the constraint.
+ */
 function isUsernameViolation(error: unknown): boolean {
   return (
     typeof error === 'object' &&

--- a/projects/service-user/src/handlers/verify-password.ts
+++ b/projects/service-user/src/handlers/verify-password.ts
@@ -6,7 +6,9 @@ import type { Kysely } from 'kysely';
 const DUMMY_HASH =
   '$argon2id$v=19$m=65536,t=2,p=1$HcnWDKgn0Ge+fMLfUNLxdQyZQP62cm11r4tp2hS9GwE$jcksXM4djDmS+FjzQVmKOHr/5+J1lvSh1lPjUesXBco';
 
-/** oRPC handler opts for the `verifyPassword` procedure. */
+/**
+ * oRPC handler opts for the `verifyPassword` procedure.
+ */
 interface VerifyPasswordOpts {
   readonly input: { readonly email: string; readonly password: string };
 }

--- a/projects/service-user/src/test-utils/factories/create-mock-session.ts
+++ b/projects/service-user/src/test-utils/factories/create-mock-session.ts
@@ -7,7 +7,9 @@ interface CreateMockSessionData extends Partial<Insertable<Sessions>> {
   readonly userId: string;
 }
 
-/** A plain, unpersisted session row with faker-generated defaults; requires an owning user. */
+/**
+ * A plain, unpersisted session row with faker-generated defaults; requires an owning user.
+ */
 export function createMockSession(data: Readonly<CreateMockSessionData>): Insertable<Sessions> {
   return {
     expiresAt: faker.date.future(),

--- a/projects/service-user/src/test-utils/factories/create-mock-verification.ts
+++ b/projects/service-user/src/test-utils/factories/create-mock-verification.ts
@@ -3,7 +3,9 @@ import { createId } from '@paralleldrive/cuid2';
 import type { Verifications } from '@vers/db';
 import type { Insertable } from 'kysely';
 
-/** A plain, unpersisted verification row with faker-generated defaults for a TOTP onboarding code. */
+/**
+ * A plain, unpersisted verification row with faker-generated defaults for a TOTP onboarding code.
+ */
 export function createMockVerification(
   overrides: Partial<Insertable<Verifications>> = {},
 ): Insertable<Verifications> {

--- a/projects/service-user/src/types.ts
+++ b/projects/service-user/src/types.ts
@@ -1,14 +1,20 @@
-/** Payload shape for an authed procedure's UNAUTHORIZED error when no acting user is present. */
+/**
+ * Payload shape for an authed procedure's UNAUTHORIZED error when no acting user is present.
+ */
 export interface MissingSessionPayload {
   readonly data: { readonly reason: 'missing-session' };
 }
 
-/** Payload shape for a data-less contract error (CONFLICT/NOT_FOUND/...). */
+/**
+ * Payload shape for a data-less contract error (CONFLICT/NOT_FOUND/...).
+ */
 export interface EmptyErrorPayload {
   readonly data: Record<never, never>;
 }
 
-/** Payload shape for a CONFLICT error naming which unique field collided. */
+/**
+ * Payload shape for a CONFLICT error naming which unique field collided.
+ */
 export interface FieldConflictPayload<Field extends string> {
   readonly data: { readonly field: Field };
 }

--- a/projects/service-verification/src/build-router.ts
+++ b/projects/service-verification/src/build-router.ts
@@ -14,7 +14,9 @@ interface BuildVerificationRouterDeps {
   readonly db: Kysely<DB>;
 }
 
-/** Assembles the verification service's oRPC router, closing each handler over the shared db client. */
+/**
+ * Assembles the verification service's oRPC router, closing each handler over the shared db client.
+ */
 export function buildVerificationRouter(deps: BuildVerificationRouterDeps) {
   const os = implement(verificationContract).$context<ServiceContext>();
 

--- a/projects/service-verification/src/create-verification-service.ts
+++ b/projects/service-verification/src/create-verification-service.ts
@@ -8,11 +8,15 @@ import * as z from 'zod';
 import { buildVerificationRouter } from './build-router';
 
 interface CreateVerificationServiceConfig {
-  /** Injected only in tests, to run the service inside the test's own transaction. */
+  /**
+   * Injected only in tests, to run the service inside the test's own transaction.
+   */
   readonly db?: Kysely<DB>;
 }
 
-/** Boots the verification service; the production entrypoint and tests both call this as the one shared config. */
+/**
+ * Boots the verification service; the production entrypoint and tests both call this as the one shared config.
+ */
 export function createVerificationService(
   config: CreateVerificationServiceConfig = {},
 ): Promise<Service<{ DATABASE_URL: z.ZodString }>> {

--- a/projects/service-verification/src/handlers/create-verification.ts
+++ b/projects/service-verification/src/handlers/create-verification.ts
@@ -18,7 +18,9 @@ const VERIFICATION_TYPE_TO_CHARSET: Record<VerificationType, string> = {
   onboarding: TOTP_CHARSET,
 };
 
-/** oRPC handler opts for the `createVerification` procedure. */
+/**
+ * oRPC handler opts for the `createVerification` procedure.
+ */
 interface CreateVerificationOpts {
   readonly input: {
     readonly expiresAt?: Date | null | undefined;

--- a/projects/service-verification/src/handlers/get-2fa-verification-uri.ts
+++ b/projects/service-verification/src/handlers/get-2fa-verification-uri.ts
@@ -3,7 +3,9 @@ import type { DB } from '@vers/db';
 import type { Kysely } from 'kysely';
 import type { EmptyErrorPayload } from '../types';
 
-/** oRPC handler opts for the `get2FAVerificationURI` procedure. */
+/**
+ * oRPC handler opts for the `get2FAVerificationURI` procedure.
+ */
 interface Get2FAVerificationURIOpts {
   readonly errors: {
     readonly NOT_FOUND: (payload: EmptyErrorPayload) => Error;
@@ -11,7 +13,9 @@ interface Get2FAVerificationURIOpts {
   readonly input: { readonly target: string };
 }
 
-/** Returns the TOTP auth URI for a target's pending 2FA setup; throws NOT_FOUND when none exists. */
+/**
+ * Returns the TOTP auth URI for a target's pending 2FA setup; throws NOT_FOUND when none exists.
+ */
 export async function get2FAVerificationURI(
   db: Kysely<DB>,
   opts: Get2FAVerificationURIOpts,

--- a/projects/service-verification/src/handlers/get-verification.ts
+++ b/projects/service-verification/src/handlers/get-verification.ts
@@ -3,12 +3,16 @@ import type { DB } from '@vers/db';
 import type { Kysely } from 'kysely';
 import { toVerificationData } from './to-verification-data';
 
-/** oRPC handler opts for the `getVerification` procedure. */
+/**
+ * oRPC handler opts for the `getVerification` procedure.
+ */
 interface GetVerificationOpts {
   readonly input: { readonly target: string; readonly type: VerificationType };
 }
 
-/** Looks up a verification by target and type; deletes and returns null when it has expired. */
+/**
+ * Looks up a verification by target and type; deletes and returns null when it has expired.
+ */
 export async function getVerification(
   db: Kysely<DB>,
   opts: GetVerificationOpts,

--- a/projects/service-verification/src/handlers/remove-verification.ts
+++ b/projects/service-verification/src/handlers/remove-verification.ts
@@ -2,7 +2,9 @@ import type { DB } from '@vers/db';
 import type { Kysely } from 'kysely';
 import type { EmptyErrorPayload } from '../types';
 
-/** oRPC handler opts for the `deleteVerification` procedure. */
+/**
+ * oRPC handler opts for the `deleteVerification` procedure.
+ */
 interface RemoveVerificationOpts {
   readonly errors: {
     readonly NOT_FOUND: (payload: EmptyErrorPayload) => Error;
@@ -10,7 +12,9 @@ interface RemoveVerificationOpts {
   readonly input: { readonly id: string };
 }
 
-/** Removes a verification record; throws NOT_FOUND when it doesn't exist. */
+/**
+ * Removes a verification record; throws NOT_FOUND when it doesn't exist.
+ */
 export async function removeVerification(
   db: Kysely<DB>,
   opts: RemoveVerificationOpts,

--- a/projects/service-verification/src/handlers/to-verification-data.ts
+++ b/projects/service-verification/src/handlers/to-verification-data.ts
@@ -2,7 +2,9 @@ import type { VerificationData } from '@vers/contract-verification';
 import type { Verifications } from '@vers/db';
 import type { Selectable } from 'kysely';
 
-/** Maps a kysely `verifications` row onto the contract's `VerificationData` shape, stripping the TOTP secret and its configuration. */
+/**
+ * Maps a kysely `verifications` row onto the contract's `VerificationData` shape, stripping the TOTP secret and its configuration.
+ */
 export function toVerificationData(row: Readonly<Selectable<Verifications>>): VerificationData {
   return {
     id: row.id,

--- a/projects/service-verification/src/handlers/update-verification.ts
+++ b/projects/service-verification/src/handlers/update-verification.ts
@@ -3,7 +3,9 @@ import type { DB } from '@vers/db';
 import type { Kysely } from 'kysely';
 import type { EmptyErrorPayload } from '../types';
 
-/** oRPC handler opts for the `updateVerification` procedure. */
+/**
+ * oRPC handler opts for the `updateVerification` procedure.
+ */
 interface UpdateVerificationOpts {
   readonly errors: {
     readonly NOT_FOUND: (payload: EmptyErrorPayload) => Error;
@@ -11,7 +13,9 @@ interface UpdateVerificationOpts {
   readonly input: { readonly id: string; readonly type?: VerificationType | undefined };
 }
 
-/** Updates a verification record's set fields; throws NOT_FOUND when it doesn't exist. */
+/**
+ * Updates a verification record's set fields; throws NOT_FOUND when it doesn't exist.
+ */
 export async function updateVerification(
   db: Kysely<DB>,
   opts: UpdateVerificationOpts,

--- a/projects/service-verification/src/handlers/verify-code.ts
+++ b/projects/service-verification/src/handlers/verify-code.ts
@@ -5,10 +5,14 @@ import type { Kysely } from 'kysely';
 import type { EmptyErrorPayload } from '../types';
 import { toVerificationData } from './to-verification-data';
 
-/** Verification types whose code is consumed once and the row deleted on a successful verify. */
+/**
+ * Verification types whose code is consumed once and the row deleted on a successful verify.
+ */
 const DELETING_TYPES: ReadonlySet<VerificationType> = new Set(['change-email', 'onboarding']);
 
-/** oRPC handler opts for the `verifyCode` procedure. */
+/**
+ * oRPC handler opts for the `verifyCode` procedure.
+ */
 interface VerifyCodeOpts {
   readonly errors: {
     readonly CODE_ALREADY_USED: (payload: EmptyErrorPayload) => Error;

--- a/projects/service-verification/src/test-utils/factories/create-mock-verification.ts
+++ b/projects/service-verification/src/test-utils/factories/create-mock-verification.ts
@@ -3,7 +3,9 @@ import { createId } from '@paralleldrive/cuid2';
 import type { Verifications } from '@vers/db';
 import type { Insertable } from 'kysely';
 
-/** A plain, unpersisted verification row with faker-generated defaults for a TOTP onboarding code. */
+/**
+ * A plain, unpersisted verification row with faker-generated defaults for a TOTP onboarding code.
+ */
 export function createMockVerification(
   overrides: Partial<Insertable<Verifications>> = {},
 ): Insertable<Verifications> {

--- a/projects/service-verification/src/types.ts
+++ b/projects/service-verification/src/types.ts
@@ -1,4 +1,6 @@
-/** Payload shape for a data-less contract error (CONFLICT/NOT_FOUND/CODE_ALREADY_USED/...). */
+/**
+ * Payload shape for a data-less contract error (CONFLICT/NOT_FOUND/CODE_ALREADY_USED/...).
+ */
 export interface EmptyErrorPayload {
   readonly data: Record<never, never>;
 }


### PR DESCRIPTION
## Description

Bumps `@zgeoff/oxlint-config` to 0.0.4, whose new `zgeoff/no-single-line-jsdoc` rule enforces the multi-line JSDoc convention with an autofix. The diff beyond the manifest is `oxlint --fix` output only.

- Every changed line is a single-line `/** … */` expanded to the multi-line form — verified mechanically, no hand edits.
- Lint passes with zero remaining violations, so no block needed manual splitting.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality (n/a — dependency bump and reformat)