### PR TITLE
ci(#441): add vers-service-email to the deploy matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,6 +161,7 @@ jobs:
         app:
           - vers-service-activity
           - vers-service-avatar
+          - vers-service-email
           - vers-service-session
           - vers-service-user
           - vers-service-verification


### PR DESCRIPTION
The email service landed in `deploy.config.ts` (#457) but not in `main.yml`'s deploy matrix, so no deploy leg fires for it and `verify-fleet` reds on the missing app. One matrix entry, matching #460's shape for service-activity.

Part of #441.