### PR TITLE
feat(#458): swap node:crypto for isomorphic sha256 in contract-activity

### DIFF
--- a/apps/web-e2e/package.json
+++ b/apps/web-e2e/package.json
@@ -10,6 +10,7 @@
   "devDependencies": {
     "@playwright/test": "catalog:",
     "@types/node": "catalog:",
+    "@vers/contract-activity": "workspace:*",
     "typescript": "catalog:"
   }
 }

--- a/apps/web-e2e/src/checkpoint-hash-parity.spec.ts
+++ b/apps/web-e2e/src/checkpoint-hash-parity.spec.ts
@@ -5,10 +5,9 @@ const FROZEN_DIGEST = '6079d244605014de9d91fcd80080ddad169ab684fccbcbd1d5523bcd5
 const CANONICAL_JSON = JSON.stringify(['hash_0', 1, 'seed_0', 'seed_1', 12, 'tick', 'chain']);
 
 /**
- * `buildCheckpointHash` swapped `node:crypto` for a sync, isomorphic sha256 so the contract
- * package stays importable into a browser bundle. This proves both sides of that swap: the
- * Node-context contract call still derives the frozen digest, and a real browser's WebCrypto
- * derives the identical digest over the same canonical bytes.
+ * Every party on the checkpoint hash chain — service, verifier, browser client — must derive
+ * byte-identical digests. This asserts the Node-context contract call and a real browser's
+ * WebCrypto both derive the frozen digest from the same canonical bytes.
  */
 test('it derives the same frozen digest from the contract call and from browser WebCrypto', async ({
   page,

--- a/apps/web-e2e/src/checkpoint-hash-parity.spec.ts
+++ b/apps/web-e2e/src/checkpoint-hash-parity.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test';
+import { buildCheckpointHash } from '@vers/contract-activity';
+
+const FROZEN_DIGEST = '6079d244605014de9d91fcd80080ddad169ab684fccbcbd1d5523bcd512e30d6';
+const CANONICAL_JSON = JSON.stringify(['hash_0', 1, 'seed_0', 'seed_1', 12, 'tick', 'chain']);
+
+/**
+ * `buildCheckpointHash` swapped `node:crypto` for a sync, isomorphic sha256 so the contract
+ * package stays importable into a browser bundle. This proves both sides of that swap: the
+ * Node-context contract call still derives the frozen digest, and a real browser's WebCrypto
+ * derives the identical digest over the same canonical bytes.
+ */
+test('it derives the same frozen digest from the contract call and from browser WebCrypto', async ({
+  page,
+}) => {
+  expect(
+    buildCheckpointHash({
+      entropySource: 'chain',
+      nextSeed: 'seed_1',
+      prevHash: 'hash_0',
+      seed: 'seed_0',
+      time: 12,
+      type: 'tick',
+      version: 1,
+    }),
+  ).toBe(FROZEN_DIGEST);
+
+  await page.goto('/');
+
+  const browserDigest = await page.evaluate(async (canonical) => {
+    const digestBuffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(canonical));
+
+    return [...new Uint8Array(digestBuffer)]
+      .map((byte) => byte.toString(16).padStart(2, '0'))
+      .join('');
+  }, CANONICAL_JSON);
+
+  expect(browserDigest).toBe(FROZEN_DIGEST);
+});

--- a/bun.lock
+++ b/bun.lock
@@ -110,6 +110,7 @@
       "devDependencies": {
         "@playwright/test": "catalog:",
         "@types/node": "catalog:",
+        "@vers/contract-activity": "workspace:*",
         "typescript": "catalog:",
       },
     },
@@ -117,6 +118,7 @@
       "name": "@vers/contract-activity",
       "version": "0.0.0",
       "dependencies": {
+        "@noble/hashes": "catalog:",
         "@orpc/contract": "catalog:",
         "@vers/contract-base": "workspace:*",
         "zod": "catalog:",
@@ -838,6 +840,7 @@
     "@happy-dom/global-registrator": "20.10.6",
     "@ladle/react": "5.1.1",
     "@msw/data": "1.1.6",
+    "@noble/hashes": "2.2.0",
     "@openfeature/core": "1.11.0",
     "@openfeature/server-sdk": "1.22.0",
     "@opentelemetry/api-logs": "0.220.0",

--- a/contracts/activity/package.json
+++ b/contracts/activity/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@noble/hashes": "catalog:",
     "@orpc/contract": "catalog:",
     "@vers/contract-base": "workspace:*",
     "zod": "catalog:"

--- a/contracts/activity/src/build-checkpoint-hash.test.ts
+++ b/contracts/activity/src/build-checkpoint-hash.test.ts
@@ -59,3 +59,17 @@ test('it produces a 64-character hex digest', () => {
 
   expect(hash).toMatch(/^[a-f0-9]{64}$/);
 });
+
+test('it derives the frozen canonical digest for a known input', () => {
+  const hash = buildCheckpointHash({
+    entropySource: 'chain',
+    nextSeed: 'seed_1',
+    prevHash: 'hash_0',
+    seed: 'seed_0',
+    time: 12,
+    type: 'tick',
+    version: 1,
+  });
+
+  expect(hash).toBe('6079d244605014de9d91fcd80080ddad169ab684fccbcbd1d5523bcd512e30d6');
+});

--- a/contracts/activity/src/build-checkpoint-hash.ts
+++ b/contracts/activity/src/build-checkpoint-hash.ts
@@ -1,4 +1,5 @@
-import { createHash } from 'node:crypto';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils.js';
 
 interface BuildCheckpointHashInput {
   readonly entropySource: string;
@@ -27,5 +28,5 @@ export function buildCheckpointHash(input: Readonly<BuildCheckpointHashInput>): 
     input.entropySource,
   ]);
 
-  return createHash('sha256').update(canonical).digest('hex');
+  return bytesToHex(sha256(utf8ToBytes(canonical)));
 }

--- a/contracts/activity/src/build-start-hash.test.ts
+++ b/contracts/activity/src/build-start-hash.test.ts
@@ -30,3 +30,14 @@ test('it produces a 64-character hex digest', () => {
 
   expect(hash).toMatch(/^[a-f0-9]{64}$/);
 });
+
+test('it derives the frozen canonical digest for a known input', () => {
+  const hash = buildStartHash({
+    activityID: 'act_1',
+    contentVersion: '0.0.0-dev',
+    seed: 'seed_0',
+    simVersion: '0.0.0-dev',
+  });
+
+  expect(hash).toBe('b28253a4cefb706f043390394294d2f528c71fc90b9e42867612e7e4032f4d4c');
+});

--- a/contracts/activity/src/build-start-hash.ts
+++ b/contracts/activity/src/build-start-hash.ts
@@ -1,4 +1,5 @@
-import { createHash } from 'node:crypto';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils.js';
 
 interface BuildStartHashInput {
   readonly activityID: string;
@@ -20,5 +21,5 @@ export function buildStartHash(input: Readonly<BuildStartHashInput>): string {
     input.contentVersion,
   ]);
 
-  return createHash('sha256').update(canonical).digest('hex');
+  return bytesToHex(sha256(utf8ToBytes(canonical)));
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
       "@happy-dom/global-registrator": "20.10.6",
       "@ladle/react": "5.1.1",
       "@msw/data": "1.1.6",
+      "@noble/hashes": "2.2.0",
       "@openfeature/core": "1.11.0",
       "@openfeature/server-sdk": "1.22.0",
       "@opentelemetry/api-logs": "0.220.0",


### PR DESCRIPTION
## Description

Closes #458

`buildCheckpointHash`/`buildStartHash` used `node:crypto`, which keeps `@vers/contract-activity` from running in a browser bundle. Swap both to `@noble/hashes`'s sync sha256, leaving the canonical JSON field order untouched.

- add a frozen-digest test to each hash builder asserting the exact hex output matches the pre-swap `node:crypto` implementation
- add a Playwright spec that computes the checkpoint hash via the contract call and via `crypto.subtle.digest` in a real Chromium page, asserting both match the frozen digest
- pin `@noble/hashes@2.2.0` in the root catalog

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality

## Context

- Benchmark (100k sequential checkpoint-link hashes, bun): `@noble/hashes` runs ~3-3.2x slower than `node:crypto` (~0.002ms/link vs ~0.0006ms/link), well under the 5x/2s flag thresholds from the verifier plan (#181) — no flag needed.
- Local Playwright run of the new spec can't boot the web dev server locally (`SERVICE_AUTH_PRIVATE_KEY` needs a secret this checkout lacks) — a pre-existing gap affecting every web-e2e spec, not introduced here. The spec typechecks locally and runs in CI.
