### PR TITLE
feat(#466): add entropy source tag to checkpoint hash

### DIFF
--- a/contracts/activity/src/build-checkpoint-hash.test.ts
+++ b/contracts/activity/src/build-checkpoint-hash.test.ts
@@ -2,7 +2,14 @@ import { expect, test } from 'bun:test';
 import { buildCheckpointHash } from './build-checkpoint-hash';
 
 test('it builds a deterministic hex digest for a given input', () => {
-  const input = { nextSeed: 'seed_1', prevHash: 'hash_0', seed: 'seed_0', time: 12, type: 'tick' };
+  const input = {
+    entropySource: 'chain',
+    nextSeed: 'seed_1',
+    prevHash: 'hash_0',
+    seed: 'seed_0',
+    time: 12,
+    type: 'tick',
+  };
 
   expect(buildCheckpointHash({ ...input, version: 1 })).toBe(
     buildCheckpointHash({ ...input, version: 1 }),
@@ -10,15 +17,38 @@ test('it builds a deterministic hex digest for a given input', () => {
 });
 
 test('it produces different hashes for different versions', () => {
-  const input = { nextSeed: 'seed_1', prevHash: 'hash_0', seed: 'seed_0', time: 12, type: 'tick' };
+  const input = {
+    entropySource: 'chain',
+    nextSeed: 'seed_1',
+    prevHash: 'hash_0',
+    seed: 'seed_0',
+    time: 12,
+    type: 'tick',
+  };
 
   expect(buildCheckpointHash({ ...input, version: 1 })).not.toBe(
     buildCheckpointHash({ ...input, version: 2 }),
   );
 });
 
+test('it produces different hashes for different entropy sources', () => {
+  const input = {
+    nextSeed: 'seed_1',
+    prevHash: 'hash_0',
+    seed: 'seed_0',
+    time: 12,
+    type: 'tick',
+    version: 1,
+  };
+
+  expect(buildCheckpointHash({ ...input, entropySource: 'chain' })).not.toBe(
+    buildCheckpointHash({ ...input, entropySource: 'beacon' }),
+  );
+});
+
 test('it produces a 64-character hex digest', () => {
   const hash = buildCheckpointHash({
+    entropySource: 'chain',
     nextSeed: 'seed_1',
     prevHash: 'hash_0',
     seed: 'seed_0',

--- a/contracts/activity/src/build-checkpoint-hash.ts
+++ b/contracts/activity/src/build-checkpoint-hash.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 
 interface BuildCheckpointHashInput {
+  readonly entropySource: string;
   readonly nextSeed: string;
   readonly prevHash: string;
   readonly seed: string;
@@ -11,8 +12,9 @@ interface BuildCheckpointHashInput {
 
 /**
  * The checkpoint hash chain's link function: a sha256 hex digest over the canonical field order
- * `[prevHash, version, seed, nextSeed, time, type]`. Shared by the contract, the service, and (via
- * this package) the client, so every party derives the same hash from the same fields.
+ * `[prevHash, version, seed, nextSeed, time, type, entropySource]`. Shared by the contract, the
+ * service, and (via this package) the client, so every party derives the same hash from the same
+ * fields.
  */
 export function buildCheckpointHash(input: Readonly<BuildCheckpointHashInput>): string {
   const canonical = JSON.stringify([
@@ -22,6 +24,7 @@ export function buildCheckpointHash(input: Readonly<BuildCheckpointHashInput>): 
     input.nextSeed,
     input.time,
     input.type,
+    input.entropySource,
   ]);
 
   return createHash('sha256').update(canonical).digest('hex');

--- a/contracts/activity/src/checkpoint-batch-entry-schema.test.ts
+++ b/contracts/activity/src/checkpoint-batch-entry-schema.test.ts
@@ -4,7 +4,7 @@ import { CheckpointBatchEntrySchema } from './checkpoint-batch-entry-schema';
 test('it accepts a well-formed batch entry', () => {
   const result = CheckpointBatchEntrySchema.safeParse({
     hash: 'hash_1',
-    payload: { nextSeed: 'seed_1', seed: 'seed_0', time: 12, type: 'tick' },
+    payload: { entropySource: 'chain', nextSeed: 'seed_1', seed: 'seed_0', time: 12, type: 'tick' },
     prevHash: 'hash_0',
     version: 1,
   });
@@ -15,7 +15,7 @@ test('it accepts a well-formed batch entry', () => {
 test('it rejects a negative version', () => {
   const result = CheckpointBatchEntrySchema.safeParse({
     hash: 'hash_1',
-    payload: { nextSeed: 'seed_1', seed: 'seed_0', time: 12, type: 'tick' },
+    payload: { entropySource: 'chain', nextSeed: 'seed_1', seed: 'seed_0', time: 12, type: 'tick' },
     prevHash: 'hash_0',
     version: -1,
   });

--- a/contracts/activity/src/checkpoint-payload-schema.test.ts
+++ b/contracts/activity/src/checkpoint-payload-schema.test.ts
@@ -36,3 +36,14 @@ test('it rejects a payload missing a hashed field', () => {
 
   expect(result.success).toBeFalse();
 });
+
+test('it rejects a payload missing the entropy-source tag', () => {
+  const result = CheckpointPayloadSchema.safeParse({
+    nextSeed: 'seed_1',
+    seed: 'seed_0',
+    time: 12,
+    type: 'tick',
+  });
+
+  expect(result.success).toBeFalse();
+});

--- a/contracts/activity/src/checkpoint-payload-schema.test.ts
+++ b/contracts/activity/src/checkpoint-payload-schema.test.ts
@@ -3,6 +3,7 @@ import { CheckpointPayloadSchema } from './checkpoint-payload-schema';
 
 test('it accepts the hashed subset with no extra fields', () => {
   const result = CheckpointPayloadSchema.safeParse({
+    entropySource: 'chain',
     nextSeed: 'seed_1',
     seed: 'seed_0',
     time: 12,
@@ -15,6 +16,7 @@ test('it accepts the hashed subset with no extra fields', () => {
 test('it accepts extra fields beyond the hashed subset', () => {
   const result = CheckpointPayloadSchema.safeParse({
     combatLog: ['hit', 'crit'],
+    entropySource: 'chain',
     nextSeed: 'seed_1',
     seed: 'seed_0',
     time: 12,
@@ -25,7 +27,12 @@ test('it accepts extra fields beyond the hashed subset', () => {
 });
 
 test('it rejects a payload missing a hashed field', () => {
-  const result = CheckpointPayloadSchema.safeParse({ nextSeed: 'seed_1', time: 12, type: 'tick' });
+  const result = CheckpointPayloadSchema.safeParse({
+    entropySource: 'chain',
+    nextSeed: 'seed_1',
+    time: 12,
+    type: 'tick',
+  });
 
   expect(result.success).toBeFalse();
 });

--- a/contracts/activity/src/checkpoint-payload-schema.ts
+++ b/contracts/activity/src/checkpoint-payload-schema.ts
@@ -7,6 +7,7 @@ import * as z from 'zod';
  */
 export const CheckpointPayloadSchema = z
   .looseObject({
+    entropySource: z.string(),
     nextSeed: z.string(),
     seed: z.string(),
     time: z.number(),

--- a/contracts/activity/src/checkpoint-schema.test.ts
+++ b/contracts/activity/src/checkpoint-schema.test.ts
@@ -5,7 +5,7 @@ test('it accepts a well-formed checkpoint', () => {
   const result = CheckpointSchema.safeParse({
     appendedAt: new Date(),
     hash: 'hash_1',
-    payload: { nextSeed: 'seed_1', seed: 'seed_0', time: 12, type: 'tick' },
+    payload: { entropySource: 'chain', nextSeed: 'seed_1', seed: 'seed_0', time: 12, type: 'tick' },
     prevHash: 'hash_0',
     version: 1,
   });
@@ -16,7 +16,7 @@ test('it accepts a well-formed checkpoint', () => {
 test('it rejects a checkpoint missing appendedAt', () => {
   const result = CheckpointSchema.safeParse({
     hash: 'hash_1',
-    payload: { nextSeed: 'seed_1', seed: 'seed_0', time: 12, type: 'tick' },
+    payload: { entropySource: 'chain', nextSeed: 'seed_1', seed: 'seed_0', time: 12, type: 'tick' },
     prevHash: 'hash_0',
     version: 1,
   });

--- a/services/activity/src/handlers/track-activity-progress.ts
+++ b/services/activity/src/handlers/track-activity-progress.ts
@@ -156,6 +156,7 @@ function findInvalidReason(
     }
 
     const expectedHash = buildCheckpointHash({
+      entropySource: checkpoint.payload.entropySource,
       nextSeed: checkpoint.payload.nextSeed,
       prevHash: checkpoint.prevHash,
       seed: checkpoint.payload.seed,

--- a/services/activity/src/test-utils/factories/create-mock-checkpoint-batch.test.ts
+++ b/services/activity/src/test-utils/factories/create-mock-checkpoint-batch.test.ts
@@ -29,6 +29,7 @@ test('it computes each hash via buildCheckpointHash', () => {
 
   expect(entry?.hash).toBe(
     buildCheckpointHash({
+      entropySource: entry?.payload.entropySource ?? '',
       nextSeed: entry?.payload.nextSeed ?? '',
       prevHash: entry?.prevHash ?? '',
       seed: entry?.payload.seed ?? '',
@@ -37,4 +38,10 @@ test('it computes each hash via buildCheckpointHash', () => {
       version: entry?.version ?? 0,
     }),
   );
+});
+
+test('it defaults entropySource to chain', () => {
+  const [entry] = createMockCheckpointBatch({ startPrevHash: 'hash_0', startVersion: 1 });
+
+  expect(entry?.payload.entropySource).toBe('chain');
 });

--- a/services/activity/src/test-utils/factories/create-mock-checkpoint-batch.ts
+++ b/services/activity/src/test-utils/factories/create-mock-checkpoint-batch.ts
@@ -36,6 +36,7 @@ export function createMockCheckpointBatch(
     const version = config.startVersion + index;
 
     const payload = {
+      entropySource: 'chain',
       nextSeed: faker.string.alphanumeric({ casing: 'lower', length: 16 }),
       seed: faker.string.alphanumeric({ casing: 'lower', length: 16 }),
       time: version * 1000,


### PR DESCRIPTION
Closes #466

Adds an `entropySource` tag to the checkpoint hashed subset, so the hash chain can distinguish checkpoints produced by different entropy sources.

- `CheckpointPayloadSchema` gains `entropySource: z.string()` as an open string (no enum)
- `buildCheckpointHash` appends `entropySource` as the last element of the canonical hash array, preserving prior field order
- `track-activity-progress` threads `checkpoint.payload.entropySource` into chain-validation hashing
- the checkpoint-batch mock factory defaults `entropySource` to `'chain'`, the only source that exists today
- `checkpoint-batch-entry-schema` and `checkpoint-schema` compose `CheckpointPayloadSchema` and needed no source changes, only updated test literals

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
