### PR TITLE
fix: install server-image deps from the root lockfile

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -15,13 +15,24 @@ COPY . .
 
 RUN turbo prune @vers/web --docker
 
+# turbo prune's subset bun.lock keeps the root's hoisting choices, which bun
+# re-resolves differently for the smaller workspace set — --frozen-lockfile
+# then fails (vercel/turborepo#11007). Install stages instead use the
+# committed root lockfile with every workspace manifest present, filtered to
+# the @vers/web graph; prune output feeds only the source (out/full) stage.
+RUN mkdir /manifests && \
+  find . -name package.json -not -path './out/*' -exec cp --parents {} /manifests/ \; && \
+  cp bun.lock bunfig.toml /manifests/ && \
+  cp -r patches /manifests/patches
+
 # --- full install (with devDependencies) to run the vite build ---
 FROM base AS installer
 
-COPY --from=pruner /app/out/json/ .
-COPY --from=pruner /app/out/bun.lock ./bun.lock
+COPY --from=pruner /manifests/ .
 
-RUN --mount=type=cache,target=/root/.bun/install/cache bun install --frozen-lockfile
+# @vers/source (the root manifest) carries the build-driving devDependencies:
+# turbo for the codegen graph and the @tsconfig base every tsconfig extends
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install --frozen-lockfile --filter=@vers/web --filter=@vers/source
 
 # --- build the client + SSR server bundle ---
 FROM installer AS builder
@@ -58,10 +69,9 @@ RUN \
 # runtime import from one flat node_modules regardless of directory depth ---
 FROM base AS prod-deps
 
-COPY --from=pruner /app/out/json/ .
-COPY --from=pruner /app/out/bun.lock ./bun.lock
+COPY --from=pruner /manifests/ .
 
-RUN --mount=type=cache,target=/root/.bun/install/cache bun install --frozen-lockfile --production --linker=hoisted --ignore-scripts
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install --frozen-lockfile --production --linker=hoisted --ignore-scripts --filter=@vers/web
 
 # --- runtime ---
 FROM node:${NODE_VERSION}-alpine

--- a/services/avatar/Dockerfile
+++ b/services/avatar/Dockerfile
@@ -14,16 +14,25 @@ COPY . .
 
 RUN turbo prune @vers/service-avatar --docker
 
+# turbo prune's subset bun.lock keeps the root's hoisting choices, which bun
+# re-resolves differently for the smaller workspace set — --frozen-lockfile
+# then fails (vercel/turborepo#11007). Install stages instead use the
+# committed root lockfile with every workspace manifest present, filtered to
+# this service's graph; prune output feeds only the source (out/full) stage.
+RUN mkdir /manifests && \
+  find . -name package.json -not -path './out/*' -exec cp --parents {} /manifests/ \; && \
+  cp bun.lock bunfig.toml /manifests/ && \
+  cp -r patches /manifests/patches
+
 # --- compile the service to a single self-contained executable ---
 # the full dependency set is needed here: `bun build --compile` inlines every JS
 # import (workspace source + external deps) into the binary. The services have no
 # native addons, so the result is standalone — no node_modules or source at runtime.
 FROM base AS builder
 
-COPY --from=pruner /app/out/json/ .
-COPY --from=pruner /app/out/bun.lock ./bun.lock
+COPY --from=pruner /manifests/ .
 
-RUN --mount=type=cache,target=/root/.bun/install/cache bun install --frozen-lockfile
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install --frozen-lockfile --filter=@vers/service-avatar
 
 COPY --from=pruner /app/out/full/ .
 

--- a/services/session/Dockerfile
+++ b/services/session/Dockerfile
@@ -14,16 +14,25 @@ COPY . .
 
 RUN turbo prune @vers/service-session --docker
 
+# turbo prune's subset bun.lock keeps the root's hoisting choices, which bun
+# re-resolves differently for the smaller workspace set — --frozen-lockfile
+# then fails (vercel/turborepo#11007). Install stages instead use the
+# committed root lockfile with every workspace manifest present, filtered to
+# this service's graph; prune output feeds only the source (out/full) stage.
+RUN mkdir /manifests && \
+  find . -name package.json -not -path './out/*' -exec cp --parents {} /manifests/ \; && \
+  cp bun.lock bunfig.toml /manifests/ && \
+  cp -r patches /manifests/patches
+
 # --- compile the service to a single self-contained executable ---
 # the full dependency set is needed here: `bun build --compile` inlines every JS
 # import (workspace source + external deps) into the binary. The services have no
 # native addons, so the result is standalone — no node_modules or source at runtime.
 FROM base AS builder
 
-COPY --from=pruner /app/out/json/ .
-COPY --from=pruner /app/out/bun.lock ./bun.lock
+COPY --from=pruner /manifests/ .
 
-RUN --mount=type=cache,target=/root/.bun/install/cache bun install --frozen-lockfile
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install --frozen-lockfile --filter=@vers/service-session
 
 COPY --from=pruner /app/out/full/ .
 

--- a/services/user/Dockerfile
+++ b/services/user/Dockerfile
@@ -14,16 +14,25 @@ COPY . .
 
 RUN turbo prune @vers/service-user --docker
 
+# turbo prune's subset bun.lock keeps the root's hoisting choices, which bun
+# re-resolves differently for the smaller workspace set — --frozen-lockfile
+# then fails (vercel/turborepo#11007). Install stages instead use the
+# committed root lockfile with every workspace manifest present, filtered to
+# this service's graph; prune output feeds only the source (out/full) stage.
+RUN mkdir /manifests && \
+  find . -name package.json -not -path './out/*' -exec cp --parents {} /manifests/ \; && \
+  cp bun.lock bunfig.toml /manifests/ && \
+  cp -r patches /manifests/patches
+
 # --- compile the service to a single self-contained executable ---
 # the full dependency set is needed here: `bun build --compile` inlines every JS
 # import (workspace source + external deps) into the binary. The services have no
 # native addons, so the result is standalone — no node_modules or source at runtime.
 FROM base AS builder
 
-COPY --from=pruner /app/out/json/ .
-COPY --from=pruner /app/out/bun.lock ./bun.lock
+COPY --from=pruner /manifests/ .
 
-RUN --mount=type=cache,target=/root/.bun/install/cache bun install --frozen-lockfile
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install --frozen-lockfile --filter=@vers/service-user
 
 COPY --from=pruner /app/out/full/ .
 

--- a/services/verification/Dockerfile
+++ b/services/verification/Dockerfile
@@ -14,16 +14,25 @@ COPY . .
 
 RUN turbo prune @vers/service-verification --docker
 
+# turbo prune's subset bun.lock keeps the root's hoisting choices, which bun
+# re-resolves differently for the smaller workspace set — --frozen-lockfile
+# then fails (vercel/turborepo#11007). Install stages instead use the
+# committed root lockfile with every workspace manifest present, filtered to
+# this service's graph; prune output feeds only the source (out/full) stage.
+RUN mkdir /manifests && \
+  find . -name package.json -not -path './out/*' -exec cp --parents {} /manifests/ \; && \
+  cp bun.lock bunfig.toml /manifests/ && \
+  cp -r patches /manifests/patches
+
 # --- compile the service to a single self-contained executable ---
 # the full dependency set is needed here: `bun build --compile` inlines every JS
 # import (workspace source + external deps) into the binary. The services have no
 # native addons, so the result is standalone — no node_modules or source at runtime.
 FROM base AS builder
 
-COPY --from=pruner /app/out/json/ .
-COPY --from=pruner /app/out/bun.lock ./bun.lock
+COPY --from=pruner /manifests/ .
 
-RUN --mount=type=cache,target=/root/.bun/install/cache bun install --frozen-lockfile
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install --frozen-lockfile --filter=@vers/service-verification
 
 COPY --from=pruner /app/out/full/ .
 


### PR DESCRIPTION
## Description

Every app-web image build since #395 fails at `bun install --frozen-lockfile`: `turbo prune`'s subset `bun.lock` keeps the root workspace's hoisting choices, and bun re-resolves the smaller workspace set differently (upstream: vercel/turborepo#11007). The service images carry the same latent failure one dependency change away, so all five server Dockerfiles now install from the committed root lockfile, with every workspace manifest staged and the install filtered to the target's graph.

- app-web's filter adds `@vers/source` — the root manifest carries turbo and the shared `@tsconfig` base its build needs; the service builds need neither.
- `turbo prune` stays for the source (`out/full`) stages; only its lockfile is distrusted.
- Cache granularity widens slightly: any workspace manifest change re-runs the install layers.
- Reverting to pruned lockfiles when upstream fixes land is tracked in #413.

Verified by full local docker builds: app-web (with real sourcemap upload post-#416) and service-user; the other three service Dockerfiles are byte-identical to service-user's modulo name.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes