### PR TITLE
feat(infra): add resend sending-domain dns records

### DIFF
--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -2,3 +2,4 @@ config:
   vers-infra:zoneName: versidle.com
   vers-infra:appHostname: vers-app-web.fly.dev
   vers-infra:zoneId: fc9e4cdc2fff4aee760c7fd1e71ffe27
+encryptionsalt: v1:X3B5c2FRqiA=:v1:6xmc+OObdCNfxT/j:hcfedYdoJcanVVXYfwNGrBvsmAtmLQ==

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -28,5 +28,49 @@ const www = new cloudflare.DnsRecord('www', {
   proxied: false,
 });
 
+// Resend sending domain: transactional.versidle.com (region ap-northeast-1). DKIM signs the
+// mail, and the send.* MX + SPF records cover the bounce/return-path host Resend uses. TXT
+// content is quote-wrapped — the Cloudflare API stores TXT values quoted, and unquoted input
+// re-diffs on every plan.
+const resendDKIM = new cloudflare.DnsRecord('resend-dkim', {
+  zoneId,
+  name: `resend._domainkey.transactional.${zoneName}`,
+  type: 'TXT',
+  content:
+    '"p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDXpfNhIJ/kY0xppICdEmDeaVBWb1rZUhhlVrW2BvD/F1v3cEHSoZeiDxx+Hl+5x6ewydAxQ3abToYMK+H2mDYoAh19xXCOCyWttCiuhbOzdVHSX1pVUnJqr5nOnWpCOczmRzsjzxbd+2AZGUyQd5voFxU/7/PRafZbZ8zFS1zMlQIDAQAB"',
+  ttl: 1,
+});
+
+const resendReturnPathMX = new cloudflare.DnsRecord('resend-return-path-mx', {
+  zoneId,
+  name: `send.transactional.${zoneName}`,
+  type: 'MX',
+  content: 'feedback-smtp.ap-northeast-1.amazonses.com',
+  priority: 10,
+  ttl: 1,
+});
+
+const resendReturnPathSPF = new cloudflare.DnsRecord('resend-return-path-spf', {
+  zoneId,
+  name: `send.transactional.${zoneName}`,
+  type: 'TXT',
+  content: '"v=spf1 include:amazonses.com ~all"',
+  ttl: 1,
+});
+
+// p=none observes only: DMARC reports flow without asking receivers to reject, which is the
+// safe starting policy for a fresh sending domain.
+const resendDMARC = new cloudflare.DnsRecord('resend-dmarc', {
+  zoneId,
+  name: `_dmarc.transactional.${zoneName}`,
+  type: 'TXT',
+  content: '"v=DMARC1; p=none;"',
+  ttl: 1,
+});
+
 export const apexRecord = apex.name;
 export const wwwRecord = www.name;
+export const resendDKIMRecord = resendDKIM.name;
+export const resendReturnPathMXRecord = resendReturnPathMX.name;
+export const resendReturnPathSPFRecord = resendReturnPathSPF.name;
+export const resendDMARCRecord = resendDMARC.name;


### PR DESCRIPTION
## Description

Adds the four DNS records Resend requires to verify `transactional.versidle.com` as the sending domain for #441's email delivery (region `ap-northeast-1`).

- DKIM TXT, return-path MX + SPF TXT on `send.transactional`, and a `p=none` DMARC TXT
- TXT contents quote-wrapped — Cloudflare stores them quoted and unquoted input re-diffs every plan
- Commits the pulumi `encryptionsalt` the passphrase provider stamps into the stack config

## Testing

- [x] `pulumi preview` — 4 creates, 3 unchanged
- [ ] `pulumi up` + Resend domain verification (pending apply approval)