### PR TITLE
chore: prune aged minimum-release-age excludes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -300,9 +300,9 @@ semantics, and moving a lib between domains changes nothing but its path.
 Panda CSS 2.0 spans all four consumers (`@vers/panda-preset`, `@vers/styled-system`,
 `@vers/design-system`, app-web), pinned at 2.0.0-beta.8 in the catalog — no stable 2.0 release
 exists. `@vers/panda-preset` composes `presets: [presetBase, presetPanda]` from
-`@pandacss/preset-base` and `@pandacss/preset-panda` — Panda 2.0 ships no bundled default preset. CSS values that aren't theme tokens need the bracket
-escape hatch (`cursor: '[pointer]'`, `borderWidth: '[1px]'`) — 2.0's `SystemStyleObject` value types
-reject arbitrary strings/numbers.
+`@pandacss/preset-base` and `@pandacss/preset-panda` — Panda 2.0 ships no bundled default preset.
+CSS values that aren't theme tokens need the bracket escape hatch (`cursor: '[pointer]'`,
+`borderWidth: '[1px]'`) — 2.0's `SystemStyleObject` value types reject arbitrary strings/numbers.
 
 ### Screens
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,10 +298,9 @@ semantics, and moving a lib between domains changes nothing but its path.
 ## Styling
 
 Panda CSS 2.0 spans all four consumers (`@vers/panda-preset`, `@vers/styled-system`,
-`@vers/design-system`, app-web), pinned at 2.0.0-beta.8 — no stable 2.0 release exists — through
-`bunfig.toml`'s `minimumReleaseAgeExcludes`. `@vers/panda-preset` composes
-`presets: [presetBase, presetPanda]` from `@pandacss/preset-base` and `@pandacss/preset-panda` —
-Panda 2.0 ships no bundled default preset. CSS values that aren't theme tokens need the bracket
+`@vers/design-system`, app-web), pinned at 2.0.0-beta.8 in the catalog — no stable 2.0 release
+exists. `@vers/panda-preset` composes `presets: [presetBase, presetPanda]` from
+`@pandacss/preset-base` and `@pandacss/preset-panda` — Panda 2.0 ships no bundled default preset. CSS values that aren't theme tokens need the bracket
 escape hatch (`cursor: '[pointer]'`, `borderWidth: '[1px]'`) — 2.0's `SystemStyleObject` value types
 reject arbitrary strings/numbers.
 

--- a/agents/project.md
+++ b/agents/project.md
@@ -91,12 +91,11 @@ semantics, and moving a lib between domains changes nothing but its path.
 ## Styling
 
 Panda CSS 2.0 spans all four consumers (`@vers/panda-preset`, `@vers/styled-system`,
-`@vers/design-system`, app-web), pinned at 2.0.0-beta.8 — no stable 2.0 release exists — through
-`bunfig.toml`'s `minimumReleaseAgeExcludes`. `@vers/panda-preset` composes
-`presets: [presetBase, presetPanda]` from `@pandacss/preset-base` and `@pandacss/preset-panda` —
-Panda 2.0 ships no bundled default preset. CSS values that aren't theme tokens need the bracket
-escape hatch (`cursor: '[pointer]'`, `borderWidth: '[1px]'`) — 2.0's `SystemStyleObject` value types
-reject arbitrary strings/numbers.
+`@vers/design-system`, app-web), pinned at 2.0.0-beta.8 in the catalog — no stable 2.0 release
+exists. `@vers/panda-preset` composes `presets: [presetBase, presetPanda]` from
+`@pandacss/preset-base` and `@pandacss/preset-panda` — Panda 2.0 ships no bundled default preset.
+CSS values that aren't theme tokens need the bracket escape hatch (`cursor: '[pointer]'`,
+`borderWidth: '[1px]'`) — 2.0's `SystemStyleObject` value types reject arbitrary strings/numbers.
 
 ### Screens
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -8,17 +8,15 @@ exact = true
 # supply-chain guard: only install versions published >= 7 days ago
 minimumReleaseAge = 604800
 
+# an exclude lives only as long as its pinned version is younger than the gate —
+# once the version ages past it, the entry is dead weight; remove it
 # format-codemod 0.0.5 (published 2026-07-08) ages past the gate ~2026-07-15 — remove its exclude then (#219)
-# panda 2.0 is still in beta with no stable ETA published — remove these excludes
-# once @pandacss/dev goes stable (#222)
 # @zgeoff/bun-test-extended 0.0.3 ages past the 7-day gate ~2026-07-16 — remove then (#257)
-# @zgeoff/oxlint-config 0.0.2 ages past the 7-day gate ~2026-07-14 — remove then (#292)
+# @zgeoff/oxlint-config 0.0.4 ages past the 7-day gate ~2026-07-18 — remove then (#292)
 # oxlint 1.73.0 (published 2026-07-06) ages past the 7-day gate ~2026-07-13 — remove then
 # typescript 7.0.2 (published 2026-07-08) ages past the 7-day gate ~2026-07-15 — remove then
 # @types/node 26.1.1 (published 2026-07-08) ages past the 7-day gate ~2026-07-15 — remove then
-# TanStack Start's RSC support is experimental and churns fast (#259) — the router/start/vite
-# ecosystem it pins ships new versions inside the 7-day window routinely; excluded per-package
-# rather than dropping the gate repo-wide.
+# vite 8.1.4 (published 2026-07-09) ages past the 7-day gate ~2026-07-16 — remove then
 minimumReleaseAgeExcludes = [
   "@zgeoff/format-codemod",
   "@zgeoff/bun-test-extended",
@@ -26,38 +24,7 @@ minimumReleaseAgeExcludes = [
   "oxlint",
   "typescript",
   "@types/node",
-  "@pandacss/dev",
-  "@pandacss/preset-base",
-  "@pandacss/preset-panda",
-  "@pandacss/cli",
-  "@pandacss/compiler",
-  "@pandacss/config",
-  "@pandacss/postcss",
-  "@pandacss/types",
-  "@pandacss/compiler-shared",
-  "@pandacss/compiler-darwin-arm64",
-  "@pandacss/compiler-darwin-x64",
-  "@pandacss/compiler-linux-x64-gnu",
-  "@pandacss/compiler-linux-arm64-gnu",
-  "@pandacss/compiler-linux-x64-musl",
-  "@pandacss/compiler-linux-arm64-musl",
-  "@pandacss/compiler-win32-x64-msvc",
-  "@pandacss/compiler-win32-arm64-msvc",
-  "@pandacss/compiler-wasm32-wasi",
   "vite",
-  "@tanstack/react-start",
-  "@tanstack/react-start-client",
-  "@tanstack/react-start-rsc",
-  "@tanstack/react-start-server",
-  "@tanstack/start-client-core",
-  "@tanstack/start-plugin-core",
-  "@tanstack/start-server-core",
-  "@tanstack/react-router",
-  "@tanstack/router-core",
-  "@tanstack/router-cli",
-  "@tanstack/start-storage-context",
-  "@tanstack/router-generator",
-  "@tanstack/router-plugin",
 ]
 
 [test]


### PR DESCRIPTION
## Summary

Removes the 34 `minimumReleaseAgeExcludes` entries whose pinned versions have aged past the 7-day gate — every `@pandacss/*` and `@tanstack/*` package. An exclude only has effect while its pinned version is younger than the gate; these were all needed at pin time and are now dead weight.

- `vite` stays: 8.1.4 (from #421) is 2 days old — ages out ~2026-07-16
- `oxlint`, `typescript`, `@types/node`, and the three `@zgeoff/*` pins stay with their age-out dates; stale `@zgeoff/oxlint-config` comment corrected (0.0.4, ~2026-07-18)
- Styling section of `agents/project.md` no longer claims the panda pin lives in the excludes list

The next fresh panda beta or TanStack bump inside its first week re-adds a single exclude consciously instead of holding a standing exemption.

## Verification

- `bun install --frozen-lockfile` passes with the pruned list
- `bun run build:agents` regenerated AGENTS.md drift-free