### PR TITLE
docs: document game simulation, entropy, and economy-mode model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,7 @@ The full conventions — taxonomy, code registry, trace context, reporting split
 Overused jargon a plainer word covers; applies to all prose — docs, comments, PR descriptions, issue
 text.
 
+- `bites` (figurative) — "applies", "takes effect", or name the consequence.
 - `load-bearing` — "required", "essential", or name what breaks without it.
 - `seam` — "boundary", "join", "integration point".
 - `surface` — noun: "area", "API", the concrete thing itself; verb: "show", "raise", "report".

--- a/agents/project.md
+++ b/agents/project.md
@@ -53,6 +53,7 @@ The full conventions — taxonomy, code registry, trace context, reporting split
 Overused jargon a plainer word covers; applies to all prose — docs, comments, PR descriptions, issue
 text.
 
+- `bites` (figurative) — "applies", "takes effect", or name the consequence.
 - `load-bearing` — "required", "essential", or name what breaks without it.
 - `seam` — "boundary", "join", "integration point".
 - `surface` — noun: "area", "API", the concrete thing itself; verb: "show", "raise", "report".

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,10 @@ How the platform is built — system design, data flows, and operational wiring.
   gating
 - [Game rendering](./architecture/game-rendering.md) — the persistent three.js canvas and scene
   state
+- [Game simulation](./architecture/game-simulation.md) — the deterministic client sim, checkpoint
+  streams, and replay verification
+- [Game entropy](./architecture/game-entropy.md) — entropy sources, sealed salt, and reward
+  provenance
 
 ## Game design
 
@@ -42,3 +46,4 @@ The game's design language and systems, numbered in reading order.
 - [Core themes and world fiction](./game-design/001-core-themes-world-fiction.md)
 - [Attributes and damage model](./game-design/002-attributes-damage-model.md)
 - [Defensive archetypes](./game-design/003-defensive-archetypes.md)
+- [Economy modes and reward integrity](./game-design/004-economy-modes.md)

--- a/docs/architecture/game-entropy.md
+++ b/docs/architecture/game-entropy.md
@@ -15,64 +15,109 @@ The quantity that matters is selection value, and it is an order statistic: a sc
 future across every reachable node and the whole offline window, so a reward distribution's danger
 lives in its tail, not its variance. Modest per-run variance with a rare outlier still hands a
 scanner a jackpot, because best-of-twenty-thousand lives in the tail. The
-[economy modes note](../game-design/004-economy-modes.md) turns this into the reward-design rule.
+[economy modes note](../game-design/004-economy-modes.md) turns this into the reward-design rules.
 
 ## The anchored seed chain
 
 Per `(avatar, node)`, the server anchors an append-only seed chain: the next run's seed derives
-deterministically from the stored end of the previous run at that node. Abandoning and restarting
-yields the same continuation — there is nothing to re-roll. This single rule closes seed-fishing,
-death-scumming via early flush, and retry-branch selection.
+deterministically from the stored end of the previous run at that node. The anchor is the last
+**verified** checkpoint's end-state at that node: terminal activity states never advance it past the
+verified prefix, and rejecting a stream at version N resets it to the end of version N−1. Abandoning
+and restarting therefore replays the same continuation — there is nothing to re-roll. This single
+rule closes seed-fishing, death-scumming via early flush, and retry-branch selection.
 
-The chain is client-computable by design — offline simulation depends on it — which makes every
-chain-seeded run peekable. Chain entropy therefore carries only rewards priced for perfect
-foresight.
+The chain is client-computable by design — offline simulation depends on it — and it seeds the
+simulation's trajectory only: enemies, timing, survival, experience, and which kills yield drop
+slots. Drop content never derives from it. Foreseeing the trajectory is throughput knowledge —
+routing, kill counts, survival — and the economy prices it as such.
 
-## Sealed server salt
+## Drop rolls and the avatar key
 
-Runs whose rewards must be unpeekable draw their entropy from server-minted salt, revealed in two
-commits:
+A kill that yields loot produces a drop slot at a deterministic coordinate
+`(avatarID, nodeID, chainIndex, ordinal)`, where `chainIndex` counts checkpoints from the node's
+seed-chain anchor and `ordinal` indexes the drops within a checkpoint under the simulation's
+canonical ordering, independent of how checkpoints are batched. The coordinate derives only from the
+hashed checkpoint subset, and it is restart-stable: because the chain replays the same continuation,
+abandoning and restarting reproduces the identical coordinate. That stability is what makes the
+reveal safe — peeking a roll and replaying the position shows the same roll, so a peek has zero
+option value.
 
-1. **Commit.** The player locks in (spends, selects a tier). The server mints the salt from a
-   server-held secret key and stores it sealed, returning only a lossy derived projection — mods,
-   difficulty, reward budget — for the preview window. All crafting decisions happen against that
-   metadata; the client never holds simulatable entropy while a decision is open.
-2. **Run-commit.** The salt is released and the client simulates. Release is commitment: the
-   position resolves under that salt, and a committed position the client never resolves is
-   force-resolved server-side at a deadline inside the replay-retention window, so an abandoned
-   commit cannot gate its node forever.
+The slot is a commitment; the item is its reveal. Drop content is `f(key, coordinate)` where `f` is
+a keyed PRF — revealed outputs carry no predictive power over unrevealed coordinates, which matters
+because every reveal hands the client a known input/output pair. Item identity is the coordinate, so
+minting is idempotent and re-verification can neither duplicate nor re-roll an item.
+
+Key custody is the economy boundary:
+
+- **Server-held key** (trade avatars): the key never leaves the server, and content resolves only
+  for coordinates whose producing checkpoint is durably appended — no protocol path returns content
+  earlier. The append is the commitment, the roll is the reveal: connected play reveals drops within
+  a batch cadence of the kill, a return from offline reveals the window's drops at once, and no
+  connectivity state changes what a slot is worth.
+- **Device-held key** (self-found avatars): the avatar rolls its own loot locally, offline, in real
+  time. A disclosed key makes every future roll computable, so the key ships only to avatars whose
+  earnings can never reach the market. Disclosure is the mode's normal operation, not a compromise —
+  and the server derives the same key, which is what lets it verify self-found streams and restore
+  the key to a new device. Self-found custody is an economic wall, not a privacy guarantee.
+
+Key derivation is a one-way KDF from a master secret, with the trade and self-found populations
+separately rooted: a self-found key must share no recoverable root with any trade key. A self-found
+key is a pure function of `(master, avatarID, keyVersion)` — re-derivable bit-for-bit, never
+re-randomized. The master secret requires managed-key custody with rotation and audit, never an
+application environment variable; a leaked trade root makes every future trade drop computable,
+which is the one unrecoverable failure this design has.
+
+Every roll is pinned by its activity's `Started` snapshot: `keyVersion` is stamped there beside the
+engine and content versions, and `f` resolves content under the pinned versions — never the live
+deploy — so reveal, replay, and mint agree across deploys, parks, and master rotations.
+
+## Sealed pre-commit salt
+
+Content the player crafts against a preview — rolled modifiers, reroll-and-lock decisions — draws
+entropy that must stay sealed while the decision is open, revealed in two commits:
+
+1. **Commit.** The player locks in the spend. The server mints the salt from a server-held secret
+   key and stores it sealed, returning only a lossy derived projection — modifier families,
+   difficulty, reward budget — for the preview window. The projection is a distribution summary and
+   never narrows the realized roll: walking away must never beat resolving, at any tier, and the
+   projection's information content is bounded by that rule. All crafting decisions happen against
+   the metadata; the client never holds simulatable entropy while a decision is open.
+2. **Run-commit.** The salt is released and the client simulates. Release is commitment: a committed
+   position the client never resolves is force-resolved as forfeited — the bundle is lost and the
+   node's gate lifts — at a server-side deadline inside the replay-retention window.
 
 The salt's keying material is a server-held secret. Domain-separation labels alone are insufficient:
 salt derived from client-visible state under a different label is still client-computable, and the
-entire unpeekability property collapses.
+sealing property collapses.
 
-Salt is minted once per chain position and re-fetch is idempotent — a client that loses the response
-retries and receives the same salt, so a lost packet cannot fork the timeline, and until the release
-arrives the run simply does not start. The build snapshot pins at mint, so deferring resolution
-cannot improve an outcome by out-leveling it first.
+Salt is minted once per node-anchored chain position — the same restart-stable index that keys drop
+coordinates — and re-fetch is idempotent: a client that loses the response retries and receives the
+same salt, so a lost packet cannot fork the timeline, and until the release arrives the run does not
+start. The build snapshot pins at mint, so deferring resolution cannot improve an outcome by
+out-leveling it first.
 
-A sealed-salt run requires a live round trip, so sealed-salt content is online content.
+Sealed salt requires a live round trip, so preview-crafted content is online content. Deterministic
+investment — a chosen tier with a known effect on difficulty and drop density — involves no
+decision-time randomness, needs no salt, and runs anywhere: the boundary is randomness at decision
+time, not investment itself. For self-found avatars no entropy is sealable at all — the player holds
+the key — which is consistent with their earnings never reaching the market.
 
 ## Provenance
 
-Every reward-bearing outcome carries a typed provenance: the entropy source kind plus a tradeable
-capability. The stamp derives at settlement from server mint records and the entropy-source
-commitment inside the hashed checkpoint subset — never from a client claim — so provenance is
-replay-derivable from the chain rather than trusted from a side table.
+Every checkpoint's hashed subset carries an entropy-source tag identifying which source rolled its
+outcomes, present from the first row ever written — the subset is frozen, so the tag cannot be added
+later, and it is what allows entropy sources beyond the current two (a verifiable-randomness beacon,
+a rotated key generation) to join without a migration. Verification validates the tag against the
+avatar's server-recorded mode; a mismatch is divergence. Settlement stamps an outcome's provenance
+from server records and the tag — never from a client claim.
 
-Tradeability keys on the security property — entropy unpredictable at commit and non-repudiable —
-not on which channel delivered it. Any source with those properties mints tradeable outcomes;
-sources without them mint bound ones.
+Tradeability keys on the security property — entropy unpredictable at the moment the outcome was
+committed, and non-repudiable — not on which channel delivered it. Server-custody rolls and sealed
+salt have the property; device-custody rolls do not.
 
 ## Mode enforcement
 
 An avatar's economy mode (the [economy modes note](../game-design/004-economy-modes.md) owns the
-choice) fixes its provenance statically:
-
-- **Trade avatars** ride the anchored chain for base expeditions — carrying static-class rewards
-  only — and sealed salt for itemized drops.
-- **Self-found avatars** ride the anchored chain for everything, juice included, and every outcome
-  settles bound.
-
-No per-run provenance adjudication exists: no fallback converts one entropy source into the other
-mid-run, so connectivity can never silently change what an outcome is worth.
+choice) fixes its key custody at creation, permanently. No path converts one custody into the other:
+connectivity changes when a trade avatar's rolls reveal, never what they are worth, and a
+device-held key is never repatriated into market eligibility.

--- a/docs/architecture/game-entropy.md
+++ b/docs/architecture/game-entropy.md
@@ -73,8 +73,8 @@ deploy — so reveal, replay, and mint agree across deploys, parks, and master r
 
 ## Sealed pre-commit salt
 
-Content the player crafts against a preview — rolled modifiers, reroll-and-lock decisions — draws
-entropy that must stay sealed while the decision is open, revealed in two commits:
+Outcomes whose distribution carries a tail worth selecting — item affix rolls, rare content — draw
+entropy that must stay sealed while a crafting decision is open, revealed in two commits:
 
 1. **Commit.** The player locks in the spend. The server mints the salt from a server-held secret
    key and stores it sealed, returning only a lossy derived projection — modifier families,
@@ -96,11 +96,13 @@ same salt, so a lost packet cannot fork the timeline, and until the release arri
 start. The build snapshot pins at mint, so deferring resolution cannot improve an outcome by
 out-leveling it first.
 
-Sealed salt requires a live round trip, so preview-crafted content is online content. Deterministic
-investment — a chosen tier with a known effect on difficulty and drop density — involves no
-decision-time randomness, needs no salt, and runs anywhere: the boundary is randomness at decision
-time, not investment itself. For self-found avatars no entropy is sealable at all — the player holds
-the key — which is consistent with their earnings never reaching the market.
+Sealed salt requires a live round trip, so tail-bearing crafted content is online content. Entropy
+placement follows the outcome distribution, not the mechanic: a normalized outcome — a chosen tier,
+an instance modifier bounded to modest scalars with no jackpot combination — carries no tail worth
+selecting, so it rides client-computable entropy anywhere, interactive rerolls included. Peeking a
+tail-free distribution reveals nothing worth acting on; only a tailed distribution needs the seal.
+For self-found avatars no entropy is sealable at all — the player holds the key — which is
+consistent with their earnings never reaching the market.
 
 ## Provenance
 

--- a/docs/architecture/game-entropy.md
+++ b/docs/architecture/game-entropy.md
@@ -10,11 +10,11 @@ player can peek: simulate the future, inspect the outcome, and choose whether �
 it. Look-ahead cannot be prevented in a deterministic client-simulated game; anything the client can
 describe, it can pre-compute. The design prices look-ahead instead of chasing it.
 
-A scanner does not play the average future. It simulates the next hour on every reachable node,
-across the whole offline window, and plays only the best one. Out of twenty thousand simulated
-futures the one that matters is the single best, so a reward distribution's danger lives in its
-tail, not its variance — modest per-run variance with a rare outlier still hands the scanner a
-jackpot. That best-of-N selection value is what every rule below prices; the
+A scanner does not play the average future. It simulates the future on every reachable node, across
+the whole offline window, and plays only the best one. Out of twenty thousand simulated futures the
+one that matters is the single best, so a reward distribution's danger lives in its tail, not its
+variance — modest per-run variance with a rare outlier still hands the scanner a jackpot. That
+best-of-N selection value is what every rule below prices; the
 [economy modes note](../game-design/004-economy-modes.md) turns it into the reward-design rules.
 
 ## The anchored seed chain

--- a/docs/architecture/game-entropy.md
+++ b/docs/architecture/game-entropy.md
@@ -85,30 +85,41 @@ deploy — so reveal, replay, and mint agree across deploys, parks, and master r
 ## Sealed pre-commit salt
 
 Some outcomes carry a tail worth selecting — item affix rolls, rare content. Their entropy stays
-sealed while a crafting decision is open, revealed in two commits:
+sealed while the decision is open, revealed in two commits:
 
 1. **Commit.** The player locks in the spend. The server mints the salt from a server-held secret
    key and stores it sealed. The player sees only a lossy projection derived from it — modifier
    families, difficulty, reward budget — for the preview window. The projection is a distribution
    summary and never narrows the realized roll: walking away must never beat resolving, at any tier,
-   and that rule bounds how much the projection may reveal. Every crafting decision happens against
-   this metadata; the client never holds simulatable entropy while a decision is open.
-2. **Run-commit.** The server releases the salt and the client simulates. Release is commitment: a
-   committed position the client never resolves is force-resolved as forfeited at a server-side
-   deadline inside the replay-retention window — the bundle is lost and the node's gate lifts.
+   and that rule bounds how much the projection may reveal. Every decision happens against this
+   metadata; the client never holds computable entropy while a decision is open.
+2. **Release.** The server releases the salt and the outcome resolves. Release is commitment: a
+   released position the client never resolves is force-resolved as forfeited — the bundle is lost —
+   at a server-side deadline inside the replay-retention window.
 
-Two rules keep the seal honest:
+Three rules keep the seal honest, independent of what consumes it:
 
 - The salt's keying material is a server-held secret. Domain-separation labels alone are
   insufficient: salt derived from client-visible state under a different label is still
   client-computable, and the sealing property collapses.
-- Salt is minted once per node-anchored chain position — the same restart-stable index that keys
-  reward coordinates — and re-fetch is idempotent. A client that loses the response retries and
-  receives the same salt, so a lost packet cannot fork the timeline; until the release arrives, the
-  run does not start. The build snapshot pins at mint, so deferring resolution cannot improve an
-  outcome by out-leveling it first.
+- Salt is minted once per position and re-fetch is idempotent. A client that loses the response
+  retries and receives the same salt, so a lost packet cannot fork the timeline; until the release
+  arrives, nothing resolves.
+- Every input the outcome depends on pins at mint, so deferring resolution cannot improve it.
 
-Sealed salt requires a live round trip, so tail-bearing crafted content is online content.
+Each consumer of the mechanism defines its own position, resolution, and pinned inputs:
+
+- **Juiced instances**: the position is the node-anchored chain position — the same restart-stable
+  index that keys reward coordinates — the resolution is the run itself, and the pinned input is the
+  build snapshot, so a peeked outcome cannot be beaten by out-leveling first. Forfeiture lifts the
+  node's gate.
+- **Item crafting**: the position is the craft action in the avatar's crafting sequence, the
+  resolution is applying the result to the item, and the pinned inputs are the target item and the
+  consumed currency at commit. Application is exactly-once per action — a network retry never
+  applies a spend twice.
+
+Sealed salt requires a live round trip, so tail-bearing content is online content wherever it
+appears.
 
 Only a tailed distribution needs the seal. A normalized outcome — a chosen tier, an instance
 modifier bounded to modest scalars with no jackpot combination — carries no tail worth selecting, so

--- a/docs/architecture/game-entropy.md
+++ b/docs/architecture/game-entropy.md
@@ -67,8 +67,9 @@ Key custody is the economy boundary:
 
 Key derivation obeys three rules:
 
-- Every key comes from a one-way KDF over a master secret, and the trade and self-found populations
-  are separately rooted: a self-found key shares no recoverable root with any trade key.
+- Every key comes from a one-way KDF (key derivation function) over a master secret, and the trade
+  and self-found populations are separately rooted: a self-found key shares no recoverable root with
+  any trade key.
 - A self-found key is a pure function of `(master, avatarID, keyVersion)` — re-derivable
   bit-for-bit, never re-randomized.
 - The master secret lives in managed-key custody with rotation and audit, never in an application

--- a/docs/architecture/game-entropy.md
+++ b/docs/architecture/game-entropy.md
@@ -1,0 +1,78 @@
+# Game entropy & provenance
+
+Where game randomness comes from, and how an entropy source's security properties decide what
+rewards may ride it.
+
+## Threat model
+
+The client is untrusted and holds the complete simulation, so any entropy the client can compute is
+entropy the player can peek: simulate the future, inspect the outcome, and choose whether — and
+where — to play it. Look-ahead cannot be prevented in a deterministic client-simulated game;
+anything the client can describe, it can pre-compute. The design prices look-ahead instead of
+chasing it.
+
+The quantity that matters is selection value, and it is an order statistic: a scanner takes the best
+future across every reachable node and the whole offline window, so a reward distribution's danger
+lives in its tail, not its variance. Modest per-run variance with a rare outlier still hands a
+scanner a jackpot, because best-of-twenty-thousand lives in the tail. The
+[economy modes note](../game-design/004-economy-modes.md) turns this into the reward-design rule.
+
+## The anchored seed chain
+
+Per `(avatar, node)`, the server anchors an append-only seed chain: the next run's seed derives
+deterministically from the stored end of the previous run at that node. Abandoning and restarting
+yields the same continuation — there is nothing to re-roll. This single rule closes seed-fishing,
+death-scumming via early flush, and retry-branch selection.
+
+The chain is client-computable by design — offline simulation depends on it — which makes every
+chain-seeded run peekable. Chain entropy therefore carries only rewards priced for perfect
+foresight.
+
+## Sealed server salt
+
+Runs whose rewards must be unpeekable draw their entropy from server-minted salt, revealed in two
+commits:
+
+1. **Commit.** The player locks in (spends, selects a tier). The server mints the salt from a
+   server-held secret key and stores it sealed, returning only a lossy derived projection — mods,
+   difficulty, reward budget — for the preview window. All crafting decisions happen against that
+   metadata; the client never holds simulatable entropy while a decision is open.
+2. **Run-commit.** The salt is released and the client simulates. Release is commitment: the
+   position resolves under that salt, and a committed position the client never resolves is
+   force-resolved server-side at a deadline inside the replay-retention window, so an abandoned
+   commit cannot gate its node forever.
+
+The salt's keying material is a server-held secret. Domain-separation labels alone are insufficient:
+salt derived from client-visible state under a different label is still client-computable, and the
+entire unpeekability property collapses.
+
+Salt is minted once per chain position and re-fetch is idempotent — a client that loses the response
+retries and receives the same salt, so a lost packet cannot fork the timeline, and until the release
+arrives the run simply does not start. The build snapshot pins at mint, so deferring resolution
+cannot improve an outcome by out-leveling it first.
+
+A sealed-salt run requires a live round trip, so sealed-salt content is online content.
+
+## Provenance
+
+Every reward-bearing outcome carries a typed provenance: the entropy source kind plus a tradeable
+capability. The stamp derives at settlement from server mint records and the entropy-source
+commitment inside the hashed checkpoint subset — never from a client claim — so provenance is
+replay-derivable from the chain rather than trusted from a side table.
+
+Tradeability keys on the security property — entropy unpredictable at commit and non-repudiable —
+not on which channel delivered it. Any source with those properties mints tradeable outcomes;
+sources without them mint bound ones.
+
+## Mode enforcement
+
+An avatar's economy mode (the [economy modes note](../game-design/004-economy-modes.md) owns the
+choice) fixes its provenance statically:
+
+- **Trade avatars** ride the anchored chain for base expeditions — carrying static-class rewards
+  only — and sealed salt for itemized drops.
+- **Self-found avatars** ride the anchored chain for everything, juice included, and every outcome
+  settles bound.
+
+No per-run provenance adjudication exists: no fallback converts one entropy source into the other
+mid-run, so connectivity can never silently change what an outcome is worth.

--- a/docs/architecture/game-entropy.md
+++ b/docs/architecture/game-entropy.md
@@ -27,17 +27,18 @@ and restarting therefore replays the same continuation — there is nothing to r
 rule closes seed-fishing, death-scumming via early flush, and retry-branch selection.
 
 The chain is client-computable by design — offline simulation depends on it. It seeds the
-simulation's trajectory only: enemies, timing, survival, experience, and which kills yield drop
-slots. Drop content never derives from it. Foreseeing the trajectory is throughput knowledge —
+simulation's trajectory only: enemies, timing, survival, experience, and which kills commit rolled
+rewards. Rolled content never derives from it. Foreseeing the trajectory is throughput knowledge —
 routing, kill counts, survival — and the economy prices it as such.
 
-## Drop rolls and the avatar key
+## Rolled rewards and the avatar key
 
-The slot is a commitment; the item is its reveal. A kill that yields loot commits a drop slot at a
-deterministic coordinate, and the item is rolled from that coordinate later, under a key.
+A rolled reward is a reward whose value lives in its roll — an item drop is the concrete case. The
+commitment comes first, the reveal second: a kill that produces one commits it at a deterministic
+coordinate, and its content is rolled from that coordinate later, under a key.
 
 The coordinate is `(avatarID, nodeID, chainIndex, ordinal)`: `chainIndex` counts checkpoints from
-the node's seed-chain anchor, and `ordinal` indexes the drops within a checkpoint under the
+the node's seed-chain anchor, and `ordinal` indexes the rolled rewards within a checkpoint under the
 simulation's canonical ordering, independent of how checkpoints are batched. The coordinate derives
 only from the hashed checkpoint subset.
 
@@ -45,23 +46,24 @@ The coordinate is also restart-stable: the chain replays the same continuation, 
 restarting reproduces the identical coordinate. That stability is what makes the reveal safe.
 Peeking a roll and replaying the position shows the same roll — a peek has zero option value.
 
-Drop content is `f(key, coordinate)`, where `f` is a keyed PRF — a pseudorandom function whose
+Rolled content is `f(key, coordinate)`, where `f` is a keyed PRF — a pseudorandom function whose
 revealed outputs carry no predictive power over unrevealed coordinates. The property matters because
-every reveal hands the client a known input/output pair. Item identity is the coordinate, so minting
-is idempotent and re-verification can neither duplicate nor re-roll an item.
+every reveal hands the client a known input/output pair. The reward's identity is its coordinate, so
+minting is idempotent and re-verification can neither duplicate nor re-roll a reward.
 
 Key custody is the economy boundary:
 
 - **Server-held key** (trade avatars): the key never leaves the server. Content resolves only for
   coordinates whose producing checkpoint is durably appended — no protocol path returns content
-  earlier. The append is the commitment, the roll is the reveal. Connected play reveals drops within
-  a batch cadence of the kill; a return from offline reveals the window's drops at once. No
-  connectivity state changes what a slot is worth.
-- **Device-held key** (self-found avatars): the avatar rolls its own loot locally, offline, in real
-  time. A disclosed key makes every future roll computable, so the key ships only to avatars whose
-  earnings can never reach the market. Disclosure is the mode's normal operation, not a compromise.
-  The server derives the same key — that is what lets it verify self-found streams and restore the
-  key to a new device — so self-found custody is an economic wall, not a privacy guarantee.
+  earlier. The append is the commitment, the roll is the reveal. Connected play reveals a kill's
+  rewards within a batch cadence; a return from offline reveals the window's rewards at once. No
+  connectivity state changes what a committed reward is worth.
+- **Device-held key** (self-found avatars): the avatar rolls its own rewards locally, offline, in
+  real time. A disclosed key makes every future roll computable, so the key ships only to avatars
+  whose earnings can never reach the market. Disclosure is the mode's normal operation, not a
+  compromise. The server derives the same key — that is what lets it verify self-found streams and
+  restore the key to a new device — so self-found custody is an economic wall, not a privacy
+  guarantee.
 
 Key derivation obeys three rules:
 
@@ -100,7 +102,7 @@ Two rules keep the seal honest:
   insufficient: salt derived from client-visible state under a different label is still
   client-computable, and the sealing property collapses.
 - Salt is minted once per node-anchored chain position — the same restart-stable index that keys
-  drop coordinates — and re-fetch is idempotent. A client that loses the response retries and
+  reward coordinates — and re-fetch is idempotent. A client that loses the response retries and
   receives the same salt, so a lost packet cannot fork the timeline; until the release arrives, the
   run does not start. The build snapshot pins at mint, so deferring resolution cannot improve an
   outcome by out-leveling it first.

--- a/docs/architecture/game-entropy.md
+++ b/docs/architecture/game-entropy.md
@@ -5,67 +5,75 @@ rewards may ride it.
 
 ## Threat model
 
-The client is untrusted and holds the complete simulation, so any entropy the client can compute is
-entropy the player can peek: simulate the future, inspect the outcome, and choose whether — and
-where — to play it. Look-ahead cannot be prevented in a deterministic client-simulated game;
-anything the client can describe, it can pre-compute. The design prices look-ahead instead of
-chasing it.
+The client is untrusted and holds the complete simulation. Any entropy the client can compute, the
+player can peek: simulate the future, inspect the outcome, and choose whether — and where — to play
+it. Look-ahead cannot be prevented in a deterministic client-simulated game; anything the client can
+describe, it can pre-compute. The design prices look-ahead instead of chasing it.
 
-The quantity that matters is selection value, and it is an order statistic: a scanner takes the best
-future across every reachable node and the whole offline window, so a reward distribution's danger
-lives in its tail, not its variance. Modest per-run variance with a rare outlier still hands a
-scanner a jackpot, because best-of-twenty-thousand lives in the tail. The
-[economy modes note](../game-design/004-economy-modes.md) turns this into the reward-design rules.
+A scanner does not play the average future. It simulates the next hour on every reachable node,
+across the whole offline window, and plays only the best one. Out of twenty thousand simulated
+futures the one that matters is the single best, so a reward distribution's danger lives in its
+tail, not its variance — modest per-run variance with a rare outlier still hands the scanner a
+jackpot. That best-of-N selection value is what every rule below prices; the
+[economy modes note](../game-design/004-economy-modes.md) turns it into the reward-design rules.
 
 ## The anchored seed chain
 
 Per `(avatar, node)`, the server anchors an append-only seed chain: the next run's seed derives
 deterministically from the stored end of the previous run at that node. The anchor is the last
-**verified** checkpoint's end-state at that node: terminal activity states never advance it past the
+**verified** checkpoint's end-state at that node. Terminal activity states never advance it past the
 verified prefix, and rejecting a stream at version N resets it to the end of version N−1. Abandoning
 and restarting therefore replays the same continuation — there is nothing to re-roll. This single
 rule closes seed-fishing, death-scumming via early flush, and retry-branch selection.
 
-The chain is client-computable by design — offline simulation depends on it — and it seeds the
+The chain is client-computable by design — offline simulation depends on it. It seeds the
 simulation's trajectory only: enemies, timing, survival, experience, and which kills yield drop
 slots. Drop content never derives from it. Foreseeing the trajectory is throughput knowledge —
 routing, kill counts, survival — and the economy prices it as such.
 
 ## Drop rolls and the avatar key
 
-A kill that yields loot produces a drop slot at a deterministic coordinate
-`(avatarID, nodeID, chainIndex, ordinal)`, where `chainIndex` counts checkpoints from the node's
-seed-chain anchor and `ordinal` indexes the drops within a checkpoint under the simulation's
-canonical ordering, independent of how checkpoints are batched. The coordinate derives only from the
-hashed checkpoint subset, and it is restart-stable: because the chain replays the same continuation,
-abandoning and restarting reproduces the identical coordinate. That stability is what makes the
-reveal safe — peeking a roll and replaying the position shows the same roll, so a peek has zero
-option value.
+The slot is a commitment; the item is its reveal. A kill that yields loot commits a drop slot at a
+deterministic coordinate, and the item is rolled from that coordinate later, under a key.
 
-The slot is a commitment; the item is its reveal. Drop content is `f(key, coordinate)` where `f` is
-a keyed PRF — revealed outputs carry no predictive power over unrevealed coordinates, which matters
-because every reveal hands the client a known input/output pair. Item identity is the coordinate, so
-minting is idempotent and re-verification can neither duplicate nor re-roll an item.
+The coordinate is `(avatarID, nodeID, chainIndex, ordinal)`: `chainIndex` counts checkpoints from
+the node's seed-chain anchor, and `ordinal` indexes the drops within a checkpoint under the
+simulation's canonical ordering, independent of how checkpoints are batched. The coordinate derives
+only from the hashed checkpoint subset.
+
+The coordinate is also restart-stable: the chain replays the same continuation, so abandoning and
+restarting reproduces the identical coordinate. That stability is what makes the reveal safe.
+Peeking a roll and replaying the position shows the same roll — a peek has zero option value.
+
+Drop content is `f(key, coordinate)`, where `f` is a keyed PRF — a pseudorandom function whose
+revealed outputs carry no predictive power over unrevealed coordinates. The property matters because
+every reveal hands the client a known input/output pair. Item identity is the coordinate, so minting
+is idempotent and re-verification can neither duplicate nor re-roll an item.
 
 Key custody is the economy boundary:
 
-- **Server-held key** (trade avatars): the key never leaves the server, and content resolves only
-  for coordinates whose producing checkpoint is durably appended — no protocol path returns content
-  earlier. The append is the commitment, the roll is the reveal: connected play reveals drops within
-  a batch cadence of the kill, a return from offline reveals the window's drops at once, and no
+- **Server-held key** (trade avatars): the key never leaves the server. Content resolves only for
+  coordinates whose producing checkpoint is durably appended — no protocol path returns content
+  earlier. The append is the commitment, the roll is the reveal. Connected play reveals drops within
+  a batch cadence of the kill; a return from offline reveals the window's drops at once. No
   connectivity state changes what a slot is worth.
 - **Device-held key** (self-found avatars): the avatar rolls its own loot locally, offline, in real
   time. A disclosed key makes every future roll computable, so the key ships only to avatars whose
-  earnings can never reach the market. Disclosure is the mode's normal operation, not a compromise —
-  and the server derives the same key, which is what lets it verify self-found streams and restore
-  the key to a new device. Self-found custody is an economic wall, not a privacy guarantee.
+  earnings can never reach the market. Disclosure is the mode's normal operation, not a compromise.
+  The server derives the same key — that is what lets it verify self-found streams and restore the
+  key to a new device — so self-found custody is an economic wall, not a privacy guarantee.
 
-Key derivation is a one-way KDF from a master secret, with the trade and self-found populations
-separately rooted: a self-found key must share no recoverable root with any trade key. A self-found
-key is a pure function of `(master, avatarID, keyVersion)` — re-derivable bit-for-bit, never
-re-randomized. The master secret requires managed-key custody with rotation and audit, never an
-application environment variable; a leaked trade root makes every future trade drop computable,
-which is the one unrecoverable failure this design has.
+Key derivation obeys three rules:
+
+- Every key comes from a one-way KDF over a master secret, and the trade and self-found populations
+  are separately rooted: a self-found key shares no recoverable root with any trade key.
+- A self-found key is a pure function of `(master, avatarID, keyVersion)` — re-derivable
+  bit-for-bit, never re-randomized.
+- The master secret lives in managed-key custody with rotation and audit, never in an application
+  environment variable.
+
+A leaked trade root makes every future trade drop computable. That is the one unrecoverable failure
+this design has.
 
 Every roll is pinned by its activity's `Started` snapshot: `keyVersion` is stamped there beside the
 engine and content versions, and `f` resolves content under the pinned versions — never the live
@@ -73,53 +81,55 @@ deploy — so reveal, replay, and mint agree across deploys, parks, and master r
 
 ## Sealed pre-commit salt
 
-Outcomes whose distribution carries a tail worth selecting — item affix rolls, rare content — draw
-entropy that must stay sealed while a crafting decision is open, revealed in two commits:
+Some outcomes carry a tail worth selecting — item affix rolls, rare content. Their entropy stays
+sealed while a crafting decision is open, revealed in two commits:
 
 1. **Commit.** The player locks in the spend. The server mints the salt from a server-held secret
-   key and stores it sealed, returning only a lossy derived projection — modifier families,
-   difficulty, reward budget — for the preview window. The projection is a distribution summary and
-   never narrows the realized roll: walking away must never beat resolving, at any tier, and the
-   projection's information content is bounded by that rule. All crafting decisions happen against
-   the metadata; the client never holds simulatable entropy while a decision is open.
-2. **Run-commit.** The salt is released and the client simulates. Release is commitment: a committed
-   position the client never resolves is force-resolved as forfeited — the bundle is lost and the
-   node's gate lifts — at a server-side deadline inside the replay-retention window.
+   key and stores it sealed. The player sees only a lossy projection derived from it — modifier
+   families, difficulty, reward budget — for the preview window. The projection is a distribution
+   summary and never narrows the realized roll: walking away must never beat resolving, at any tier,
+   and that rule bounds how much the projection may reveal. Every crafting decision happens against
+   this metadata; the client never holds simulatable entropy while a decision is open.
+2. **Run-commit.** The server releases the salt and the client simulates. Release is commitment: a
+   committed position the client never resolves is force-resolved as forfeited at a server-side
+   deadline inside the replay-retention window — the bundle is lost and the node's gate lifts.
 
-The salt's keying material is a server-held secret. Domain-separation labels alone are insufficient:
-salt derived from client-visible state under a different label is still client-computable, and the
-sealing property collapses.
+Two rules keep the seal honest:
 
-Salt is minted once per node-anchored chain position — the same restart-stable index that keys drop
-coordinates — and re-fetch is idempotent: a client that loses the response retries and receives the
-same salt, so a lost packet cannot fork the timeline, and until the release arrives the run does not
-start. The build snapshot pins at mint, so deferring resolution cannot improve an outcome by
-out-leveling it first.
+- The salt's keying material is a server-held secret. Domain-separation labels alone are
+  insufficient: salt derived from client-visible state under a different label is still
+  client-computable, and the sealing property collapses.
+- Salt is minted once per node-anchored chain position — the same restart-stable index that keys
+  drop coordinates — and re-fetch is idempotent. A client that loses the response retries and
+  receives the same salt, so a lost packet cannot fork the timeline; until the release arrives, the
+  run does not start. The build snapshot pins at mint, so deferring resolution cannot improve an
+  outcome by out-leveling it first.
 
-Sealed salt requires a live round trip, so tail-bearing crafted content is online content. Entropy
-placement follows the outcome distribution, not the mechanic: a normalized outcome — a chosen tier,
-an instance modifier bounded to modest scalars with no jackpot combination — carries no tail worth
-selecting, so it rides client-computable entropy anywhere, interactive rerolls included. Peeking a
-tail-free distribution reveals nothing worth acting on; only a tailed distribution needs the seal.
+Sealed salt requires a live round trip, so tail-bearing crafted content is online content.
+
+Only a tailed distribution needs the seal. A normalized outcome — a chosen tier, an instance
+modifier bounded to modest scalars with no jackpot combination — carries no tail worth selecting, so
+it rides client-computable entropy anywhere, interactive rerolls included; the
+[economy modes note](../game-design/004-economy-modes.md) owns that rule.
+
 For self-found avatars no entropy is sealable at all — the player holds the key — which is
 consistent with their earnings never reaching the market.
 
 ## Provenance
 
 Every checkpoint's hashed subset carries an entropy-source tag identifying which source rolled its
-outcomes, present from the first row ever written — the subset is frozen, so the tag cannot be added
-later, and it is what allows entropy sources beyond the current two (a verifiable-randomness beacon,
-a rotated key generation) to join without a migration. Verification validates the tag against the
-avatar's server-recorded mode; a mismatch is divergence. Settlement stamps an outcome's provenance
-from server records and the tag — never from a client claim.
+outcomes, present from the first row ever written. The subset is frozen, so the tag cannot be added
+later — and the tag is what lets entropy sources beyond the current two (a verifiable-randomness
+beacon, a rotated key generation) join without a migration. Verification validates the tag against
+the avatar's server-recorded mode; a mismatch is divergence. Settlement stamps an outcome's
+provenance from server records and the tag — never from a client claim.
 
-Tradeability keys on the security property — entropy unpredictable at the moment the outcome was
-committed, and non-repudiable — not on which channel delivered it. Server-custody rolls and sealed
-salt have the property; device-custody rolls do not.
+Tradeability keys on the security property: entropy unpredictable at the moment the outcome was
+committed, and provably tied to the party that minted it. Server-custody rolls and sealed salt have
+the property; device-custody rolls do not. The delivery channel is irrelevant.
 
 ## Mode enforcement
 
 An avatar's economy mode (the [economy modes note](../game-design/004-economy-modes.md) owns the
-choice) fixes its key custody at creation, permanently. No path converts one custody into the other:
-connectivity changes when a trade avatar's rolls reveal, never what they are worth, and a
-device-held key is never repatriated into market eligibility.
+choice) fixes its key custody at creation, permanently. No path converts one custody into the other,
+and a device-held key is never repatriated into market eligibility.

--- a/docs/architecture/game-simulation.md
+++ b/docs/architecture/game-simulation.md
@@ -7,14 +7,15 @@ replay.
 
 The simulation is a pure function: a server-authored input snapshot plus a seed stream fully
 determine every tick. The engine (`@vers/idle-core`) and encounter derivation (`@vers/game-utils`)
-are shared libraries, so the client worker and the server verifier import the same code and compute
-byte-identical results from the same inputs.
+are shared libraries, so the client worker and the verification worker — the server process that
+replays submitted checkpoints — import the same code and compute byte-identical results from the
+same inputs.
 
-The client does all real-time simulation. One writer runs the fixed-timestep loop per browser
-profile — a SharedWorker, with leader election where SharedWorker is unavailable — and other tabs
-are pure viewers. A return from offline fast-forwards the simulation from the last verified
-checkpoint. The server never simulates on the request path; it replays asynchronously to decide
-whether to trust what the client submitted.
+The client does all real-time simulation. One writer per browser profile runs the fixed-timestep
+loop — a SharedWorker, with leader election where SharedWorker is unavailable — and other tabs are
+pure viewers. On returning from offline, the client fast-forwards the simulation from the last
+verified checkpoint. The server never simulates on the request path; it replays asynchronously to
+decide whether to trust what the client submitted.
 
 ## Server-authored inputs
 
@@ -29,23 +30,24 @@ between activities. A snapshot that cannot change mid-activity is what makes rep
 
 ## Checkpoint streams
 
-Each activity is one append-only stream: a head row carrying the `appended_head` and `verified_head`
-cursors, the last chain hash, and the activity status, plus one checkpoint row per version keyed
-`(activity_id, version)`.
+Each activity is one append-only stream: one checkpoint row per version, keyed
+`(activity_id, version)`, plus a head row. The head row carries the stream's two cursors —
+`appended_head` (how far the client has written) and `verified_head` (how far the server has
+replayed) — the last chain hash, and the activity status.
 
 - Each checkpoint hashes `{seed/nextSeed, time, type, entropySource}` and links the previous
-  checkpoint's hash. The hashed subset is frozen from the first row ever written — it never gains,
-  loses, or repurposes a field — and the entropy-source tag inside it makes a checkpoint's
-  provenance derivable from the chain itself.
-- The hash is a chain link, not an outcome proof: rewards ride outside the hashed subset as signed
+  checkpoint's hash. The hashed subset is frozen from the first row ever written: it never gains,
+  loses, or repurposes a field. The entropy-source tag inside it makes a checkpoint's provenance
+  derivable from the chain itself.
+- The hash is a chain link, not an outcome proof. Rewards ride outside the hashed subset as signed
   deltas in an open keyed map, and only replay validates them.
-- Appends are a compare-and-swap on the head row's `appended_head`. A stale head returns a retryable
-  conflict carrying the current head (the client resends the tail); `UNIQUE(activity_id, version)`
-  plus deterministic checkpoint content makes resubmission a free dedupe, and dedupe runs before
-  elapsed-time accounting so replays never inflate duration.
-- A session-epoch fence rejects appends from evicted sessions as fatal, and terminal statuses
-  (stopped, rejected, capped, quarantined) reject any later append — together these resolve every
-  race between logout, forced logout, stop, rejection, and cap.
+- Appends compare-and-swap the head row's `appended_head`. A stale head returns a retryable conflict
+  carrying the current head, and the client resends the tail. Resubmission is a free dedupe —
+  `UNIQUE(activity_id, version)` plus deterministic checkpoint content — and dedupe runs before
+  elapsed-time accounting, so replays never inflate duration.
+- A session-epoch fence rejects appends from evicted sessions as fatal. Terminal statuses (stopped,
+  rejected, capped, quarantined) reject any later append. Together these resolve every race between
+  logout, forced logout, stop, rejection, and cap.
 
 ## Verification
 
@@ -54,11 +56,11 @@ per-stream FIFO — version N+1 never verifies before N, because the seed chain 
 worker replays from the `Started` snapshot under the engine version stamped into it, dispatched
 through a provider registry so old segments replay under the code and content that produced them.
 
-Ambiguity parks, it never rejects: a version mismatch, an unknown engine, or a timeout is an
-operational state, not a cheat signal. Only reproducible divergence under a matched version and
-snapshot, on repetition, is treated as cheating, and enforcement lands at a session boundary — never
-mid-session. A stream that fails verification repeatedly is quarantined and alerted on rather than
-retried forever.
+Ambiguity parks, it never rejects: a version mismatch, an unknown engine, or a timeout is held as an
+operational state, not judged as a cheat signal. Only reproducible divergence under a matched
+version and snapshot, on repetition, is treated as cheating, and enforcement lands at a session
+boundary — never mid-session. A stream that fails verification repeatedly is quarantined and alerted
+on rather than retried forever.
 
 The primary health gauge is verification lag: the oldest unverified append across all streams.
 Rejection rates are tracked split by cause — an integrity-mismatch spike is almost always a bad
@@ -66,9 +68,10 @@ deploy, not a cheating wave.
 
 ## Applying verified progress
 
-Verified deltas apply exactly once through a cursor-guarded transaction: compare-and-swap the
-stream's `verified_head` forward, apply the delta to identity state, and append the outcome event —
-all in one local transaction, so a crashed worker retries idempotently.
+Verified deltas apply exactly once through a cursor-guarded transaction: advance `verified_head`
+with a compare-and-swap — the update applies only if the cursor still holds its expected value —
+then apply the delta to identity state and append the outcome event, all in one local transaction. A
+crashed worker retries idempotently.
 
 - First-clears, achievements, and other one-shot grants insert into a unique-keyed grant table with
   `ON CONFLICT DO NOTHING` inside the same transaction — idempotent across re-farms and replays.

--- a/docs/architecture/game-simulation.md
+++ b/docs/architecture/game-simulation.md
@@ -33,9 +33,10 @@ Each activity is one append-only stream: a head row carrying the `appended_head`
 cursors, the last chain hash, and the activity status, plus one checkpoint row per version keyed
 `(activity_id, version)`.
 
-- Each checkpoint hashes `{seed/nextSeed, time, type}` and links the previous checkpoint's hash. The
-  hashed subset is frozen — it never gains, loses, or repurposes a field — and includes the
-  entropy-source commitment, so a checkpoint's provenance is derivable from the chain itself.
+- Each checkpoint hashes `{seed/nextSeed, time, type, entropySource}` and links the previous
+  checkpoint's hash. The hashed subset is frozen from the first row ever written — it never gains,
+  loses, or repurposes a field — and the entropy-source tag inside it makes a checkpoint's
+  provenance derivable from the chain itself.
 - The hash is a chain link, not an outcome proof: rewards ride outside the hashed subset as signed
   deltas in an open keyed map, and only replay validates them.
 - Appends are a compare-and-swap on the head row's `appended_head`. A stale head returns a retryable
@@ -71,9 +72,15 @@ all in one local transaction, so a crashed worker retries idempotently.
 
 - First-clears, achievements, and other one-shot grants insert into a unique-keyed grant table with
   `ON CONFLICT DO NOTHING` inside the same transaction — idempotent across re-farms and replays.
-- Item instances mint at settlement from their deterministic drop coordinate, idempotently —
-  re-verification never duplicates an item.
-- A rejected claim rolls back by forward compensating events, never by snapshot restore.
+- Item instances mint at settlement: identity is the restart-stable drop coordinate and content is
+  rolled from the avatar's key under the activity's pinned versions (see
+  [game entropy](./game-entropy.md)), so re-verification never duplicates or re-rolls an item.
+- Drop content is revealed only for coordinates whose producing checkpoint is durably appended, and
+  the reveal is a pure function of the coordinate — append retries and bulk offline resends return
+  identical reveals.
+- A rejected claim rolls back by forward compensating events, never by snapshot restore: the node's
+  seed anchor resets to the verified prefix and revealed-but-unsettled drops past it are cleared
+  from optimistic display.
 
 Resume always anchors on the last verified checkpoint. The client rebuilds optimistic state by
 simulating forward from that anchor; it never renders the server's settled progression columns

--- a/docs/architecture/game-simulation.md
+++ b/docs/architecture/game-simulation.md
@@ -75,14 +75,14 @@ crashed worker retries idempotently.
 
 - First-clears, achievements, and other one-shot grants insert into a unique-keyed grant table with
   `ON CONFLICT DO NOTHING` inside the same transaction — idempotent across re-farms and replays.
-- Item instances mint at settlement: identity is the restart-stable drop coordinate and content is
+- Item instances mint at settlement: identity is the restart-stable reward coordinate and content is
   rolled from the avatar's key under the activity's pinned versions (see
   [game entropy](./game-entropy.md)), so re-verification never duplicates or re-rolls an item.
-- Drop content is revealed only for coordinates whose producing checkpoint is durably appended, and
-  the reveal is a pure function of the coordinate — append retries and bulk offline resends return
-  identical reveals.
+- Rolled content is revealed only for coordinates whose producing checkpoint is durably appended,
+  and the reveal is a pure function of the coordinate — append retries and bulk offline resends
+  return identical reveals.
 - A rejected claim rolls back by forward compensating events, never by snapshot restore: the node's
-  seed anchor resets to the verified prefix and revealed-but-unsettled drops past it are cleared
+  seed anchor resets to the verified prefix and revealed-but-unsettled rewards past it are cleared
   from optimistic display.
 
 Resume always anchors on the last verified checkpoint. The client rebuilds optimistic state by

--- a/docs/architecture/game-simulation.md
+++ b/docs/architecture/game-simulation.md
@@ -1,0 +1,89 @@
+# Game simulation & verification
+
+How gameplay is computed on the client, recorded as checkpoint streams, and trusted through server
+replay.
+
+## The deterministic core
+
+The simulation is a pure function: a server-authored input snapshot plus a seed stream fully
+determine every tick. The engine (`@vers/idle-core`) and encounter derivation (`@vers/game-utils`)
+are shared libraries, so the client worker and the server verifier import the same code and compute
+byte-identical results from the same inputs.
+
+The client does all real-time simulation. One writer runs the fixed-timestep loop per browser
+profile — a SharedWorker, with leader election where SharedWorker is unavailable — and other tabs
+are pure viewers. A return from offline fast-forwards the simulation from the last verified
+checkpoint. The server never simulates on the request path; it replays asynchronously to decide
+whether to trust what the client submitted.
+
+## Server-authored inputs
+
+`startActivity` is a server action that owns every simulation input: it mints the seed (see
+[game entropy](./game-entropy.md)), resolves the node's enemy content, snapshots the avatar's build
+(equipment, passives, level) from server truth, and stamps the engine and content versions.
+Client-submitted activity and avatar payloads are display hints — the verifier replays from the
+snapshot, never from round-tripped values.
+
+Build mutations are gated while an activity is active: level-ups render optimistically and apply
+between activities. A snapshot that cannot change mid-activity is what makes replay exact.
+
+## Checkpoint streams
+
+Each activity is one append-only stream: a head row carrying the `appended_head` and `verified_head`
+cursors, the last chain hash, and the activity status, plus one checkpoint row per version keyed
+`(activity_id, version)`.
+
+- Each checkpoint hashes `{seed/nextSeed, time, type}` and links the previous checkpoint's hash. The
+  hashed subset is frozen — it never gains, loses, or repurposes a field — and includes the
+  entropy-source commitment, so a checkpoint's provenance is derivable from the chain itself.
+- The hash is a chain link, not an outcome proof: rewards ride outside the hashed subset as signed
+  deltas in an open keyed map, and only replay validates them.
+- Appends are a compare-and-swap on the head row's `appended_head`. A stale head returns a retryable
+  conflict carrying the current head (the client resends the tail); `UNIQUE(activity_id, version)`
+  plus deterministic checkpoint content makes resubmission a free dedupe, and dedupe runs before
+  elapsed-time accounting so replays never inflate duration.
+- A session-epoch fence rejects appends from evicted sessions as fatal, and terminal statuses
+  (stopped, rejected, capped, quarantined) reject any later append — together these resolve every
+  race between logout, forced logout, stop, rejection, and cap.
+
+## Verification
+
+A queue-fed worker replays submitted checkpoint batches and compares results. Verification is
+per-stream FIFO — version N+1 never verifies before N, because the seed chain would break — and the
+worker replays from the `Started` snapshot under the engine version stamped into it, dispatched
+through a provider registry so old segments replay under the code and content that produced them.
+
+Ambiguity parks, it never rejects: a version mismatch, an unknown engine, or a timeout is an
+operational state, not a cheat signal. Only reproducible divergence under a matched version and
+snapshot, on repetition, is treated as cheating, and enforcement lands at a session boundary — never
+mid-session. A stream that fails verification repeatedly is quarantined and alerted on rather than
+retried forever.
+
+The primary health gauge is verification lag: the oldest unverified append across all streams.
+Rejection rates are tracked split by cause — an integrity-mismatch spike is almost always a bad
+deploy, not a cheating wave.
+
+## Applying verified progress
+
+Verified deltas apply exactly once through a cursor-guarded transaction: compare-and-swap the
+stream's `verified_head` forward, apply the delta to identity state, and append the outcome event —
+all in one local transaction, so a crashed worker retries idempotently.
+
+- First-clears, achievements, and other one-shot grants insert into a unique-keyed grant table with
+  `ON CONFLICT DO NOTHING` inside the same transaction — idempotent across re-farms and replays.
+- Item instances mint at settlement from their deterministic drop coordinate, idempotently —
+  re-verification never duplicates an item.
+- A rejected claim rolls back by forward compensating events, never by snapshot restore.
+
+Resume always anchors on the last verified checkpoint. The client rebuilds optimistic state by
+simulating forward from that anchor; it never renders the server's settled progression columns
+directly, because they lag verification by design.
+
+## Offline progress
+
+Offline progress is bounded per return. Past the cap the activity stops server-side and resuming
+requires a resync. The fast-forward simulates from the last verified anchor; re-simulating a few
+already-submitted minutes is harmless — the results are deterministic and resubmission dedupes.
+
+Which rewards offline simulation may produce is an economy rule, not a protocol one: the
+[economy modes note](../game-design/004-economy-modes.md) owns it.

--- a/docs/game-design/004-economy-modes.md
+++ b/docs/game-design/004-economy-modes.md
@@ -1,7 +1,7 @@
 # Economy Modes & Reward Integrity
 
 This note defines how Vers keeps a fair player economy when the simulation runs on the player's
-machine: the mode chosen at avatar creation, the rule for which rewards may be predictable, and
+machine: the mode chosen at avatar creation, the rules for which outcomes may be predictable, and
 juice's economic role. The entropy architecture doc owns the mechanisms; this note owns the design
 they enforce.
 
@@ -9,7 +9,7 @@ they enforce.
 
 Vers simulates on the client, deterministically. That is what makes idle play free to run and
 offline progress possible — and it means a motivated player can compute their own future: simulate
-the runs ahead, see what drops, and choose which futures to play. This cannot be prevented, only
+the runs ahead, see what happens, and choose which futures to play. This cannot be prevented, only
 priced.
 
 Foresight is harmless when outcomes are steady and devastating when they are rare: a player who can
@@ -20,57 +20,91 @@ playing for it, and a market lets them sell it. The economy's one hard rule foll
 
 ## The Mode Choice
 
-Every avatar chooses its economy at creation:
+Every avatar chooses its economy at creation, and the choice is a single fact: who holds the
+avatar's loot key.
 
-- **Trade** (working label) — full market access. Itemized drops come from sealed-entropy content,
-  which resolves online; predictable play — including the whole offline loop — yields progression
-  and static materials.
-- **Self-Found** (working label) — the whole game, fully offline, juice included. Nothing the avatar
-  earns can ever be traded, gifted, or moved to another avatar. Foresight is legitimate texture:
-  planning around a computed future is the mode's own kind of mastery.
+- **Trade** (working label) — full market access. The avatar's loot key stays on the server, so
+  drops resolve as the run's records land: live while connected, and in one reveal on returning from
+  offline. The same expedition yields the same loot either way — being away changes when loot is
+  seen, never what it is worth.
+- **Self-Found** (working label) — the avatar's loot key lives with the player, so loot resolves
+  locally, offline, in real time, juice included. Nothing the avatar earns can ever be traded,
+  gifted, or moved to another avatar. Foresight is legitimate texture: planning around a computed
+  future is the mode's own kind of mastery.
 
-The choice is permanent. A self-found avatar's wealth was accumulated under perfect foresight, so
-migrating it into a market would launder foresight-selected value; permanence is the price of
-unrestricted offline play. Both labels follow the naming grammar in the core note before they reach
-the UI.
+Trade is the default and the pre-selected choice at creation. Self-Found is a deliberate opt-in
+behind an explicit warning, because the choice is permanent: a self-found avatar's wealth was rolled
+under a key its player holds — accumulated under perfect foresight — so migrating it into a market
+would launder foresight-selected value. Permanence is the price of a key of one's own. A new player
+who never touches the market loses nothing by staying Trade; only Self-Found forecloses anything.
 
-Mode is an avatar property, and avatars are league-scoped, so league resets contain self-found
-holdings with no extra rule.
+The mode difference carries its own fiction: the market institution assays and logs a trade avatar's
+finds — that is why they take a moment to appear and why they can be sold — while a self-found
+avatar's haul is off the books, never assayed, kept in its own hands. Both labels follow the naming
+grammar in the core note before they reach the UI.
 
-## Predictable Rewards
+Mode partitions every economic container and every reward-bearing space, as a standing invariant
+rather than a list: stashes, banks, ladders, prize events — anything that stores value or pays it
+out is scoped to one mode, and no container is ever shared across the boundary, including between
+one account's own avatars. Self-found ladders rank on server-verifiable play — depth, level, clear
+speed — never on gear, which only the player's own device rolled. Avatars are league-scoped, so
+league resets contain self-found holdings with no extra rule.
 
-Rewards earned on predictable entropy are generic and static-class:
+## Predictable Outcomes
+
+The simulation's trajectory is predictable by design — offline play depends on computing it — so
+everything the trajectory carries is priced for foresight:
 
 - **Experience.** Per-encounter variance is acceptable — foreseeing it only improves routing, which
   is calculator play, not arbitrage.
 - **Fixed material and currency trickles** at published rates.
 - **Completion payouts** — first-clear bonuses and unlock grants, fixed per region.
+- **Drop slots.** Which kills yield loot, and how many, is trajectory knowledge: foreseeing it
+  reveals a route's throughput, never what any slot contains.
 
-Itemized drops are never predictable for a trade avatar. A drop only means something when its roll
-does, and a foreseeable roll is a roll the whole map gets scanned for — so there is no capped-tail
-compromise version of a monster drop. Drops whose rolls matter exist only behind sealed entropy, or
-on self-found avatars, where they are unrestricted everywhere.
+Because slot counts are foreseeable and every slot carries market value for a trade avatar, drop
+density obeys the tail rule that drop quality no longer needs: routes may differ modestly in drops
+per hour — grindy play averages out — but no route is a density jackpot worth scanning thousands of
+futures to find. Density outliers belong in invested content, priced by their cost.
 
-This gives a trade avatar's play a deliberate rhythm: predictable play — base expeditions, the
-offline loop — is the progression engine, and sealed-entropy sessions are the loot engine. The grind
-builds the avatar; the sessions produce the finds.
+What a slot contains is never predictable for a trade avatar: content rolls under the server-held
+key only after every choice that produced the slot is committed. Loot therefore drops everywhere —
+base expeditions, invested expeditions, the offline loop — with full ordinary variance, and none of
+it can be fished for.
+
+Two consequences the wider economy design carries as obligations. Offline accrual is wall-clock
+metered and non-resettable — an hour of absence yields an hour of progress, capped, with no way to
+bank a window and immediately re-arm it — and because unattended play now mints market-grade loot,
+per-account throughput limits and account-legitimacy gates at market access are economy-design
+prerequisites, alongside sinks sized to a faucet that runs while players sleep. The economy-loop
+note owns them.
 
 ## Juice
 
-Juice is spending to modify an expedition instance, and for trade avatars it is the variance faucet:
-commit the spend, craft against the preview's metadata, lock in, and the sealed outcome resolves.
-Its constraints hold regardless of how juice mechanics evolve:
+Juice is spending to modify an expedition instance, in two forms split by one boundary: whether
+randomness is involved at decision time.
+
+- **Invested difficulty** — choose a tier, pay its cost, and the instance hardens and yields more
+  drop slots, deterministically. Nothing rolls when the choice is made, so there is nothing to peek
+  and nothing to fish: the spend buys known throughput, and the loot it yields stays sealed like any
+  other slot. Invested runs work anywhere, offline included.
+- **Crafted instances** — modifiers are rolled, previewed, rerolled, and locked. Rolling at decision
+  time needs entropy sealed while the player decides, which takes a live exchange: crafted content
+  is online content. Self-found avatars craft against their own key — nothing is sealed from them,
+  and nothing they make can leave.
+
+Base drops fall everywhere; juice in either form is deliberate investment layered on top. Its value
+is aim, not access: crafted instances are the targeted-outcome market — shaping what kind of reward
+a run can produce — beside base play's open lottery, and their costs are a real consumption of
+wealth. Its constraints hold regardless of how juice mechanics evolve:
 
 - Juiced rewards are a separable overlay — never a multiplier on a quantity the player could
   foresee. A multiplier on foreseeable value invites scanning for the best base outcome and
   amplifying it; the overlay form has nothing to scan.
 - Difficulty conditions on the chosen tier alone, with flat expected value per cost across tiers.
-- A juiced bundle settles all-or-nothing, and a committed instance always resolves — bailing
+- A crafted bundle settles all-or-nothing, and a committed instance always resolves — bailing
   forfeits the bundle, so peeking-then-declining has zero option value.
 - Juiced failure costs only the forgone yield, never experience.
-
-Self-found juice runs anywhere, offline included, on predictable entropy — its outputs are bound
-like everything else the avatar earns.
 
 ## Extraction & Settlement
 
@@ -81,17 +115,28 @@ only once the checkpoints that produced it verify. Opening a trade bumps the pla
 checkpoints to the front of the verification queue, so honest players feel a brief gate exactly when
 they transfer and nowhere else.
 
+The verification gate follows value through transformation: an output crafted, salvaged, or combined
+from an unverified input inherits the gate until every contributing input verifies. Interactive
+crafting that consumes tradeable currency rolls server-side — decision-time randomness is the same
+boundary everywhere — and applies exactly once per action.
+
 Experience and levels are never tradeable, render optimistically, and reconcile lazily. Defeat costs
-follow the core note.
+follow the core note, with one constraint from foresight: survival is trajectory knowledge, so a
+player who plans can avoid nearly every death — death is a texture cost, and the economy never
+relies on it as a sink or a throughput brake.
 
 ## Competition
 
-- Ladders partition by mode: self-found avatars rank among self-found avatars.
+- Ladders, prize events, and every future reward-bearing space partition by mode — the standing
+  invariant from the mode choice.
 - Guild banks hold tradeable goods, so only trade avatars deposit.
 - Ghost PvP is build against build, and mode partitioning follows the ladders.
+- Group content resolves loot personally: each participant rolls shared encounters under their own
+  key, so a mixed-mode party yields each member their own mode's loot and no shared pool exists.
 
 ## Non-Goals
 
 This note does not define reward tables or rates, juice mechanics and costs, drop design, ladder
-structure, guild mechanics, offline caps per mode, or the modes' world names. Those belong to the
-progression, itemisation, economy-loop, and fiction notes.
+structure, guild mechanics, offline caps per mode, sink and throughput-limit design (the
+economy-loop note owns them), or the modes' world names. Those belong to the progression,
+itemisation, economy-loop, and fiction notes.

--- a/docs/game-design/004-economy-modes.md
+++ b/docs/game-design/004-economy-modes.md
@@ -108,13 +108,17 @@ targeted-outcome market beside base play's open lottery — it shapes what kind 
 produce, and its costs are a real consumption of wealth. The constraints hold regardless of how
 juice mechanics evolve:
 
-- Juiced rewards are a separable overlay — never a multiplier on a quantity the player could
-  foresee. A multiplier on foreseeable value invites scanning for the best base outcome and
-  amplifying it; the overlay form has nothing to scan.
+- An investment's effect commits before the reveal of anything it touches. Scaling a steady quantity
+  deterministically — more difficulty, more rolls per hour — is buying throughput and is safe
+  anywhere; nothing may scale or select on a revealed roll. An effect that is itself rolled is
+  classified by the tail rule like any reward.
 - Difficulty conditions on the chosen tier alone, with flat expected value per cost across tiers.
-- A sealed craft settles all-or-nothing, and a committed craft always resolves — bailing forfeits
-  the bundle, so peeking-then-declining has zero option value.
-- Juiced failure costs only the forgone yield, never experience.
+- A sealed craft settles all-or-nothing, and a committed craft always resolves — as bailed when
+  abandoned. Bailing forfeits the bundle, and rolled content stays sealed under the avatar key even
+  after the salt releases, so a bail can never select rewards.
+- Death costs are uniform: the core note's rules apply to juiced and base play alike. Avoiding a
+  foreseen death — routing before a spend, bailing after one — is accepted texture, and the bundle
+  forfeit is the bail's price.
 
 ## Extraction & Settlement
 

--- a/docs/game-design/004-economy-modes.md
+++ b/docs/game-design/004-economy-modes.md
@@ -12,7 +12,7 @@ offline progress possible — and it means a motivated player can compute their 
 the runs ahead, see what happens, and choose which futures to play. This cannot be prevented, only
 priced.
 
-Foresight is harmless when outcomes are steady and devastating when they are rare: a player who can
+Foresight is harmless when outcomes are steady and devastating when they are rare. A player who can
 scan thousands of regions for the one future holding a great roll gets that roll's value without
 playing for it, and a market lets them sell it. The economy's one hard rule follows:
 
@@ -20,17 +20,17 @@ playing for it, and a market lets them sell it. The economy's one hard rule foll
 
 ## The Mode Choice
 
-Every avatar chooses its economy at creation, and the choice is a single fact: who holds the
-avatar's loot key.
+Every avatar chooses its economy at creation: **Trade** or **Self-Found** (working labels). The
+choice is a single fact — who holds the avatar's loot key.
 
-- **Trade** (working label) — full market access. The avatar's loot key stays on the server, so
-  drops resolve as the run's records land: live while connected, and in one reveal on returning from
-  offline. The same expedition yields the same loot either way — being away changes when loot is
-  seen, never what it is worth.
-- **Self-Found** (working label) — the avatar's loot key lives with the player, so loot resolves
-  locally, offline, in real time, juice included. Nothing the avatar earns can ever be traded,
-  gifted, or moved to another avatar. Foresight is legitimate texture: planning around a computed
-  future is the mode's own kind of mastery.
+- **Trade** — full market access. The avatar's loot key stays on the server, so drops resolve as the
+  run's records land: live while connected, in one reveal on returning from offline. The same
+  expedition yields the same loot either way — being away changes when loot is seen, never what it
+  is worth.
+- **Self-Found** — the avatar's loot key lives with the player, so loot resolves locally, offline,
+  in real time, juice included. Nothing the avatar earns can ever be traded, gifted, or moved to
+  another avatar. Foresight is legitimate texture: planning around a computed future is the mode's
+  own kind of mastery.
 
 Trade is the default and the pre-selected choice at creation. Self-Found is a deliberate opt-in
 behind an explicit warning, because the choice is permanent: a self-found avatar's wealth was rolled
@@ -43,12 +43,14 @@ finds — that is why they take a moment to appear and why they can be sold — 
 avatar's haul is off the books, never assayed, kept in its own hands. Both labels follow the naming
 grammar in the core note before they reach the UI.
 
-Mode partitions every economic container and every reward-bearing space, as a standing invariant
-rather than a list: stashes, banks, ladders, prize events — anything that stores value or pays it
-out is scoped to one mode, and no container is ever shared across the boundary, including between
-one account's own avatars. Self-found ladders rank on server-verifiable play — depth, level, clear
-speed — never on gear, which only the player's own device rolled. Avatars are league-scoped, so
-league resets contain self-found holdings with no extra rule.
+Mode partitions every economic container and every reward-bearing space — a standing invariant, not
+a list of today's features:
+
+- No container is shared across the boundary — stashes, banks, prize pools — including between one
+  account's own avatars.
+- Self-found ladders rank on server-verifiable play — depth, level, clear speed — never on gear,
+  which only the player's own device rolled.
+- Avatars are league-scoped, so league resets contain self-found holdings with no extra rule.
 
 ## Predictable Outcomes
 
@@ -62,8 +64,8 @@ everything the trajectory carries is priced for foresight:
 - **Drop slots.** Which kills yield loot, and how many, is trajectory knowledge: foreseeing it
   reveals a route's throughput, never what any slot contains.
 
-Because slot counts are foreseeable and every slot carries market value for a trade avatar, drop
-density obeys the tail rule that drop quality no longer needs: routes may differ modestly in drops
+Slot counts are foreseeable, and every slot carries market value for a trade avatar. Drop density
+therefore obeys the tail rule that drop quality no longer needs: routes may differ modestly in drops
 per hour — grindy play averages out — but no route is a density jackpot worth scanning thousands of
 futures to find. Density outliers belong in invested content, priced by their cost.
 
@@ -72,12 +74,11 @@ key only after every choice that produced the slot is committed. Loot therefore 
 base expeditions, invested expeditions, the offline loop — with full ordinary variance, and none of
 it can be fished for.
 
-Two consequences the wider economy design carries as obligations. Offline accrual is wall-clock
-metered and non-resettable — an hour of absence yields an hour of progress, capped, with no way to
-bank a window and immediately re-arm it — and because unattended play now mints market-grade loot,
-per-account throughput limits and account-legitimacy gates at market access are economy-design
-prerequisites, alongside sinks sized to a faucet that runs while players sleep. The economy-loop
-note owns them.
+The wider economy design inherits two obligations. First, offline accrual is wall-clock metered and
+non-resettable: an hour of absence yields an hour of progress, capped, and a window cannot be banked
+and immediately re-armed. Second, unattended play mints market-grade loot, so market access needs
+per-account throughput limits and account-legitimacy gates, with sinks sized to a faucet that runs
+while players sleep. The economy-loop note owns both.
 
 ## Juice
 
@@ -94,10 +95,10 @@ rule, not the mechanic:
   sealed server entropy behind the preview flow, online. Self-found avatars craft against their own
   key — nothing is sealed from them, and nothing they make can leave.
 
-Base drops fall everywhere; juice is deliberate investment layered on top, and item crafting is the
-targeted-outcome market — shaping what kind of reward play can produce — beside base play's open
-lottery, its costs a real consumption of wealth. The constraints hold regardless of how juice
-mechanics evolve:
+Base drops fall everywhere; juice is deliberate investment layered on top. Item crafting is the
+targeted-outcome market beside base play's open lottery — it shapes what kind of reward play can
+produce, and its costs are a real consumption of wealth. The constraints hold regardless of how
+juice mechanics evolve:
 
 - Juiced rewards are a separable overlay — never a multiplier on a quantity the player could
   foresee. A multiplier on foreseeable value invites scanning for the best base outcome and
@@ -110,7 +111,7 @@ mechanics evolve:
 ## Extraction & Settlement
 
 Progress and yield render instantly; verification is latency, not a gate on play. Extraction — the
-core note's mid-run banking policy — is where the economy's gate sits: extracted yield joins the
+core note's mid-run banking policy — is where the economy's gate sits. Extracted yield joins the
 avatar's holdings immediately, but for a trade avatar it leaves the account (trade, market, guild)
 only once the checkpoints that produced it verify. Opening a trade bumps the player's unverified
 checkpoints to the front of the verification queue, so honest players feel a brief gate exactly when

--- a/docs/game-design/004-economy-modes.md
+++ b/docs/game-design/004-economy-modes.md
@@ -16,7 +16,10 @@ Foresight is harmless when outcomes are steady and devastating when they are rar
 scan thousands of regions for the one future holding a great roll gets that roll's value without
 playing for it, and a market lets them sell it. The economy's one hard rule follows:
 
-**An outcome may be predictable, or it may reach the market — never both.**
+**An outcome worth selecting may be predictable, or it may reach the market — never both.**
+
+Steady outcomes carry both properties safely — they give a scanner nothing to select. The rule bites
+only where a distribution has a tail.
 
 ## The Mode Choice
 

--- a/docs/game-design/004-economy-modes.md
+++ b/docs/game-design/004-economy-modes.md
@@ -81,29 +81,30 @@ note owns them.
 
 ## Juice
 
-Juice is spending to modify an expedition instance, in two forms split by one boundary: whether
-randomness is involved at decision time.
+Juice is spending to modify an expedition instance. Where its randomness lives follows the tail
+rule, not the mechanic:
 
-- **Invested difficulty** — choose a tier, pay its cost, and the instance hardens and yields more
-  drop slots, deterministically. Nothing rolls when the choice is made, so there is nothing to peek
-  and nothing to fish: the spend buys known throughput, and the loot it yields stays sealed like any
-  other slot. Invested runs work anywhere, offline included.
-- **Crafted instances** — modifiers are rolled, previewed, rerolled, and locked. Rolling at decision
-  time needs entropy sealed while the player decides, which takes a live exchange: crafted content
-  is online content. Self-found avatars craft against their own key — nothing is sealed from them,
-  and nothing they make can leave.
+- **Tiers and instance modifiers** — choose a tier, roll and reroll the instance's modifiers, lock
+  in. Modifier outcomes are normalized by design: bounded scalars on difficulty and yield, no
+  jackpot combinations, never coupled to a reward tail. A tail-free distribution reveals nothing
+  worth selecting, so instance rolling is client-trustable and works anywhere, offline included,
+  rerolls and all. Keeping modifiers jackpot-free is a standing content constraint, the same
+  obligation as drop density.
+- **Item crafting** — affix rolls are the tail; shaping items is the point. Crafting rolls draw
+  sealed server entropy behind the preview flow, online. Self-found avatars craft against their own
+  key — nothing is sealed from them, and nothing they make can leave.
 
-Base drops fall everywhere; juice in either form is deliberate investment layered on top. Its value
-is aim, not access: crafted instances are the targeted-outcome market — shaping what kind of reward
-a run can produce — beside base play's open lottery, and their costs are a real consumption of
-wealth. Its constraints hold regardless of how juice mechanics evolve:
+Base drops fall everywhere; juice is deliberate investment layered on top, and item crafting is the
+targeted-outcome market — shaping what kind of reward play can produce — beside base play's open
+lottery, its costs a real consumption of wealth. The constraints hold regardless of how juice
+mechanics evolve:
 
 - Juiced rewards are a separable overlay — never a multiplier on a quantity the player could
   foresee. A multiplier on foreseeable value invites scanning for the best base outcome and
   amplifying it; the overlay form has nothing to scan.
 - Difficulty conditions on the chosen tier alone, with flat expected value per cost across tiers.
-- A crafted bundle settles all-or-nothing, and a committed instance always resolves — bailing
-  forfeits the bundle, so peeking-then-declining has zero option value.
+- A sealed craft settles all-or-nothing, and a committed craft always resolves — bailing forfeits
+  the bundle, so peeking-then-declining has zero option value.
 - Juiced failure costs only the forgone yield, never experience.
 
 ## Extraction & Settlement
@@ -116,9 +117,9 @@ checkpoints to the front of the verification queue, so honest players feel a bri
 they transfer and nowhere else.
 
 The verification gate follows value through transformation: an output crafted, salvaged, or combined
-from an unverified input inherits the gate until every contributing input verifies. Interactive
-crafting that consumes tradeable currency rolls server-side — decision-time randomness is the same
-boundary everywhere — and applies exactly once per action.
+from an unverified input inherits the gate until every contributing input verifies. Item crafting
+that consumes tradeable currency rolls server-side — the tail rule is the same boundary everywhere —
+and applies exactly once per action.
 
 Experience and levels are never tradeable, render optimistically, and reconcile lazily. Defeat costs
 follow the core note, with one constraint from foresight: survival is trajectory knowledge, so a

--- a/docs/game-design/004-economy-modes.md
+++ b/docs/game-design/004-economy-modes.md
@@ -18,8 +18,8 @@ playing for it, and a market lets them sell it. The economy's one hard rule foll
 
 **An outcome worth selecting may be predictable, or it may reach the market — never both.**
 
-Steady outcomes carry both properties safely — they give a scanner nothing to select. The rule bites
-only where a distribution has a tail.
+Steady outcomes carry both properties safely — they give a scanner nothing to select. The rule
+applies only where a distribution has a tail.
 
 ## The Mode Choice
 

--- a/docs/game-design/004-economy-modes.md
+++ b/docs/game-design/004-economy-modes.md
@@ -23,7 +23,7 @@ playing for it, and a market lets them sell it. The economy's one hard rule foll
 Every avatar chooses its economy at creation: **Trade** or **Self-Found** (working labels). The
 choice is a single fact — who holds the avatar's loot key.
 
-- **Trade** — full market access. The avatar's loot key stays on the server, so drops resolve as the
+- **Trade** — full market access. The avatar's loot key stays on the server, so loot resolves as the
   run's records land: live while connected, in one reveal on returning from offline. The same
   expedition yields the same loot either way — being away changes when loot is seen, never what it
   is worth.
@@ -52,25 +52,30 @@ a list of today's features:
   which only the player's own device rolled.
 - Avatars are league-scoped, so league resets contain self-found holdings with no extra rule.
 
-## Predictable Outcomes
+## Reward Classes
 
-The simulation's trajectory is predictable by design — offline play depends on computing it — so
-everything the trajectory carries is priced for foresight:
+Every reward is either steady or rolled, and the class decides what may be predictable.
+
+**Steady rewards** accrue from the trajectory, which is predictable by design — offline play depends
+on computing it — so they are priced for foresight:
 
 - **Experience.** Per-encounter variance is acceptable — foreseeing it only improves routing, which
   is calculator play, not arbitrage.
 - **Fixed material and currency trickles** at published rates.
 - **Completion payouts** — first-clear bonuses and unlock grants, fixed per region.
-- **Drop slots.** Which kills yield loot, and how many, is trajectory knowledge: foreseeing it
-  reveals a route's throughput, never what any slot contains.
 
-Slot counts are foreseeable, and every slot carries market value for a trade avatar. Drop density
-therefore obeys the tail rule that drop quality no longer needs: routes may differ modestly in drops
-per hour — grindy play averages out — but no route is a density jackpot worth scanning thousands of
-futures to find. Density outliers belong in invested content, priced by their cost.
+**Rolled rewards** are rewards whose value lives in the roll — item drops are the concrete case. The
+trajectory commits them, and which kills produce them, and how many, is trajectory knowledge:
+foreseeing that reveals a route's throughput, never what any roll contains.
 
-What a slot contains is never predictable for a trade avatar: content rolls under the server-held
-key only after every choice that produced the slot is committed. Loot therefore drops everywhere —
+Roll counts are foreseeable, and every rolled reward carries market value for a trade avatar. Roll
+density therefore obeys the tail rule that rolled content no longer needs: routes may differ
+modestly in rolls per hour — grindy play averages out — but no route is a density jackpot worth
+scanning thousands of futures to find. Density outliers belong in invested content, priced by their
+cost.
+
+What a roll contains is never predictable for a trade avatar: content resolves under the server-held
+key only after every choice that produced the roll is committed. Loot therefore drops everywhere —
 base expeditions, invested expeditions, the offline loop — with full ordinary variance, and none of
 it can be fished for.
 
@@ -90,7 +95,7 @@ rule, not the mechanic:
   jackpot combinations, never coupled to a reward tail. A tail-free distribution reveals nothing
   worth selecting, so instance rolling is client-trustable and works anywhere, offline included,
   rerolls and all. Keeping modifiers jackpot-free is a standing content constraint, the same
-  obligation as drop density.
+  obligation as roll density.
 - **Item crafting** — affix rolls are the tail; shaping items is the point. Crafting rolls draw
   sealed server entropy behind the preview flow, online. Self-found avatars craft against their own
   key — nothing is sealed from them, and nothing they make can leave.

--- a/docs/game-design/004-economy-modes.md
+++ b/docs/game-design/004-economy-modes.md
@@ -1,0 +1,97 @@
+# Economy Modes & Reward Integrity
+
+This note defines how Vers keeps a fair player economy when the simulation runs on the player's
+machine: the mode chosen at avatar creation, the rule for which rewards may be predictable, and
+juice's economic role. The entropy architecture doc owns the mechanisms; this note owns the design
+they enforce.
+
+## Perfect Foresight
+
+Vers simulates on the client, deterministically. That is what makes idle play free to run and
+offline progress possible — and it means a motivated player can compute their own future: simulate
+the runs ahead, see what drops, and choose which futures to play. This cannot be prevented, only
+priced.
+
+Foresight is harmless when outcomes are steady and devastating when they are rare: a player who can
+scan thousands of regions for the one future holding a great roll gets that roll's value without
+playing for it, and a market lets them sell it. The economy's one hard rule follows:
+
+**An outcome may be predictable, or it may reach the market — never both.**
+
+## The Mode Choice
+
+Every avatar chooses its economy at creation:
+
+- **Trade** (working label) — full market access. Itemized drops come from sealed-entropy content,
+  which resolves online; predictable play — including the whole offline loop — yields progression
+  and static materials.
+- **Self-Found** (working label) — the whole game, fully offline, juice included. Nothing the avatar
+  earns can ever be traded, gifted, or moved to another avatar. Foresight is legitimate texture:
+  planning around a computed future is the mode's own kind of mastery.
+
+The choice is permanent. A self-found avatar's wealth was accumulated under perfect foresight, so
+migrating it into a market would launder foresight-selected value; permanence is the price of
+unrestricted offline play. Both labels follow the naming grammar in the core note before they reach
+the UI.
+
+Mode is an avatar property, and avatars are league-scoped, so league resets contain self-found
+holdings with no extra rule.
+
+## Predictable Rewards
+
+Rewards earned on predictable entropy are generic and static-class:
+
+- **Experience.** Per-encounter variance is acceptable — foreseeing it only improves routing, which
+  is calculator play, not arbitrage.
+- **Fixed material and currency trickles** at published rates.
+- **Completion payouts** — first-clear bonuses and unlock grants, fixed per region.
+
+Itemized drops are never predictable for a trade avatar. A drop only means something when its roll
+does, and a foreseeable roll is a roll the whole map gets scanned for — so there is no capped-tail
+compromise version of a monster drop. Drops whose rolls matter exist only behind sealed entropy, or
+on self-found avatars, where they are unrestricted everywhere.
+
+This gives a trade avatar's play a deliberate rhythm: predictable play — base expeditions, the
+offline loop — is the progression engine, and sealed-entropy sessions are the loot engine. The grind
+builds the avatar; the sessions produce the finds.
+
+## Juice
+
+Juice is spending to modify an expedition instance, and for trade avatars it is the variance faucet:
+commit the spend, craft against the preview's metadata, lock in, and the sealed outcome resolves.
+Its constraints hold regardless of how juice mechanics evolve:
+
+- Juiced rewards are a separable overlay — never a multiplier on a quantity the player could
+  foresee. A multiplier on foreseeable value invites scanning for the best base outcome and
+  amplifying it; the overlay form has nothing to scan.
+- Difficulty conditions on the chosen tier alone, with flat expected value per cost across tiers.
+- A juiced bundle settles all-or-nothing, and a committed instance always resolves — bailing
+  forfeits the bundle, so peeking-then-declining has zero option value.
+- Juiced failure costs only the forgone yield, never experience.
+
+Self-found juice runs anywhere, offline included, on predictable entropy — its outputs are bound
+like everything else the avatar earns.
+
+## Extraction & Settlement
+
+Progress and yield render instantly; verification is latency, not a gate on play. Extraction — the
+core note's mid-run banking policy — is where the economy's gate sits: extracted yield joins the
+avatar's holdings immediately, but for a trade avatar it leaves the account (trade, market, guild)
+only once the checkpoints that produced it verify. Opening a trade bumps the player's unverified
+checkpoints to the front of the verification queue, so honest players feel a brief gate exactly when
+they transfer and nowhere else.
+
+Experience and levels are never tradeable, render optimistically, and reconcile lazily. Defeat costs
+follow the core note.
+
+## Competition
+
+- Ladders partition by mode: self-found avatars rank among self-found avatars.
+- Guild banks hold tradeable goods, so only trade avatars deposit.
+- Ghost PvP is build against build, and mode partitioning follows the ladders.
+
+## Non-Goals
+
+This note does not define reward tables or rates, juice mechanics and costs, drop design, ladder
+structure, guild mechanics, offline caps per mode, or the modes' world names. Those belong to the
+progression, itemisation, economy-loop, and fiction notes.


### PR DESCRIPTION
## Description

Documents the settled game-integrity model as canonical repo docs, so the design lives in one place and the issue threads become discovery notes. Two architecture docs (deterministic simulation/verification protocol, entropy sources and provenance) plus game-design note 004 (economy modes and reward integrity), indexed in the docs README.

- Avatar economy mode is chosen at creation (Trade / Self-Found, permanent) — no per-run provenance adjudication exists
- Sealed server salt is the only unpeekable entropy; the anchored seed chain stays client-computable and carries static-class rewards only
- Itemized drops never ride predictable entropy for trade avatars; self-found is unrestricted and fully bound

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality (docs-only)