### PR TITLE
feat(#168): carry reward deltas on activity checkpoints

### DIFF
--- a/apps/web/src/routes/-explore-current/explore-current-panel.test.tsx
+++ b/apps/web/src/routes/-explore-current/explore-current-panel.test.tsx
@@ -26,6 +26,7 @@ function buildFakeActivityAppState(id: string): ActivityAppState {
     enemyGroupsRemaining: 0,
     id,
     name: 'World Node',
+    rewards: { xp: 0 },
   };
 }
 

--- a/libs/game/idle-client/src/components/activity-info.test.tsx
+++ b/libs/game/idle-client/src/components/activity-info.test.tsx
@@ -13,6 +13,7 @@ test('it renders info about the provided activity', () => {
     enemyGroupsRemaining: 4,
     id: 'test-activity',
     name: 'Test Activity',
+    rewards: { xp: 150 },
   };
 
   render(<ActivityInfo activity={activity} />);
@@ -20,8 +21,10 @@ test('it renders info about the provided activity', () => {
   const activityName = screen.getByText('Test Activity');
   const enemiesRemaining = screen.getByText(nodeHasText('20 enemies remain'));
   const enemyGroupsRemaining = screen.getByText(nodeHasText('4 enemy groups remain'));
+  const xpEarned = screen.getByText(nodeHasText('150 xp earned'));
 
   expect(activityName).toBeInTheDocument();
   expect(enemiesRemaining).toBeInTheDocument();
   expect(enemyGroupsRemaining).toBeInTheDocument();
+  expect(xpEarned).toBeInTheDocument();
 });

--- a/libs/game/idle-client/src/components/activity-info.tsx
+++ b/libs/game/idle-client/src/components/activity-info.tsx
@@ -21,6 +21,9 @@ export function ActivityInfo(props: Readonly<ActivityInfoProps>) {
       <Text>
         <strong>{props.activity.enemiesRemaining}</strong> enemies remain
       </Text>
+      <Text>
+        <strong>{props.activity.rewards.xp}</strong> xp earned
+      </Text>
     </section>
   );
 }

--- a/libs/game/idle-client/src/state/set-activity.test.ts
+++ b/libs/game/idle-client/src/state/set-activity.test.ts
@@ -13,6 +13,7 @@ test('it updates the activity state', () => {
     enemyGroupsRemaining: 4,
     id: '1',
     name: 'Test Activity',
+    rewards: { xp: 0 },
   };
 
   setActivity(activity);
@@ -27,5 +28,6 @@ test('it updates the activity state', () => {
     enemyGroupsRemaining: 4,
     id: '1',
     name: 'Test Activity',
+    rewards: { xp: 0 },
   });
 });

--- a/libs/game/idle-client/src/state/use-activity.test.ts
+++ b/libs/game/idle-client/src/state/use-activity.test.ts
@@ -13,6 +13,7 @@ test('it provides activity state', () => {
     enemyGroupsRemaining: 4,
     id: 'test-activity',
     name: 'Test Activity',
+    rewards: { xp: 0 },
   };
 
   setActivity(activity);
@@ -27,5 +28,6 @@ test('it provides activity state', () => {
     enemyGroupsRemaining: 4,
     id: 'test-activity',
     name: 'Test Activity',
+    rewards: { xp: 0 },
   });
 });

--- a/libs/game/idle-client/src/worker/create-simulation-update-message.test.ts
+++ b/libs/game/idle-client/src/worker/create-simulation-update-message.test.ts
@@ -15,6 +15,7 @@ test('it creates a simulation update message', () => {
       enemyGroupsRemaining: 0,
       id: '1',
       name: 'Test Activity',
+      rewards: { xp: 0 },
     },
     avatar: {
       behaviours: {},

--- a/libs/game/idle-core/src/core/create-activity.test.ts
+++ b/libs/game/idle-core/src/core/create-activity.test.ts
@@ -52,8 +52,8 @@ test('it accrues rewards across multiple calls', () => {
   const activityData = createMockActivityData();
   const activity = createActivity(activityData, ctx);
 
-  activity.accrueRewards({ xp: 10 });
-  activity.accrueRewards({ xp: 5 });
+  activity.updateRewards({ xp: 10 });
+  activity.updateRewards({ xp: 5 });
 
   expect(activity.rewards).toStrictEqual({ xp: 15 });
   expect(activity.getAppState().rewards).toStrictEqual({ xp: 15 });

--- a/libs/game/idle-core/src/core/create-activity.test.ts
+++ b/libs/game/idle-core/src/core/create-activity.test.ts
@@ -43,5 +43,18 @@ test('it returns the expected activity state for a client app', () => {
     enemyGroupsRemaining: expect.toBeNumber(),
     id: activity.id,
     name: activity.name,
+    rewards: { xp: 0 },
   });
+});
+
+test('it accrues rewards across multiple calls', () => {
+  const ctx = createMockSimulationContext();
+  const activityData = createMockActivityData();
+  const activity = createActivity(activityData, ctx);
+
+  activity.accrueRewards({ xp: 10 });
+  activity.accrueRewards({ xp: 5 });
+
+  expect(activity.rewards).toStrictEqual({ xp: 15 });
+  expect(activity.getAppState().rewards).toStrictEqual({ xp: 15 });
 });

--- a/libs/game/idle-core/src/core/create-activity.ts
+++ b/libs/game/idle-core/src/core/create-activity.ts
@@ -32,7 +32,7 @@ export function createActivity(
     elapsed += time;
   };
 
-  const accrueRewards = (delta: ActivityRewards) => {
+  const updateRewards = (delta: ActivityRewards) => {
     rewards = mergeRewards(rewards, delta);
   };
 
@@ -78,15 +78,12 @@ export function createActivity(
     getAppState,
 
     // utils
-    accrueRewards,
+    updateRewards,
     elapseTime,
     moveToNextEnemyGroup,
   };
 }
 
-/**
- * Adds two reward maps keywise. A key an interface later adds is a mechanical addition here.
- */
 function mergeRewards(base: ActivityRewards, delta: ActivityRewards): ActivityRewards {
   return { xp: base.xp + delta.xp };
 }

--- a/libs/game/idle-core/src/core/create-activity.ts
+++ b/libs/game/idle-core/src/core/create-activity.ts
@@ -2,6 +2,7 @@ import type {
   Activity,
   ActivityAppState,
   ActivityData,
+  ActivityRewards,
   EnemyGroup,
   SimulationContext,
 } from '../types';
@@ -19,6 +20,7 @@ export function createActivity(
 ): Activity {
   let elapsed = 0;
   let currentEnemyGroupIdx = 0;
+  let rewards: ActivityRewards = { xp: 0 };
   const enemyGroups: Array<EnemyGroup> = getEnemyGroups(data, ctx, config);
   const isEnemyGroupsRemaining = () => enemyGroups.some((group) => group.remaining > 0);
 
@@ -28,6 +30,10 @@ export function createActivity(
 
   const elapseTime = (time: number) => {
     elapsed += time;
+  };
+
+  const accrueRewards = (delta: ActivityRewards) => {
+    rewards = mergeRewards(rewards, delta);
   };
 
   const getAppState = (): ActivityAppState => {
@@ -43,6 +49,7 @@ export function createActivity(
       enemyGroupsRemaining,
       id: data.id,
       name: data.name,
+      rewards,
     };
   };
 
@@ -63,12 +70,23 @@ export function createActivity(
     get isEnemyGroupsRemaining() {
       return isEnemyGroupsRemaining();
     },
+    get rewards() {
+      return rewards;
+    },
 
     // core
     getAppState,
 
     // utils
+    accrueRewards,
     elapseTime,
     moveToNextEnemyGroup,
   };
+}
+
+/**
+ * Adds two reward maps keywise. A key an interface later adds is a mechanical addition here.
+ */
+function mergeRewards(base: ActivityRewards, delta: ActivityRewards): ActivityRewards {
+  return { xp: base.xp + delta.xp };
 }

--- a/libs/game/idle-core/src/core/create-simulation.test.ts
+++ b/libs/game/idle-core/src/core/create-simulation.test.ts
@@ -119,6 +119,7 @@ test('it runs an activity and returns checkpoints', async () => {
 
   expect(firstCheckpoint).toStrictEqual({
     hash: expect.toBeString(),
+    rewards: { xp: 0 },
     seed: expect.toBeNumber(),
     time: 0,
     type: ActivityCheckpointType.Started,
@@ -129,6 +130,7 @@ test('it runs an activity and returns checkpoints', async () => {
   expect(secondCheckpoint).toStrictEqual({
     hash: expect.toBeString(),
     nextSeed: expect.toBeNumber(),
+    rewards: expect.toBeObject(),
     time: expect.toBeNumber(),
     type: ActivityCheckpointType.Progress,
   });

--- a/libs/game/idle-core/src/core/run-simulation.test.ts
+++ b/libs/game/idle-core/src/core/run-simulation.test.ts
@@ -27,6 +27,9 @@ test('runs a simulation with default configuration', async () => {
       "checkpoints": [
         {
           "hash": "cbd6cc9427a79b1e",
+          "rewards": {
+            "xp": 0,
+          },
           "seed": 3047525658,
           "time": 0,
           "type": "started",
@@ -34,35 +37,53 @@ test('runs a simulation with default configuration', async () => {
         {
           "hash": "611b08f1de148c51",
           "nextSeed": 685112472,
+          "rewards": {
+            "xp": 60,
+          },
           "time": 16300,
           "type": "progress",
         },
         {
           "hash": "d0100e711451eca4",
           "nextSeed": 2866488649,
+          "rewards": {
+            "xp": 60,
+          },
           "time": 36300,
           "type": "progress",
         },
         {
           "hash": "754e2d41cc9f551d",
           "nextSeed": 2249575321,
+          "rewards": {
+            "xp": 30,
+          },
           "time": 46300,
           "type": "progress",
         },
         {
           "hash": "e9f8306aa299f8cc",
           "nextSeed": 3183217100,
+          "rewards": {
+            "xp": 40,
+          },
           "time": 57600,
           "type": "progress",
         },
         {
           "hash": "0ad2f691a6d94aa0",
           "nextSeed": 4197947599,
+          "rewards": {
+            "xp": 0,
+          },
           "time": 57600,
           "type": "completed",
         },
         {
           "hash": "f1dd0c3fcae677d9",
+          "rewards": {
+            "xp": 0,
+          },
           "seed": 4197947599,
           "time": 0,
           "type": "started",
@@ -70,6 +91,9 @@ test('runs a simulation with default configuration', async () => {
         {
           "hash": "18975faf33fdc719",
           "nextSeed": 2381219441,
+          "rewards": {
+            "xp": 60,
+          },
           "time": 18800,
           "type": "progress",
         },
@@ -130,6 +154,7 @@ test('it stops at the specified seed if provided', async () => {
   expect(finalCheckpoint).toStrictEqual({
     hash: expect.toBeString(),
     nextSeed: config.stopAtSeed,
+    rewards: expect.toBeObject(),
     time: expect.toBeNumber(),
     type: ActivityCheckpointType.Completed,
   });
@@ -165,6 +190,7 @@ test('it aborts on failure if failure action is set to abort', async () => {
   expect(lastCheckpoint).toStrictEqual({
     hash: expect.toBeString(),
     nextSeed: expect.toBeNumber(),
+    rewards: { xp: 0 },
     time: expect.toBeNumber(),
     type: ActivityCheckpointType.Failed,
   });

--- a/libs/game/idle-core/src/core/simulate-activity.test.ts
+++ b/libs/game/idle-core/src/core/simulate-activity.test.ts
@@ -35,6 +35,7 @@ test('it immediately generates a started checkpoint', async () => {
 
   expect(firstCheckpoint).toStrictEqual({
     hash: expect.toBeString(),
+    rewards: { xp: 0 },
     seed: 999_999_999,
     time: 0,
     type: ActivityCheckpointType.Started,
@@ -87,6 +88,7 @@ test('it generates enemy group killed checkpoints', async () => {
   expect(secondCheckpoint).toStrictEqual({
     hash: expect.toBeString(),
     nextSeed: expect.toBeNumber(),
+    rewards: { xp: 50 },
     time: expect.toBeNumber(),
     type: ActivityCheckpointType.Progress,
   });
@@ -94,9 +96,54 @@ test('it generates enemy group killed checkpoints', async () => {
   expect(thirdCheckpoint).toStrictEqual({
     hash: expect.toBeString(),
     nextSeed: expect.toBeNumber(),
+    rewards: { xp: 50 },
     time: expect.toBeNumber(),
     type: ActivityCheckpointType.Progress,
   });
+});
+
+test('it accrues rewards across multiple cleared groups', async () => {
+  const weapon: EquipmentWeapon = {
+    id: 'test-weapon',
+    maxDamage: 9999,
+    minDamage: 9999,
+    name: 'Test Weapon',
+    speed: 6,
+  };
+
+  const avatarData = createMockAvatarData({
+    paperdoll: {
+      [EquipmentSlot.MainHand]: weapon,
+    },
+  });
+
+  const enemyData = createMockEnemyData({ life: 1, xp: 10 });
+
+  const activityData = createMockActivityData({
+    enemies: [enemyData],
+    failureAction: ActivityFailureAction.Retry,
+    id: 'world_node_1',
+    type: ActivityType.WorldNode,
+  });
+
+  const ctx = createMockSimulationContext();
+  const activity = createActivity(activityData, ctx, { groupCount: 2, groupSize: 5 });
+  const avatar = createAvatar(avatarData, ctx);
+  const executor = createCombatExecutor(activity, avatar, ctx);
+  const generator = simulateActivity(executor, activity, avatar, ctx);
+
+  // skip the started checkpoint
+  await generator.next(1000);
+
+  // clear the first group
+  await generator.next(1000);
+
+  expect(activity.rewards).toStrictEqual({ xp: 50 });
+
+  // clear the second group
+  await generator.next(1000);
+
+  expect(activity.rewards).toStrictEqual({ xp: 100 });
 });
 
 test('it generates a failed checkpoint when the avatar dies', async () => {
@@ -129,6 +176,7 @@ test('it generates a failed checkpoint when the avatar dies', async () => {
   expect(checkpoint).toStrictEqual({
     hash: expect.toBeString(),
     nextSeed: expect.toBeNumber(),
+    rewards: { xp: 0 },
     time: expect.toBeNumber(),
     type: ActivityCheckpointType.Failed,
   });
@@ -175,6 +223,7 @@ test('it returns a completed checkpoint when all enemies are defeated', async ()
   expect(checkpoint).toStrictEqual({
     hash: expect.toBeString(),
     nextSeed: expect.toBeNumber(),
+    rewards: { xp: 0 },
     time: expect.toBeNumber(),
     type: ActivityCheckpointType.Completed,
   });

--- a/libs/game/idle-core/src/core/simulate-activity.ts
+++ b/libs/game/idle-core/src/core/simulate-activity.ts
@@ -34,7 +34,7 @@ export async function* simulateActivity(
     if (activity.currentEnemyGroup?.remaining === 0) {
       const rewards = buildGroupClearRewards(activity.currentEnemyGroup);
 
-      activity.accrueRewards(rewards);
+      activity.updateRewards(rewards);
       yield createProgressCheckpoint(activity, ctx, rewards);
       logger.debug(`${label} moving to next enemy group`);
 

--- a/libs/game/idle-core/src/core/simulate-activity.ts
+++ b/libs/game/idle-core/src/core/simulate-activity.ts
@@ -6,6 +6,7 @@ import type {
   SimulationContext,
 } from '../types';
 import { logger } from '../utils/logger';
+import { buildGroupClearRewards } from './utils/build-group-clear-rewards';
 import { createCompletedCheckpoint } from './utils/create-completed-checkpoint';
 import { createFailedCheckpoint } from './utils/create-failed-checkpoint';
 import { createProgressCheckpoint } from './utils/create-progress-checkpoint';
@@ -31,7 +32,10 @@ export async function* simulateActivity(
     executor.run(timestep);
 
     if (activity.currentEnemyGroup?.remaining === 0) {
-      yield createProgressCheckpoint(activity, ctx);
+      const rewards = buildGroupClearRewards(activity.currentEnemyGroup);
+
+      activity.accrueRewards(rewards);
+      yield createProgressCheckpoint(activity, ctx, rewards);
       logger.debug(`${label} moving to next enemy group`);
 
       // move to the next enemy group

--- a/libs/game/idle-core/src/core/utils/build-group-clear-rewards.test.ts
+++ b/libs/game/idle-core/src/core/utils/build-group-clear-rewards.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from 'bun:test';
+import { createMockActivityData } from '../../test-utils/create-mock-activity-data';
+import { createMockEnemyData } from '../../test-utils/create-mock-enemy-data';
+import { createMockSimulationContext } from '../../test-utils/create-mock-simulation-context';
+import { buildGroupClearRewards } from './build-group-clear-rewards';
+import { createEnemyGroup } from './create-enemy-group';
+
+test('it sums the xp of every enemy in the group', () => {
+  const enemyData = createMockEnemyData({ xp: 10 });
+  const activity = createMockActivityData({ enemies: [enemyData] });
+  const ctx = createMockSimulationContext();
+  const group = createEnemyGroup(activity, ctx, 3);
+
+  expect(buildGroupClearRewards(group)).toStrictEqual({ xp: 30 });
+});
+
+test('it returns zero xp for an empty group', () => {
+  const activity = createMockActivityData();
+  const ctx = createMockSimulationContext();
+  const group = createEnemyGroup(activity, ctx, 0);
+
+  expect(buildGroupClearRewards(group)).toStrictEqual({ xp: 0 });
+});

--- a/libs/game/idle-core/src/core/utils/build-group-clear-rewards.ts
+++ b/libs/game/idle-core/src/core/utils/build-group-clear-rewards.ts
@@ -1,0 +1,7 @@
+import type { ActivityRewards, EnemyGroup } from '../../types';
+
+export function buildGroupClearRewards(group: EnemyGroup): ActivityRewards {
+  const xp = group.enemies.reduce((total, enemy) => total + enemy.xp, 0);
+
+  return { xp };
+}

--- a/libs/game/idle-core/src/core/utils/create-completed-checkpoint.test.ts
+++ b/libs/game/idle-core/src/core/utils/create-completed-checkpoint.test.ts
@@ -11,6 +11,7 @@ test('it creates a completed checkpoint', () => {
   expect(checkpoint).toStrictEqual({
     hash: expect.toBeString(),
     nextSeed: expect.toBeNumber(),
+    rewards: { xp: 0 },
     time: 2500,
     type: ActivityCheckpointType.Completed,
   });
@@ -19,7 +20,7 @@ test('it creates a completed checkpoint', () => {
 test('it includes a hash based on checkpoint data', () => {
   const ctx = createMockSimulationContext();
   const checkpoint = createCompletedCheckpoint(2500, ctx);
-  const { hash, ...hashParts } = checkpoint;
+  const { hash, rewards, ...hashParts } = checkpoint;
 
   expect(hash).toStrictEqual(hashObject(ctx.hasher, hashParts));
 });

--- a/libs/game/idle-core/src/core/utils/create-completed-checkpoint.ts
+++ b/libs/game/idle-core/src/core/utils/create-completed-checkpoint.ts
@@ -1,4 +1,4 @@
-import type { ActivityCompletedCheckpoint, SimulationContext } from '../../types';
+import type { ActivityCompletedCheckpoint, ActivityRewards, SimulationContext } from '../../types';
 import { ActivityCheckpointType } from '../../types';
 import { hashObject } from '../../utils/hash-object';
 
@@ -6,13 +6,18 @@ export function createCompletedCheckpoint(
   elapsed: number,
   ctx: SimulationContext,
 ): ActivityCompletedCheckpoint {
-  const result: Omit<ActivityCompletedCheckpoint, 'hash'> = {
+  // hash chain covers only this frozen subset — rewards ride outside it, verified by server
+  // replay-recompute instead
+  const hashed: Omit<ActivityCompletedCheckpoint, 'hash' | 'rewards'> = {
     nextSeed: ctx.rng.generateNewSeed(),
     time: elapsed,
     type: ActivityCheckpointType.Completed,
   };
 
-  const hash = hashObject(ctx.hasher, result);
+  const hash = hashObject(ctx.hasher, hashed);
 
-  return { ...result, hash };
+  // completion payouts land here once the content layer authors them
+  const rewards: ActivityRewards = { xp: 0 };
+
+  return { ...hashed, hash, rewards };
 }

--- a/libs/game/idle-core/src/core/utils/create-failed-checkpoint.test.ts
+++ b/libs/game/idle-core/src/core/utils/create-failed-checkpoint.test.ts
@@ -18,6 +18,7 @@ test('it creates a failed checkpoint', () => {
   expect(checkpoint).toStrictEqual({
     hash: expect.toBeString(),
     nextSeed: expect.toBeNumber(),
+    rewards: { xp: 0 },
     time: 2500,
     type: ActivityCheckpointType.Failed,
   });
@@ -28,7 +29,7 @@ test('it includes a hash based on checkpoint data', () => {
   const activityData = createMockActivityData();
   const activity = createActivity(activityData, ctx);
   const checkpoint = createFailedCheckpoint(activity, ctx);
-  const { hash, ...hashParts } = checkpoint;
+  const { hash, rewards, ...hashParts } = checkpoint;
 
   expect(hash).toStrictEqual(hashObject(ctx.hasher, hashParts));
 });

--- a/libs/game/idle-core/src/core/utils/create-failed-checkpoint.ts
+++ b/libs/game/idle-core/src/core/utils/create-failed-checkpoint.ts
@@ -1,4 +1,9 @@
-import type { Activity, ActivityFailedCheckpoint, SimulationContext } from '../../types';
+import type {
+  Activity,
+  ActivityFailedCheckpoint,
+  ActivityRewards,
+  SimulationContext,
+} from '../../types';
 import { ActivityCheckpointType } from '../../types';
 import { hashObject } from '../../utils/hash-object';
 
@@ -6,13 +11,18 @@ export function createFailedCheckpoint(
   activity: Activity,
   ctx: SimulationContext,
 ): ActivityFailedCheckpoint {
-  const result: Omit<ActivityFailedCheckpoint, 'hash'> = {
+  // hash chain covers only this frozen subset — rewards ride outside it, verified by server
+  // replay-recompute instead
+  const hashed: Omit<ActivityFailedCheckpoint, 'hash' | 'rewards'> = {
     nextSeed: ctx.rng.generateNewSeed(),
     time: activity.elapsed,
     type: ActivityCheckpointType.Failed,
   };
 
-  const hash = hashObject(ctx.hasher, result);
+  const hash = hashObject(ctx.hasher, hashed);
 
-  return { ...result, hash };
+  // defeat cost (negative xp) lands here once the content layer defines its magnitude
+  const rewards: ActivityRewards = { xp: 0 };
+
+  return { ...hashed, hash, rewards };
 }

--- a/libs/game/idle-core/src/core/utils/create-progress-checkpoint.test.ts
+++ b/libs/game/idle-core/src/core/utils/create-progress-checkpoint.test.ts
@@ -13,11 +13,12 @@ test('it creates a progress checkpoint', () => {
 
   activity.elapseTime(2500);
 
-  const checkpoint = createProgressCheckpoint(activity, ctx);
+  const checkpoint = createProgressCheckpoint(activity, ctx, { xp: 15 });
 
   expect(checkpoint).toStrictEqual({
     hash: expect.toBeString(),
     nextSeed: expect.toBeNumber(),
+    rewards: { xp: 15 },
     time: 2500,
     type: ActivityCheckpointType.Progress,
   });
@@ -30,8 +31,29 @@ test('it includes a hash based on checkpoint data', () => {
 
   activity.elapseTime(2500);
 
-  const checkpoint = createProgressCheckpoint(activity, ctx);
-  const { hash, ...hashParts } = checkpoint;
+  const checkpoint = createProgressCheckpoint(activity, ctx, { xp: 15 });
+  const { hash, rewards, ...hashParts } = checkpoint;
 
   expect(hash).toStrictEqual(hashObject(ctx.hasher, hashParts));
+});
+
+test('it produces the same hash for checkpoints that differ only by rewards', () => {
+  const activityData = createMockActivityData();
+  const ctxWithNoRewards = createMockSimulationContext();
+  const activityWithNoRewards = createActivity(activityData, ctxWithNoRewards);
+
+  activityWithNoRewards.elapseTime(2500);
+
+  const withNoRewards = createProgressCheckpoint(activityWithNoRewards, ctxWithNoRewards, {
+    xp: 0,
+  });
+
+  const ctxWithRewards = createMockSimulationContext();
+  const activityWithRewards = createActivity(activityData, ctxWithRewards);
+
+  activityWithRewards.elapseTime(2500);
+
+  const withRewards = createProgressCheckpoint(activityWithRewards, ctxWithRewards, { xp: 15 });
+
+  expect(withRewards.hash).toStrictEqual(withNoRewards.hash);
 });

--- a/libs/game/idle-core/src/core/utils/create-progress-checkpoint.ts
+++ b/libs/game/idle-core/src/core/utils/create-progress-checkpoint.ts
@@ -1,18 +1,26 @@
-import type { Activity, ActivityProgressCheckpoint, SimulationContext } from '../../types';
+import type {
+  Activity,
+  ActivityProgressCheckpoint,
+  ActivityRewards,
+  SimulationContext,
+} from '../../types';
 import { ActivityCheckpointType } from '../../types';
 import { hashObject } from '../../utils/hash-object';
 
 export function createProgressCheckpoint(
   activity: Activity,
   ctx: SimulationContext,
+  rewards: ActivityRewards,
 ): ActivityProgressCheckpoint {
-  const data: Omit<ActivityProgressCheckpoint, 'hash'> = {
+  // hash chain covers only this frozen subset — rewards ride outside it, verified by server
+  // replay-recompute instead
+  const hashed: Omit<ActivityProgressCheckpoint, 'hash' | 'rewards'> = {
     nextSeed: ctx.rng.generateNewSeed(),
     time: activity.elapsed,
     type: ActivityCheckpointType.Progress,
   };
 
-  const hash = hashObject(ctx.hasher, data);
+  const hash = hashObject(ctx.hasher, hashed);
 
-  return { ...data, hash };
+  return { ...hashed, hash, rewards };
 }

--- a/libs/game/idle-core/src/core/utils/create-started-checkpoint.test.ts
+++ b/libs/game/idle-core/src/core/utils/create-started-checkpoint.test.ts
@@ -10,6 +10,7 @@ test('it creates a started checkpoint', () => {
 
   expect(checkpoint).toStrictEqual({
     hash: expect.toBeString(),
+    rewards: { xp: 0 },
     seed: ctx.rng.seed,
     time: 0,
     type: ActivityCheckpointType.Started,
@@ -19,7 +20,7 @@ test('it creates a started checkpoint', () => {
 test('it includes a hash based on checkpoint data', () => {
   const ctx = createMockSimulationContext();
   const checkpoint = createStartedCheckpoint(ctx);
-  const { hash, ...hashParts } = checkpoint;
+  const { hash, rewards, ...hashParts } = checkpoint;
 
   expect(hash).toStrictEqual(hashObject(ctx.hasher, hashParts));
 });

--- a/libs/game/idle-core/src/core/utils/create-started-checkpoint.ts
+++ b/libs/game/idle-core/src/core/utils/create-started-checkpoint.ts
@@ -1,15 +1,18 @@
-import type { ActivityStartedCheckpoint, SimulationContext } from '../../types';
+import type { ActivityRewards, ActivityStartedCheckpoint, SimulationContext } from '../../types';
 import { ActivityCheckpointType } from '../../types';
 import { hashObject } from '../../utils/hash-object';
 
 export function createStartedCheckpoint(ctx: SimulationContext): ActivityStartedCheckpoint {
-  const result: Omit<ActivityStartedCheckpoint, 'hash'> = {
+  // hash chain covers only this frozen subset — rewards ride outside it, verified by server
+  // replay-recompute instead
+  const hashed: Omit<ActivityStartedCheckpoint, 'hash' | 'rewards'> = {
     seed: ctx.rng.seed,
     time: 0,
     type: ActivityCheckpointType.Started,
   };
 
-  const hash = hashObject(ctx.hasher, result);
+  const hash = hashObject(ctx.hasher, hashed);
+  const rewards: ActivityRewards = { xp: 0 };
 
-  return { ...result, hash };
+  return { ...hashed, hash, rewards };
 }

--- a/libs/game/idle-core/src/entities/create-enemy.test.ts
+++ b/libs/game/idle-core/src/entities/create-enemy.test.ts
@@ -24,6 +24,7 @@ test('it creates an enemy with correct initial values', () => {
   expect(enemy.life).toBe(data.life);
   expect(enemy.status).toBe(EntityStatus.Alive);
   expect(enemy.isAlive).toBeTrue();
+  expect(enemy.xp).toBe(data.xp);
 });
 
 test('it exposes a method for setting the enemy state', () => {

--- a/libs/game/idle-core/src/entities/create-enemy.ts
+++ b/libs/game/idle-core/src/entities/create-enemy.ts
@@ -74,6 +74,7 @@ export function createEnemy(data: EnemyData, ctx: SimulationContext): Enemy {
     level: data.level,
     name: data.name,
     type: EntityType.Enemy,
+    xp: data.xp,
 
     // getters
     get isAlive() {

--- a/libs/game/idle-core/src/test-utils/create-mock-activity-data.test.ts
+++ b/libs/game/idle-core/src/test-utils/create-mock-activity-data.test.ts
@@ -17,6 +17,7 @@ test('it creates activity data with expected properties', () => {
           minDamage: 1,
           speed: 0.5,
         },
+        xp: 10,
       },
     ],
     failureAction: ActivityFailureAction.Retry,

--- a/libs/game/idle-core/src/test-utils/create-mock-enemy-data.test.ts
+++ b/libs/game/idle-core/src/test-utils/create-mock-enemy-data.test.ts
@@ -13,6 +13,7 @@ test('it creates enemy data with expected properties', () => {
       minDamage: 1,
       speed: 0.5,
     },
+    xp: 10,
   });
 });
 
@@ -26,6 +27,7 @@ test('it creates enemy data with custom properties', () => {
       minDamage: 5,
       speed: 1,
     },
+    xp: 25,
   });
 
   expect(enemy).toStrictEqual({
@@ -37,5 +39,6 @@ test('it creates enemy data with custom properties', () => {
       minDamage: 5,
       speed: 1,
     },
+    xp: 25,
   });
 });

--- a/libs/game/idle-core/src/test-utils/create-mock-enemy-data.ts
+++ b/libs/game/idle-core/src/test-utils/create-mock-enemy-data.ts
@@ -5,6 +5,7 @@ export function createMockEnemyData(overrides: Partial<EnemyData> = {}): EnemyDa
     level: 1,
     life: 30,
     name: 'Test Enemy',
+    xp: 10,
     ...overrides,
     primaryAttack: {
       maxDamage: 3,

--- a/libs/game/idle-core/src/types/activity.ts
+++ b/libs/game/idle-core/src/types/activity.ts
@@ -57,7 +57,7 @@ export interface Activity {
   get rewards(): ActivityRewards;
 
   // utils
-  accrueRewards: (delta: ActivityRewards) => void;
+  updateRewards: (delta: ActivityRewards) => void;
   elapseTime: (time: number) => void;
   getAppState: () => ActivityAppState;
   moveToNextEnemyGroup: () => void;

--- a/libs/game/idle-core/src/types/activity.ts
+++ b/libs/game/idle-core/src/types/activity.ts
@@ -24,6 +24,14 @@ export interface WorldNodeActivityData extends IActivityData {
 
 export type ActivityData = WorldNodeActivityData;
 
+/**
+ * An open keyed map of signed reward deltas. Future keys are added as optional and never
+ * repurposed, so an older reader that doesn't know a key can ignore it safely.
+ */
+export interface ActivityRewards {
+  readonly xp: number;
+}
+
 export interface ActivityAppState {
   readonly currentEnemyGroup: EnemyGroupAppState | null;
   readonly elapsed: number;
@@ -32,6 +40,7 @@ export interface ActivityAppState {
   readonly enemyGroupsRemaining: number;
   readonly id: string;
   readonly name: string;
+  readonly rewards: ActivityRewards;
 }
 
 export interface Activity {
@@ -45,8 +54,10 @@ export interface Activity {
   get currentEnemyGroup(): EnemyGroup | null;
   get elapsed(): number;
   get isEnemyGroupsRemaining(): boolean;
+  get rewards(): ActivityRewards;
 
   // utils
+  accrueRewards: (delta: ActivityRewards) => void;
   elapseTime: (time: number) => void;
   getAppState: () => ActivityAppState;
   moveToNextEnemyGroup: () => void;
@@ -60,6 +71,7 @@ export type ActivityCheckpointGenerator = AsyncGenerator<
 
 interface IActivityCheckpoint {
   readonly hash: string;
+  readonly rewards: ActivityRewards;
   readonly time: number;
   readonly type: ActivityCheckpointType;
 }

--- a/libs/game/idle-core/src/types/entities.ts
+++ b/libs/game/idle-core/src/types/entities.ts
@@ -25,6 +25,7 @@ export interface EnemyData {
   life: number;
   name: string;
   primaryAttack: AttackData;
+  xp: number;
 }
 
 export type HandleTickFn = (combatExecutor: CombatExecutor) => void;
@@ -123,6 +124,7 @@ export interface Enemy extends IEntity<EnemyState, EnemyAppState> {
   // meta
   readonly name: string;
   readonly type: EntityType.Enemy;
+  readonly xp: number;
 
   // getters
   get primaryAttack(): AttackData;

--- a/libs/game/idle-core/src/utils/is-completed-checkpoint.test.ts
+++ b/libs/game/idle-core/src/utils/is-completed-checkpoint.test.ts
@@ -12,6 +12,7 @@ test('returns true for completed checkpoints', () => {
   const completedCheckpoint: ActivityCompletedCheckpoint = {
     hash: 'abc123',
     nextSeed: 12_345,
+    rewards: { xp: 0 },
     time: 1000,
     type: ActivityCheckpointType.Completed,
   };
@@ -23,6 +24,7 @@ test('returns false for non-completed checkpoints', () => {
   const startedCheckpoint: ActivityStartedCheckpoint = {
     hash: 'def456',
     seed: 54_321,
+    rewards: { xp: 0 },
     time: 0,
     type: ActivityCheckpointType.Started,
   };
@@ -30,6 +32,7 @@ test('returns false for non-completed checkpoints', () => {
   const failedCheckpoint: ActivityFailedCheckpoint = {
     hash: 'ghi789',
     nextSeed: 98_765,
+    rewards: { xp: 0 },
     time: 500,
     type: ActivityCheckpointType.Failed,
   };
@@ -37,6 +40,7 @@ test('returns false for non-completed checkpoints', () => {
   const progressCheckpoint: ActivityProgressCheckpoint = {
     hash: 'jkl012',
     nextSeed: 24_680,
+    rewards: { xp: 0 },
     time: 300,
     type: ActivityCheckpointType.Progress,
   };

--- a/libs/game/idle-core/src/utils/is-failed-checkpoint.test.ts
+++ b/libs/game/idle-core/src/utils/is-failed-checkpoint.test.ts
@@ -12,6 +12,7 @@ test('returns true for failed checkpoints', () => {
   const failedCheckpoint: ActivityFailedCheckpoint = {
     hash: 'abc123',
     nextSeed: 12_345,
+    rewards: { xp: 0 },
     time: 500,
     type: ActivityCheckpointType.Failed,
   };
@@ -23,6 +24,7 @@ test('returns false for non-failed checkpoints', () => {
   const startedCheckpoint: ActivityStartedCheckpoint = {
     hash: 'def456',
     seed: 54_321,
+    rewards: { xp: 0 },
     time: 0,
     type: ActivityCheckpointType.Started,
   };
@@ -30,6 +32,7 @@ test('returns false for non-failed checkpoints', () => {
   const completedCheckpoint: ActivityCompletedCheckpoint = {
     hash: 'ghi789',
     nextSeed: 98_765,
+    rewards: { xp: 0 },
     time: 1000,
     type: ActivityCheckpointType.Completed,
   };
@@ -37,6 +40,7 @@ test('returns false for non-failed checkpoints', () => {
   const progressCheckpoint: ActivityProgressCheckpoint = {
     hash: 'jkl012',
     nextSeed: 24_680,
+    rewards: { xp: 0 },
     time: 300,
     type: ActivityCheckpointType.Progress,
   };

--- a/libs/game/idle-core/src/utils/is-progress-checkpoint.test.ts
+++ b/libs/game/idle-core/src/utils/is-progress-checkpoint.test.ts
@@ -12,6 +12,7 @@ test('returns true for progress checkpoints', () => {
   const progressCheckpoint: ActivityProgressCheckpoint = {
     hash: 'abc123',
     nextSeed: 12_345,
+    rewards: { xp: 0 },
     time: 300,
     type: ActivityCheckpointType.Progress,
   };
@@ -23,6 +24,7 @@ test('returns false for non-progress checkpoints', () => {
   const startedCheckpoint: ActivityStartedCheckpoint = {
     hash: 'def456',
     seed: 54_321,
+    rewards: { xp: 0 },
     time: 0,
     type: ActivityCheckpointType.Started,
   };
@@ -30,6 +32,7 @@ test('returns false for non-progress checkpoints', () => {
   const completedCheckpoint: ActivityCompletedCheckpoint = {
     hash: 'ghi789',
     nextSeed: 98_765,
+    rewards: { xp: 0 },
     time: 1000,
     type: ActivityCheckpointType.Completed,
   };
@@ -37,6 +40,7 @@ test('returns false for non-progress checkpoints', () => {
   const failedCheckpoint: ActivityFailedCheckpoint = {
     hash: 'jkl012',
     nextSeed: 24_680,
+    rewards: { xp: 0 },
     time: 500,
     type: ActivityCheckpointType.Failed,
   };

--- a/libs/game/idle-core/src/utils/is-started-checkpoint.test.ts
+++ b/libs/game/idle-core/src/utils/is-started-checkpoint.test.ts
@@ -12,6 +12,7 @@ test('returns true for started checkpoints', () => {
   const startedCheckpoint: ActivityStartedCheckpoint = {
     hash: 'abc123',
     seed: 12_345,
+    rewards: { xp: 0 },
     time: 0,
     type: ActivityCheckpointType.Started,
   };
@@ -23,6 +24,7 @@ test('returns false for non-started checkpoints', () => {
   const completedCheckpoint: ActivityCompletedCheckpoint = {
     hash: 'def456',
     nextSeed: 54_321,
+    rewards: { xp: 0 },
     time: 1000,
     type: ActivityCheckpointType.Completed,
   };
@@ -30,6 +32,7 @@ test('returns false for non-started checkpoints', () => {
   const failedCheckpoint: ActivityFailedCheckpoint = {
     hash: 'ghi789',
     nextSeed: 98_765,
+    rewards: { xp: 0 },
     time: 500,
     type: ActivityCheckpointType.Failed,
   };
@@ -37,6 +40,7 @@ test('returns false for non-started checkpoints', () => {
   const progressCheckpoint: ActivityProgressCheckpoint = {
     hash: 'jkl012',
     nextSeed: 24_680,
+    rewards: { xp: 0 },
     time: 300,
     type: ActivityCheckpointType.Progress,
   };


### PR DESCRIPTION
## Description

Closes #168

Carries reward deltas (currently `{ xp }`) on activity checkpoints so clients can show accrued rewards without recomputing simulation history. Rewards ride outside the checkpoint hash chain, verified by server replay-recompute instead.

- Enemies now declare an `xp` value; a group clear sums it into a delta that's accrued onto the activity and stamped on the resulting progress checkpoint.
- Started/completed/failed checkpoints carry `{ xp: 0 }` for now — completion payouts and defeat costs land in follow-ups.
- Each checkpoint creator now builds its hashed subset separately from the returned checkpoint via `Omit<Checkpoint, 'hash' | 'rewards'>`, keeping the hashed field set byte-identical to before.
- `activity-info` gains an accrued-xp readout using existing design-system components only.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
