### PR TITLE
fix(app-web): deliver sourcemaps to the error tracker

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -26,6 +26,13 @@ RUN --mount=type=cache,target=/root/.bun/install/cache bun install --frozen-lock
 # --- build the client + SSR server bundle ---
 FROM installer AS builder
 
+# sentry-cli uploads sourcemaps over TLS through libcurl, which reads the
+# system CA store the slim base image omits — without it every upload fails
+# certificate verification (bun is unaffected: it bundles its own roots)
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends ca-certificates && \
+  rm -rf /var/lib/apt/lists/*
+
 COPY --from=pruner /app/out/full/ .
 # turbo prune only copies workspace packages — the tsconfig every
 # project's tsconfig.json extends lives outside any package, so it comes

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -6,8 +6,8 @@ import rsc from '@vitejs/plugin-rsc';
 import type { Plugin } from 'vite';
 import { defineConfig } from 'vite';
 
-const sentryAuthToken = process.env['SENTRY_AUTH_TOKEN'];
-const sentryDSN = process.env['VITE_SENTRY_DSN'];
+const sentryAuthToken = findNonEmptyEnv('SENTRY_AUTH_TOKEN');
+const sentryDSN = findNonEmptyEnv('VITE_SENTRY_DSN');
 
 export default defineConfig({
   build: { sourcemap: sentryAuthToken === undefined ? false : 'hidden' },
@@ -31,6 +31,13 @@ export default defineConfig({
             sourcemaps: { filesToDeleteAfterUpload: ['dist/**/*.map'] },
             telemetry: false,
             url: new URL(sentryDSN).origin,
+
+            // the plugin's default handler logs upload failures and lets the build pass,
+            // shipping an image whose stack traces can never be symbolicated — a build
+            // that can't deliver its sourcemaps must not ship
+            errorHandler(error) {
+              throw error;
+            },
           }),
         ]
       : []),
@@ -58,6 +65,17 @@ export default defineConfig({
   },
   server: { port: 3000 },
 });
+
+/**
+ * Docker passes declared-but-unset build args through as empty strings, so an empty
+ * value counts as absent — otherwise an argless image build enables the sourcemap
+ * plugin with blank credentials instead of skipping it.
+ */
+function findNonEmptyEnv(name: string): string | undefined {
+  const value = process.env[name];
+
+  return value === undefined || value === '' ? undefined : value;
+}
 
 /**
  * Starts the shared MSW server for `vite dev` only — `configureServer` never fires for


### PR DESCRIPTION
## Description

Closes #404

Every image build's sourcemap upload failed TLS verification: `oven/bun:slim` ships no system CA store, and sentry-cli speaks TLS through libcurl (bun never notices — it bundles its own roots). sentry-cli reported only `API request failed`, and the plugin's default error handler let the build ship unsymbolicatable.

- Install `ca-certificates` in the builder stage.
- `errorHandler` now throws: a deliberate upload failure fails the build.
- Empty-string build args (Docker's pass-through for unset ARGs) count as absent, so argless builds skip the plugin instead of crashing on `new URL('')`.
- `--release undefined` was a red herring — verified harmless against Bugsink's debug-ID matching.

Verified by docker builds atop #415's branch: real token → three bundles' maps land in Bugsink; wrong token → build fails with the 401. Merge #415 first; without it builds fail earlier at the install stage.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes