### PR TITLE
fix(#484): survive busy dev_base template during provisioning

### DIFF
--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -125,6 +125,10 @@ database catches up with migrations that landed after the template was last refr
   `dev_base` never matches it.
 - Provisioning and sweeping connect to `vers` on the dev branch, never to `dev_base`: postgres
   refuses to clone a template that has open connections.
+- `dev_base` refuses connections outright (`ALLOW_CONNECTIONS false`, like template0) except during
+  a rebuild — Neon parks invisible backends on recently connected databases for minutes, and any
+  session on the template blocks cloning. Neon's compute also opens short-lived internal sessions
+  while waking from scale-to-zero, so provisioning retries a busy-template failure briefly.
 
 ### Provisioning agent access from nothing
 

--- a/scripts/src/postgres/create-dev-db.ts
+++ b/scripts/src/postgres/create-dev-db.ts
@@ -1,3 +1,4 @@
+import { setTimeout as sleep } from 'node:timers/promises';
 import { migrateToLatest } from '@vers/db';
 import postgres from 'postgres';
 import invariant from 'tiny-invariant';
@@ -27,7 +28,7 @@ export async function createDevDB(config: Readonly<CreateDevDBConfig>): Promise<
     const existing = await pg`SELECT 1 FROM pg_database WHERE datname = ${config.dbName}`;
 
     if (existing.length === 0) {
-      await pg.unsafe(`CREATE DATABASE ${config.dbName} TEMPLATE dev_base`);
+      await createCloneOfDevBase(pg, config.dbName);
 
       const provenance = JSON.stringify({
         branch: config.branch,
@@ -51,5 +52,32 @@ export async function createDevDB(config: Readonly<CreateDevDBConfig>): Promise<
     throw result.error instanceof Error
       ? result.error
       : new Error('dev database migration failed', { cause: result.error });
+  }
+}
+
+const CLONE_ATTEMPTS = 4;
+const CLONE_RETRY_DELAY_MS = 1500;
+
+/**
+ * Neon's compute briefly opens its own sessions against databases while
+ * waking from scale-to-zero, and a session on dev_base makes the clone fail
+ * with 55006 (object_in_use) — retry through that window; anything else
+ * throws immediately.
+ */
+async function createCloneOfDevBase(pg: postgres.Sql, dbName: string): Promise<void> {
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      await pg.unsafe(`CREATE DATABASE ${dbName} TEMPLATE dev_base`);
+
+      return;
+    } catch (error) {
+      const isTemplateBusy = error instanceof postgres.PostgresError && error.code === '55006';
+
+      if (!isTemplateBusy || attempt >= CLONE_ATTEMPTS) {
+        throw error;
+      }
+
+      await sleep(CLONE_RETRY_DELAY_MS);
+    }
   }
 }

--- a/scripts/src/postgres/refresh-dev-base.ts
+++ b/scripts/src/postgres/refresh-dev-base.ts
@@ -5,10 +5,15 @@ import postgres from 'postgres';
 import { buildDevDSN } from './build-dev-dsn';
 
 /**
- * Rebuilds dev_base from nothing: forced drop, create, migrate, seed. The
- * seed step shells out to @vers/db's kysely-ctl script because seeds are a
- * kysely-ctl feature with no library entrypoint. Existing per-worktree clones
- * are untouched — they pick up new migrations on their next session.
+ * Rebuilds dev_base from nothing: forced drop, create, migrate, seed, then
+ * lock. The seed step shells out to @vers/db's kysely-ctl script because
+ * seeds are a kysely-ctl feature with no library entrypoint. Existing
+ * per-worktree clones are untouched — they pick up new migrations on their
+ * next session. The finished template refuses connections (like template0):
+ * cloning fails while any session exists on the source, and Neon parks
+ * invisible backends on recently connected databases for minutes — so the
+ * only connections dev_base ever sees are this rebuild's own, and those are
+ * terminated once it's locked.
  */
 export async function refreshDevBase(maintenanceDSN: string, repoRoot: string): Promise<void> {
   const pg = postgres(maintenanceDSN, { max: 1 });
@@ -35,4 +40,17 @@ export async function refreshDevBase(maintenanceDSN: string, repoRoot: string): 
     env: { DATABASE_URL: devBaseDSN },
     stdio: 'inherit',
   });
+
+  const lock = postgres(maintenanceDSN, { max: 1 });
+
+  try {
+    await lock.unsafe('ALTER DATABASE dev_base WITH ALLOW_CONNECTIONS false');
+
+    await lock`
+      SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+      WHERE datname = 'dev_base' AND usename = current_user
+    `;
+  } finally {
+    await lock.end();
+  }
 }


### PR DESCRIPTION
Closes #484

## Description

First dev tool call after Neon compute idles could fail: internal wake-time sessions on `dev_base` make `CREATE DATABASE … TEMPLATE` error with 55006, and Neon parks invisible backends on recently connected databases for minutes.

- Provisioning retries a 55006 clone failure (4 attempts; each also rides postgres's internal 5s busy-wait, covering ~26s).
- `pg:dev:refresh-base` locks `dev_base` with `ALLOW_CONNECTIONS false` after seeding (like template0) and terminates its own lingering backends, so the template can never be held by a session.
- Reproduced live by holding a session on `dev_base`; post-fix, cloning immediately after a refresh succeeds in ~4s where it previously blocked for minutes.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality