### PR TITLE
feat(#459): add schema isolation strategy to service-test-utils

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -113,6 +113,8 @@
             "name": "StartedPostgreSqlContainer",
             "package": "@testcontainers/postgresql"
           },
+          // a live postgres.js client handle: connection pool state, no readonly form
+          { "from": "package", "name": "Sql", "package": "postgres" },
           {
             "from": "package",
             "name": ["AnyContractRouter", "AnyContractProcedure"],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -440,13 +440,17 @@ Everywhere:
   `INSERT ... ON CONFLICT`, or a data-modifying CTE claims a single-row invariant and survives a
   serverless process kill with no orphaned transaction state. Reach for an interactive
   `db.transaction()` only for a genuine multi-row invariant that doesn't reduce to one statement —
-  and give that handler's suite `database` isolation, since the default transaction-isolation handle
+  and give that handler's suite `schema` isolation, since the default transaction-isolation handle
   cannot nest.
 - **Isolation strategy.** Acquire the database through `@vers/service-test-utils/bun`:
-  `createTestDB()` returns an `await using` handle; `transaction` isolation (rollback on dispose) is
-  the default, `database` isolation (a real, committed clone) is the opt-out for code that commits
-  mid-op, takes advisory locks, or asserts something that only fires at COMMIT. Inject the handle's
-  `db` into the code under test — code that opens its own connection bypasses the rollback.
+  `createTestDB()` returns an `await using` handle over one of three isolation levels. `transaction`
+  (rollback on dispose) is the default. `schema` (a real, committed clone of `public` in its own
+  schema on a shared database) is the opt-out for code that commits mid-op or continues after a
+  caught constraint violation, cases where a rolled-back transaction can't nest and an aborted
+  statement poisons the rest of a shared test transaction. `database` (a real, committed clone
+  database) is reserved for database-scoped state (advisory locks, LISTEN/NOTIFY), DDL and migration
+  exercises, and structures `LIKE` can't reproduce (partitioned parents). Inject the handle's `db`
+  into the code under test — code that opens its own connection bypasses the isolation.
 - **Test setup.** A local `setupTest()` per suite — typed config in, named props out, no `if` —
   builds the db and boots the service, with no data. Never centralise it: a shared `setupTest`
   accretes conditionals as services multiply.

--- a/agents/project.md
+++ b/agents/project.md
@@ -295,13 +295,17 @@ Everywhere:
   `INSERT ... ON CONFLICT`, or a data-modifying CTE claims a single-row invariant and survives a
   serverless process kill with no orphaned transaction state. Reach for an interactive
   `db.transaction()` only for a genuine multi-row invariant that doesn't reduce to one statement —
-  and give that handler's suite `database` isolation, since the default transaction-isolation handle
+  and give that handler's suite `schema` isolation, since the default transaction-isolation handle
   cannot nest.
 - **Isolation strategy.** Acquire the database through `@vers/service-test-utils/bun`:
-  `createTestDB()` returns an `await using` handle; `transaction` isolation (rollback on dispose) is
-  the default, `database` isolation (a real, committed clone) is the opt-out for code that commits
-  mid-op, takes advisory locks, or asserts something that only fires at COMMIT. Inject the handle's
-  `db` into the code under test — code that opens its own connection bypasses the rollback.
+  `createTestDB()` returns an `await using` handle over one of three isolation levels. `transaction`
+  (rollback on dispose) is the default. `schema` (a real, committed clone of `public` in its own
+  schema on a shared database) is the opt-out for code that commits mid-op or continues after a
+  caught constraint violation, cases where a rolled-back transaction can't nest and an aborted
+  statement poisons the rest of a shared test transaction. `database` (a real, committed clone
+  database) is reserved for database-scoped state (advisory locks, LISTEN/NOTIFY), DDL and migration
+  exercises, and structures `LIKE` can't reproduce (partitioned parents). Inject the handle's `db`
+  into the code under test — code that opens its own connection bypasses the isolation.
 - **Test setup.** A local `setupTest()` per suite — typed config in, named props out, no `if` —
   builds the db and boots the service, with no data. Never centralise it: a shared `setupTest`
   accretes conditionals as services multiply.

--- a/bun.lock
+++ b/bun.lock
@@ -628,6 +628,7 @@
         "@types/node": "catalog:",
         "@vers/test-utils": "workspace:*",
         "@zgeoff/bun-test-extended": "catalog:",
+        "tiny-invariant": "catalog:",
         "typescript": "catalog:",
       },
     },

--- a/libs/data/db/src/create-db.ts
+++ b/libs/data/db/src/create-db.ts
@@ -5,6 +5,7 @@ import type { DB } from './schema.generated';
 
 interface CreateDBConfig {
   readonly databaseURL: string;
+  readonly searchPath?: string;
 }
 
 /**
@@ -24,6 +25,7 @@ export function createDB(config: CreateDBConfig): Kysely<DB> {
         connection: {
           idle_in_transaction_session_timeout: 30_000,
           statement_timeout: 30_000,
+          ...(config.searchPath === undefined ? {} : { search_path: config.searchPath }),
         },
       }),
     }),

--- a/libs/testing/service-test-utils/package.json
+++ b/libs/testing/service-test-utils/package.json
@@ -27,6 +27,7 @@
     "@types/node": "catalog:",
     "@vers/test-utils": "workspace:*",
     "@zgeoff/bun-test-extended": "catalog:",
+    "tiny-invariant": "catalog:",
     "typescript": "catalog:"
   }
 }

--- a/libs/testing/service-test-utils/src/bun/create-test-db.test.ts
+++ b/libs/testing/service-test-utils/src/bun/create-test-db.test.ts
@@ -29,3 +29,11 @@ test('it opts into database isolation on request', async () => {
 
   expect(result.rows[0]?.currentDatabase).toStartWith('test_');
 });
+
+test('it opts into schema isolation on request', async () => {
+  await using testDB = await createTestDB({ isolation: 'schema' });
+
+  const result = await sql<{ searchPath: string }>`show search_path`.execute(testDB.db);
+
+  expect(result.rows[0]?.searchPath).toStartWith('tu_');
+});

--- a/libs/testing/service-test-utils/src/bun/create-test-db.ts
+++ b/libs/testing/service-test-utils/src/bun/create-test-db.ts
@@ -1,9 +1,11 @@
 import { makeTestDB } from './make-test-db';
 
 /**
- * The repo's default test-DB factory: transaction isolation, with database isolation opt-in.
+ * The repo's default test-DB factory: transaction isolation by default, schema isolation for code
+ * that commits mid-op or continues after a caught constraint violation, database isolation for
+ * database-scoped state and structures `LIKE` can't reproduce.
  */
 export const createTestDB = makeTestDB({
   default: 'transaction',
-  enabled: ['transaction', 'database'],
+  enabled: ['transaction', 'schema', 'database'],
 });

--- a/libs/testing/service-test-utils/src/bun/make-test-db.test.ts
+++ b/libs/testing/service-test-utils/src/bun/make-test-db.test.ts
@@ -38,3 +38,16 @@ test('it acquires an explicitly requested isolation from those enabled', async (
 
   expect(rows).toBeArray();
 });
+
+test('it acquires schema isolation when declared enabled', async () => {
+  const createTestDB = makeTestDB({
+    default: 'transaction',
+    enabled: ['transaction', 'schema'],
+  });
+
+  await using testDB = await createTestDB({ isolation: 'schema' });
+
+  const rows = await testDB.db.selectFrom('users').selectAll().execute();
+
+  expect(rows).toBeArray();
+});

--- a/libs/testing/service-test-utils/src/bun/make-test-db.ts
+++ b/libs/testing/service-test-utils/src/bun/make-test-db.ts
@@ -1,8 +1,9 @@
 import { createDatabaseTestDB } from './strategies/create-database-test-db';
+import { createSchemaTestDB } from './strategies/create-schema-test-db';
 import { createTransactionTestDB } from './strategies/create-transaction-test-db';
 import type { TestDBHandle } from './test-db-handle';
 
-export type Isolation = 'database' | 'transaction';
+export type Isolation = 'database' | 'schema' | 'transaction';
 
 interface TestDBConfig {
   readonly default: Isolation;
@@ -15,6 +16,7 @@ interface CreateTestDBOptions {
 
 const STRATEGIES: Record<Isolation, () => Promise<TestDBHandle>> = {
   database: createDatabaseTestDB,
+  schema: createSchemaTestDB,
   transaction: createTransactionTestDB,
 };
 

--- a/libs/testing/service-test-utils/src/bun/strategies/create-schema-test-db.test.ts
+++ b/libs/testing/service-test-utils/src/bun/strategies/create-schema-test-db.test.ts
@@ -1,0 +1,149 @@
+import { expect, test } from 'bun:test';
+import type { DB } from '@vers/db';
+import type { Kysely } from 'kysely';
+import { sql } from 'kysely';
+import postgres from 'postgres';
+import invariant from 'tiny-invariant';
+import { createTestUser } from '../create-test-user';
+import { resolveTestDBTarget } from '../resolve-test-db-target';
+import { createSchemaTestDB } from './create-schema-test-db';
+
+test('it commits real writes visible to a second connection onto the same clone', async () => {
+  await using handle = await createSchemaTestDB();
+
+  const created = await createTestUser(handle.db, { email: 'schema-commit@test.com' });
+  const location = await getCloneLocation(handle.db);
+
+  const raw = postgres(location.databaseURL, { connection: { search_path: location.searchPath } });
+
+  try {
+    const rows = await raw`select id from users where id = ${created.user.id}`;
+
+    expect(rows).toHaveLength(1);
+  } finally {
+    await raw.end();
+  }
+});
+
+test('it nests a db.transaction() call', async () => {
+  await using handle = await createSchemaTestDB();
+
+  await handle.db.transaction().execute(async (trx) => {
+    await createTestUser(trx, { email: 'schema-nested@test.com' });
+  });
+
+  const row = await handle.db
+    .selectFrom('users')
+    .selectAll()
+    .where('email', '=', 'schema-nested@test.com')
+    .executeTakeFirst();
+
+  expect(row).toBeDefined();
+});
+
+test('it keeps the handle queryable after a caught unique violation', async () => {
+  await using handle = await createSchemaTestDB();
+
+  await createTestUser(handle.db, { email: 'schema-conflict@test.com' });
+
+  expect(createTestUser(handle.db, { email: 'schema-conflict@test.com' })).rejects.toMatchObject({
+    code: '23505',
+  });
+
+  const rows = await handle.db.selectFrom('users').selectAll().execute();
+
+  expect(rows).toBeArray();
+});
+
+test('it fires the updated_at trigger on clone tables', async () => {
+  await using handle = await createSchemaTestDB();
+
+  const created = await createTestUser(handle.db, { email: 'schema-trigger@test.com' });
+
+  const updated = await handle.db
+    .updateTable('users')
+    .set({ name: 'Updated Name' })
+    .where('id', '=', created.user.id)
+    .returningAll()
+    .executeTakeFirstOrThrow();
+
+  expect(updated.updatedAt).toBeAfter(created.user.updatedAt);
+});
+
+test('it isolates rows between two concurrently acquired clones', async () => {
+  await using first = await createSchemaTestDB();
+  await using second = await createSchemaTestDB();
+
+  await createTestUser(first.db, { email: 'schema-clone-a@test.com' });
+  await createTestUser(second.db, { email: 'schema-clone-b@test.com' });
+
+  const seenFromFirst = await first.db
+    .selectFrom('users')
+    .selectAll()
+    .where('email', '=', 'schema-clone-b@test.com')
+    .executeTakeFirst();
+
+  const seenFromSecond = await second.db
+    .selectFrom('users')
+    .selectAll()
+    .where('email', '=', 'schema-clone-a@test.com')
+    .executeTakeFirst();
+
+  expect(seenFromFirst).toBeUndefined();
+  expect(seenFromSecond).toBeUndefined();
+});
+
+test('it drops the clone schema once disposed', async () => {
+  const handle = await createSchemaTestDB();
+  const location = await getCloneLocation(handle.db);
+
+  await handle[Symbol.asyncDispose]();
+
+  const raw = postgres(location.databaseURL);
+
+  try {
+    const rows = await raw`select 1 from pg_namespace where nspname = ${location.searchPath}`;
+
+    expect(rows).toHaveLength(0);
+  } finally {
+    await raw.end();
+  }
+});
+
+test('it rejects a write that violates a cloned foreign key', async () => {
+  await using handle = await createSchemaTestDB();
+
+  expect(
+    handle.db
+      .insertInto('avatars')
+      .values({ class: 'scholar', id: 'av_schema_fk_test', name: 'FK Test', userId: 'usr_missing' })
+      .execute(),
+  ).rejects.toMatchObject({ code: '23503' });
+});
+
+interface CloneLocation {
+  readonly databaseURL: string;
+  readonly searchPath: string;
+}
+
+/**
+ * Resolves the clone's connection URL and `search_path` from inside the handle itself, for tests
+ * that verify what a second, independent connection can see.
+ */
+async function getCloneLocation(db: Kysely<DB>): Promise<CloneLocation> {
+  const target = resolveTestDBTarget();
+
+  const dbNameResult = await sql<{ currentDatabase: string }>`select current_database()`.execute(
+    db,
+  );
+
+  const searchPathResult = await sql<{ searchPath: string }>`show search_path`.execute(db);
+
+  const currentDatabase = dbNameResult.rows[0]?.currentDatabase;
+  const searchPath = searchPathResult.rows[0]?.searchPath;
+
+  invariant(currentDatabase !== undefined, 'expected current_database() to return a row');
+  invariant(searchPath !== undefined, 'expected show search_path to return a row');
+
+  return { databaseURL: `${target.baseURI}/${currentDatabase}`, searchPath };
+}

--- a/libs/testing/service-test-utils/src/bun/strategies/create-schema-test-db.ts
+++ b/libs/testing/service-test-utils/src/bun/strategies/create-schema-test-db.ts
@@ -23,11 +23,11 @@ export async function createSchemaTestDB(): Promise<TestDBHandle> {
   await host.sql`CREATE SCHEMA ${host.sql(cloneSchema)}`;
 
   try {
-    await cloneTables(host.sql, cloneSchema);
-    await cloneForeignKeys(host.sql, cloneSchema);
-    await cloneTriggers(host.sql, cloneSchema);
+    await createCloneTables(host.sql, cloneSchema);
+    await createCloneForeignKeys(host.sql, cloneSchema);
+    await createCloneTriggers(host.sql, cloneSchema);
   } catch (error) {
-    await dropCloneSchema(host.sql, cloneSchema);
+    await removeCloneSchema(host.sql, cloneSchema);
 
     throw error;
   }
@@ -39,7 +39,7 @@ export async function createSchemaTestDB(): Promise<TestDBHandle> {
     [Symbol.asyncDispose]: async () => {
       await db.destroy();
 
-      await dropCloneSchema(host.sql, cloneSchema);
+      await removeCloneSchema(host.sql, cloneSchema);
     },
   };
 }
@@ -67,7 +67,7 @@ async function buildHost(): Promise<Host> {
   return { databaseURL, sql: postgres(databaseURL, { onnotice: () => {} }) };
 }
 
-async function cloneTables(sql: postgres.Sql, cloneSchema: string): Promise<void> {
+async function createCloneTables(sql: postgres.Sql, cloneSchema: string): Promise<void> {
   const tables = await sql<Array<{ tablename: string }>>`
     SELECT tablename FROM pg_tables WHERE schemaname = 'public'
   `;
@@ -104,7 +104,7 @@ const FOREIGN_KEY_ACTIONS: Readonly<Record<string, string>> = {
  * `LIKE ... INCLUDING ALL` never copies foreign keys, so every public→public FK is rediscovered
  * from `pg_constraint` and rebuilt against the clone tables.
  */
-async function cloneForeignKeys(sql: postgres.Sql, cloneSchema: string): Promise<void> {
+async function createCloneForeignKeys(sql: postgres.Sql, cloneSchema: string): Promise<void> {
   const foreignKeys = await sql<Array<ForeignKeyRow>>`
     SELECT
       con.conname,
@@ -153,7 +153,7 @@ interface TriggerRow {
  * repointed at the clone schema; the trigger function they call (`set_updated_at()`) resolves
  * against `public` at creation time and is stateless, so every clone safely shares it.
  */
-async function cloneTriggers(sql: postgres.Sql, cloneSchema: string): Promise<void> {
+async function createCloneTriggers(sql: postgres.Sql, cloneSchema: string): Promise<void> {
   const triggers = await sql<Array<TriggerRow>>`
     SELECT c.relname AS "tableName", pg_get_triggerdef(t.oid) AS def
     FROM pg_trigger t
@@ -172,6 +172,6 @@ async function cloneTriggers(sql: postgres.Sql, cloneSchema: string): Promise<vo
   }
 }
 
-async function dropCloneSchema(sql: postgres.Sql, cloneSchema: string): Promise<void> {
+async function removeCloneSchema(sql: postgres.Sql, cloneSchema: string): Promise<void> {
   await sql`DROP SCHEMA IF EXISTS ${sql(cloneSchema)} CASCADE`;
 }

--- a/libs/testing/service-test-utils/src/bun/strategies/create-schema-test-db.ts
+++ b/libs/testing/service-test-utils/src/bun/strategies/create-schema-test-db.ts
@@ -1,0 +1,177 @@
+import { createId } from '@paralleldrive/cuid2';
+import { createDB } from '@vers/db';
+import postgres from 'postgres';
+import { createDatabaseFromTemplate } from '../create-database-from-template';
+import type { TestDBHandle } from '../test-db-handle';
+
+/**
+ * Schema isolation: a fresh clone of every `public` table (structure, indexes, foreign keys, and
+ * `updated_at` triggers) in its own schema on a shared host database, with `search_path` scoped to
+ * that schema alone. Writes are real, committed statements — unlike transaction isolation, a
+ * caught constraint violation doesn't poison later queries on the same handle, and the handler's
+ * own `db.transaction()` calls nest normally. Only code that runs entirely through the returned
+ * `db` stays inside the boundary: a handler that opens its own connection, or that
+ * schema-qualifies `public.<table>` directly, reaches the shared host state instead of the clone.
+ * Database-scoped state (advisory locks, LISTEN/NOTIFY), DDL, and structures `LIKE` can't
+ * reproduce (partitioned parents) still need `database` isolation.
+ */
+export async function createSchemaTestDB(): Promise<TestDBHandle> {
+  const host = await getHost();
+
+  const cloneSchema = `tu_${createId()}`;
+
+  await host.sql`CREATE SCHEMA ${host.sql(cloneSchema)}`;
+
+  try {
+    await cloneTables(host.sql, cloneSchema);
+    await cloneForeignKeys(host.sql, cloneSchema);
+    await cloneTriggers(host.sql, cloneSchema);
+  } catch (error) {
+    await dropCloneSchema(host.sql, cloneSchema);
+
+    throw error;
+  }
+
+  const db = createDB({ databaseURL: host.databaseURL, searchPath: cloneSchema });
+
+  return {
+    db,
+    [Symbol.asyncDispose]: async () => {
+      await db.destroy();
+
+      await dropCloneSchema(host.sql, cloneSchema);
+    },
+  };
+}
+
+interface Host {
+  readonly databaseURL: string;
+  readonly sql: postgres.Sql;
+}
+
+let host: Promise<Host> | undefined;
+
+/**
+ * One template clone per test process, memoized independently of the sibling strategies' own
+ * per-process databases: every schema-isolation acquire clones into this same host.
+ */
+function getHost(): Promise<Host> {
+  host ??= buildHost();
+
+  return host;
+}
+
+async function buildHost(): Promise<Host> {
+  const databaseURL = await createDatabaseFromTemplate();
+
+  return { databaseURL, sql: postgres(databaseURL, { onnotice: () => {} }) };
+}
+
+async function cloneTables(sql: postgres.Sql, cloneSchema: string): Promise<void> {
+  const tables = await sql<Array<{ tablename: string }>>`
+    SELECT tablename FROM pg_tables WHERE schemaname = 'public'
+  `;
+
+  for (const table of tables) {
+    await sql`
+      CREATE TABLE ${sql(cloneSchema)}.${sql(table.tablename)}
+      (LIKE public.${sql(table.tablename)} INCLUDING ALL)
+    `;
+  }
+}
+
+interface ForeignKeyRow {
+  readonly columns: ReadonlyArray<string>;
+  readonly conname: string;
+  readonly condeferrable: boolean;
+  readonly condeferred: boolean;
+  readonly confdeltype: string;
+  readonly confupdtype: string;
+  readonly refColumns: ReadonlyArray<string>;
+  readonly refTableName: string;
+  readonly tableName: string;
+}
+
+const FOREIGN_KEY_ACTIONS: Readonly<Record<string, string>> = {
+  a: 'NO ACTION',
+  c: 'CASCADE',
+  d: 'SET DEFAULT',
+  n: 'SET NULL',
+  r: 'RESTRICT',
+};
+
+/**
+ * `LIKE ... INCLUDING ALL` never copies foreign keys, so every public→public FK is rediscovered
+ * from `pg_constraint` and rebuilt against the clone tables.
+ */
+async function cloneForeignKeys(sql: postgres.Sql, cloneSchema: string): Promise<void> {
+  const foreignKeys = await sql<Array<ForeignKeyRow>>`
+    SELECT
+      con.conname,
+      con.conrelid::regclass::text AS "tableName",
+      con.confrelid::regclass::text AS "refTableName",
+      con.confupdtype,
+      con.confdeltype,
+      con.condeferrable,
+      con.condeferred,
+      array_agg(att.attname ORDER BY k.ord) AS columns,
+      array_agg(refatt.attname ORDER BY k.ord) AS "refColumns"
+    FROM pg_constraint con
+    CROSS JOIN LATERAL unnest(con.conkey, con.confkey) WITH ORDINALITY AS k(attnum, refattnum, ord)
+    JOIN pg_attribute att ON att.attrelid = con.conrelid AND att.attnum = k.attnum
+    JOIN pg_attribute refatt ON refatt.attrelid = con.confrelid AND refatt.attnum = k.refattnum
+    WHERE con.contype = 'f' AND con.connamespace = 'public'::regnamespace
+    GROUP BY
+      con.conname, con.conrelid, con.confrelid,
+      con.confupdtype, con.confdeltype, con.condeferrable, con.condeferred
+  `;
+
+  for (const fk of foreignKeys) {
+    const deferrable = fk.condeferrable
+      ? `DEFERRABLE${fk.condeferred ? ' INITIALLY DEFERRED' : ''}`
+      : '';
+
+    await sql`
+      ALTER TABLE ${sql(cloneSchema)}.${sql(fk.tableName)}
+      ADD CONSTRAINT ${sql(fk.conname)}
+      FOREIGN KEY (${sql(fk.columns)})
+      REFERENCES ${sql(cloneSchema)}.${sql(fk.refTableName)} (${sql(fk.refColumns)})
+      ON UPDATE ${sql.unsafe(FOREIGN_KEY_ACTIONS[fk.confupdtype] ?? 'NO ACTION')}
+      ON DELETE ${sql.unsafe(FOREIGN_KEY_ACTIONS[fk.confdeltype] ?? 'NO ACTION')}
+      ${sql.unsafe(deferrable)}
+    `;
+  }
+}
+
+interface TriggerRow {
+  readonly def: string;
+  readonly tableName: string;
+}
+
+/**
+ * Trigger definitions are copied verbatim except for their `ON <table>` target, which is
+ * repointed at the clone schema; the trigger function they call (`set_updated_at()`) resolves
+ * against `public` at creation time and is stateless, so every clone safely shares it.
+ */
+async function cloneTriggers(sql: postgres.Sql, cloneSchema: string): Promise<void> {
+  const triggers = await sql<Array<TriggerRow>>`
+    SELECT c.relname AS "tableName", pg_get_triggerdef(t.oid) AS def
+    FROM pg_trigger t
+    JOIN pg_class c ON c.oid = t.tgrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public' AND NOT t.tgisinternal
+  `;
+
+  for (const trigger of triggers) {
+    const rewritten = trigger.def.replace(
+      new RegExp(` ON (public\\.)?"?${trigger.tableName}"? `),
+      ` ON "${cloneSchema}"."${trigger.tableName}" `,
+    );
+
+    await sql.unsafe(rewritten);
+  }
+}
+
+async function dropCloneSchema(sql: postgres.Sql, cloneSchema: string): Promise<void> {
+  await sql`DROP SCHEMA IF EXISTS ${sql(cloneSchema)} CASCADE`;
+}

--- a/services/activity/src/handlers/get-latest-activity-progress.test.ts
+++ b/services/activity/src/handlers/get-latest-activity-progress.test.ts
@@ -33,10 +33,10 @@ test('it returns a fresh activity with a null anchor at verifiedHead 0', async (
   });
 });
 
-// database isolation: this exercises trackActivityProgress, whose own db.transaction() can't
+// schema isolation: this exercises trackActivityProgress, whose own db.transaction() can't
 // nest under the default rollback-on-dispose isolation.
 test('it returns the activity anchored to its verified checkpoint once verifiedHead advances', async () => {
-  await using ctx = await setupTest({ isolation: 'database' });
+  await using ctx = await setupTest({ isolation: 'schema' });
 
   const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
   const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });

--- a/services/activity/src/handlers/start-activity.test.ts
+++ b/services/activity/src/handlers/start-activity.test.ts
@@ -58,11 +58,11 @@ test('it starts an activity for an avatar owned by the acting user', async () =>
   expect(activity.lastHash).toBe(activity.startHash);
 });
 
-// database isolation: the handler re-queries for the conflicting activity after catching the
+// schema isolation: the handler re-queries for the conflicting activity after catching the
 // unique violation, and a prior statement's constraint violation aborts the rest of a shared
 // test transaction under the default isolation.
 test('it rejects a second start with CONFLICT carrying the already-active activity', async () => {
-  await using ctx = await setupTest({ isolation: 'database' });
+  await using ctx = await setupTest({ isolation: 'schema' });
 
   const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
   const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });

--- a/services/activity/src/handlers/track-activity-progress.test.ts
+++ b/services/activity/src/handlers/track-activity-progress.test.ts
@@ -9,10 +9,10 @@ import { createMockCheckpointBatch } from '../test-utils/factories/create-mock-c
 /**
  * `trackActivityProgress` opens its own `db.transaction()` for the head-row CAS, which can't nest
  * under the default rollback-on-dispose isolation — this suite runs against a real, committed
- * database clone instead.
+ * schema clone instead.
  */
 async function setupTest() {
-  const db = await createTestDB({ isolation: 'database' });
+  const db = await createTestDB({ isolation: 'schema' });
   const service = await createActivityService({ db: db.db });
 
   return { app: service.app, db: db.db, [Symbol.asyncDispose]: db[Symbol.asyncDispose] };


### PR DESCRIPTION
Closes #459

Adds a `schema` isolation strategy to `@vers/service-test-utils`, sitting between `transaction` and `database`: each acquire clones every `public` table into its own schema on a shared database, rebuilds foreign keys from `pg_constraint` (since `LIKE ... INCLUDING ALL` never copies them), and clones `updated_at` triggers retargeted at the clone. Real, committed writes mean a caught constraint violation doesn't poison later queries and a handler's own `db.transaction()` nests normally, without `database` isolation's full-clone cost.

- `@vers/db`'s `createDB` gains an optional `searchPath`, passed through as postgres.js's `search_path` startup parameter
- `Isolation` gains `'schema'`; the repo's default factory now enables `['transaction', 'schema', 'database']`
- new strategy covered end-to-end: committed writes, nested transactions, post-violation queryability, trigger firing, cross-clone isolation, schema drop, FK-violation rejection
- flips `service-activity`'s three `database`-isolation suites to `schema`
- `AGENTS.md`/`agents/project.md` document the three-rung ladder
- `.oxlintrc.json` allow-lists postgres.js's `Sql` handle

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
