### PR TITLE
feat(#465): reconcile scheduled machines on deploy

### DIFF
--- a/deploy.config.ts
+++ b/deploy.config.ts
@@ -37,6 +37,14 @@ export default defineDeployManifest({
       app: 'vers-service-email',
       configDir: 'services/email',
       dockerfile: 'services/email/Dockerfile',
+      scheduledMachines: [
+        {
+          command: ['/usr/local/bin/sweep'],
+          name: 'email-sweeper',
+          region: 'syd',
+          schedule: 'hourly',
+        },
+      ],
       trigger: { kind: 'turbo-affected', pkg: '@vers/service-email' },
     },
     {

--- a/docs/architecture/deployment.md
+++ b/docs/architecture/deployment.md
@@ -70,6 +70,14 @@ rolls out:
 4. `verify-fleet` runs on every green push — even when every deploy leg skipped — and asserts every
    manifest app is online and current, catching an app at zero machines or a fleet behind HEAD.
 
+A `fly machine run --schedule` machine is unmanaged: `fly deploy` never rolls its image forward. An
+app entry's `scheduledMachines` in `deploy.config.ts` declares each one (name, command, schedule,
+region), and the CLI reconciles them right after the app's rollout lands — creating a declared
+machine that doesn't exist yet on the app's just-deployed image, and moving one on a stale image
+onto it. Provisioning a new scheduled machine is a manifest edit; creation happens on the app's next
+deploy, not a manual `fly machine run`. `verify-fleet` reds if a declared scheduled machine is
+missing or drifts onto a different image than the app's service machines.
+
 `app-web` rolls out `bluegreen` — a full parallel fleet passes `/health` before traffic cuts over —
 because it is the user-facing app. Services use `rolling` with `max_unavailable = 1`: a broken boot
 fails the health gate with the old machine still up. Deploy jobs queue rather than cancel — killing

--- a/docs/architecture/queues.md
+++ b/docs/architecture/queues.md
@@ -34,7 +34,8 @@ awake around the clock. Delivery instead rides three one-shot drains:
    was down.
 3. **Hourly sweep** — a Fly scheduled machine (`--schedule hourly`) runs the service's sweep binary:
    start the queue, drain to completion, exit. It catches retries whose delay elapsed while no
-   machine was awake, and anything a crash orphaned.
+   machine was awake, and anything a crash orphaned. The machine is declared in the deploy manifest
+   and reconciled onto the service's current image on every deploy.
 
 Durability lives in Postgres, so a job between drains is late, never lost.
 

--- a/scripts/src/bin/deploy.ts
+++ b/scripts/src/bin/deploy.ts
@@ -1,9 +1,12 @@
 import { Command } from 'commander';
 import { execa } from 'execa';
+import invariant from 'tiny-invariant';
 import { applyDeploy } from '../deploy/apply-deploy';
+import { applyScheduledMachineActions } from '../deploy/apply-scheduled-machine-actions';
 import { checkTarget } from '../deploy/check-target';
 import { findStaleReason } from '../deploy/find-stale-reason';
 import { loadDeployManifest } from '../deploy/load-deploy-manifest';
+import { planScheduledMachineActions } from '../deploy/plan-scheduled-machine-actions';
 import { readAppState } from '../deploy/read-app-state';
 import { readChangesSince } from '../deploy/read-changes-since';
 import { runProbes } from '../deploy/run-probes';
@@ -65,6 +68,7 @@ async function runDeploy(app: string): Promise<void> {
 
   await applyDeploy(target, sha);
   await waitForDeployedSHA(target.app, sha);
+  await runScheduledMachineReconcile(target, sha);
 
   const findings = await runProbes(target.probes ?? []);
 
@@ -75,6 +79,34 @@ async function runDeploy(app: string): Promise<void> {
 
     process.exitCode = 1;
   }
+}
+
+/**
+ * Reconciles a target's declared scheduled machines against its fleet.
+ * Runs after `waitForDeployedSHA` so `state.serviceImage` reflects the
+ * rollout that just landed, not a mid-cutover mix.
+ */
+async function runScheduledMachineReconcile(target: DeployTarget, sha: string): Promise<void> {
+  const declarations = target.scheduledMachines ?? [];
+
+  if (declarations.length === 0) {
+    return;
+  }
+
+  const state = await readAppState(target.app);
+
+  invariant(
+    state.serviceImage !== null,
+    `${target.app} has no single service image to reconcile scheduled machines against`,
+  );
+
+  const actions = planScheduledMachineActions(
+    declarations,
+    state.serviceImage,
+    state.scheduledMachines,
+  );
+
+  await applyScheduledMachineActions(target.app, sha, actions);
 }
 
 async function runVerify(): Promise<void> {

--- a/scripts/src/bin/deploy.ts
+++ b/scripts/src/bin/deploy.ts
@@ -1,6 +1,5 @@
 import { Command } from 'commander';
 import { execa } from 'execa';
-import invariant from 'tiny-invariant';
 import { applyDeploy } from '../deploy/apply-deploy';
 import { applyScheduledMachineActions } from '../deploy/apply-scheduled-machine-actions';
 import { checkTarget } from '../deploy/check-target';
@@ -61,6 +60,8 @@ async function runDeploy(app: string): Promise<void> {
   if (staleReason === null) {
     console.log(`${target.app} is current at ${state.deployedSHA ?? 'unknown'} — skipping`);
 
+    await runScheduledMachineReconcile(target);
+
     return;
   }
 
@@ -68,7 +69,7 @@ async function runDeploy(app: string): Promise<void> {
 
   await applyDeploy(target, sha);
   await waitForDeployedSHA(target.app, sha);
-  await runScheduledMachineReconcile(target, sha);
+  await runScheduledMachineReconcile(target);
 
   const findings = await runProbes(target.probes ?? []);
 
@@ -82,12 +83,15 @@ async function runDeploy(app: string): Promise<void> {
 }
 
 /**
- * Reconciles a target's declared scheduled machines against its fleet.
- * Runs only after the rollout's SHA is confirmed, so the fleet's single
- * service image reflects the deploy that just landed rather than a
- * mid-cutover mix.
+ * Reconciles a target's declared scheduled machines against its fleet,
+ * aligning them to the image and SHA the service machines currently agree
+ * on. Runs after a rollout's SHA is confirmed and on skipped deploys alike,
+ * so a machine created behind the fleet converges on the next push rather
+ * than waiting for a commit that redeploys its app. Without a single fleet
+ * image to reconcile against nothing happens — the verify pass reports the
+ * drift instead.
  */
-async function runScheduledMachineReconcile(target: DeployTarget, sha: string): Promise<void> {
+async function runScheduledMachineReconcile(target: DeployTarget): Promise<void> {
   const declarations = target.scheduledMachines ?? [];
 
   if (declarations.length === 0) {
@@ -96,10 +100,11 @@ async function runScheduledMachineReconcile(target: DeployTarget, sha: string): 
 
   const state = await readAppState(target.app);
 
-  invariant(
-    state.serviceImage !== null,
-    `${target.app} has no single service image to reconcile scheduled machines against`,
-  );
+  if (state.serviceImage === null || state.deployedSHA === null) {
+    console.log(`${target.app} has no single service image — skipping scheduled machines`);
+
+    return;
+  }
 
   const actions = planScheduledMachineActions(
     declarations,
@@ -107,7 +112,7 @@ async function runScheduledMachineReconcile(target: DeployTarget, sha: string): 
     state.scheduledMachines,
   );
 
-  await applyScheduledMachineActions(target.app, sha, actions);
+  await applyScheduledMachineActions(target.app, state.deployedSHA, actions);
 }
 
 async function runVerify(): Promise<void> {

--- a/scripts/src/bin/deploy.ts
+++ b/scripts/src/bin/deploy.ts
@@ -83,8 +83,9 @@ async function runDeploy(app: string): Promise<void> {
 
 /**
  * Reconciles a target's declared scheduled machines against its fleet.
- * Runs after `waitForDeployedSHA` so `state.serviceImage` reflects the
- * rollout that just landed, not a mid-cutover mix.
+ * Runs only after the rollout's SHA is confirmed, so the fleet's single
+ * service image reflects the deploy that just landed rather than a
+ * mid-cutover mix.
  */
 async function runScheduledMachineReconcile(target: DeployTarget, sha: string): Promise<void> {
   const declarations = target.scheduledMachines ?? [];

--- a/scripts/src/deploy/apply-scheduled-machine-actions.ts
+++ b/scripts/src/deploy/apply-scheduled-machine-actions.ts
@@ -8,7 +8,7 @@ const UPDATE_RETRY_DELAY_MS = 5000;
 /**
  * Runs the planned create/update-image actions against Fly. An update can
  * collide with a scheduled machine mid-run — it's stopped outside its
- * schedule window — so it retries a few times before the error surfaces.
+ * schedule window — so it retries a few times before the error is raised.
  */
 export async function applyScheduledMachineActions(
   app: string,

--- a/scripts/src/deploy/apply-scheduled-machine-actions.ts
+++ b/scripts/src/deploy/apply-scheduled-machine-actions.ts
@@ -16,7 +16,9 @@ export async function applyScheduledMachineActions(
   actions: ReadonlyArray<ScheduledMachineAction>,
 ): Promise<void> {
   for (const action of actions) {
-    await (action.kind === 'create' ? runCreate(app, sha, action) : runUpdateImage(app, action));
+    await (action.kind === 'create'
+      ? runCreate(app, sha, action)
+      : runUpdateImage(app, sha, action));
   }
 }
 
@@ -50,6 +52,7 @@ async function runCreate(
 
 async function runUpdateImage(
   app: string,
+  sha: string,
   action: Extract<ScheduledMachineAction, { kind: 'update-image' }>,
 ): Promise<void> {
   await withRetry(
@@ -62,6 +65,8 @@ async function runUpdateImage(
         app,
         '--image',
         action.image,
+        '--env',
+        `GIT_SHA=${sha}`,
         '--yes',
       ]),
     { attempts: UPDATE_ATTEMPTS, delayMS: UPDATE_RETRY_DELAY_MS },

--- a/scripts/src/deploy/apply-scheduled-machine-actions.ts
+++ b/scripts/src/deploy/apply-scheduled-machine-actions.ts
@@ -1,0 +1,69 @@
+import { runFlyctl } from '../utils/run-flyctl';
+import { withRetry } from '../utils/with-retry';
+import type { ScheduledMachineAction } from './types';
+
+const UPDATE_ATTEMPTS = 5;
+const UPDATE_RETRY_DELAY_MS = 5000;
+
+/**
+ * Runs the planned create/update-image actions against Fly. An update can
+ * collide with a scheduled machine mid-run — it's stopped outside its
+ * schedule window — so it retries a few times before the error surfaces.
+ */
+export async function applyScheduledMachineActions(
+  app: string,
+  sha: string,
+  actions: ReadonlyArray<ScheduledMachineAction>,
+): Promise<void> {
+  for (const action of actions) {
+    await (action.kind === 'create' ? runCreate(app, sha, action) : runUpdateImage(app, action));
+  }
+}
+
+async function runCreate(
+  app: string,
+  sha: string,
+  action: Extract<ScheduledMachineAction, { kind: 'create' }>,
+): Promise<void> {
+  const args = [
+    'machine',
+    'run',
+    action.image,
+    ...action.machine.command,
+    '--schedule',
+    action.machine.schedule,
+    '--name',
+    action.machine.name,
+    '-a',
+    app,
+    '--detach',
+    '--env',
+    `GIT_SHA=${sha}`,
+  ];
+
+  if (action.machine.region !== undefined) {
+    args.push('--region', action.machine.region);
+  }
+
+  await runFlyctl(args);
+}
+
+async function runUpdateImage(
+  app: string,
+  action: Extract<ScheduledMachineAction, { kind: 'update-image' }>,
+): Promise<void> {
+  await withRetry(
+    () =>
+      runFlyctl([
+        'machine',
+        'update',
+        action.machineID,
+        '-a',
+        app,
+        '--image',
+        action.image,
+        '--yes',
+      ]),
+    { attempts: UPDATE_ATTEMPTS, delayMS: UPDATE_RETRY_DELAY_MS },
+  );
+}

--- a/scripts/src/deploy/check-target.test.ts
+++ b/scripts/src/deploy/check-target.test.ts
@@ -9,7 +9,7 @@ const target: DeployTarget = {
 };
 
 test('it flags an app with no machines', () => {
-  const state = { deployedSHA: null, machines: [] };
+  const state = { deployedSHA: null, machines: [], scheduledMachines: [], serviceImage: null };
 
   expect(checkTarget(target, state, null)).toStrictEqual(['no machines exist']);
 });
@@ -18,6 +18,8 @@ test('it passes a current app with a suspended machine', () => {
   const state = {
     deployedSHA: 'abc123',
     machines: [{ gitSHA: 'abc123', id: 'm1', state: 'suspended' }],
+    scheduledMachines: [],
+    serviceImage: 'registry.fly.io/x:tag1',
   };
 
   const changes = { affectedPkgs: [], changedPaths: [] };
@@ -31,6 +33,8 @@ test('it flags an app below its warm-machine floor', () => {
   const state = {
     deployedSHA: 'abc123',
     machines: [{ gitSHA: 'abc123', id: 'm1', state: 'suspended' }],
+    scheduledMachines: [],
+    serviceImage: 'registry.fly.io/x:tag1',
   };
 
   const changes = { affectedPkgs: [], changedPaths: [] };
@@ -44,6 +48,8 @@ test('it flags a stale app whose package changed since the deployed SHA', () => 
   const state = {
     deployedSHA: 'abc123',
     machines: [{ gitSHA: 'abc123', id: 'm1', state: 'started' }],
+    scheduledMachines: [],
+    serviceImage: 'registry.fly.io/x:tag1',
   };
 
   const changes = { affectedPkgs: ['@vers/service-user'], changedPaths: [] };
@@ -51,4 +57,68 @@ test('it flags a stale app whose package changed since the deployed SHA', () => 
   expect(checkTarget(target, state, changes)).toStrictEqual([
     expect.toInclude('@vers/service-user'),
   ]);
+});
+
+const emailSweeper = {
+  command: ['/usr/local/bin/sweep'],
+  name: 'email-sweeper',
+  schedule: 'hourly' as const,
+};
+
+const emailTarget: DeployTarget = { ...target, scheduledMachines: [emailSweeper] };
+
+test('it flags a declared scheduled machine that does not exist', () => {
+  const state = {
+    deployedSHA: 'abc123',
+    machines: [{ gitSHA: 'abc123', id: 'm1', state: 'started' }],
+    scheduledMachines: [],
+    serviceImage: 'registry.fly.io/x:tag1',
+  };
+
+  const changes = { affectedPkgs: [], changedPaths: [] };
+
+  expect(checkTarget(emailTarget, state, changes)).toStrictEqual([
+    'scheduled machine email-sweeper missing',
+  ]);
+});
+
+test('it flags a declared scheduled machine on a different image than the service machines', () => {
+  const state = {
+    deployedSHA: 'abc123',
+    machines: [{ gitSHA: 'abc123', id: 'm1', state: 'started' }],
+    scheduledMachines: [{ id: 'm2', image: 'registry.fly.io/x:old', name: 'email-sweeper' }],
+    serviceImage: 'registry.fly.io/x:tag1',
+  };
+
+  const changes = { affectedPkgs: [], changedPaths: [] };
+
+  expect(checkTarget(emailTarget, state, changes)).toStrictEqual([
+    'scheduled machine email-sweeper image differs from service machines',
+  ]);
+});
+
+test('it passes a declared scheduled machine already on the service image', () => {
+  const state = {
+    deployedSHA: 'abc123',
+    machines: [{ gitSHA: 'abc123', id: 'm1', state: 'started' }],
+    scheduledMachines: [{ id: 'm2', image: 'registry.fly.io/x:tag1', name: 'email-sweeper' }],
+    serviceImage: 'registry.fly.io/x:tag1',
+  };
+
+  const changes = { affectedPkgs: [], changedPaths: [] };
+
+  expect(checkTarget(emailTarget, state, changes)).toBeEmpty();
+});
+
+test('it leaves an app with no scheduled-machine declarations untouched', () => {
+  const state = {
+    deployedSHA: 'abc123',
+    machines: [{ gitSHA: 'abc123', id: 'm1', state: 'started' }],
+    scheduledMachines: [{ id: 'm2', image: 'registry.fly.io/x:old', name: 'some-other-machine' }],
+    serviceImage: 'registry.fly.io/x:tag1',
+  };
+
+  const changes = { affectedPkgs: [], changedPaths: [] };
+
+  expect(checkTarget(target, state, changes)).toBeEmpty();
 });

--- a/scripts/src/deploy/check-target.ts
+++ b/scripts/src/deploy/check-target.ts
@@ -31,5 +31,26 @@ export function checkTarget(
     findings.push(`stale: ${staleReason}`);
   }
 
+  findings.push(...checkScheduledMachines(target, state));
+
+  return findings;
+}
+
+function checkScheduledMachines(target: DeployTarget, state: AppState): ReadonlyArray<string> {
+  const findings: Array<string> = [];
+
+  for (const declared of target.scheduledMachines ?? []) {
+    const existing = state.scheduledMachines.find((machine) => machine.name === declared.name);
+
+    if (existing === undefined) {
+      findings.push(`scheduled machine ${declared.name} missing`);
+      continue;
+    }
+
+    if (state.serviceImage !== null && existing.image !== state.serviceImage) {
+      findings.push(`scheduled machine ${declared.name} image differs from service machines`);
+    }
+  }
+
   return findings;
 }

--- a/scripts/src/deploy/parse-app-state.test.ts
+++ b/scripts/src/deploy/parse-app-state.test.ts
@@ -1,10 +1,20 @@
 import { expect, test } from 'bun:test';
 import { parseAppState } from './parse-app-state';
 
-test('it reads the deployed SHA the whole fleet agrees on', () => {
+test('it reads the deployed SHA and image the whole fleet agrees on', () => {
   const json = [
-    { config: { env: { GIT_SHA: 'abc123' } }, id: 'm1', state: 'started' },
-    { config: { env: { GIT_SHA: 'abc123' } }, id: 'm2', state: 'suspended' },
+    {
+      config: { env: { GIT_SHA: 'abc123' }, image: 'registry.fly.io/x:tag1' },
+      id: 'm1',
+      name: 'm1',
+      state: 'started',
+    },
+    {
+      config: { env: { GIT_SHA: 'abc123' }, image: 'registry.fly.io/x:tag1' },
+      id: 'm2',
+      name: 'm2',
+      state: 'suspended',
+    },
   ];
 
   expect(parseAppState(json)).toStrictEqual({
@@ -13,30 +23,42 @@ test('it reads the deployed SHA the whole fleet agrees on', () => {
       { gitSHA: 'abc123', id: 'm1', state: 'started' },
       { gitSHA: 'abc123', id: 'm2', state: 'suspended' },
     ],
+    scheduledMachines: [],
+    serviceImage: 'registry.fly.io/x:tag1',
   });
 });
 
 test('it treats a fleet with mixed SHAs as having no deployed SHA', () => {
   const json = [
-    { config: { env: { GIT_SHA: 'abc123' } }, id: 'm1', state: 'started' },
-    { config: { env: { GIT_SHA: 'def456' } }, id: 'm2', state: 'started' },
+    { config: { env: { GIT_SHA: 'abc123' } }, id: 'm1', name: 'm1', state: 'started' },
+    { config: { env: { GIT_SHA: 'def456' } }, id: 'm2', name: 'm2', state: 'started' },
   ];
 
   expect(parseAppState(json).deployedSHA).toBeNull();
 });
 
 test('it treats machines without a stamped SHA as having no deployed SHA', () => {
-  const json = [{ config: { env: {} }, id: 'm1', state: 'started' }];
+  const json = [{ config: { env: {} }, id: 'm1', name: 'm1', state: 'started' }];
 
   expect(parseAppState(json).deployedSHA).toBeNull();
 });
 
+test('it treats a fleet with mixed images as having no service image', () => {
+  const json = [
+    { config: { image: 'registry.fly.io/x:tag1' }, id: 'm1', name: 'm1', state: 'started' },
+    { config: { image: 'registry.fly.io/x:tag2' }, id: 'm2', name: 'm2', state: 'started' },
+  ];
+
+  expect(parseAppState(json).serviceImage).toBeNull();
+});
+
 test('it ignores machines outside the app process group', () => {
   const json = [
-    { config: { env: { GIT_SHA: 'abc123' } }, id: 'm1', state: 'started' },
+    { config: { env: { GIT_SHA: 'abc123' } }, id: 'm1', name: 'm1', state: 'started' },
     {
       config: { env: { GIT_SHA: 'def456' }, metadata: { fly_process_group: 'release_command' } },
       id: 'm2',
+      name: 'm2',
       state: 'destroyed',
     },
   ];
@@ -44,9 +66,40 @@ test('it ignores machines outside the app process group', () => {
   expect(parseAppState(json)).toStrictEqual({
     deployedSHA: 'abc123',
     machines: [{ gitSHA: 'abc123', id: 'm1', state: 'started' }],
+    scheduledMachines: [],
+    serviceImage: null,
+  });
+});
+
+test('it separates a scheduled machine from the app process group by its schedule, not its metadata', () => {
+  const json = [
+    {
+      config: { env: { GIT_SHA: 'abc123' }, image: 'registry.fly.io/x:tag1' },
+      id: 'm1',
+      name: 'm1',
+      state: 'started',
+    },
+    {
+      config: { image: 'registry.fly.io/x:old', schedule: 'hourly' },
+      id: 'm2',
+      name: 'sweeper',
+      state: 'stopped',
+    },
+  ];
+
+  expect(parseAppState(json)).toStrictEqual({
+    deployedSHA: 'abc123',
+    machines: [{ gitSHA: 'abc123', id: 'm1', state: 'started' }],
+    scheduledMachines: [{ id: 'm2', image: 'registry.fly.io/x:old', name: 'sweeper' }],
+    serviceImage: 'registry.fly.io/x:tag1',
   });
 });
 
 test('it parses an empty fleet', () => {
-  expect(parseAppState([])).toStrictEqual({ deployedSHA: null, machines: [] });
+  expect(parseAppState([])).toStrictEqual({
+    deployedSHA: null,
+    machines: [],
+    scheduledMachines: [],
+    serviceImage: null,
+  });
 });

--- a/scripts/src/deploy/parse-app-state.test.ts
+++ b/scripts/src/deploy/parse-app-state.test.ts
@@ -95,6 +95,33 @@ test('it separates a scheduled machine from the app process group by its schedul
   });
 });
 
+test('it reads images with the resolved digest stripped', () => {
+  const json = [
+    {
+      config: { env: { GIT_SHA: 'abc123' }, image: 'registry.fly.io/x:tag1' },
+      id: 'm1',
+      name: 'm1',
+      state: 'started',
+    },
+    {
+      config: {
+        image: 'registry.fly.io/x:tag1@sha256:753a468f590de55c28f75131897f9242',
+        schedule: 'hourly',
+      },
+      id: 'm2',
+      name: 'sweeper',
+      state: 'stopped',
+    },
+  ];
+
+  expect(parseAppState(json)).toStrictEqual({
+    deployedSHA: 'abc123',
+    machines: [{ gitSHA: 'abc123', id: 'm1', state: 'started' }],
+    scheduledMachines: [{ id: 'm2', image: 'registry.fly.io/x:tag1', name: 'sweeper' }],
+    serviceImage: 'registry.fly.io/x:tag1',
+  });
+});
+
 test('it parses an empty fleet', () => {
   expect(parseAppState([])).toStrictEqual({
     deployedSHA: null,

--- a/scripts/src/deploy/parse-app-state.ts
+++ b/scripts/src/deploy/parse-app-state.ts
@@ -45,7 +45,7 @@ export function parseAppState(json: unknown): AppState {
     .map((machine) => ({
       id: machine.id,
       name: machine.name,
-      image: machine.config?.image ?? '',
+      image: normalizeImage(machine.config?.image) ?? '',
     }));
 
   return {
@@ -69,6 +69,20 @@ function isServiceMachine(machine: MachineRecord): boolean {
   );
 }
 
+/**
+ * `flyctl deploy` records a machine's image as a bare tag, while
+ * `flyctl machine run`/`update` store the same release with its resolved
+ * `@sha256:…` digest appended — so images compare with the digest stripped,
+ * or a reconciled scheduled machine would read as drifted forever.
+ */
+function normalizeImage(image: string | undefined): string | null {
+  if (image === undefined) {
+    return null;
+  }
+
+  return image.split('@')[0] ?? null;
+}
+
 function pickDeployedSHA(machines: ReadonlyArray<AppMachine>): string | null {
   const shas = new Set(machines.map((machine) => machine.gitSHA));
 
@@ -81,7 +95,7 @@ function pickDeployedSHA(machines: ReadonlyArray<AppMachine>): string | null {
 
 // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- z.infer of the machine-list row schema, a ZodType-bearing shape with no readonly form
 function pickServiceImage(serviceRecords: ReadonlyArray<MachineRecord>): string | null {
-  const images = new Set(serviceRecords.map((machine) => machine.config?.image ?? null));
+  const images = new Set(serviceRecords.map((machine) => normalizeImage(machine.config?.image)));
 
   if (images.size !== 1) {
     return null;

--- a/scripts/src/deploy/parse-app-state.ts
+++ b/scripts/src/deploy/parse-app-state.ts
@@ -61,6 +61,7 @@ export function parseAppState(json: unknown): AppState {
  * never a service machine either — its process group is always stamped
  * explicitly, unlike a bare app machine's, so the default only applies there.
  */
+// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- z.infer of machineSchema, a ZodType-bearing shape with no readonly form
 function isServiceMachine(machine: MachineRecord): boolean {
   return (
     machine.config?.schedule === undefined &&
@@ -78,6 +79,7 @@ function pickDeployedSHA(machines: ReadonlyArray<AppMachine>): string | null {
   return [...shas][0] ?? null;
 }
 
+// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- z.infer of machineSchema, a ZodType-bearing shape with no readonly form
 function pickServiceImage(serviceRecords: ReadonlyArray<MachineRecord>): string | null {
   const images = new Set(serviceRecords.map((machine) => machine.config?.image ?? null));
 

--- a/scripts/src/deploy/parse-app-state.ts
+++ b/scripts/src/deploy/parse-app-state.ts
@@ -1,21 +1,25 @@
 import { z } from 'zod';
 import type { AppMachine, AppState, ScheduledMachineState } from './types';
 
-const stringRecordSchema = z.record(z.string(), z.string());
+const stringRecordSchema = z.record(z.string(), z.string()).readonly();
 
-const machineConfigSchema = z.object({
-  env: stringRecordSchema.optional(),
-  image: z.string().optional(),
-  metadata: stringRecordSchema.optional(),
-  schedule: z.string().optional(),
-});
+const machineConfigSchema = z
+  .object({
+    env: stringRecordSchema.optional(),
+    image: z.string().optional(),
+    metadata: stringRecordSchema.optional(),
+    schedule: z.string().optional(),
+  })
+  .readonly();
 
-const machineSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  state: z.string(),
-  config: machineConfigSchema.optional(),
-});
+const machineSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    state: z.string(),
+    config: machineConfigSchema.optional(),
+  })
+  .readonly();
 
 type MachineRecord = z.infer<typeof machineSchema>;
 
@@ -61,7 +65,6 @@ export function parseAppState(json: unknown): AppState {
  * never a service machine either — its process group is always stamped
  * explicitly, unlike a bare app machine's, so the default only applies there.
  */
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- z.infer of the machine-list row schema, a ZodType-bearing shape with no readonly form
 function isServiceMachine(machine: MachineRecord): boolean {
   return (
     machine.config?.schedule === undefined &&
@@ -93,7 +96,6 @@ function pickDeployedSHA(machines: ReadonlyArray<AppMachine>): string | null {
   return [...shas][0] ?? null;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- z.infer of the machine-list row schema, a ZodType-bearing shape with no readonly form
 function pickServiceImage(serviceRecords: ReadonlyArray<MachineRecord>): string | null {
   const images = new Set(serviceRecords.map((machine) => normalizeImage(machine.config?.image)));
 

--- a/scripts/src/deploy/parse-app-state.ts
+++ b/scripts/src/deploy/parse-app-state.ts
@@ -1,39 +1,71 @@
 import { z } from 'zod';
-import type { AppMachine, AppState } from './types';
+import type { AppMachine, AppState, ScheduledMachineState } from './types';
 
 const stringRecordSchema = z.record(z.string(), z.string());
 
 const machineConfigSchema = z.object({
   env: stringRecordSchema.optional(),
+  image: z.string().optional(),
   metadata: stringRecordSchema.optional(),
+  schedule: z.string().optional(),
 });
 
 const machineSchema = z.object({
   id: z.string(),
+  name: z.string(),
   state: z.string(),
   config: machineConfigSchema.optional(),
 });
+
+type MachineRecord = z.infer<typeof machineSchema>;
 
 const machinesSchema = z.array(machineSchema);
 
 /**
  * Parses `flyctl machines list --json` output into the fleet view the deploy
- * pipeline reasons about. Machines outside the `app` process group (release
- * commands, builders) are dropped. `deployedSHA` is the `GIT_SHA` machine env
- * every app machine agrees on — a mixed or absent value yields null, which
- * downstream treats as "unknown, assume stale".
+ * pipeline reasons about. A scheduled machine (`config.schedule` set) is
+ * never a service machine, regardless of its process-group metadata — it
+ * carries neither, since it's created by `fly machine run --schedule` rather
+ * than `fly deploy`. `deployedSHA` and `serviceImage` are the `GIT_SHA` env
+ * and image every service machine agrees on — a mixed or absent value yields
+ * null, which downstream treats as "unknown, assume stale".
  */
 export function parseAppState(json: unknown): AppState {
-  const machines = machinesSchema
-    .parse(json)
-    .filter((machine) => (machine.config?.metadata?.['fly_process_group'] ?? 'app') === 'app')
+  const records = machinesSchema.parse(json);
+  const serviceRecords = records.filter((machine) => isServiceMachine(machine));
+
+  const machines = serviceRecords.map((machine) => ({
+    id: machine.id,
+    state: machine.state,
+    gitSHA: machine.config?.env?.['GIT_SHA'] ?? null,
+  }));
+
+  const scheduledMachines: ReadonlyArray<ScheduledMachineState> = records
+    .filter((machine) => machine.config?.schedule !== undefined)
     .map((machine) => ({
       id: machine.id,
-      state: machine.state,
-      gitSHA: machine.config?.env?.['GIT_SHA'] ?? null,
+      name: machine.name,
+      image: machine.config?.image ?? '',
     }));
 
-  return { deployedSHA: pickDeployedSHA(machines), machines };
+  return {
+    deployedSHA: pickDeployedSHA(machines),
+    machines,
+    scheduledMachines,
+    serviceImage: pickServiceImage(serviceRecords),
+  };
+}
+
+/**
+ * A machine outside the `app` process group (release commands, builders) is
+ * never a service machine either — its process group is always stamped
+ * explicitly, unlike a bare app machine's, so the default only applies there.
+ */
+function isServiceMachine(machine: MachineRecord): boolean {
+  return (
+    machine.config?.schedule === undefined &&
+    (machine.config?.metadata?.['fly_process_group'] ?? 'app') === 'app'
+  );
 }
 
 function pickDeployedSHA(machines: ReadonlyArray<AppMachine>): string | null {
@@ -44,4 +76,14 @@ function pickDeployedSHA(machines: ReadonlyArray<AppMachine>): string | null {
   }
 
   return [...shas][0] ?? null;
+}
+
+function pickServiceImage(serviceRecords: ReadonlyArray<MachineRecord>): string | null {
+  const images = new Set(serviceRecords.map((machine) => machine.config?.image ?? null));
+
+  if (images.size !== 1) {
+    return null;
+  }
+
+  return [...images][0] ?? null;
 }

--- a/scripts/src/deploy/parse-app-state.ts
+++ b/scripts/src/deploy/parse-app-state.ts
@@ -61,7 +61,7 @@ export function parseAppState(json: unknown): AppState {
  * never a service machine either — its process group is always stamped
  * explicitly, unlike a bare app machine's, so the default only applies there.
  */
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- z.infer of machineSchema, a ZodType-bearing shape with no readonly form
+// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- z.infer of the machine-list row schema, a ZodType-bearing shape with no readonly form
 function isServiceMachine(machine: MachineRecord): boolean {
   return (
     machine.config?.schedule === undefined &&
@@ -79,7 +79,7 @@ function pickDeployedSHA(machines: ReadonlyArray<AppMachine>): string | null {
   return [...shas][0] ?? null;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- z.infer of machineSchema, a ZodType-bearing shape with no readonly form
+// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- z.infer of the machine-list row schema, a ZodType-bearing shape with no readonly form
 function pickServiceImage(serviceRecords: ReadonlyArray<MachineRecord>): string | null {
   const images = new Set(serviceRecords.map((machine) => machine.config?.image ?? null));
 

--- a/scripts/src/deploy/plan-scheduled-machine-actions.test.ts
+++ b/scripts/src/deploy/plan-scheduled-machine-actions.test.ts
@@ -1,0 +1,76 @@
+import { expect, test } from 'bun:test';
+import { planScheduledMachineActions } from './plan-scheduled-machine-actions';
+import type { ScheduledMachine } from './types';
+
+const sweeper: ScheduledMachine = {
+  command: ['/usr/local/bin/sweep'],
+  name: 'email-sweeper',
+  region: 'syd',
+  schedule: 'hourly',
+};
+
+test('it creates a declared machine absent from the existing fleet', () => {
+  const actions = planScheduledMachineActions([sweeper], 'registry.fly.io/x:tag1', []);
+
+  expect(actions).toStrictEqual([
+    { image: 'registry.fly.io/x:tag1', kind: 'create', machine: sweeper },
+  ]);
+});
+
+test('it updates a declared machine whose image differs from the target', () => {
+  const existing = [{ id: 'm1', image: 'registry.fly.io/x:old', name: 'email-sweeper' }];
+  const actions = planScheduledMachineActions([sweeper], 'registry.fly.io/x:new', existing);
+
+  expect(actions).toStrictEqual([
+    { image: 'registry.fly.io/x:new', kind: 'update-image', machineID: 'm1' },
+  ]);
+});
+
+test('it takes no action for a declared machine already on the target image', () => {
+  const existing = [{ id: 'm1', image: 'registry.fly.io/x:tag1', name: 'email-sweeper' }];
+  const actions = planScheduledMachineActions([sweeper], 'registry.fly.io/x:tag1', existing);
+
+  expect(actions).toBeEmpty();
+});
+
+test('it plans a mix of create, update, and no-op actions across declarations', () => {
+  const current: ScheduledMachine = { ...sweeper, name: 'current-sweeper' };
+  const stale: ScheduledMachine = { ...sweeper, name: 'stale-sweeper' };
+  const missing: ScheduledMachine = { ...sweeper, name: 'missing-sweeper' };
+
+  const existing = [
+    { id: 'm1', image: 'registry.fly.io/x:tag1', name: 'current-sweeper' },
+    { id: 'm2', image: 'registry.fly.io/x:old', name: 'stale-sweeper' },
+  ];
+
+  const actions = planScheduledMachineActions(
+    [current, stale, missing],
+    'registry.fly.io/x:tag1',
+    existing,
+  );
+
+  expect(actions).toStrictEqual([
+    { image: 'registry.fly.io/x:tag1', kind: 'update-image', machineID: 'm2' },
+    { image: 'registry.fly.io/x:tag1', kind: 'create', machine: missing },
+  ]);
+});
+
+test('it never leaks state between separate planning calls', () => {
+  const existingForOtherApp = [
+    { id: 'other-app-machine', image: 'registry.fly.io/other:tag', name: 'email-sweeper' },
+  ];
+
+  const actionsForThisApp = planScheduledMachineActions([sweeper], 'registry.fly.io/x:tag1', []);
+
+  const actionsForOtherApp = planScheduledMachineActions(
+    [sweeper],
+    'registry.fly.io/other:tag',
+    existingForOtherApp,
+  );
+
+  expect(actionsForThisApp).toStrictEqual([
+    { image: 'registry.fly.io/x:tag1', kind: 'create', machine: sweeper },
+  ]);
+
+  expect(actionsForOtherApp).toBeEmpty();
+});

--- a/scripts/src/deploy/plan-scheduled-machine-actions.ts
+++ b/scripts/src/deploy/plan-scheduled-machine-actions.ts
@@ -1,0 +1,37 @@
+import type { ScheduledMachine, ScheduledMachineAction, ScheduledMachineState } from './types';
+
+/**
+ * Diffs a target's declared scheduled machines against its existing ones,
+ * matched by name. A declaration absent from `existing` needs creating; one
+ * present on a different image needs its image updated; a current match
+ * needs nothing.
+ */
+export function planScheduledMachineActions(
+  declarations: ReadonlyArray<ScheduledMachine>,
+  image: string,
+  existing: ReadonlyArray<ScheduledMachineState>,
+): ReadonlyArray<ScheduledMachineAction> {
+  const actions: Array<ScheduledMachineAction> = [];
+
+  for (const declaration of declarations) {
+    const current = findExisting(declaration.name, existing);
+
+    if (current === undefined) {
+      actions.push({ image, kind: 'create', machine: declaration });
+      continue;
+    }
+
+    if (current.image !== image) {
+      actions.push({ image, kind: 'update-image', machineID: current.id });
+    }
+  }
+
+  return actions;
+}
+
+function findExisting(
+  name: string,
+  existing: ReadonlyArray<ScheduledMachineState>,
+): ScheduledMachineState | undefined {
+  return existing.find((machine) => machine.name === name);
+}

--- a/scripts/src/deploy/types.ts
+++ b/scripts/src/deploy/types.ts
@@ -10,6 +10,20 @@ export interface DeployTarget {
   readonly minStartedMachines?: number;
   readonly buildArgsFromEnv?: ReadonlyArray<string>;
   readonly probes?: ReadonlyArray<Probe>;
+  readonly scheduledMachines?: ReadonlyArray<ScheduledMachine>;
+}
+
+/**
+ * A `fly machine run --schedule` machine the deploy CLI reconciles on every
+ * deploy of its app — created at the fleet's default sizing (shared-cpu-1x,
+ * 256MB) when absent, and moved onto the app's just-deployed image when it
+ * drifts.
+ */
+export interface ScheduledMachine {
+  readonly name: string;
+  readonly command: ReadonlyArray<string>;
+  readonly schedule: 'hourly' | 'daily' | 'weekly' | 'monthly';
+  readonly region?: string;
 }
 
 export type DeployTrigger =
@@ -33,7 +47,9 @@ interface JSONPostProbe {
 
 export interface AppState {
   readonly machines: ReadonlyArray<AppMachine>;
+  readonly scheduledMachines: ReadonlyArray<ScheduledMachineState>;
   readonly deployedSHA: string | null;
+  readonly serviceImage: string | null;
 }
 
 export interface AppMachine {
@@ -41,6 +57,20 @@ export interface AppMachine {
   readonly state: string;
   readonly gitSHA: string | null;
 }
+
+/**
+ * A scheduled machine as it currently exists on Fly, keyed by name for
+ * matching against the manifest's declarations.
+ */
+export interface ScheduledMachineState {
+  readonly id: string;
+  readonly name: string;
+  readonly image: string;
+}
+
+export type ScheduledMachineAction =
+  | { readonly kind: 'create'; readonly machine: ScheduledMachine; readonly image: string }
+  | { readonly kind: 'update-image'; readonly machineID: string; readonly image: string };
 
 export interface ChangeSet {
   readonly affectedPkgs: ReadonlyArray<string>;

--- a/scripts/src/index.ts
+++ b/scripts/src/index.ts
@@ -1,2 +1,9 @@
 export { defineDeployManifest } from './deploy/define-deploy-manifest';
-export type { DeployManifest, DeployTarget, DeployTrigger, Probe } from './deploy/types';
+
+export type {
+  DeployManifest,
+  DeployTarget,
+  DeployTrigger,
+  Probe,
+  ScheduledMachine,
+} from './deploy/types';


### PR DESCRIPTION
## Description

Closes #465

Adds scheduled-machine reconciliation to the deploy CLI: manifest-declared `fly machine run --schedule` machines (e.g. `vers-service-email`'s `email-sweeper`) are now created or moved onto the app's just-deployed image on every deploy, and verify flags drift between deploys.

- Fixed a latent `parse-app-state` bug: a manually-created scheduled machine has no `fly_process_group` metadata, so the old `?? 'app'` default folded it into the service-machine group and corrupted `deployedSHA` for `vers-service-email` in production. Now keys service-vs-scheduled off `config.schedule` instead.
- New pure `plan-scheduled-machine-actions.ts` diffs declared vs. existing scheduled machines by name (create / update-image / no-op); thin `apply-scheduled-machine-actions.ts` runs the corresponding `flyctl` commands, retrying machine updates since a scheduled machine is stopped outside its run window.
- `runDeploy` reconciles scheduled machines right after `waitForDeployedSHA` succeeds; `check-target` gains "missing" and "image differs" findings for verify.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality


## Follow-up hardening

- Images compare with the resolved `@sha256` digest stripped — `machine run`/`update` store digest-qualified images, `fly deploy` a bare tag, so raw comparison read a reconciled machine as drifted forever.
- Reconcile also runs when a deploy skips as current, so the live stale `email-sweeper` converges on the next push without a commit that redeploys the email service.
- Image updates stamp `GIT_SHA` like creation does.
