### PR TITLE
docs(#228): add base class template

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -55,3 +55,5 @@ The game's design language and systems.
   reward-design rules
 - [Base classes](./game-design/base-classes.md) — a class as a signature mechanic, the class-design
   laws, and the specialization model
+- [Base class template](./game-design/base-class-template.md) — the fill-in sheet for speccing a
+  single class against the base-class model

--- a/docs/game-design/base-class-template.md
+++ b/docs/game-design/base-class-template.md
@@ -1,0 +1,39 @@
+# Base Class Template
+
+One filled copy specs one class against the base-class model. Fill every field; a blank is an
+undesigned decision, not a default.
+
+## Base Mechanic
+
+- **Name** — working name; a placeholder is fine.
+- **Rule or resource** — the one thing this class adds that no other system expresses. If it names a
+  damage type, a minion, or a crit, it is a build and fails the model — restate it as a generic
+  engine or a transformative rule.
+- **Accrual** — how the resource builds or the rule triggers, in ordinary play.
+- **Effect** — what the resource spends on or the rule changes.
+- **Idle policy** — the automatic decision for every choice the mechanic introduces: when it spends,
+  when a mode switches, what it targets. A mechanic with no sane unattended policy is disqualified.
+- **Drawback check** — name any tradeoff and show it emerges from the mechanic's own rules. A
+  tradeoff bolted on with no mechanical source fails the model.
+
+## Specializations
+
+Aim for three. Each deepens the base mechanic rather than adding a second, so everything the class
+becomes still traces to the one rule.
+
+Per specialization:
+
+- **Name** — working name.
+- **System drawn on** — the universal system it interlocks with (a resource pool, a defensive layer,
+  the beat cadence) or the mechanic itself. Never a damage type or a build archetype.
+- **Tier 1** — the choices offered, one exclusive pick.
+- **Tier 2** — the choices offered, one exclusive pick.
+- **Tier 3** — the choices offered, one exclusive pick.
+
+The tiers may follow any internal framework. One example runs output, then fuel, then fusion: what
+the mechanic drives, then how it scales, then how it and the coupled system become one engine.
+
+## Open Questions
+
+Decisions this class leaves for a later pass — unlock condition, respec cost, specific interactions
+with skills, gear, or enemy families.


### PR DESCRIPTION
## Description

Adds the base-class iteration resource: a fill-in template that specs one class against the model in `base-classes.md`.

- Base-mechanic fields carry the model's laws inline — a required idle policy, and checks that the mechanic is generic-or-transformative rather than a build, with no bolted-on drawback.
- Specialization block captures three specializations, each a three-tier branch drawing on a universal system.
- Linked from the game-design index.

## Testing

Docs-only — no code paths. `format:check` is the relevant gate.

## Context

Closes #228 — this is the final Anatomy item (the design note merged in #488). Downstream tickets filed separately.
