### PR TITLE
fix(#408): bump postgres to 3.4.9 so connection-phase failures reject

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -810,7 +810,7 @@
     "pino": "10.3.1",
     "pino-pretty": "13.0.0",
     "postcss": "8.5.16",
-    "postgres": "3.4.5",
+    "postgres": "3.4.9",
     "pure-rand": "7.0.1",
     "qrcode": "1.5.4",
     "react": "19.2.7",
@@ -3455,7 +3455,7 @@
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 
-    "postgres": ["postgres@3.4.5", "", {}, "sha512-cDWgoah1Gez9rN3H4165peY9qfpEo+SA61oQv65O3cRUE1pOEoJWwddwcqKE8XZYjbblOJlYDlLV4h67HrEVDg=="],
+    "postgres": ["postgres@3.4.9", "", {}, "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw=="],
 
     "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
 

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
       "pino": "10.3.1",
       "pino-pretty": "13.0.0",
       "postcss": "8.5.16",
-      "postgres": "3.4.5",
+      "postgres": "3.4.9",
       "pure-rand": "7.0.1",
       "qrcode": "1.5.4",
       "react": "19.2.7",


### PR DESCRIPTION
## Description

Closes #408. Bumps the `postgres` catalog pin 3.4.5 → 3.4.9, whose fixed error path makes connection-phase failures reject the query promise instead of throwing an uncaught TypeError that kills the process.

- 3.4.5 recorded a connecting socket's pending query as `true` when there was none, so a connection error dereferenced `query.origin` and crashed Bun
- Verified with the issue's repro: on 3.4.5 the RPC kills the process; on 3.4.9 it returns a 500 envelope, the interceptor logs with a traceID, and `/health` stays up
- The pin predates 3.4.6 (Apr 2025 era) and was carried forward verbatim through the kysely and catalog migrations

## Testing

- [x] `bun run typecheck` passes (35/35)
- [x] `bun run test` for `@vers/db`, `@vers/service-utils`, `@vers/service-user`, `@vers/service-avatar` passes
- [x] Socket repro: unreachable-DB RPC now 500s, process survives