### PR TITLE
feat(#417): add home and login auth links, land signin in-game

### DIFF
--- a/apps/web-e2e/src/home-smoke.spec.ts
+++ b/apps/web-e2e/src/home-smoke.spec.ts
@@ -24,7 +24,6 @@ test('it serves the anonymous home page server-rendered and hydrates the session
   );
 
   await expect(page.getByTestId('current-user-panel-error')).toBeVisible();
-
   await expect(page.getByRole('link', { name: 'Log in' })).toBeVisible();
   await expect(page.getByRole('link', { name: 'Sign up' })).toBeVisible();
 });

--- a/apps/web-e2e/src/home-smoke.spec.ts
+++ b/apps/web-e2e/src/home-smoke.spec.ts
@@ -24,9 +24,12 @@ test('it serves the anonymous home page server-rendered and hydrates the session
   );
 
   await expect(page.getByTestId('current-user-panel-error')).toBeVisible();
+
+  await expect(page.getByRole('link', { name: 'Log in' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Sign up' })).toBeVisible();
 });
 
-test('it serves the signed-in home page server-rendered and hydrates the session badge', async ({
+test('it serves the signed-in home page server-rendered, lands at respite, and logs out back to anonymous', async ({
   page,
 }) => {
   await page.setExtraHTTPHeaders({ 'x-forwarded-for': '127.0.0.1' });
@@ -39,7 +42,7 @@ test('it serves the signed-in home page server-rendered and hydrates the session
   // clears it, a scripted fill+click doesn't
   await page.waitForTimeout(1600);
   await page.getByRole('button', { exact: true, name: 'Login' }).click();
-  await page.waitForURL((url) => !url.pathname.startsWith('/login'));
+  await page.waitForURL(/\/respite$/);
 
   // the raw SSR body, read through the page's own cookie jar — the bare `request` fixture keeps a
   // separate jar and would render anonymous
@@ -59,4 +62,28 @@ test('it serves the signed-in home page server-rendered and hydrates the session
   await expect(page.getByTestId('current-user-panel-data')).toHaveText(
     'Client-lane read: signed in as Demo Account.',
   );
+
+  await page.getByRole('link', { name: 'Enter game' }).click();
+
+  await expect(page).toHaveURL(/\/respite$/);
+
+  // the game canvas's initial scene setup blocks the main thread for a variable stretch (worse
+  // under parallel worker load), long enough that a click fired mid-block is silently dropped —
+  // retry the click until the nav visibly opens rather than trusting a single one
+  const accountLink = page.getByRole('link', { exact: true, name: 'Account' });
+
+  await expect(async () => {
+    await page.getByRole('button', { name: 'Menu' }).click();
+
+    await expect(accountLink).toBeVisible({ timeout: 1000 });
+  }).toPass({ timeout: 15_000 });
+
+  await accountLink.click();
+
+  await expect(page).toHaveURL(/\/account$/);
+
+  await page.getByRole('button', { name: 'Logout' }).click();
+
+  await expect(page).toHaveURL('/');
+  await expect(page.getByRole('link', { name: 'Log in' })).toBeVisible();
 });

--- a/apps/web/src/lib/auth/complete-session-sign-in.ts
+++ b/apps/web/src/lib/auth/complete-session-sign-in.ts
@@ -26,6 +26,7 @@ export async function completeSessionSignIn(
   if (otherSessions.some((other) => other.id !== opts.session.id)) {
     await updateVerifySession({
       'loginLogout#email': opts.email,
+      'loginLogout#redirect': opts.redirectTo,
       'loginLogout#sessionID': opts.session.id,
       'loginLogout#userID': actingUserID,
     });
@@ -48,5 +49,5 @@ export async function completeSessionSignIn(
     { expiresAt: opts.session.expiresAt },
   );
 
-  throw redirect({ href: toSafeRedirectPath(opts.redirectTo, '/') });
+  throw redirect({ href: toSafeRedirectPath(opts.redirectTo, '/respite') });
 }

--- a/apps/web/src/lib/auth/types.ts
+++ b/apps/web/src/lib/auth/types.ts
@@ -17,6 +17,7 @@ type VerifySessionKey =
   | 'login2FA#sessionID'
   | 'login2FA#target'
   | 'loginLogout#email'
+  | 'loginLogout#redirect'
   | 'loginLogout#sessionID'
   | 'loginLogout#userID'
   | 'onboarding#email';

--- a/apps/web/src/routes/-home/home-hero.test.tsx
+++ b/apps/web/src/routes/-home/home-hero.test.tsx
@@ -1,0 +1,32 @@
+import { expect, test } from 'bun:test';
+import { screen } from '@testing-library/react';
+import { orpc } from '../../lib/rpc/orpc';
+import { createSignedInUser } from '../../test-utils/create-signed-in-user';
+import { renderWithRouter } from '../../test-utils/render-with-router';
+import { withRequestContext } from '../../test-utils/with-request-context';
+import { HomeHero } from './home-hero';
+
+test('it invites an anonymous visitor to log in or sign up', async () => {
+  await withRequestContext({}, async () => {
+    renderWithRouter(<HomeHero orpc={orpc} />);
+
+    const login = await screen.findByText('Log in');
+
+    expect(login.closest('a')).toHaveAttribute('href', '/login');
+    expect(screen.getByText('Sign up').closest('a')).toHaveAttribute('href', '/signup');
+  });
+});
+
+test('it welcomes a signed-in visitor with links into the game and account', async () => {
+  const signedIn = await createSignedInUser({ name: 'Demo Account' });
+
+  await withRequestContext({ cookies: signedIn.cookies }, async () => {
+    renderWithRouter(<HomeHero orpc={orpc} />);
+
+    const welcome = await screen.findByText('Welcome back, Demo Account.');
+
+    expect(welcome).toBeVisible();
+    expect(screen.getByText('Enter game').closest('a')).toHaveAttribute('href', '/respite');
+    expect(screen.getByText('Account').closest('a')).toHaveAttribute('href', '/account');
+  });
+});

--- a/apps/web/src/routes/-home/home-hero.tsx
+++ b/apps/web/src/routes/-home/home-hero.tsx
@@ -1,0 +1,41 @@
+import { useQuery } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
+import { Brand, Heading, Text } from '@vers/design-system';
+import { css } from '@vers/styled-system/css';
+import type { OrpcQueryUtils } from '../../lib/rpc/orpc';
+
+interface HomeHeroProps {
+  readonly orpc: OrpcQueryUtils;
+}
+
+const heroStyles = css({ display: 'flex', flexDirection: 'column', gap: '2' });
+const linkRowStyles = css({ display: 'flex', gap: '4' });
+
+export function HomeHero(props: HomeHeroProps) {
+  const query = useQuery(props.orpc.user.getCurrentUser.queryOptions({ input: {} }));
+
+  return (
+    <section className={heroStyles}>
+      <Brand size="xl" />
+      {!query.isPending &&
+        (query.error ? (
+          <>
+            <Heading level={2}>Welcome to vers</Heading>
+            <Text>Sign in to enter the game, or create an account to get started.</Text>
+            <nav className={linkRowStyles}>
+              <Link to="/login">Log in</Link>
+              <Link to="/signup">Sign up</Link>
+            </nav>
+          </>
+        ) : (
+          <>
+            <Heading level={2}>Welcome back, {query.data.name}.</Heading>
+            <nav className={linkRowStyles}>
+              <Link to="/respite">Enter game</Link>
+              <Link to="/account">Account</Link>
+            </nav>
+          </>
+        ))}
+    </section>
+  );
+}

--- a/apps/web/src/routes/-login-force-logout/force-logout-handler.test.ts
+++ b/apps/web/src/routes/-login-force-logout/force-logout-handler.test.ts
@@ -68,9 +68,38 @@ test('it signs out every other live session and completes sign-in on confirm', a
     },
   );
 
-  expect(outcome.value).toBe('/');
+  expect(outcome.value).toBe('/respite');
   expect(outcome.cookies['en_verification']).toStrictEqual({});
   expect(outcome.cookies['en_session']).toContainKeys(['accessToken', 'refreshToken', 'sessionID']);
   expect(db.sessionCollection.findFirst((q) => q.where({ id: otherSessionID }))).toBeUndefined();
   expect(db.sessionCollection.findFirst((q) => q.where({ id: pendingSessionID }))).toBeDefined();
+});
+
+test('it honors a stashed redirect target on confirm', async () => {
+  const userID = createId();
+  const pendingSessionID = createId();
+
+  await db.sessionCollection.create({ id: pendingSessionID, userID, verified: false });
+
+  const outcome = await withRequestContext(
+    {
+      cookies: {
+        en_verification: {
+          'loginLogout#email': 'force-logout-redirect@vers.test',
+          'loginLogout#redirect': '/nexus',
+          'loginLogout#sessionID': pendingSessionID,
+          'loginLogout#userID': userID,
+        },
+      },
+    },
+    async () => {
+      const redirectHref = await forceLogoutHandler(buildFormData({ intent: 'confirm' }))
+        .then(() => null)
+        .catch((error: unknown) => (isRedirect(error) ? error.options.href : null));
+
+      return redirectHref;
+    },
+  );
+
+  expect(outcome.value).toBe('/nexus');
 });

--- a/apps/web/src/routes/-login-force-logout/force-logout-handler.ts
+++ b/apps/web/src/routes/-login-force-logout/force-logout-handler.ts
@@ -1,6 +1,7 @@
 import { redirect } from '@tanstack/react-router';
 import { getVerifySession } from '../../lib/auth/get-verify-session';
 import { requireAnonymous } from '../../lib/auth/require-anonymous';
+import { toSafeRedirectPath } from '../../lib/auth/to-safe-redirect-path';
 import type { VerifySessionData } from '../../lib/auth/types';
 import { updateAuthSession } from '../../lib/auth/update-auth-session';
 import { updateVerifySession } from '../../lib/auth/update-verify-session';
@@ -8,6 +9,7 @@ import { sessionClient } from '../../lib/rpc/clients/session-client';
 
 const CLEAR_PENDING_SESSION: VerifySessionData = {
   'loginLogout#email': undefined,
+  'loginLogout#redirect': undefined,
   'loginLogout#sessionID': undefined,
   'loginLogout#userID': undefined,
 };
@@ -27,6 +29,7 @@ export async function forceLogoutHandler(formData: FormData): Promise<never> {
 
   const sessionID = verifySession['loginLogout#sessionID'];
   const actingUserID = verifySession['loginLogout#userID'];
+  const redirectTo = verifySession['loginLogout#redirect'];
 
   if (intent !== 'confirm' || sessionID === undefined || actingUserID === undefined) {
     await updateVerifySession(CLEAR_PENDING_SESSION);
@@ -55,5 +58,5 @@ export async function forceLogoutHandler(formData: FormData): Promise<never> {
     updateOptions,
   );
 
-  throw redirect({ href: '/' });
+  throw redirect({ href: toSafeRedirectPath(redirectTo, '/respite') });
 }

--- a/apps/web/src/routes/-login/login-form.test.tsx
+++ b/apps/web/src/routes/-login/login-form.test.tsx
@@ -83,6 +83,21 @@ test('it disables the submit button while the login request is pending', async (
   });
 });
 
+test('it links to signup and forgot password', async () => {
+  await withRequestContext({}, async () => {
+    renderWithRouter(<LoginForm />);
+
+    const signupLink = await screen.findByRole('link', { name: 'Create an account' });
+
+    expect(signupLink).toHaveAttribute('href', '/signup');
+
+    expect(screen.getByRole('link', { name: 'Forgot password?' })).toHaveAttribute(
+      'href',
+      '/forgot-password',
+    );
+  });
+});
+
 test('it renders the redirect target as a hidden field', async () => {
   await withRequestContext({}, async () => {
     renderWithRouter(<LoginForm redirectTo="/nexus" />);

--- a/apps/web/src/routes/-login/login-form.tsx
+++ b/apps/web/src/routes/-login/login-form.tsx
@@ -104,6 +104,9 @@ export function LoginForm(props: LoginFormProps) {
           Login
         </StatusButton>
       </form>
+      <Text>Don&apos;t have an account?</Text>
+      <Link to="/signup">Create an account</Link>
+      <Link to="/forgot-password">Forgot password?</Link>
     </>
   );
 }

--- a/apps/web/src/routes/-login/login-handler.test.ts
+++ b/apps/web/src/routes/-login/login-handler.test.ts
@@ -122,6 +122,29 @@ test('it redirects to force-logout and stores the pending session when another s
   });
 });
 
+test('it stashes the redirect target alongside the pending force-logout session', async () => {
+  const user = await db.userCollection.create({
+    email: 'force-logout-redirect@vers.test',
+    password: 'password123',
+  });
+
+  await db.sessionCollection.create({ userID: user.id });
+
+  const outcome = await withRequestContext({}, () =>
+    loginHandler(
+      buildFormData({
+        email: 'force-logout-redirect@vers.test',
+        password: 'password123',
+        redirectTo: '/nexus',
+      }),
+    )
+      .then(() => null)
+      .catch((error: unknown) => (isRedirect(error) ? error.options.href : null)),
+  );
+
+  expect(outcome.cookies['en_verification']).toContainEntry(['loginLogout#redirect', '/nexus']);
+});
+
 test('it signs a first-time caller in directly and clears their redirect target', async () => {
   await db.userCollection.create({ email: 'first-login@vers.test', password: 'password123' });
 
@@ -141,4 +164,20 @@ test('it signs a first-time caller in directly and clears their redirect target'
 
   expect(outcome.value).toBe('/nexus');
   expect(outcome.cookies['en_session']).toContainKeys(['accessToken', 'refreshToken', 'sessionID']);
+});
+
+test('it lands a caller with no redirect target at respite', async () => {
+  await db.userCollection.create({ email: 'default-landing@vers.test', password: 'password123' });
+
+  const outcome = await withRequestContext({}, async () => {
+    const redirectHref = await loginHandler(
+      buildFormData({ email: 'default-landing@vers.test', password: 'password123' }),
+    )
+      .then(() => null)
+      .catch((error: unknown) => (isRedirect(error) ? error.options.href : null));
+
+    return redirectHref;
+  });
+
+  expect(outcome.value).toBe('/respite');
 });

--- a/apps/web/src/routes/-onboarding/onboarding-handler.test.ts
+++ b/apps/web/src/routes/-onboarding/onboarding-handler.test.ts
@@ -113,7 +113,7 @@ test('it creates the account, signs the caller in, and clears the onboarding ses
     },
   );
 
-  expect(outcome.value).toBe('/');
+  expect(outcome.value).toBe('/respite');
   expect(outcome.cookies['en_session']).toContainKeys(['accessToken', 'refreshToken', 'sessionID']);
   expect(outcome.cookies['en_verification']).toStrictEqual({});
 

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -25,7 +25,6 @@ export const Route = createFileRoute('/')({
 });
 
 const heroStyles = css({ display: 'flex', flexDirection: 'column', gap: '2' });
-
 const linkRowStyles = css({ display: 'flex', gap: '4' });
 
 const diagnosticsStyles = css({

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,8 +1,11 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { useQuery } from '@tanstack/react-query';
+import { Link, createFileRoute } from '@tanstack/react-router';
+import { Brand, Heading, Text } from '@vers/design-system';
 import { css } from '@vers/styled-system/css';
 import { Suspense } from 'react';
 import { CurrentUserPanel } from '../components/current-user-panel';
 import { SessionBadgeSlot } from '../components/session-badge-slot';
+import type { OrpcQueryUtils } from '../lib/rpc/orpc';
 import { getHomeContent } from '../lib/session/get-home-content';
 import { sessionBadgeQueryOptions } from '../lib/session/session-badge-query-options';
 
@@ -21,17 +24,61 @@ export const Route = createFileRoute('/')({
   },
 });
 
+const heroStyles = css({ display: 'flex', flexDirection: 'column', gap: '2' });
+
+const linkRowStyles = css({ display: 'flex', gap: '4' });
+
+const diagnosticsStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '4',
+  marginTop: '8',
+});
+
 function HomePage() {
   const data = Route.useLoaderData();
   const ctx = Route.useRouteContext();
 
   return (
     <main className={css({ display: 'flex', flexDirection: 'column', gap: '4', padding: '6' })}>
-      {data.Content}
-      <CurrentUserPanel orpc={ctx.orpc} />
-      <Suspense fallback={<p data-testid="session-badge-loading">Loading session badge…</p>}>
-        <SessionBadgeSlot />
-      </Suspense>
+      <HomeHero orpc={ctx.orpc} />
+      <section className={diagnosticsStyles}>
+        <Heading level={2}>Diagnostics</Heading>
+        {data.Content}
+        <CurrentUserPanel orpc={ctx.orpc} />
+        <Suspense fallback={<p data-testid="session-badge-loading">Loading session badge…</p>}>
+          <SessionBadgeSlot />
+        </Suspense>
+      </section>
     </main>
+  );
+}
+
+function HomeHero(props: Readonly<{ orpc: OrpcQueryUtils }>) {
+  const query = useQuery(props.orpc.user.getCurrentUser.queryOptions({ input: {} }));
+
+  return (
+    <section className={heroStyles}>
+      <Brand size="xl" />
+      {!query.isPending &&
+        (query.error ? (
+          <>
+            <Heading level={2}>Welcome to vers</Heading>
+            <Text>Sign in to enter the game, or create an account to get started.</Text>
+            <nav className={linkRowStyles}>
+              <Link to="/login">Log in</Link>
+              <Link to="/signup">Sign up</Link>
+            </nav>
+          </>
+        ) : (
+          <>
+            <Heading level={2}>Welcome back, {query.data.name}.</Heading>
+            <nav className={linkRowStyles}>
+              <Link to="/respite">Enter game</Link>
+              <Link to="/account">Account</Link>
+            </nav>
+          </>
+        ))}
+    </section>
   );
 }

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,13 +1,12 @@
-import { useQuery } from '@tanstack/react-query';
-import { Link, createFileRoute } from '@tanstack/react-router';
-import { Brand, Heading, Text } from '@vers/design-system';
+import { createFileRoute } from '@tanstack/react-router';
+import { Heading } from '@vers/design-system';
 import { css } from '@vers/styled-system/css';
 import { Suspense } from 'react';
 import { CurrentUserPanel } from '../components/current-user-panel';
 import { SessionBadgeSlot } from '../components/session-badge-slot';
-import type { OrpcQueryUtils } from '../lib/rpc/orpc';
 import { getHomeContent } from '../lib/session/get-home-content';
 import { sessionBadgeQueryOptions } from '../lib/session/session-badge-query-options';
+import { HomeHero } from './-home/home-hero';
 
 export const Route = createFileRoute('/')({
   component: HomePage,
@@ -23,9 +22,6 @@ export const Route = createFileRoute('/')({
     return { Content: Renderable };
   },
 });
-
-const heroStyles = css({ display: 'flex', flexDirection: 'column', gap: '2' });
-const linkRowStyles = css({ display: 'flex', gap: '4' });
 
 const diagnosticsStyles = css({
   display: 'flex',
@@ -50,34 +46,5 @@ function HomePage() {
         </Suspense>
       </section>
     </main>
-  );
-}
-
-function HomeHero(props: Readonly<{ orpc: OrpcQueryUtils }>) {
-  const query = useQuery(props.orpc.user.getCurrentUser.queryOptions({ input: {} }));
-
-  return (
-    <section className={heroStyles}>
-      <Brand size="xl" />
-      {!query.isPending &&
-        (query.error ? (
-          <>
-            <Heading level={2}>Welcome to vers</Heading>
-            <Text>Sign in to enter the game, or create an account to get started.</Text>
-            <nav className={linkRowStyles}>
-              <Link to="/login">Log in</Link>
-              <Link to="/signup">Sign up</Link>
-            </nav>
-          </>
-        ) : (
-          <>
-            <Heading level={2}>Welcome back, {query.data.name}.</Heading>
-            <nav className={linkRowStyles}>
-              <Link to="/respite">Enter game</Link>
-              <Link to="/account">Account</Link>
-            </nav>
-          </>
-        ))}
-    </section>
   );
 }


### PR DESCRIPTION
## Description

Closes #417

Home and login now branch on auth state, and post-signin flows land in the game instead of the home page.

- Home hero shows Log in / Sign up when anonymous, or a welcome message plus Enter game / Account links when signed in; existing diagnostic panels move under a "Diagnostics" heading
- Login form gains "Create an account" and "Forgot password?" cross-links
- Sign-in now redirects to `/respite` by default instead of `/`
- Force-logout stashes the caller's `redirectTo` so a deep-link survives a concurrent-session bounce, landing there (or `/respite`) on confirm; cancel still lands at `/`
- e2e home-smoke walks the full signed-in journey: login, enter game, open the nav, go to account, log out, land back on `/` anonymous

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
