### PR TITLE
feat(#441): wire transactional email sends into app-web auth flows

### DIFF
--- a/apps/web/fly.toml
+++ b/apps/web/fly.toml
@@ -28,6 +28,7 @@ grace_period = '10s'
 
 [env]
 AVATAR_SERVICE_URL = 'http://vers-service-avatar.flycast'
+EMAIL_SERVICE_URL = 'http://vers-service-email.flycast'
 SESSION_SERVICE_URL = 'http://vers-service-session.flycast'
 USER_SERVICE_URL = 'http://vers-service-user.flycast'
 VERIFICATION_SERVICE_URL = 'http://vers-service-verification.flycast'

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -32,6 +32,7 @@
     "@tanstack/react-start": "catalog:",
     "@vers/contract-avatar": "workspace:*",
     "@vers/contract-base": "workspace:*",
+    "@vers/contract-email": "workspace:*",
     "@vers/contract-session": "workspace:*",
     "@vers/contract-user": "workspace:*",
     "@vers/contract-verification": "workspace:*",

--- a/apps/web/src/lib/rpc/clients/email-client.ts
+++ b/apps/web/src/lib/rpc/clients/email-client.ts
@@ -1,0 +1,8 @@
+import { createORPCClient } from '@orpc/client';
+import type { ContractRouterClient } from '@orpc/contract';
+import type { emailContract } from '@vers/contract-email';
+import type { ServiceLinkContext } from '../build-service-link';
+import { buildServiceLink } from '../build-service-link';
+
+export const emailClient: ContractRouterClient<typeof emailContract, ServiceLinkContext> =
+  createORPCClient(buildServiceLink('email'));

--- a/apps/web/src/lib/rpc/service-urls.ts
+++ b/apps/web/src/lib/rpc/service-urls.ts
@@ -7,6 +7,7 @@ import type { ServiceName } from '@vers/service-auth';
  */
 export const SERVICE_URLS: Readonly<Record<ServiceName, string>> = {
   avatar: process.env['AVATAR_SERVICE_URL'] ?? 'http://localhost:3005',
+  email: process.env['EMAIL_SERVICE_URL'] ?? 'http://localhost:3006',
   session: process.env['SESSION_SERVICE_URL'] ?? 'http://localhost:3002',
   user: process.env['USER_SERVICE_URL'] ?? 'http://localhost:3003',
   verification: process.env['VERIFICATION_SERVICE_URL'] ?? 'http://localhost:3004',

--- a/apps/web/src/lib/rpc/service-urls.ts
+++ b/apps/web/src/lib/rpc/service-urls.ts
@@ -7,7 +7,7 @@ import type { ServiceName } from '@vers/service-auth';
  */
 export const SERVICE_URLS: Readonly<Record<ServiceName, string>> = {
   avatar: process.env['AVATAR_SERVICE_URL'] ?? 'http://localhost:3005',
-  email: process.env['EMAIL_SERVICE_URL'] ?? 'http://localhost:3006',
+  email: process.env['EMAIL_SERVICE_URL'] ?? 'http://localhost:3007',
   session: process.env['SESSION_SERVICE_URL'] ?? 'http://localhost:3002',
   user: process.env['USER_SERVICE_URL'] ?? 'http://localhost:3003',
   verification: process.env['VERIFICATION_SERVICE_URL'] ?? 'http://localhost:3004',

--- a/apps/web/src/mocks/db/index.ts
+++ b/apps/web/src/mocks/db/index.ts
@@ -1,5 +1,6 @@
 export { avatarCollection } from './avatar-collection';
 export { pendingTransactionCollection } from './pending-transaction-collection';
+export { sentEmailCollection } from './sent-email-collection';
 export { sessionCollection } from './session-collection';
 export { usedTransactionTokenCollection } from './used-transaction-token-collection';
 export { userCollection } from './user-collection';

--- a/apps/web/src/mocks/db/sent-email-collection.ts
+++ b/apps/web/src/mocks/db/sent-email-collection.ts
@@ -1,29 +1,23 @@
-import { faker } from '@faker-js/faker';
 import { Collection } from '@msw/data';
 import { createId } from '@paralleldrive/cuid2';
 import * as z from 'zod';
 
 /**
- * A stored mock sent-email row, one per enqueued send. `template` stays required — it's what the
- * row is for — and every other field defaults, including the templates' own optional payload
- * fields, so tests state only the fields their assertions depend on.
+ * A stored mock sent-email row, one per enqueued send, mirroring the email service's delivery
+ * queue rows: `template` is the queue's job name and `payload` its job data — the verbatim send
+ * input, `to` included.
  */
 const SentEmailRowSchema = z.object({
-  email: z.string().default(() => faker.internet.email()),
   id: z.string().default(() => createId()),
-  newEmail: z.string().default(() => faker.internet.email()),
-  resetURL: z.string().default(() => faker.internet.url()),
+  payload: z.record(z.string(), z.string()).default({}),
   template: z.enum([
-    'welcome',
-    'existing-account',
-    'change-email-verification',
-    'change-email-notification',
-    'reset-password',
-    'password-changed',
+    'send-change-email-notification',
+    'send-change-email-verification',
+    'send-existing-account',
+    'send-password-changed',
+    'send-reset-password',
+    'send-welcome',
   ]),
-  to: z.string().default(() => faker.internet.email()),
-  verificationCode: z.string().default(() => faker.string.numeric(6)),
-  verificationURL: z.string().default(() => faker.internet.url()),
 });
 
 export const sentEmailCollection = new Collection({ schema: SentEmailRowSchema });

--- a/apps/web/src/mocks/db/sent-email-collection.ts
+++ b/apps/web/src/mocks/db/sent-email-collection.ts
@@ -1,0 +1,29 @@
+import { faker } from '@faker-js/faker';
+import { Collection } from '@msw/data';
+import { createId } from '@paralleldrive/cuid2';
+import * as z from 'zod';
+
+/**
+ * A stored mock sent-email row, one per enqueued send. `template` stays required — it's what the
+ * row is for — and every other field defaults, including the templates' own optional payload
+ * fields, so tests state only the fields their assertions depend on.
+ */
+const SentEmailRowSchema = z.object({
+  email: z.string().default(() => faker.internet.email()),
+  id: z.string().default(() => createId()),
+  newEmail: z.string().default(() => faker.internet.email()),
+  resetURL: z.string().default(() => faker.internet.url()),
+  template: z.enum([
+    'welcome',
+    'existing-account',
+    'change-email-verification',
+    'change-email-notification',
+    'reset-password',
+    'password-changed',
+  ]),
+  to: z.string().default(() => faker.internet.email()),
+  verificationCode: z.string().default(() => faker.string.numeric(6)),
+  verificationURL: z.string().default(() => faker.internet.url()),
+});
+
+export const sentEmailCollection = new Collection({ schema: SentEmailRowSchema });

--- a/apps/web/src/mocks/handlers.ts
+++ b/apps/web/src/mocks/handlers.ts
@@ -1,5 +1,6 @@
 import { buildMockService } from '@vers/client-test-utils/orpc';
 import { avatarContract } from '@vers/contract-avatar';
+import { emailContract } from '@vers/contract-email';
 import { sessionContract } from '@vers/contract-session';
 import { userContract } from '@vers/contract-user';
 import { verificationContract } from '@vers/contract-verification';
@@ -8,6 +9,7 @@ import { SERVICE_URLS } from '../lib/rpc/service-urls';
 import { createDemoSeed } from './db/create-demo-seed';
 import { resolveSessionContext } from './resolve-session-context';
 import { avatarRouter } from './routers/avatar/avatar-router';
+import { emailRouter } from './routers/email/email-router';
 import { sessionRouter } from './routers/session/session-router';
 import { userRouter } from './routers/user/user-router';
 import { verificationRouter } from './routers/verification/verification-router';
@@ -38,5 +40,11 @@ export const handlers: Array<HttpHandler> = [
     contract: avatarContract,
     resolveContext: resolveSessionContext,
     router: avatarRouter,
+  }),
+  ...buildMockService({
+    baseUrl: SERVICE_URLS.email,
+    contract: emailContract,
+    resolveContext: resolveSessionContext,
+    router: emailRouter,
   }),
 ];

--- a/apps/web/src/mocks/routers/email/email-router.ts
+++ b/apps/web/src/mocks/routers/email/email-router.ts
@@ -1,0 +1,15 @@
+import { sendChangeEmailNotification } from './send-change-email-notification';
+import { sendChangeEmailVerification } from './send-change-email-verification';
+import { sendExistingAccount } from './send-existing-account';
+import { sendPasswordChanged } from './send-password-changed';
+import { sendResetPassword } from './send-reset-password';
+import { sendWelcome } from './send-welcome';
+
+export const emailRouter = {
+  sendChangeEmailNotification,
+  sendChangeEmailVerification,
+  sendExistingAccount,
+  sendPasswordChanged,
+  sendResetPassword,
+  sendWelcome,
+};

--- a/apps/web/src/mocks/routers/email/os.ts
+++ b/apps/web/src/mocks/routers/email/os.ts
@@ -1,0 +1,5 @@
+import { implement } from '@orpc/server';
+import { emailContract } from '@vers/contract-email';
+import type { MockContext } from '../../resolve-session-context';
+
+export const os = implement(emailContract).$context<MockContext>();

--- a/apps/web/src/mocks/routers/email/send-change-email-notification.ts
+++ b/apps/web/src/mocks/routers/email/send-change-email-notification.ts
@@ -3,8 +3,8 @@ import { os } from './os';
 
 export const sendChangeEmailNotification = os.sendChangeEmailNotification.handler(async (opts) => {
   const row = await db.sentEmailCollection.create({
-    ...opts.input,
-    template: 'change-email-notification',
+    payload: { ...opts.input },
+    template: 'send-change-email-notification',
   });
 
   return { jobID: row.id };

--- a/apps/web/src/mocks/routers/email/send-change-email-notification.ts
+++ b/apps/web/src/mocks/routers/email/send-change-email-notification.ts
@@ -1,0 +1,11 @@
+import * as db from '../../db';
+import { os } from './os';
+
+export const sendChangeEmailNotification = os.sendChangeEmailNotification.handler(async (opts) => {
+  const row = await db.sentEmailCollection.create({
+    ...opts.input,
+    template: 'change-email-notification',
+  });
+
+  return { jobID: row.id };
+});

--- a/apps/web/src/mocks/routers/email/send-change-email-verification.ts
+++ b/apps/web/src/mocks/routers/email/send-change-email-verification.ts
@@ -1,0 +1,11 @@
+import * as db from '../../db';
+import { os } from './os';
+
+export const sendChangeEmailVerification = os.sendChangeEmailVerification.handler(async (opts) => {
+  const row = await db.sentEmailCollection.create({
+    ...opts.input,
+    template: 'change-email-verification',
+  });
+
+  return { jobID: row.id };
+});

--- a/apps/web/src/mocks/routers/email/send-change-email-verification.ts
+++ b/apps/web/src/mocks/routers/email/send-change-email-verification.ts
@@ -3,8 +3,8 @@ import { os } from './os';
 
 export const sendChangeEmailVerification = os.sendChangeEmailVerification.handler(async (opts) => {
   const row = await db.sentEmailCollection.create({
-    ...opts.input,
-    template: 'change-email-verification',
+    payload: { ...opts.input },
+    template: 'send-change-email-verification',
   });
 
   return { jobID: row.id };

--- a/apps/web/src/mocks/routers/email/send-existing-account.ts
+++ b/apps/web/src/mocks/routers/email/send-existing-account.ts
@@ -1,0 +1,11 @@
+import * as db from '../../db';
+import { os } from './os';
+
+export const sendExistingAccount = os.sendExistingAccount.handler(async (opts) => {
+  const row = await db.sentEmailCollection.create({
+    ...opts.input,
+    template: 'existing-account',
+  });
+
+  return { jobID: row.id };
+});

--- a/apps/web/src/mocks/routers/email/send-existing-account.ts
+++ b/apps/web/src/mocks/routers/email/send-existing-account.ts
@@ -3,8 +3,8 @@ import { os } from './os';
 
 export const sendExistingAccount = os.sendExistingAccount.handler(async (opts) => {
   const row = await db.sentEmailCollection.create({
-    ...opts.input,
-    template: 'existing-account',
+    payload: { ...opts.input },
+    template: 'send-existing-account',
   });
 
   return { jobID: row.id };

--- a/apps/web/src/mocks/routers/email/send-password-changed.ts
+++ b/apps/web/src/mocks/routers/email/send-password-changed.ts
@@ -3,8 +3,8 @@ import { os } from './os';
 
 export const sendPasswordChanged = os.sendPasswordChanged.handler(async (opts) => {
   const row = await db.sentEmailCollection.create({
-    ...opts.input,
-    template: 'password-changed',
+    payload: { ...opts.input },
+    template: 'send-password-changed',
   });
 
   return { jobID: row.id };

--- a/apps/web/src/mocks/routers/email/send-password-changed.ts
+++ b/apps/web/src/mocks/routers/email/send-password-changed.ts
@@ -1,0 +1,11 @@
+import * as db from '../../db';
+import { os } from './os';
+
+export const sendPasswordChanged = os.sendPasswordChanged.handler(async (opts) => {
+  const row = await db.sentEmailCollection.create({
+    ...opts.input,
+    template: 'password-changed',
+  });
+
+  return { jobID: row.id };
+});

--- a/apps/web/src/mocks/routers/email/send-reset-password.ts
+++ b/apps/web/src/mocks/routers/email/send-reset-password.ts
@@ -3,8 +3,8 @@ import { os } from './os';
 
 export const sendResetPassword = os.sendResetPassword.handler(async (opts) => {
   const row = await db.sentEmailCollection.create({
-    ...opts.input,
-    template: 'reset-password',
+    payload: { ...opts.input },
+    template: 'send-reset-password',
   });
 
   return { jobID: row.id };

--- a/apps/web/src/mocks/routers/email/send-reset-password.ts
+++ b/apps/web/src/mocks/routers/email/send-reset-password.ts
@@ -1,0 +1,11 @@
+import * as db from '../../db';
+import { os } from './os';
+
+export const sendResetPassword = os.sendResetPassword.handler(async (opts) => {
+  const row = await db.sentEmailCollection.create({
+    ...opts.input,
+    template: 'reset-password',
+  });
+
+  return { jobID: row.id };
+});

--- a/apps/web/src/mocks/routers/email/send-welcome.ts
+++ b/apps/web/src/mocks/routers/email/send-welcome.ts
@@ -1,0 +1,8 @@
+import * as db from '../../db';
+import { os } from './os';
+
+export const sendWelcome = os.sendWelcome.handler(async (opts) => {
+  const row = await db.sentEmailCollection.create({ ...opts.input, template: 'welcome' });
+
+  return { jobID: row.id };
+});

--- a/apps/web/src/mocks/routers/email/send-welcome.ts
+++ b/apps/web/src/mocks/routers/email/send-welcome.ts
@@ -2,7 +2,10 @@ import * as db from '../../db';
 import { os } from './os';
 
 export const sendWelcome = os.sendWelcome.handler(async (opts) => {
-  const row = await db.sentEmailCollection.create({ ...opts.input, template: 'welcome' });
+  const row = await db.sentEmailCollection.create({
+    payload: { ...opts.input },
+    template: 'send-welcome',
+  });
 
   return { jobID: row.id };
 });

--- a/apps/web/src/routes/-account-change-email/change-email-handler.test.ts
+++ b/apps/web/src/routes/-account-change-email/change-email-handler.test.ts
@@ -33,9 +33,22 @@ test('it starts a change-email verification and redirects to verify-otp for a ca
 
   expect(outcome.value).toBe('/verify-otp?target=new%40vers.test&type=change-email');
 
-  expect(
-    db.verificationCollection.findFirst((q) => q.where({ target: 'new@vers.test' })),
-  ).toMatchObject({ type: 'change-email' });
+  const verification = db.verificationCollection.findFirst((q) =>
+    q.where({ target: 'new@vers.test' }),
+  );
+
+  expect(verification).toMatchObject({ type: 'change-email' });
+
+  const verificationEmail = db.sentEmailCollection.findFirst((q) =>
+    q.where({ template: 'change-email-verification', to: 'new@vers.test' }),
+  );
+
+  expect(verificationEmail).toMatchObject({
+    newEmail: 'new@vers.test',
+    to: 'new@vers.test',
+    verificationCode: verification?.code,
+    verificationURL: `http://localhost/verify-otp?${new URLSearchParams({ code: verification?.code ?? '', target: 'new@vers.test', type: 'change-email' }).toString()}`,
+  });
 });
 
 test('it reports step-up-required for a 2FA-enabled caller with no transaction token', async () => {

--- a/apps/web/src/routes/-account-change-email/change-email-handler.test.ts
+++ b/apps/web/src/routes/-account-change-email/change-email-handler.test.ts
@@ -40,13 +40,13 @@ test('it starts a change-email verification and redirects to verify-otp for a ca
   expect(verification).toMatchObject({ type: 'change-email' });
 
   const verificationEmail = db.sentEmailCollection.findFirst((q) =>
-    q.where({ template: 'change-email-verification', to: 'new@vers.test' }),
+    q.where({ payload: { to: 'new@vers.test' }, template: 'send-change-email-verification' }),
   );
 
-  expect(verificationEmail).toMatchObject({
+  expect(verificationEmail?.payload).toStrictEqual({
     newEmail: 'new@vers.test',
     to: 'new@vers.test',
-    verificationCode: verification?.code,
+    verificationCode: verification?.code ?? '',
     verificationURL: `http://localhost/verify-otp?${new URLSearchParams({ code: verification?.code ?? '', target: 'new@vers.test', type: 'change-email' }).toString()}`,
   });
 });

--- a/apps/web/src/routes/-account-change-email/change-email-handler.ts
+++ b/apps/web/src/routes/-account-change-email/change-email-handler.ts
@@ -1,7 +1,9 @@
 import { redirect } from '@tanstack/react-router';
+import { getRequest } from '@tanstack/react-start/server';
 import { checkStepUp } from '../../lib/auth/check-step-up';
 import { findStepUpToken } from '../../lib/auth/find-step-up-token';
 import { requireAuth } from '../../lib/auth/require-auth';
+import { emailClient } from '../../lib/rpc/clients/email-client';
 import { userClient } from '../../lib/rpc/clients/user-client';
 import { verificationClient } from '../../lib/rpc/clients/verification-client';
 import { ChangeEmailFormSchema } from './change-email-form-schema';
@@ -10,8 +12,9 @@ import type { ChangeEmailResult } from './types';
 /**
  * Runs the change-email form's submission: field validation, then a step-up gate for a
  * 2FA-enabled caller. Once cleared (immediately, or via a step-up-token resubmission), a
- * `change-email`-typed verification code is created for the new address and the caller is sent to
- * the shared verify-otp hub to confirm ownership before the address is actually applied.
+ * `change-email`-typed verification code is created for the new address, a verification email is
+ * sent to it, and the caller is sent to the shared verify-otp hub to confirm ownership before the
+ * address is actually applied.
  */
 export async function changeEmailHandler(formData: FormData): Promise<ChangeEmailResult> {
   await requireAuth();
@@ -39,9 +42,20 @@ export async function changeEmailHandler(formData: FormData): Promise<ChangeEmai
     return { status: 'step-up-required', target: user.id, transactionID: stepUp.transactionID };
   }
 
-  await verificationClient.createVerification({
+  const verification = await verificationClient.createVerification({
     target: submission.data.email,
     type: 'change-email',
+  });
+
+  const origin = new URL(getRequest().url).origin;
+
+  const verificationURL = `${origin}/verify-otp?${new URLSearchParams({ code: verification.otp, target: submission.data.email, type: 'change-email' }).toString()}`;
+
+  await emailClient.sendChangeEmailVerification({
+    newEmail: submission.data.email,
+    to: submission.data.email,
+    verificationCode: verification.otp,
+    verificationURL,
   });
 
   const searchParams = new URLSearchParams({

--- a/apps/web/src/routes/-forgot-password/forgot-password-handler.test.ts
+++ b/apps/web/src/routes/-forgot-password/forgot-password-handler.test.ts
@@ -60,10 +60,13 @@ test('it mints a reset token for a matching account and redirects', async () => 
   expect(updated?.passwordResetToken).toBeString();
 
   const resetPasswordEmail = db.sentEmailCollection.findFirst((q) =>
-    q.where({ template: 'reset-password', to: 'forgot-password-existing@vers.test' }),
+    q.where({
+      payload: { to: 'forgot-password-existing@vers.test' },
+      template: 'send-reset-password',
+    }),
   );
 
-  expect(resetPasswordEmail).toMatchObject({
+  expect(resetPasswordEmail?.payload).toStrictEqual({
     resetURL: `http://localhost/reset-password?${new URLSearchParams({ email: 'forgot-password-existing@vers.test', token: updated?.passwordResetToken ?? '' }).toString()}`,
     to: 'forgot-password-existing@vers.test',
   });
@@ -84,7 +87,10 @@ test('it redirects the same way for an email with no matching account', async ()
 
   expect(
     db.sentEmailCollection.findFirst((q) =>
-      q.where({ template: 'reset-password', to: 'forgot-password-unknown@vers.test' }),
+      q.where({
+        payload: { to: 'forgot-password-unknown@vers.test' },
+        template: 'send-reset-password',
+      }),
     ),
   ).toBeUndefined();
 });

--- a/apps/web/src/routes/-forgot-password/forgot-password-handler.test.ts
+++ b/apps/web/src/routes/-forgot-password/forgot-password-handler.test.ts
@@ -58,6 +58,15 @@ test('it mints a reset token for a matching account and redirects', async () => 
   const updated = db.userCollection.findFirst((q) => q.where({ id: user.id }));
 
   expect(updated?.passwordResetToken).toBeString();
+
+  const resetPasswordEmail = db.sentEmailCollection.findFirst((q) =>
+    q.where({ template: 'reset-password', to: 'forgot-password-existing@vers.test' }),
+  );
+
+  expect(resetPasswordEmail).toMatchObject({
+    resetURL: `http://localhost/reset-password?${new URLSearchParams({ email: 'forgot-password-existing@vers.test', token: updated?.passwordResetToken ?? '' }).toString()}`,
+    to: 'forgot-password-existing@vers.test',
+  });
 });
 
 test('it redirects the same way for an email with no matching account', async () => {
@@ -72,4 +81,10 @@ test('it redirects the same way for an email with no matching account', async ()
   });
 
   expect(outcome.value).toBe('/reset-password-started');
+
+  expect(
+    db.sentEmailCollection.findFirst((q) =>
+      q.where({ template: 'reset-password', to: 'forgot-password-unknown@vers.test' }),
+    ),
+  ).toBeUndefined();
 });

--- a/apps/web/src/routes/-forgot-password/forgot-password-handler.ts
+++ b/apps/web/src/routes/-forgot-password/forgot-password-handler.ts
@@ -1,16 +1,19 @@
 import type { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod/v4';
 import { redirect } from '@tanstack/react-router';
+import { getRequest } from '@tanstack/react-start/server';
 import { checkHoneypot } from '../../lib/auth/check-honeypot';
 import { requireAnonymous } from '../../lib/auth/require-anonymous';
 import { SpamError } from '../../lib/auth/spam-error';
+import { emailClient } from '../../lib/rpc/clients/email-client';
 import { userClient } from '../../lib/rpc/clients/user-client';
 import { ForgotPasswordFormSchema } from './forgot-password-form-schema';
 
 /**
  * Runs the forgot-password form's submission: honeypot then field validation, then — for a
- * matching account — mints a reset token to email out. Always ends in the same redirect whether
- * or not the address matches an account, so this page can't be used to enumerate accounts.
+ * matching account — mints a reset token and emails the reset link out. Always ends in the same
+ * redirect whether or not the address matches an account, so this page can't be used to
+ * enumerate accounts.
  */
 export async function forgotPasswordHandler(
   formData: FormData,
@@ -36,7 +39,13 @@ export async function forgotPasswordHandler(
   const user = await userClient.getUser({ email: submission.value.email });
 
   if (user !== null) {
-    await userClient.createPasswordResetToken({ id: user.id });
+    const passwordResetToken = await userClient.createPasswordResetToken({ id: user.id });
+
+    const origin = new URL(getRequest().url).origin;
+
+    const resetURL = `${origin}/reset-password?${new URLSearchParams({ email: submission.value.email, token: passwordResetToken.resetToken }).toString()}`;
+
+    await emailClient.sendResetPassword({ resetURL, to: submission.value.email });
   }
 
   throw redirect({ href: '/reset-password-started' });

--- a/apps/web/src/routes/-forgot-password/forgot-password-handler.ts
+++ b/apps/web/src/routes/-forgot-password/forgot-password-handler.ts
@@ -39,11 +39,11 @@ export async function forgotPasswordHandler(
   const user = await userClient.getUser({ email: submission.value.email });
 
   if (user !== null) {
-    const passwordResetToken = await userClient.createPasswordResetToken({ id: user.id });
+    const passwordReset = await userClient.createPasswordResetToken({ id: user.id });
 
     const origin = new URL(getRequest().url).origin;
 
-    const resetURL = `${origin}/reset-password?${new URLSearchParams({ email: submission.value.email, token: passwordResetToken.resetToken }).toString()}`;
+    const resetURL = `${origin}/reset-password?${new URLSearchParams({ email: submission.value.email, token: passwordReset.resetToken }).toString()}`;
 
     await emailClient.sendResetPassword({ resetURL, to: submission.value.email });
   }

--- a/apps/web/src/routes/-reset-password/reset-password-handler.test.ts
+++ b/apps/web/src/routes/-reset-password/reset-password-handler.test.ts
@@ -83,6 +83,12 @@ test('it reports a form error for a stale or invalid reset token', async () => {
   expect(outcome.value.error).toStrictEqual({
     '': ['This reset link is invalid or has expired.'],
   });
+
+  expect(
+    db.sentEmailCollection.findFirst((q) =>
+      q.where({ template: 'password-changed', to: 'reset-password-bad-token@vers.test' }),
+    ),
+  ).toBeUndefined();
 });
 
 test('it resets the password, signs the caller out everywhere, and redirects to login', async () => {
@@ -117,4 +123,13 @@ test('it resets the password, signs the caller out everywhere, and redirects to 
   const remainingSessions = db.sessionCollection.findMany((q) => q.where({ userID: user.id }));
 
   expect(remainingSessions).toStrictEqual([]);
+
+  const passwordChangedEmail = db.sentEmailCollection.findFirst((q) =>
+    q.where({ template: 'password-changed', to: 'reset-password-success@vers.test' }),
+  );
+
+  expect(passwordChangedEmail).toMatchObject({
+    email: 'reset-password-success@vers.test',
+    to: 'reset-password-success@vers.test',
+  });
 });

--- a/apps/web/src/routes/-reset-password/reset-password-handler.test.ts
+++ b/apps/web/src/routes/-reset-password/reset-password-handler.test.ts
@@ -86,7 +86,10 @@ test('it reports a form error for a stale or invalid reset token', async () => {
 
   expect(
     db.sentEmailCollection.findFirst((q) =>
-      q.where({ template: 'password-changed', to: 'reset-password-bad-token@vers.test' }),
+      q.where({
+        payload: { to: 'reset-password-bad-token@vers.test' },
+        template: 'send-password-changed',
+      }),
     ),
   ).toBeUndefined();
 });
@@ -125,10 +128,13 @@ test('it resets the password, signs the caller out everywhere, and redirects to 
   expect(remainingSessions).toStrictEqual([]);
 
   const passwordChangedEmail = db.sentEmailCollection.findFirst((q) =>
-    q.where({ template: 'password-changed', to: 'reset-password-success@vers.test' }),
+    q.where({
+      payload: { to: 'reset-password-success@vers.test' },
+      template: 'send-password-changed',
+    }),
   );
 
-  expect(passwordChangedEmail).toMatchObject({
+  expect(passwordChangedEmail?.payload).toStrictEqual({
     email: 'reset-password-success@vers.test',
     to: 'reset-password-success@vers.test',
   });

--- a/apps/web/src/routes/-reset-password/reset-password-handler.ts
+++ b/apps/web/src/routes/-reset-password/reset-password-handler.ts
@@ -5,6 +5,7 @@ import { redirect } from '@tanstack/react-router';
 import { checkHoneypot } from '../../lib/auth/check-honeypot';
 import { requireAnonymous } from '../../lib/auth/require-anonymous';
 import { SpamError } from '../../lib/auth/spam-error';
+import { emailClient } from '../../lib/rpc/clients/email-client';
 import { userClient } from '../../lib/rpc/clients/user-client';
 import { ResetPasswordFormSchema } from './reset-password-form-schema';
 
@@ -12,7 +13,8 @@ const INVALID_LINK_ERROR = 'This reset link is invalid or has expired.';
 
 /**
  * Runs the reset-password form's submission: honeypot then field validation, then applies the new
- * password against the emailed link's token. Signs the caller out everywhere on success.
+ * password against the emailed link's token and emails a password-changed notice. Signs the
+ * caller out everywhere on success.
  */
 export async function resetPasswordHandler(
   formData: FormData,
@@ -52,6 +54,11 @@ export async function resetPasswordHandler(
   if (error) {
     return submission.reply({ formErrors: [INVALID_LINK_ERROR] });
   }
+
+  await emailClient.sendPasswordChanged({
+    email: submission.value.email,
+    to: submission.value.email,
+  });
 
   throw redirect({ href: '/login' });
 }

--- a/apps/web/src/routes/-signup/signup-handler.test.ts
+++ b/apps/web/src/routes/-signup/signup-handler.test.ts
@@ -60,16 +60,16 @@ test('it redirects to verify-otp without creating a verification for an email al
   expect(verification).toBeUndefined();
 
   const existingAccountEmail = db.sentEmailCollection.findFirst((q) =>
-    q.where({ template: 'existing-account', to: 'signup-existing@vers.test' }),
+    q.where({ payload: { to: 'signup-existing@vers.test' }, template: 'send-existing-account' }),
   );
 
-  expect(existingAccountEmail).toMatchObject({
+  expect(existingAccountEmail?.payload).toStrictEqual({
     email: 'signup-existing@vers.test',
     to: 'signup-existing@vers.test',
   });
 
   const welcomeEmail = db.sentEmailCollection.findFirst((q) =>
-    q.where({ template: 'welcome', to: 'signup-existing@vers.test' }),
+    q.where({ payload: { to: 'signup-existing@vers.test' }, template: 'send-welcome' }),
   );
 
   expect(welcomeEmail).toBeUndefined();
@@ -93,12 +93,12 @@ test('it creates an onboarding verification and redirects to verify-otp', async 
   expect(verification).toBeDefined();
 
   const welcomeEmail = db.sentEmailCollection.findFirst((q) =>
-    q.where({ template: 'welcome', to: 'signup-new@vers.test' }),
+    q.where({ payload: { to: 'signup-new@vers.test' }, template: 'send-welcome' }),
   );
 
-  expect(welcomeEmail).toMatchObject({
+  expect(welcomeEmail?.payload).toStrictEqual({
     to: 'signup-new@vers.test',
-    verificationCode: verification?.code,
+    verificationCode: verification?.code ?? '',
     verificationURL: `http://localhost/verify-otp?${new URLSearchParams({ code: verification?.code ?? '', target: 'signup-new@vers.test', type: 'onboarding' }).toString()}`,
   });
 });

--- a/apps/web/src/routes/-signup/signup-handler.test.ts
+++ b/apps/web/src/routes/-signup/signup-handler.test.ts
@@ -58,6 +58,21 @@ test('it redirects to verify-otp without creating a verification for an email al
   );
 
   expect(verification).toBeUndefined();
+
+  const existingAccountEmail = db.sentEmailCollection.findFirst((q) =>
+    q.where({ template: 'existing-account', to: 'signup-existing@vers.test' }),
+  );
+
+  expect(existingAccountEmail).toMatchObject({
+    email: 'signup-existing@vers.test',
+    to: 'signup-existing@vers.test',
+  });
+
+  const welcomeEmail = db.sentEmailCollection.findFirst((q) =>
+    q.where({ template: 'welcome', to: 'signup-existing@vers.test' }),
+  );
+
+  expect(welcomeEmail).toBeUndefined();
 });
 
 test('it creates an onboarding verification and redirects to verify-otp', async () => {
@@ -76,4 +91,14 @@ test('it creates an onboarding verification and redirects to verify-otp', async 
   );
 
   expect(verification).toBeDefined();
+
+  const welcomeEmail = db.sentEmailCollection.findFirst((q) =>
+    q.where({ template: 'welcome', to: 'signup-new@vers.test' }),
+  );
+
+  expect(welcomeEmail).toMatchObject({
+    to: 'signup-new@vers.test',
+    verificationCode: verification?.code,
+    verificationURL: `http://localhost/verify-otp?${new URLSearchParams({ code: verification?.code ?? '', target: 'signup-new@vers.test', type: 'onboarding' }).toString()}`,
+  });
 });

--- a/apps/web/src/routes/-signup/signup-handler.ts
+++ b/apps/web/src/routes/-signup/signup-handler.ts
@@ -1,18 +1,20 @@
 import type { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod/v4';
 import { redirect } from '@tanstack/react-router';
+import { getRequest } from '@tanstack/react-start/server';
 import { checkHoneypot } from '../../lib/auth/check-honeypot';
 import { requireAnonymous } from '../../lib/auth/require-anonymous';
 import { SpamError } from '../../lib/auth/spam-error';
+import { emailClient } from '../../lib/rpc/clients/email-client';
 import { userClient } from '../../lib/rpc/clients/user-client';
 import { verificationClient } from '../../lib/rpc/clients/verification-client';
 import { SignupFormSchema } from './signup-form-schema';
 
 /**
- * Runs the signup form's submission: honeypot then field validation, then — for a caller with no
- * account yet — an onboarding verification code sent to that address. Always redirects to
- * verify-otp, including for an existing account (which gets no verification created for it), so
- * the response never distinguishes an existing account from a new one.
+ * Runs the signup form's submission: honeypot then field validation, then either an onboarding
+ * verification code emailed to a caller with no account yet, or an existing-account notice for
+ * one that already has an account. Always redirects to verify-otp, so the response never
+ * distinguishes which email was sent.
  */
 export async function signupHandler(formData: FormData): Promise<Response | SubmissionResult> {
   await requireAnonymous();
@@ -33,16 +35,30 @@ export async function signupHandler(formData: FormData): Promise<Response | Subm
     return submission.reply();
   }
 
-  const existing = await userClient.getUser({ email: submission.value.email });
+  const email = submission.value.email;
+
+  const existing = await userClient.getUser({ email });
 
   if (existing === null) {
-    await verificationClient.createVerification({
-      target: submission.value.email,
+    const verification = await verificationClient.createVerification({
+      target: email,
       type: 'onboarding',
     });
+
+    const origin = new URL(getRequest().url).origin;
+
+    const verificationURL = `${origin}/verify-otp?${new URLSearchParams({ code: verification.otp, target: email, type: 'onboarding' }).toString()}`;
+
+    await emailClient.sendWelcome({
+      to: email,
+      verificationCode: verification.otp,
+      verificationURL,
+    });
+  } else {
+    await emailClient.sendExistingAccount({ email, to: email });
   }
 
-  const searchParams = new URLSearchParams({ target: submission.value.email, type: 'onboarding' });
+  const searchParams = new URLSearchParams({ target: email, type: 'onboarding' });
 
   throw redirect({ href: `/verify-otp?${searchParams.toString()}` });
 }

--- a/apps/web/src/routes/-verify-otp/run-change-email.ts
+++ b/apps/web/src/routes/-verify-otp/run-change-email.ts
@@ -1,10 +1,16 @@
+import { emailClient } from '../../lib/rpc/clients/email-client';
 import { userClient } from '../../lib/rpc/clients/user-client';
 import type { RunVerificationContext } from './types';
 
 /**
- * Confirms ownership of a new email address and applies it to the caller's own account. Returns
- * instead of throwing a redirect, leaving navigation to the caller.
+ * Confirms ownership of a new email address and applies it to the caller's own account, then
+ * notifies the old address of the change. Captures the old address before applying the mutation,
+ * since `getCurrentUser` would otherwise see the new one. Returns instead of throwing a redirect,
+ * leaving navigation to the caller.
  */
 export async function runChangeEmail(ctx: Readonly<RunVerificationContext>): Promise<void> {
+  const user = await userClient.getCurrentUser({});
+
   await userClient.updateEmail({ email: ctx.target });
+  await emailClient.sendChangeEmailNotification({ to: user.email });
 }

--- a/apps/web/src/routes/-verify-otp/verify-otp-handler.test.ts
+++ b/apps/web/src/routes/-verify-otp/verify-otp-handler.test.ts
@@ -217,4 +217,10 @@ test('it applies a confirmed email change for the signed-in caller', async () =>
   const updated = db.userCollection.findFirst((q) => q.where({ id: signedIn.userID }));
 
   expect(updated?.email).toBe('verify-otp-change-email-new@vers.test');
+
+  const notificationEmail = db.sentEmailCollection.findFirst((q) =>
+    q.where({ template: 'change-email-notification' }),
+  );
+
+  expect(notificationEmail).toMatchObject({ to: 'verify-otp-change-email-old@vers.test' });
 });

--- a/apps/web/src/routes/-verify-otp/verify-otp-handler.test.ts
+++ b/apps/web/src/routes/-verify-otp/verify-otp-handler.test.ts
@@ -219,8 +219,8 @@ test('it applies a confirmed email change for the signed-in caller', async () =>
   expect(updated?.email).toBe('verify-otp-change-email-new@vers.test');
 
   const notificationEmail = db.sentEmailCollection.findFirst((q) =>
-    q.where({ template: 'change-email-notification' }),
+    q.where({ template: 'send-change-email-notification' }),
   );
 
-  expect(notificationEmail).toMatchObject({ to: 'verify-otp-change-email-old@vers.test' });
+  expect(notificationEmail?.payload).toStrictEqual({ to: 'verify-otp-change-email-old@vers.test' });
 });

--- a/bun.lock
+++ b/bun.lock
@@ -49,6 +49,7 @@
         "@tanstack/react-start": "catalog:",
         "@vers/contract-avatar": "workspace:*",
         "@vers/contract-base": "workspace:*",
+        "@vers/contract-email": "workspace:*",
         "@vers/contract-session": "workspace:*",
         "@vers/contract-user": "workspace:*",
         "@vers/contract-verification": "workspace:*",

--- a/libs/service/service-auth/src/types.ts
+++ b/libs/service/service-auth/src/types.ts
@@ -1,3 +1,3 @@
-export type ServiceName = 'avatar' | 'session' | 'user' | 'verification';
+export type ServiceName = 'avatar' | 'email' | 'session' | 'user' | 'verification';
 
 export type ServiceAudience = `service-${ServiceName}`;

--- a/services/email/.env.development
+++ b/services/email/.env.development
@@ -1,6 +1,6 @@
 NODE_ENV="development"
 HOSTNAME="0.0.0.0"
-PORT="3006"
+PORT="3007"
 DATABASE_URL="postgresql://admin:password@0.0.0.0:5433/vers"
 RESEND_API_KEY="dev-resend-api-key"
 EMAIL_FROM="noreply@transactional.versidle.com"

--- a/services/email/.env.test
+++ b/services/email/.env.test
@@ -1,6 +1,6 @@
 NODE_ENV="test"
 HOSTNAME="localhost"
-PORT="3006"
+PORT="3007"
 DATABASE_URL="postgresql://admin:password@localhost:5432/vers"
 RESEND_API_KEY="test-resend-api-key"
 EMAIL_FROM="noreply@transactional.versidle.com"


### PR DESCRIPTION
Closes #441

## Description

Wires the six transactional email sends into app-web's auth flows, backed by a new `email` service client and its MSW mock.

- Extends `ServiceName` in `service-auth` with `'email'` and adds `EMAIL_SERVICE_URL` plumbing (`service-urls.ts`, `fly.toml`, `email-client.ts`).
- Adds a full mock email backend (`sent-email-collection.ts`, `mocks/routers/email/*`) wired into `handlers.ts`, so handler tests assert against sent emails.
- Signup sends a welcome email (with verification link) for a new account, or an existing-account notice for one that already exists — the redirect stays identical either way.
- Change-email sends a verification email to the new address on request, then a change notice to the old address once the code is confirmed; `run-change-email.ts` captures the old address via `getCurrentUser` before applying the mutation, since it would otherwise read the new one.
- Forgot-password emails the reset link; reset-password emails a password-changed confirmation on success.
- Absolute links use `getRequest()` for the request origin. No try/catch — failures propagate through the existing handler error path.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
