### PR TITLE
ci: sweep upkeep triggers and stale audit ignores weekly

### DIFF
--- a/.github/workflows/dep-health.yml
+++ b/.github/workflows/dep-health.yml
@@ -58,6 +58,27 @@ jobs:
         if: steps.audit.outputs.exit != '0'
         run: exit 1
 
+  # comments on upkeep issues whose trigger condition now holds and flags audit
+  # ignores that stopped matching a live advisory; red only on new findings
+  upkeep:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: .bun-version
+
+      - name: Install Dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Sweep
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bun scripts/src/bin/upkeep-sweep.ts
+
   outdated:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,6 +212,14 @@ milestone, apply the area, type, and priority labels, record blocking edges agai
 depends on, add it to the delivery board, and set its board status. An open issue that isn't on the
 board with a milestone and status is a defect.
 
+Upkeep issues are the exception: event- or date-triggered maintenance (dropping a dependency
+override, deleting an audit ignore, pruning a `minimumReleaseAgeExcludes` entry) carries the
+`upkeep` label plus an area label, no milestone, and stays off the delivery board. Each upkeep
+issue's body opens with a fenced trigger line — `trigger: release <pkg> ><version>` or
+`trigger: date <YYYY-MM-DD>` — that the weekly dep-health sweep evaluates; when the condition holds,
+the sweep comments on the issue and marks it `upkeep-ready`. An upkeep issue without a parseable
+trigger line fails the sweep.
+
 ## Type-only modules
 
 A module whose exports are all types or interfaces is a defect: those exports belong in the

--- a/agents/project.md
+++ b/agents/project.md
@@ -5,6 +5,14 @@ milestone, apply the area, type, and priority labels, record blocking edges agai
 depends on, add it to the delivery board, and set its board status. An open issue that isn't on the
 board with a milestone and status is a defect.
 
+Upkeep issues are the exception: event- or date-triggered maintenance (dropping a dependency
+override, deleting an audit ignore, pruning a `minimumReleaseAgeExcludes` entry) carries the
+`upkeep` label plus an area label, no milestone, and stays off the delivery board. Each upkeep
+issue's body opens with a fenced trigger line — `trigger: release <pkg> ><version>` or
+`trigger: date <YYYY-MM-DD>` — that the weekly dep-health sweep evaluates; when the condition holds,
+the sweep comments on the issue and marks it `upkeep-ready`. An upkeep issue without a parseable
+trigger line fails the sweep.
+
 ## Type-only modules
 
 A module whose exports are all types or interfaces is a defect: those exports belong in the

--- a/knip.json
+++ b/knip.json
@@ -7,7 +7,7 @@
     "libs/game/aether-core/generate-graph.ts",
     ".claude/**"
   ],
-  "ignoreBinaries": ["flyctl", "ladle", "op", "pulumi"],
+  "ignoreBinaries": ["flyctl", "gh", "ladle", "op", "pulumi"],
   "rules": {
     "enumMembers": "off"
   },

--- a/scripts/src/bin/upkeep-sweep.ts
+++ b/scripts/src/bin/upkeep-sweep.ts
@@ -1,0 +1,105 @@
+import { $ } from 'bun';
+import { z } from 'zod';
+import { isTriggerFired } from '../upkeep/is-trigger-fired';
+import { parseIgnoredAdvisories } from '../upkeep/parse-ignored-advisories';
+import { parseTrigger } from '../upkeep/parse-trigger';
+
+const GHSA_PATTERN = /GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}/g;
+const READY_LABEL = 'upkeep-ready';
+const manifestSchema = z.object({ scripts: z.record(z.string(), z.string()) });
+
+// stale ignores: an --ignore that no longer matches a live advisory must be deleted
+const rawManifest: unknown = await Bun.file('package.json').json();
+
+const manifest = manifestSchema.parse(rawManifest);
+const ignored = parseIgnoredAdvisories(manifest.scripts['audit'] ?? '');
+
+const rawAudit = await $`bun audit --json`.nothrow().text();
+
+const liveAdvisories = new Set(rawAudit.match(GHSA_PATTERN));
+
+const staleIgnores = ignored.filter((id) => !liveAdvisories.has(id));
+
+for (const id of staleIgnores) {
+  console.log(
+    `stale ignore: ${id} no longer matches any advisory - delete it from the audit script`,
+  );
+}
+
+// trigger sweep: comment and label each upkeep issue whose condition now holds
+const labelSchema = z.object({ name: z.string() });
+
+const issueSchema = z.object({
+  body: z.string(),
+  labels: z.array(labelSchema),
+  number: z.number(),
+  title: z.string(),
+});
+
+const issuesSchema = z.array(issueSchema);
+
+const rawIssues: unknown =
+  await $`gh issue list --label upkeep --state open --json number,title,body,labels`.json();
+
+const issues = issuesSchema.parse(rawIssues);
+
+const today = new Date().toISOString().slice(0, 10);
+
+let newlyFired = 0;
+
+for (const issue of issues) {
+  const trigger = parseTrigger(issue.body);
+
+  if (!trigger) {
+    console.log(`#${issue.number} carries no parseable trigger line - fix its body`);
+
+    newlyFired += 1;
+    continue;
+  }
+
+  const latestVersion =
+    trigger.kind === 'release' ? await readLatestVersion(trigger.pkg) : undefined;
+
+  if (!isTriggerFired(trigger, { latestVersion, today })) {
+    continue;
+  }
+
+  if (issue.labels.some((label) => label.name === READY_LABEL)) {
+    console.log(`#${issue.number} already marked ${READY_LABEL} - awaiting cleanup`);
+    continue;
+  }
+
+  const detail =
+    trigger.kind === 'release'
+      ? `\`${trigger.pkg}\` has a release newer than ${trigger.version} (latest: ${latestVersion})`
+      : `the recorded date ${trigger.date} has passed`;
+
+  await $`gh issue comment ${issue.number} --body ${`Trigger fired: ${detail}. This upkeep is actionable now.`}`;
+  await $`gh issue edit ${issue.number} --add-label ${READY_LABEL}`;
+
+  console.log(`#${issue.number} trigger fired: ${issue.title}`);
+
+  newlyFired += 1;
+}
+
+if (staleIgnores.length > 0 || newlyFired > 0) {
+  process.exit(1);
+}
+
+console.log(
+  `swept ${issues.length} upkeep issues, ${ignored.length} audit ignores - nothing newly actionable`,
+);
+
+async function readLatestVersion(pkg: string): Promise<string | undefined> {
+  const response = await fetch(`https://registry.npmjs.org/${pkg}/latest`);
+
+  if (!response.ok) {
+    return undefined;
+  }
+
+  const latestSchema = z.object({ version: z.string().optional() });
+
+  const payload = await response.json();
+
+  return latestSchema.parse(payload).version;
+}

--- a/scripts/src/upkeep/is-trigger-fired.test.ts
+++ b/scripts/src/upkeep/is-trigger-fired.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from 'bun:test';
+import { isTriggerFired } from './is-trigger-fired';
+
+test('it fires a release trigger when a newer version exists', () => {
+  const trigger = { kind: 'release', pkg: 'x', version: '1.4.11' } as const;
+
+  expect(isTriggerFired(trigger, { latestVersion: '1.4.12', today: '2026-07-11' })).toBe(true);
+});
+
+test('it holds a release trigger while the bound version is still latest', () => {
+  const trigger = { kind: 'release', pkg: 'x', version: '1.4.11' } as const;
+
+  expect(isTriggerFired(trigger, { latestVersion: '1.4.11', today: '2026-07-11' })).toBe(false);
+});
+
+test('it holds a release trigger when the registry lookup produced nothing', () => {
+  const trigger = { kind: 'release', pkg: 'x', version: '1.4.11' } as const;
+
+  expect(isTriggerFired(trigger, { today: '2026-07-11' })).toBe(false);
+});
+
+test('it fires a date trigger on the recorded day', () => {
+  const trigger = { date: '2026-07-18', kind: 'date' } as const;
+
+  expect(isTriggerFired(trigger, { today: '2026-07-18' })).toBe(true);
+});
+
+test('it holds a date trigger before the recorded day', () => {
+  const trigger = { date: '2026-07-18', kind: 'date' } as const;
+
+  expect(isTriggerFired(trigger, { today: '2026-07-17' })).toBe(false);
+});

--- a/scripts/src/upkeep/is-trigger-fired.ts
+++ b/scripts/src/upkeep/is-trigger-fired.ts
@@ -1,0 +1,23 @@
+import type { Trigger } from './types';
+
+interface TriggerFacts {
+  readonly latestVersion?: string | undefined;
+  readonly today: string;
+}
+
+/**
+ * Decides whether a trigger's condition holds given already-fetched facts:
+ * a release trigger fires when the registry's latest version exceeds the
+ * recorded bound, a date trigger when today reaches the recorded date.
+ */
+export function isTriggerFired(trigger: Trigger, facts: TriggerFacts): boolean {
+  if (trigger.kind === 'date') {
+    return facts.today >= trigger.date;
+  }
+
+  if (facts.latestVersion === undefined || facts.latestVersion === '') {
+    return false;
+  }
+
+  return Bun.semver.order(facts.latestVersion, trigger.version) > 0;
+}

--- a/scripts/src/upkeep/parse-ignored-advisories.test.ts
+++ b/scripts/src/upkeep/parse-ignored-advisories.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'bun:test';
+import { parseIgnoredAdvisories } from './parse-ignored-advisories';
+
+test('it collects every ignored GHSA id from the audit script', () => {
+  const script = 'bun audit --ignore=GHSA-8988-4f7v-96qf --ignore=GHSA-q7rr-3cgh-j5r3';
+
+  expect(parseIgnoredAdvisories(script)).toStrictEqual([
+    'GHSA-8988-4f7v-96qf',
+    'GHSA-q7rr-3cgh-j5r3',
+  ]);
+});
+
+test('it returns an empty list for an audit script with no ignores', () => {
+  expect(parseIgnoredAdvisories('bun audit')).toStrictEqual([]);
+});

--- a/scripts/src/upkeep/parse-ignored-advisories.ts
+++ b/scripts/src/upkeep/parse-ignored-advisories.ts
@@ -1,0 +1,9 @@
+const IGNORE_FLAG_PATTERN = /--ignore=(?<id>\S+)/g;
+
+/**
+ * Collects the GHSA ids the root manifest's audit script suppresses, so the
+ * sweep can flag any that no longer match a live advisory.
+ */
+export function parseIgnoredAdvisories(auditScript: string): Array<string> {
+  return [...auditScript.matchAll(IGNORE_FLAG_PATTERN)].map((match) => match.groups?.['id'] ?? '');
+}

--- a/scripts/src/upkeep/parse-trigger.test.ts
+++ b/scripts/src/upkeep/parse-trigger.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from 'bun:test';
+import { parseTrigger } from './parse-trigger';
+
+test('it reads a release trigger out of an issue body', () => {
+  const body = '```\ntrigger: release @elysiajs/opentelemetry >1.4.11\n```\n\nContext paragraph.';
+
+  expect(parseTrigger(body)).toStrictEqual({
+    kind: 'release',
+    pkg: '@elysiajs/opentelemetry',
+    version: '1.4.11',
+  });
+});
+
+test('it reads a date trigger out of an issue body', () => {
+  const body = '```\ntrigger: date 2026-07-18\n```\n\nContext paragraph.';
+
+  expect(parseTrigger(body)).toStrictEqual({ date: '2026-07-18', kind: 'date' });
+});
+
+test('it returns null when the body carries no trigger line', () => {
+  expect(parseTrigger('just prose, no trigger anywhere')).toBeNull();
+});
+
+test('it rejects a date trigger that is not YYYY-MM-DD', () => {
+  expect(parseTrigger('trigger: date next tuesday')).toBeNull();
+});
+
+test('it rejects a release trigger without a > version bound', () => {
+  expect(parseTrigger('trigger: release @elysiajs/opentelemetry 1.4.11')).toBeNull();
+});

--- a/scripts/src/upkeep/parse-trigger.ts
+++ b/scripts/src/upkeep/parse-trigger.ts
@@ -1,0 +1,31 @@
+import type { Trigger } from './types';
+
+const TRIGGER_PATTERN = /^trigger:\s+(?<kind>release|date)\s+(?<rest>.+)$/m;
+
+/**
+ * Reads the machine-readable trigger line an upkeep issue carries in its body:
+ * `trigger: release <pkg> ><version>` or `trigger: date <YYYY-MM-DD>`.
+ */
+export function parseTrigger(body: string): Trigger | null {
+  const match = TRIGGER_PATTERN.exec(body);
+
+  if (!match?.groups) {
+    return null;
+  }
+
+  const rest = match.groups['rest']?.trim() ?? '';
+
+  if (match.groups['kind'] === 'date') {
+    return /^\d{4}-\d{2}-\d{2}$/.test(rest) ? { date: rest, kind: 'date' } : null;
+  }
+
+  const release = /^(?<pkg>\S+)\s+>(?<version>\S+)$/.exec(rest);
+  const pkg = release?.groups?.['pkg'];
+  const version = release?.groups?.['version'];
+
+  if (pkg === undefined || version === undefined) {
+    return null;
+  }
+
+  return { kind: 'release', pkg, version };
+}

--- a/scripts/src/upkeep/types.ts
+++ b/scripts/src/upkeep/types.ts
@@ -1,0 +1,12 @@
+interface ReleaseTrigger {
+  readonly kind: 'release';
+  readonly pkg: string;
+  readonly version: string;
+}
+
+interface DateTrigger {
+  readonly kind: 'date';
+  readonly date: string;
+}
+
+export type Trigger = DateTrigger | ReleaseTrigger;


### PR DESCRIPTION
## Summary

Adds an `upkeep` job to the weekly dep-health workflow and formalizes the upkeep issue track: event- or date-triggered maintenance carries the `upkeep` label, no milestone, stays off the delivery board, and opens with a fenced trigger line the sweep evaluates.

- `scripts/src/bin/upkeep-sweep.ts`: fired triggers (registry release / calendar date) get a comment + `upkeep-ready` label and fail the run; an unparseable trigger line also fails
- Stale-ignore ratchet: an audit-script `--ignore` that no longer matches a live advisory fails with a delete-me message
- Pure logic in `scripts/src/upkeep/` with co-located tests; AGENTS.md issue-hygiene section documents the upkeep exception
- Existing upkeep issues (#257, #292, #443, #444, #445) already follow the format

## Verification

- Live run against the repo: 5 upkeep issues + 1 ignore swept, correctly quiet, exit 0
- `@vers/scripts` tests (28) green; typecheck, lint, deadcode, format all green