### PR TITLE
ci(#127): add vers-service-activity to the deploy matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -159,6 +159,7 @@ jobs:
       fail-fast: false
       matrix:
         app:
+          - vers-service-activity
           - vers-service-avatar
           - vers-service-session
           - vers-service-user


### PR DESCRIPTION
## Summary

Fixes the red main push after #452: the deploy matrix in `main.yml` is a hardcoded app list, so the activities service landed in `deploy.config.ts` with no deploy leg, and `verify-fleet` failed with `vers-service-activity — no machines exist`.

- adds the one matrix entry; the leg self-gates on `GIT_SHA` staleness, so the merge push performs the service's first deploy against its staged secrets

## Testing

- [x] one-line workflow list change; the merge push's pipeline is the verification

## Context

Closes the gap between the manifest and the matrix for #127's rollout.