### PR TITLE
docs: revise activity risk model to a forward seed chain

### DIFF
--- a/docs/architecture/game-entropy.md
+++ b/docs/architecture/game-entropy.md
@@ -19,19 +19,29 @@ best-of-N selection value is what every rule below prices; the
 
 ## The seed chain
 
-Per `(avatar, node)`, an append-only seed chain runs forward: each activity's seed derives
-deterministically from the end-state of the previous activity at that node. The chain is
+Per `(avatar, node)`, an append-only seed chain runs forward. The node's first activity takes a
+server-minted seed; every continuation derives its seed deterministically from the previous
+activity's final checkpoint — the `nextSeed` in its frozen hashed subset, which the verifier
+reproduces byte-for-byte. Deriving from an appended-but-unverified checkpoint is safe because
+settlement trusts only the verified prefix and claws back any rejected suffix. The chain is
 client-computable — offline simulation depends on it — and every activity advances it, a failed or
 abandoned attempt exactly as a completed one. The attempt after a failure is a fresh continuation,
 never a replay of the one that failed.
 
 The chain seeds the trajectory only — enemies, timing, survival, experience, and which kills commit
 rolled rewards — and rolled content resolves separately, under a key keyed to the committing kill.
-Steering the chain by failing early or scanning ahead reaches a different trajectory, and a different
-set of committed rolls, but never a more valuable one: steady rewards are published, rolled-reward
-density varies only within bounded margins, and each roll's content carries equal expected value
-regardless of position. The steering returns less than the attempts it costs, so look-ahead stays
-legal by staying unprofitable rather than by being blocked.
+For a market reward a different continuation is worth nothing: steady rewards are published,
+rolled-reward density varies only within bounded margins, and each roll's content carries equal
+expected value regardless of position, so steering the chain for a better reward returns less than
+the attempts it costs.
+
+Competition scores the trajectory itself — clear speed, depth — which is client-computable and does
+vary across attempts, so reward-flatness does not cover it. Difficulty stays within bounded margins
+across attempts, so a re-attempt is a comparable node rather than an easier one, and difficulty
+scales with depth, so re-attempting walls out rather than compounding. The variance that survives is
+caught rather than prevented: every attempt at a node is a link in the append-only, server-verified
+chain, so reroll-scanning is observable and enforced against as a cheat signal. Mining that residual
+takes a purpose-built tool and never clears fully — the ceiling every client-simulated game shares.
 
 ## Rolled rewards and the avatar key
 
@@ -47,9 +57,11 @@ hashed checkpoint subset, so replaying the chain reproduces every coordinate exa
 
 A failed or abandoned attempt advances the chain past its spent indices, so the next attempt rolls at
 fresh coordinates rather than re-reaching the old ones. The reveal needs no replay-identity to stay
-safe: every position carries equal expected value, so re-reaching one through another attempt trades
-a roll for an independent roll of equal worth, never a better one, and the attempt costs more than
-the trade returns.
+safe: content resolves at equal expected value regardless of position, and under server custody a
+coordinate cannot be read until its checkpoint is appended, so re-reaching a position trades one
+blind roll for an independent roll of equal worth. Device custody lets a self-found avatar read its
+own rolls before committing, but its loot never reaches a market, and any standing it earns rides the
+same appended, verifiable record.
 
 Rolled content is `f(key, coordinate)`, where `f` is a keyed PRF — a pseudorandom function whose
 revealed outputs carry no predictive power over unrevealed coordinates. The property matters because
@@ -89,8 +101,8 @@ deploy — so reveal, replay, and mint agree across deploys, parks, and master r
 
 ## Sealed pre-commit salt
 
-Some outcomes carry a tail worth selecting — item affix rolls, rare content. Their entropy stays
-sealed while the decision is open, revealed in two commits:
+Some outcomes carry a tail worth selecting — item affix rolls are the concrete case. Their entropy
+stays sealed while the decision is open, revealed in two commits:
 
 1. **Commit.** The player locks in the spend. The server mints the salt from a server-held secret
    key and stores it sealed. The player sees only a lossy projection derived from it — modifier
@@ -121,10 +133,12 @@ retry never applies a spend twice.
 Sealed salt requires a live round trip, so tail-bearing content is online content wherever it
 appears.
 
-Only a tailed distribution needs the seal. A normalized outcome — a chosen tier, an instance
-modifier bounded to modest scalars with no jackpot combination — carries no tail worth selecting, so
-it rides client-computable entropy anywhere, interactive rerolls included; the
-[economy modes note](../game-design/economy-modes.md) owns that rule.
+Only a rolled tail needs the seal. A chosen tier at a published scalar carries no tail worth
+selecting and rides client-computable entropy anywhere, interactive selection included. A rolled
+magnitude does carry one — bounded is not flat, and best-of-N selects the maximum of a bounded spread
+as readily as an unbounded one — so any modifier that rolls a market-grade quantity (yield, roll or
+pack count, density) is a rolled reward under the tail rule: sealed or forbidden. The
+[economy modes note](../game-design/economy-modes.md) owns the content rule.
 
 For self-found avatars no entropy is sealable at all — the player holds the key — which is
 consistent with their earnings never reaching the market.

--- a/docs/architecture/game-entropy.md
+++ b/docs/architecture/game-entropy.md
@@ -35,14 +35,17 @@ rolled-reward density varies only within bounded margins, and each roll's conten
 expected value regardless of position, so steering the chain for a better reward returns less than
 the attempts it costs.
 
-Competition scores the trajectory itself — clear speed, depth — which is client-computable and does
-vary across attempts, so reward-flatness does not cover it. Difficulty stays within bounded margins
-across attempts, so a re-attempt is a comparable node rather than an easier one, and difficulty
-scales with depth, so re-attempting walls out rather than compounding. The variance that survives is
-caught rather than prevented: every attempt at a node is a link in the append-only, server-verified
-chain, so reroll-scanning is observable and enforced against as a cheat signal. Exploiting the
-residual takes a purpose-built cheat tool, and no detection catches all of it — the ceiling of
-anti-cheat in any game.
+Competition scores the trajectory itself — depth, boss-kill speed — which is client-computable and
+varies across attempts, so reward-flatness does not cover it. Meaningful competition is endgame, and
+the edge a re-attempt buys is bounded by the cost of reaching the position, not by hiding it: the
+peek is free, but the walk is not. Each attempt appends to the chain and spends its metered offline
+time, an entry-gated target burns a non-refundable entry per attempt, and a second competitive avatar
+is a full endgame build's worth of investment. Depth self-limits, because difficulty scales with
+depth until a build can no longer clear regardless of re-attempts. Bounded margins keep any single
+attempt's edge small on top. What survives is caught, not prevented — an avatar whose results ride
+the favorable tail of its verified history is a behavioural cheat signal, scored offline. The
+residual is a wealthy, motivated actor with a purpose-built tool: defended in layers, never zero, the
+ceiling of anti-cheat in any game.
 
 ## Rolled rewards and the avatar key
 

--- a/docs/architecture/game-entropy.md
+++ b/docs/architecture/game-entropy.md
@@ -40,8 +40,9 @@ vary across attempts, so reward-flatness does not cover it. Difficulty stays wit
 across attempts, so a re-attempt is a comparable node rather than an easier one, and difficulty
 scales with depth, so re-attempting walls out rather than compounding. The variance that survives is
 caught rather than prevented: every attempt at a node is a link in the append-only, server-verified
-chain, so reroll-scanning is observable and enforced against as a cheat signal. Mining that residual
-takes a purpose-built tool and never clears fully — the ceiling every client-simulated game shares.
+chain, so reroll-scanning is observable and enforced against as a cheat signal. Exploiting the
+residual takes a purpose-built cheat tool, and no detection catches all of it — the limit inherent to
+any client-simulated game.
 
 ## Rolled rewards and the avatar key
 

--- a/docs/architecture/game-entropy.md
+++ b/docs/architecture/game-entropy.md
@@ -30,7 +30,7 @@ never a replay of the one that failed.
 
 The chain seeds the trajectory only — enemies, timing, survival, experience, and which kills commit
 rolled rewards — and rolled content resolves separately, under a key keyed to the committing kill.
-For a market reward a different continuation is worth nothing: steady rewards are published,
+In reward terms one continuation is worth no more than another: steady rewards are published,
 rolled-reward density varies only within bounded margins, and each roll's content carries equal
 expected value regardless of position, so steering the chain for a better reward returns less than
 the attempts it costs.

--- a/docs/architecture/game-entropy.md
+++ b/docs/architecture/game-entropy.md
@@ -29,11 +29,11 @@ abandoned attempt exactly as a completed one. The attempt after a failure is a f
 never a replay of the one that failed.
 
 The chain seeds the trajectory only — enemies, timing, survival, experience, and which kills commit
-rolled rewards — and rolled content resolves separately, under a key keyed to the committing kill.
-In reward terms one continuation is worth no more than another: steady rewards are published,
-rolled-reward density varies only within bounded margins, and each roll's content carries equal
-expected value regardless of position, so steering the chain for a better reward returns less than
-the attempts it costs.
+rolled rewards — and rolled content resolves separately, at a coordinate fixed by the kill that
+commits it. In reward terms one continuation is worth no more than another: steady rewards are
+published, rolled-reward density varies only within bounded margins, and each roll's content carries
+equal expected value regardless of position, so steering the chain for a better tradeable reward
+returns less than the attempts it costs.
 
 Competition scores the trajectory itself — depth, boss-kill speed — which is client-computable and
 varies across attempts, so reward-flatness does not cover it. Meaningful competition is endgame, and

--- a/docs/architecture/game-entropy.md
+++ b/docs/architecture/game-entropy.md
@@ -37,15 +37,17 @@ the attempts it costs.
 
 Competition scores the trajectory itself — depth, boss-kill speed — which is client-computable and
 varies across attempts, so reward-flatness does not cover it. Meaningful competition is endgame, and
-the edge a re-attempt buys is bounded by the cost of reaching the position, not by hiding it: the
-peek is free, but the walk is not. Each attempt appends to the chain and spends its metered offline
-time, an entry-gated target burns a non-refundable entry per attempt, and a second competitive avatar
-is a full endgame build's worth of investment. Depth self-limits, because difficulty scales with
-depth until a build can no longer clear regardless of re-attempts. Bounded margins keep any single
-attempt's edge small on top. What survives is caught, not prevented — an avatar whose results ride
-the favorable tail of its verified history is a behavioural cheat signal, scored offline. The
-residual is a wealthy, motivated actor with a purpose-built tool: defended in layers, never zero, the
-ceiling of anti-cheat in any game.
+the edge a re-attempt buys is bounded by the cost of reaching the position rather than by hiding it.
+The peek is free; the position is not. An entry-gated target burns a non-refundable entry on every
+attempt, abandons included, so walking the chain toward a favorable seed is paid for in resources; a
+second competitive avatar is a full endgame build's worth of investment; and the counted attempt is
+always played in full. Depth self-limits, because difficulty scales with depth until a build can no
+longer clear regardless of re-attempts. Where a metric is open enough that near-free abandoned
+attempts can churn the chain forward, cost stops gating and detection takes over: an avatar whose
+results ride the favorable tail of its verified history is a behavioural cheat signal, scored
+offline. Bounded margins keep any single attempt's edge small throughout. The residual is a wealthy,
+motivated actor with a purpose-built tool: defended in layers, never zero, the ceiling of anti-cheat
+in any game.
 
 ## Rolled rewards and the avatar key
 

--- a/docs/architecture/game-entropy.md
+++ b/docs/architecture/game-entropy.md
@@ -42,8 +42,10 @@ The peek is free; the position is not. An entry-gated target burns a non-refunda
 attempt, abandons included, so walking the chain toward a favorable seed is paid for in resources; a
 second competitive avatar is a full endgame build's worth of investment; and the counted attempt is
 always played in full. Depth self-limits, because difficulty scales with depth until a build can no
-longer clear regardless of re-attempts. Where a metric is open enough that near-free abandoned
-attempts can churn the chain forward, cost stops gating and detection takes over: an avatar whose
+longer clear regardless of re-attempts.
+
+Where a metric is open enough that near-free abandoned attempts can churn the chain forward, cost
+stops gating and detection takes over: an avatar whose
 results ride the favorable tail of its verified history is a behavioural cheat signal, scored
 offline. Bounded margins keep any single attempt's edge small throughout. The residual is a wealthy,
 motivated actor with a purpose-built tool: defended in layers, never zero, the ceiling of anti-cheat
@@ -103,7 +105,7 @@ this design has.
 
 Every roll is pinned by its activity's `Started` snapshot: `keyVersion` is stamped there beside the
 engine and content versions, and `f` resolves content under the pinned versions — never the live
-deploy — so reveal, replay, and mint agree across deploys, parks, and master rotations.
+deploy — so reveal, replay, and mint agree across deploys and master rotations.
 
 ## Sealed pre-commit salt
 
@@ -116,9 +118,10 @@ stays sealed while the decision is open, revealed in two commits:
    summary and never narrows the realized roll: walking away must never beat resolving, at any tier,
    and that rule bounds how much the projection may reveal. Every decision happens against this
    metadata; the client never holds computable entropy while a decision is open.
-2. **Release.** The server releases the salt and the outcome resolves. Release is commitment: a
-   released position the client never resolves is force-resolved as forfeited — the bundle is lost —
-   at a server-side deadline inside the replay-retention window.
+2. **Release.** The server resolves the outcome under the salt and returns the result; under server
+   custody the salt itself never reaches the client. Release is commitment: a released position the
+   client never resolves is force-resolved as forfeited — the bundle is lost — at a server-side
+   deadline inside the replay-retention window.
 
 Three rules keep the seal honest, independent of what consumes it:
 
@@ -134,17 +137,18 @@ The mechanism admits any tail-bearing outcome; each consumer defines its own pos
 and pinned inputs. Item crafting is the worked case: the position is the craft action in the avatar's
 crafting sequence, the resolution is applying the result to the item, and the pinned inputs are the
 target item and the consumed currency at commit. Application is exactly-once per action — a network
-retry never applies a spend twice.
+retry never applies a spend twice. A craft's affixes draw this sealed salt; a base drop's content
+resolves under the avatar key instead, and the two mechanisms never compose within one outcome.
 
 Sealed salt requires a live round trip, so tail-bearing content is online content wherever it
 appears.
 
 Only a rolled tail needs the seal. A chosen tier at a published scalar carries no tail worth
 selecting and rides client-computable entropy anywhere, interactive selection included. A rolled
-magnitude does carry one — bounded is not flat, and best-of-N selects the maximum of a bounded spread
-as readily as an unbounded one — so any modifier that rolls a market-grade quantity (yield, roll or
-pack count, density) is a rolled reward under the tail rule: sealed or forbidden. The
-[economy modes note](../game-design/economy-modes.md) owns the content rule.
+magnitude does carry a tail: bounded is not flat, and best-of-N selects the maximum of a bounded
+spread as readily as an unbounded one. So any modifier that rolls a market-grade quantity — yield,
+roll or pack count, density — is a rolled reward under the tail rule, and must be sealed or forbidden.
+The [economy modes note](../game-design/economy-modes.md) owns the content rule.
 
 For self-found avatars no entropy is sealable at all — the player holds the key — which is
 consistent with their earnings never reaching the market.
@@ -153,8 +157,9 @@ consistent with their earnings never reaching the market.
 
 Every checkpoint's hashed subset carries an entropy-source tag identifying which source rolled its
 outcomes, present from the first row ever written. The subset is frozen, so the tag cannot be added
-later — and the tag is what lets entropy sources beyond the current two (a verifiable-randomness
-beacon, a rotated key generation) join without a migration. Verification validates the tag against
+later. The two sources it distinguishes today are server-custody and device-custody rolls, and the
+tag is what lets further sources — a verifiable-randomness beacon, a rotated key generation — join
+without a migration. Verification validates the tag against
 the avatar's server-recorded mode; a mismatch is divergence. Settlement stamps an outcome's
 provenance from server records and the tag — never from a client claim.
 

--- a/docs/architecture/game-entropy.md
+++ b/docs/architecture/game-entropy.md
@@ -41,8 +41,8 @@ across attempts, so a re-attempt is a comparable node rather than an easier one,
 scales with depth, so re-attempting walls out rather than compounding. The variance that survives is
 caught rather than prevented: every attempt at a node is a link in the append-only, server-verified
 chain, so reroll-scanning is observable and enforced against as a cheat signal. Exploiting the
-residual takes a purpose-built cheat tool, and no detection catches all of it — the limit inherent to
-any client-simulated game.
+residual takes a purpose-built cheat tool, and no detection catches all of it — the ceiling of
+anti-cheat in any game.
 
 ## Rolled rewards and the avatar key
 

--- a/docs/architecture/game-entropy.md
+++ b/docs/architecture/game-entropy.md
@@ -45,11 +45,10 @@ always played in full. Depth self-limits, because difficulty scales with depth u
 longer clear regardless of re-attempts.
 
 Where a metric is open enough that near-free abandoned attempts can churn the chain forward, cost
-stops gating and detection takes over: an avatar whose
-results ride the favorable tail of its verified history is a behavioural cheat signal, scored
-offline. Bounded margins keep any single attempt's edge small throughout. The residual is a wealthy,
-motivated actor with a purpose-built tool: defended in layers, never zero, the ceiling of anti-cheat
-in any game.
+stops gating and detection takes over: an avatar whose results ride the favorable tail of its
+verified history is a behavioural cheat signal, scored offline. Bounded margins keep any single
+attempt's edge small throughout. The residual is a wealthy, motivated actor with a purpose-built
+tool: defended in layers, never zero, the ceiling of anti-cheat in any game.
 
 ## Rolled rewards and the avatar key
 
@@ -63,13 +62,13 @@ than reused, and `ordinal` indexes the rolled rewards within a checkpoint under 
 canonical ordering, independent of how checkpoints are batched. The coordinate derives only from the
 hashed checkpoint subset, so replaying the chain reproduces every coordinate exactly.
 
-A failed or abandoned attempt advances the chain past its spent indices, so the next attempt rolls at
-fresh coordinates rather than re-reaching the old ones. The reveal needs no replay-identity to stay
-safe: content resolves at equal expected value regardless of position, and under server custody a
-coordinate cannot be read until its checkpoint is appended, so re-reaching a position trades one
+A failed or abandoned attempt advances the chain past its spent indices, so the next attempt rolls
+at fresh coordinates rather than re-reaching the old ones. The reveal needs no replay-identity to
+stay safe: content resolves at equal expected value regardless of position, and under server custody
+a coordinate cannot be read until its checkpoint is appended, so re-reaching a position trades one
 blind roll for an independent roll of equal worth. Device custody lets a self-found avatar read its
-own rolls before committing, but its loot never reaches a market, and any standing it earns rides the
-same appended, verifiable record.
+own rolls before committing, but its loot never reaches a market, and any standing it earns rides
+the same appended, verifiable record.
 
 Rolled content is `f(key, coordinate)`, where `f` is a keyed PRF — a pseudorandom function whose
 revealed outputs carry no predictive power over unrevealed coordinates. The property matters because
@@ -134,11 +133,12 @@ Three rules keep the seal honest, independent of what consumes it:
 - Every input the outcome depends on pins at mint, so deferring resolution cannot improve it.
 
 The mechanism admits any tail-bearing outcome; each consumer defines its own position, resolution,
-and pinned inputs. Item crafting is the worked case: the position is the craft action in the avatar's
-crafting sequence, the resolution is applying the result to the item, and the pinned inputs are the
-target item and the consumed currency at commit. Application is exactly-once per action — a network
-retry never applies a spend twice. A craft's affixes draw this sealed salt; a base drop's content
-resolves under the avatar key instead, and the two mechanisms never compose within one outcome.
+and pinned inputs. Item crafting is the worked case: the position is the craft action in the
+avatar's crafting sequence, the resolution is applying the result to the item, and the pinned inputs
+are the target item and the consumed currency at commit. Application is exactly-once per action — a
+network retry never applies a spend twice. A craft's affixes draw this sealed salt; a base drop's
+content resolves under the avatar key instead, and the two mechanisms never compose within one
+outcome.
 
 Sealed salt requires a live round trip, so tail-bearing content is online content wherever it
 appears.
@@ -147,8 +147,8 @@ Only a rolled tail needs the seal. A chosen tier at a published scalar carries n
 selecting and rides client-computable entropy anywhere, interactive selection included. A rolled
 magnitude does carry a tail: bounded is not flat, and best-of-N selects the maximum of a bounded
 spread as readily as an unbounded one. So any modifier that rolls a market-grade quantity — yield,
-roll or pack count, density — is a rolled reward under the tail rule, and must be sealed or forbidden.
-The [economy modes note](../game-design/economy-modes.md) owns the content rule.
+roll or pack count, density — is a rolled reward under the tail rule, and must be sealed or
+forbidden. The [economy modes note](../game-design/economy-modes.md) owns the content rule.
 
 For self-found avatars no entropy is sealable at all — the player holds the key — which is
 consistent with their earnings never reaching the market.
@@ -159,9 +159,9 @@ Every checkpoint's hashed subset carries an entropy-source tag identifying which
 outcomes, present from the first row ever written. The subset is frozen, so the tag cannot be added
 later. The two sources it distinguishes today are server-custody and device-custody rolls, and the
 tag is what lets further sources — a verifiable-randomness beacon, a rotated key generation — join
-without a migration. Verification validates the tag against
-the avatar's server-recorded mode; a mismatch is divergence. Settlement stamps an outcome's
-provenance from server records and the tag — never from a client claim.
+without a migration. Verification validates the tag against the avatar's server-recorded mode; a
+mismatch is divergence. Settlement stamps an outcome's provenance from server records and the tag —
+never from a client claim.
 
 Tradeability keys on the security property: entropy unpredictable at the moment the outcome was
 committed, and provably tied to the party that minted it. Server-custody rolls and sealed salt have

--- a/docs/architecture/game-entropy.md
+++ b/docs/architecture/game-entropy.md
@@ -17,19 +17,21 @@ variance — modest per-run variance with a rare outlier still hands the scanner
 best-of-N selection value is what every rule below prices; the
 [economy modes note](../game-design/economy-modes.md) turns it into the reward-design rules.
 
-## The anchored seed chain
+## The seed chain
 
-Per `(avatar, node)`, the server anchors an append-only seed chain: the next run's seed derives
-deterministically from the stored end of the previous run at that node. The anchor is the last
-**verified** checkpoint's end-state at that node. Terminal activity states never advance it past the
-verified prefix, and rejecting a stream at version N resets it to the end of version N−1. Abandoning
-and restarting therefore replays the same continuation — there is nothing to re-roll. This single
-rule closes seed-fishing, death-scumming via early flush, and retry-branch selection.
+Per `(avatar, node)`, an append-only seed chain runs forward: each activity's seed derives
+deterministically from the end-state of the previous activity at that node. The chain is
+client-computable — offline simulation depends on it — and every activity advances it, a failed or
+abandoned attempt exactly as a completed one. The attempt after a failure is a fresh continuation,
+never a replay of the one that failed.
 
-The chain is client-computable by design — offline simulation depends on it. It seeds the
-simulation's trajectory only: enemies, timing, survival, experience, and which kills commit rolled
-rewards. Rolled content never derives from it. Foreseeing the trajectory is throughput knowledge —
-routing, kill counts, survival — and the economy prices it as such.
+The chain seeds the trajectory only — enemies, timing, survival, experience, and which kills commit
+rolled rewards — and rolled content resolves separately, under a key keyed to the committing kill.
+Steering the chain by failing early or scanning ahead reaches a different trajectory, and a different
+set of committed rolls, but never a more valuable one: steady rewards are published, rolled-reward
+density varies only within bounded margins, and each roll's content carries equal expected value
+regardless of position. The steering returns less than the attempts it costs, so look-ahead stays
+legal by staying unprofitable rather than by being blocked.
 
 ## Rolled rewards and the avatar key
 
@@ -37,14 +39,17 @@ A rolled reward is a reward whose value lives in its roll — an item drop is th
 commitment comes first, the reveal second: a kill that produces one commits it at a deterministic
 coordinate, and its content is rolled from that coordinate later, under a key.
 
-The coordinate is `(avatarID, nodeID, chainIndex, ordinal)`: `chainIndex` counts checkpoints from
-the node's seed-chain anchor, and `ordinal` indexes the rolled rewards within a checkpoint under the
-simulation's canonical ordering, independent of how checkpoints are batched. The coordinate derives
-only from the hashed checkpoint subset.
+The coordinate is `(avatarID, nodeID, chainIndex, ordinal)`: `chainIndex` counts checkpoints along
+the node's seed chain, monotonic across activities so a failed attempt's indices are spent rather
+than reused, and `ordinal` indexes the rolled rewards within a checkpoint under the simulation's
+canonical ordering, independent of how checkpoints are batched. The coordinate derives only from the
+hashed checkpoint subset, so replaying the chain reproduces every coordinate exactly.
 
-The coordinate is also restart-stable: the chain replays the same continuation, so abandoning and
-restarting reproduces the identical coordinate. That stability is what makes the reveal safe.
-Peeking a roll and replaying the position shows the same roll — a peek has zero option value.
+A failed or abandoned attempt advances the chain past its spent indices, so the next attempt rolls at
+fresh coordinates rather than re-reaching the old ones. The reveal needs no replay-identity to stay
+safe: every position carries equal expected value, so re-reaching one through another attempt trades
+a roll for an independent roll of equal worth, never a better one, and the attempt costs more than
+the trade returns.
 
 Rolled content is `f(key, coordinate)`, where `f` is a keyed PRF — a pseudorandom function whose
 revealed outputs carry no predictive power over unrevealed coordinates. The property matters because
@@ -107,16 +112,11 @@ Three rules keep the seal honest, independent of what consumes it:
   arrives, nothing resolves.
 - Every input the outcome depends on pins at mint, so deferring resolution cannot improve it.
 
-Each consumer of the mechanism defines its own position, resolution, and pinned inputs:
-
-- **Juiced instances**: the position is the node-anchored chain position — the same restart-stable
-  index that keys reward coordinates — the resolution is the run itself, and the pinned input is the
-  build snapshot, so a peeked outcome cannot be beaten by out-leveling first. Forfeiture lifts the
-  node's gate.
-- **Item crafting**: the position is the craft action in the avatar's crafting sequence, the
-  resolution is applying the result to the item, and the pinned inputs are the target item and the
-  consumed currency at commit. Application is exactly-once per action — a network retry never
-  applies a spend twice.
+The mechanism admits any tail-bearing outcome; each consumer defines its own position, resolution,
+and pinned inputs. Item crafting is the worked case: the position is the craft action in the avatar's
+crafting sequence, the resolution is applying the result to the item, and the pinned inputs are the
+target item and the consumed currency at commit. Application is exactly-once per action — a network
+retry never applies a spend twice.
 
 Sealed salt requires a live round trip, so tail-bearing content is online content wherever it
 appears.

--- a/docs/architecture/game-simulation.md
+++ b/docs/architecture/game-simulation.md
@@ -3,13 +3,21 @@
 How gameplay is computed on the client, recorded as checkpoint streams, and trusted through server
 replay.
 
+## Activities and encounters
+
+An **activity** is one attempt at a piece of content, recorded as a single append-only checkpoint
+stream and verified as a unit. Every activity has a type. A **world map encounter** is the type where
+an avatar fights through a node's enemies, arranged in **waves** — ordered groups the avatar clears
+one at a time. `@vers/idle-core` runs any activity type; `@vers/game-utils` derives a world map
+encounter's waves, enemies, and timing from `(node, seed, content)` as a pure function.
+
 ## The deterministic core
 
 The simulation is a pure function: a server-authored input snapshot plus a seed stream fully
-determine every tick. The engine (`@vers/idle-core`) and encounter derivation (`@vers/game-utils`)
-are shared libraries, so the client worker and the verification worker — the server process that
-replays submitted checkpoints — import the same code and compute byte-identical results from the
-same inputs.
+determine every tick. The engine (`@vers/idle-core`) and world map encounter derivation
+(`@vers/game-utils`) are shared libraries, so the client worker and the verification worker — the
+server process that replays submitted checkpoints — import the same code and compute byte-identical
+results from the same inputs.
 
 The client does all real-time simulation. One writer per browser profile runs the fixed-timestep
 loop — a SharedWorker, with leader election where SharedWorker is unavailable — and other tabs are
@@ -75,15 +83,15 @@ crashed worker retries idempotently.
 
 - First-clears, achievements, and other one-shot grants insert into a unique-keyed grant table with
   `ON CONFLICT DO NOTHING` inside the same transaction — idempotent across re-farms and replays.
-- Item instances mint at settlement: identity is the restart-stable reward coordinate and content is
-  rolled from the avatar's key under the activity's pinned versions (see
-  [game entropy](./game-entropy.md)), so re-verification never duplicates or re-rolls an item.
+- Item instances mint at settlement: identity is the reward coordinate and content is rolled from the
+  avatar's key under the activity's pinned versions (see [game entropy](./game-entropy.md)), so
+  re-verification never duplicates or re-rolls an item.
 - Rolled content is revealed only for coordinates whose producing checkpoint is durably appended,
   and the reveal is a pure function of the coordinate — append retries and bulk offline resends
   return identical reveals.
-- A rejected claim rolls back by forward compensating events, never by snapshot restore: the node's
-  seed anchor resets to the verified prefix and revealed-but-unsettled rewards past it are cleared
-  from optimistic display.
+- A rejected claim rolls back by forward compensating events, never by snapshot restore: settlement
+  resets to the node's verified prefix and revealed-but-unsettled rewards past it are cleared from
+  optimistic display.
 
 Resume always anchors on the last verified checkpoint. The client rebuilds optimistic state by
 simulating forward from that anchor; it never renders the server's settled progression columns

--- a/docs/architecture/game-simulation.md
+++ b/docs/architecture/game-simulation.md
@@ -73,11 +73,12 @@ boundary — never mid-session. A stream that fails verification repeatedly is q
 on rather than retried forever.
 
 Replay divergence is not the only cheat signal. Because every attempt at a node is a link in the
-append-only, server-verified chain, reroll-scanning is visible in the record: an avatar whose
-completions land in the favorable tail of a node's distribution after abnormally many failed attempts
-stands out from honest play. It is a behavioural signal, not a divergence, scored under the same
-restraint — a soft consequence before a hard one, at a session boundary — because an honest grinder
-also fails, and a false accusation costs more than the edge it denies.
+append-only, server-verified chain, reroll-scanning leaves a record: an avatar whose results ride the
+favorable tail of its own verified history — faster clears, better positions, more often than the
+distribution predicts — stands out from honest play, whether it reached them by failing attempts or
+by completing and discarding them. It is a behavioural signal, not a divergence, scored under the
+same restraint — a soft consequence before a hard one, at a session boundary — because an honest
+grinder also swings, and a false accusation costs more than the edge it denies.
 
 The primary health gauge is verification lag: the oldest unverified append across all streams.
 Rejection rates are tracked split by cause — an integrity-mismatch spike is almost always a bad

--- a/docs/architecture/game-simulation.md
+++ b/docs/architecture/game-simulation.md
@@ -27,11 +27,13 @@ decide whether to trust what the client submitted.
 
 ## Server-authored inputs
 
-`startActivity` is a server action that owns every simulation input: it mints the seed (see
-[game entropy](./game-entropy.md)), resolves the node's enemy content, snapshots the avatar's build
-(equipment, passives, level) from server truth, and stamps the engine and content versions.
-Client-submitted activity and avatar payloads are display hints — the verifier replays from the
-snapshot, never from round-tripped values.
+`startActivity` is a server action that owns every simulation input: it mints the seed for a node's
+first activity and derives each continuation's seed from the previous activity's committed checkpoint
+(see [game entropy](./game-entropy.md)), resolves the node's enemy content, snapshots the avatar's
+build (equipment, passives, level) from server truth, and stamps the engine and content versions.
+Client-submitted activity and avatar payloads are display hints, and a continuation's seed is a
+client computation the verifier reproduces from the committed chain — never a round-tripped value
+taken on trust.
 
 Build mutations are gated while an activity is active: level-ups render optimistically and apply
 between activities. A snapshot that cannot change mid-activity is what makes replay exact.
@@ -69,6 +71,13 @@ operational state, not judged as a cheat signal. Only reproducible divergence un
 version and snapshot, on repetition, is treated as cheating, and enforcement lands at a session
 boundary — never mid-session. A stream that fails verification repeatedly is quarantined and alerted
 on rather than retried forever.
+
+Replay divergence is not the only cheat signal. Because every attempt at a node is a link in the
+append-only, server-verified chain, reroll-scanning is visible in the record: an avatar whose
+completions land in the favorable tail of a node's distribution after abnormally many failed attempts
+stands out from honest play. It is a behavioural signal, not a divergence, scored under the same
+restraint — a soft consequence before a hard one, at a session boundary — because an honest grinder
+also fails, and a false accusation costs more than the edge it denies.
 
 The primary health gauge is verification lag: the oldest unverified append across all streams.
 Rejection rates are tracked split by cause — an integrity-mismatch spike is almost always a bad

--- a/docs/architecture/game-simulation.md
+++ b/docs/architecture/game-simulation.md
@@ -6,10 +6,10 @@ replay.
 ## Activities and encounters
 
 An **activity** is one attempt at a piece of content, recorded as a single append-only checkpoint
-stream and verified as a unit. Every activity has a type. A **world map encounter** is the type where
-an avatar fights through a node's enemies, arranged in **waves** — ordered groups the avatar clears
-one at a time. `@vers/idle-core` runs any activity type; `@vers/game-utils` derives a world map
-encounter's waves, enemies, and timing from `(node, seed, content)` as a pure function.
+stream and verified as a unit. Every activity has a type. A **world map encounter** is the type
+where an avatar fights through a node's enemies, arranged in **waves** — ordered groups the avatar
+clears one at a time. `@vers/idle-core` runs any activity type; `@vers/game-utils` derives a world
+map encounter's waves, enemies, and timing from `(node, seed, content)` as a pure function.
 
 ## The deterministic core
 
@@ -73,10 +73,10 @@ boundary — never mid-session. A stream that fails verification repeatedly is q
 on rather than retried forever.
 
 Replay divergence is not the only cheat signal. Because every attempt at a node is a link in the
-append-only, server-verified chain, reroll-scanning leaves a record: an avatar whose results ride the
-favorable tail of its own verified history — faster clears, better positions, more often than the
-distribution predicts — stands out from honest play, whether it reached them by failing attempts or
-by completing and discarding them. This is a behavioural signal, not a divergence, and it is
+append-only, server-verified chain, reroll-scanning leaves a record: an avatar whose results ride
+the favorable tail of its own verified history — faster clears, better positions, more often than
+the distribution predicts — stands out from honest play, whether it reached them by failing attempts
+or by completing and discarding them. This is a behavioural signal, not a divergence, and it is
 scored with the same restraint: a soft consequence before a hard one, always at a session boundary.
 Honest grinders swing too, and a false accusation costs more than the edge it denies.
 
@@ -93,8 +93,8 @@ crashed worker retries idempotently.
 
 - First-clears, achievements, and other one-shot grants insert into a unique-keyed grant table with
   `ON CONFLICT DO NOTHING` inside the same transaction — idempotent across re-farms and replays.
-- Item instances mint at settlement: identity is the reward coordinate and content is rolled from the
-  avatar's key under the activity's pinned versions (see [game entropy](./game-entropy.md)), so
+- Item instances mint at settlement: identity is the reward coordinate and content is rolled from
+  the avatar's key under the activity's pinned versions (see [game entropy](./game-entropy.md)), so
   re-verification never duplicates or re-rolls an item.
 - Rolled content is revealed only for coordinates whose producing checkpoint is durably appended,
   and the reveal is a pure function of the coordinate — append retries and bulk offline resends

--- a/docs/architecture/game-simulation.md
+++ b/docs/architecture/game-simulation.md
@@ -28,12 +28,12 @@ decide whether to trust what the client submitted.
 ## Server-authored inputs
 
 `startActivity` is a server action that owns every simulation input: it mints the seed for a node's
-first activity and derives each continuation's seed from the previous activity's committed checkpoint
+first activity and derives each continuation's seed from the previous activity's appended checkpoint
 (see [game entropy](./game-entropy.md)), resolves the node's enemy content, snapshots the avatar's
 build (equipment, passives, level) from server truth, and stamps the engine and content versions.
 Client-submitted activity and avatar payloads are display hints, and a continuation's seed is a
-client computation the verifier reproduces from the committed chain — never a round-tripped value
-taken on trust.
+client computation the verifier reproduces from the appended chain — online and offline alike, never
+a round-tripped value taken on trust.
 
 Build mutations are gated while an activity is active: level-ups render optimistically and apply
 between activities. A snapshot that cannot change mid-activity is what makes replay exact.

--- a/docs/architecture/game-simulation.md
+++ b/docs/architecture/game-simulation.md
@@ -76,9 +76,9 @@ Replay divergence is not the only cheat signal. Because every attempt at a node 
 append-only, server-verified chain, reroll-scanning leaves a record: an avatar whose results ride the
 favorable tail of its own verified history — faster clears, better positions, more often than the
 distribution predicts — stands out from honest play, whether it reached them by failing attempts or
-by completing and discarding them. It is a behavioural signal, not a divergence, scored under the
-same restraint — a soft consequence before a hard one, at a session boundary — because an honest
-grinder also swings, and a false accusation costs more than the edge it denies.
+by completing and discarding them. This is a behavioural signal, not a divergence, and it is
+scored with the same restraint: a soft consequence before a hard one, always at a session boundary.
+Honest grinders swing too, and a false accusation costs more than the edge it denies.
 
 The primary health gauge is verification lag: the oldest unverified append across all streams.
 Rejection rates are tracked split by cause — an integrity-mismatch spike is almost always a bad

--- a/docs/game-design/economy-modes.md
+++ b/docs/game-design/economy-modes.md
@@ -1,9 +1,10 @@
 # Economy Modes & Reward Integrity
 
 This note defines how Vers keeps a fair player economy when the simulation runs on the player's
-machine: the mode chosen at avatar creation, the rules for which outcomes may be predictable, and
-juice's economic role. The entropy architecture doc owns the mechanisms; this note owns the design
-they enforce.
+machine: the mode chosen at avatar creation, the rules for which outcomes may be predictable, and the
+economic role of juice — spending that modifies an expedition instance. The
+[entropy architecture doc](../architecture/game-entropy.md) owns the mechanisms; this note owns the
+design they enforce.
 
 ## Perfect Foresight
 
@@ -36,9 +37,9 @@ choice is a single fact — who holds the avatar's loot key.
   own kind of mastery.
 
 Trade is the default and the pre-selected choice at creation. Self-Found is a deliberate opt-in
-behind an explicit warning, because the choice is permanent: a self-found avatar's wealth was rolled
-under a key its player holds — accumulated under perfect foresight — so migrating it into a market
-would launder foresight-selected value. Permanence is the price of a key of one's own. A new player
+behind an explicit warning, because the choice is permanent. A self-found avatar accumulates its
+wealth under perfect foresight, rolled against a key its own player holds; migrating that wealth into
+a market would launder foresight-selected value. Permanence is the price of a key of one's own. A new player
 who never touches the market loses nothing by staying Trade; only Self-Found forecloses anything.
 
 The mode difference carries its own fiction: the market institution assays and logs a trade avatar's
@@ -73,10 +74,10 @@ on computing it — so they are priced for foresight:
 trajectory commits them, and which kills produce them, and how many, is trajectory knowledge:
 foreseeing that reveals a route's throughput, never what any roll contains.
 
-Roll counts are foreseeable, and every rolled reward carries market value for a trade avatar. Roll
-density therefore obeys the tail rule that rolled content no longer needs: routes may differ
-modestly in rolls per hour — grindy play averages out — but no route is a density jackpot worth
-scanning thousands of futures to find. Density outliers belong in invested content, priced by their
+Roll counts are foreseeable, and every rolled reward carries market value for a trade avatar. Density
+is foreseeable where content is not, so it must obey the tail rule: routes may differ modestly in
+rolls per hour — grindy play averages out — but no route is a density jackpot worth scanning
+thousands of futures to find. Density outliers belong in invested content, priced by their
 cost.
 
 What a roll contains is never client-computable for a trade avatar: content resolves under the

--- a/docs/game-design/economy-modes.md
+++ b/docs/game-design/economy-modes.md
@@ -51,8 +51,10 @@ a list of today's features:
 
 - No container is shared across the boundary — stashes, banks, prize pools — including between one
   account's own avatars.
-- Self-found ladders rank on server-verifiable play — depth, level, clear speed — never on gear,
-  which only the player's own device rolled.
+- Self-found ladders rank on server-verifiable play — depth, level, clear speed. Those outcomes are
+  gear-influenced and a device-held key rolls that gear locally, so self-found standing leans harder
+  on reroll detection than a trade avatar's; the same appended, verified record defends it, and it is
+  not held to be tamper-proof.
 - Avatars are league-scoped, so league resets contain self-found holdings with no extra rule.
 
 ## Reward Classes
@@ -93,12 +95,13 @@ while players sleep. The economy-loop note owns both.
 Juice is spending to modify an expedition instance. Where its randomness lives follows the tail
 rule, not the mechanic:
 
-- **Tiers and instance modifiers** — choose a tier, roll and reroll the instance's modifiers, lock
-  in. Modifier outcomes are normalized by design: bounded scalars on difficulty and yield, no
-  jackpot combinations, never coupled to a reward tail. A tail-free distribution reveals nothing
-  worth selecting, so instance rolling is client-trustable and works anywhere, offline included,
-  rerolls and all. Keeping modifiers jackpot-free is a standing content constraint, the same
-  obligation as roll density.
+- **Tiers and instance modifiers** — choose a tier, then roll and reroll the instance's flavour
+  modifiers, lock in. Any modifier that scales a market-grade quantity — yield, roll or pack count —
+  is set by the chosen tier at a published scalar, never rolled, so it reveals nothing to select. The
+  modifiers that may be rolled are normalized: bounded scalars, no jackpot combinations, never
+  coupled to a reward tail. A tail-free distribution is client-trustable and works anywhere, offline
+  included, rerolls and all. Keeping rolled modifiers tail-free is a standing content constraint, the
+  same obligation as roll density.
 - **Item crafting** — affix rolls are the tail; shaping items is the point. Crafting rolls draw
   sealed server entropy behind the preview flow, online. Self-found avatars craft against their own
   key — nothing is sealed from them, and nothing they make can leave.

--- a/docs/game-design/economy-modes.md
+++ b/docs/game-design/economy-modes.md
@@ -79,10 +79,12 @@ modestly in rolls per hour — grindy play averages out — but no route is a de
 scanning thousands of futures to find. Density outliers belong in invested content, priced by their
 cost.
 
-What a roll contains is never predictable for a trade avatar: content resolves under the server-held
-key only after every choice that produced the roll is committed. Loot therefore drops everywhere —
-base expeditions, invested expeditions, the offline loop — with full ordinary variance, and none of
-it can be fished for.
+What a roll contains is never client-computable for a trade avatar: content resolves under the
+server-held key, revealed only once its checkpoint is durably appended. A revealed roll can be
+observed before it verifies but cannot leave the account until it does, and re-reaching its
+coordinate means re-appending the path — so early observation yields no tradeable edge. Loot
+therefore drops everywhere — base expeditions, invested expeditions, the offline loop — with full
+ordinary variance.
 
 The wider economy design inherits two obligations. First, offline accrual is wall-clock metered and
 non-resettable: an hour of absence yields an hour of progress, capped, and a window cannot be banked
@@ -117,8 +119,9 @@ juice mechanics evolve:
   classified by the tail rule like any reward.
 - Difficulty conditions on the chosen tier alone, with flat expected value per cost across tiers.
 - A sealed craft settles all-or-nothing, and a committed craft always resolves — as bailed when
-  abandoned. Bailing forfeits the bundle, and rolled content stays sealed under the avatar key even
-  after the salt releases, so a bail can never select rewards.
+  abandoned. Bailing forfeits the bundle; under server custody rolled content stays sealed even after
+  the salt releases, so a trade bail selects nothing. A self-found craft has nothing sealed from it,
+  so a bail there can select — priced by the forfeited bundle and confined off-market.
 - Death costs are uniform: the core note's rules apply to juiced and base play alike. Avoiding a
   foreseen death — routing before a spend, bailing after one — is accepted texture, and the bundle
   forfeit is the bail's price.

--- a/docs/game-design/economy-modes.md
+++ b/docs/game-design/economy-modes.md
@@ -1,8 +1,8 @@
 # Economy Modes & Reward Integrity
 
 This note defines how Vers keeps a fair player economy when the simulation runs on the player's
-machine: the mode chosen at avatar creation, the rules for which outcomes may be predictable, and the
-economic role of juice — spending that modifies an expedition instance. The
+machine: the mode chosen at avatar creation, the rules for which outcomes may be predictable, and
+the economic role of juice — spending that modifies an activity. The
 [entropy architecture doc](../architecture/game-entropy.md) owns the mechanisms; this note owns the
 design they enforce.
 
@@ -14,7 +14,7 @@ the runs ahead, see what happens, and choose which futures to play. This cannot 
 priced.
 
 Foresight is harmless when outcomes are steady and devastating when they are rare. A player who can
-scan thousands of regions for the one future holding a great roll gets that roll's value without
+scan thousands of nodes for the one future holding a great roll gets that roll's value without
 playing for it, and a market lets them sell it. The economy's one hard rule follows:
 
 **An outcome worth selecting may be predictable, or it may reach the market — never both.**
@@ -29,8 +29,8 @@ choice is a single fact — who holds the avatar's loot key.
 
 - **Trade** — full market access. The avatar's loot key stays on the server, so loot resolves as the
   run's records land: live while connected, in one reveal on returning from offline. The same
-  expedition yields the same loot either way — being away changes when loot is seen, never what it
-  is worth.
+  activity yields the same loot either way — being away changes when loot is seen, never what it is
+  worth.
 - **Self-Found** — the avatar's loot key lives with the player, so loot resolves locally, offline,
   in real time, juice included. Nothing the avatar earns can ever be traded, gifted, or moved to
   another avatar. Foresight is legitimate texture: planning around a computed future is the mode's
@@ -38,14 +38,14 @@ choice is a single fact — who holds the avatar's loot key.
 
 Trade is the default and the pre-selected choice at creation. Self-Found is a deliberate opt-in
 behind an explicit warning, because the choice is permanent. A self-found avatar accumulates its
-wealth under perfect foresight, rolled against a key its own player holds; migrating that wealth into
-a market would launder foresight-selected value. Permanence is the price of a key of one's own. A new player
-who never touches the market loses nothing by staying Trade; only Self-Found forecloses anything.
+wealth under perfect foresight, rolled against a key its own player holds; migrating that wealth
+into a market would launder foresight-selected value. Permanence is the price of a key of one's own.
+A new player who never touches the market loses nothing by staying Trade; only Self-Found forecloses
+anything.
 
 The mode difference carries its own fiction: the market institution assays and logs a trade avatar's
 finds — that is why they take a moment to appear and why they can be sold — while a self-found
-avatar's haul is off the books, never assayed, kept in its own hands. Both labels follow the naming
-grammar in the core note before they reach the UI.
+avatar's haul is off the books, never assayed, kept in its own hands.
 
 Mode partitions every economic container and every reward-bearing space — a standing invariant, not
 a list of today's features:
@@ -54,8 +54,8 @@ a list of today's features:
   account's own avatars.
 - Self-found ladders rank on server-verifiable play — depth, level, clear speed. Those outcomes are
   gear-influenced and a device-held key rolls that gear locally, so self-found standing leans harder
-  on reroll detection than a trade avatar's; the same appended, verified record defends it, and it is
-  not held to be tamper-proof.
+  on reroll detection than a trade avatar's; the same appended, verified record defends it, and it
+  is not held to be tamper-proof.
 - Avatars are league-scoped, so league resets contain self-found holdings with no extra rule.
 
 ## Reward Classes
@@ -68,23 +68,23 @@ on computing it — so they are priced for foresight:
 - **Experience.** Per-encounter variance is acceptable — foreseeing it only improves routing, which
   is calculator play, not arbitrage.
 - **Fixed material and currency trickles** at published rates.
-- **Completion payouts** — first-clear bonuses and unlock grants, fixed per region.
+- **Completion payouts** — first-clear bonuses and unlock grants, fixed per node.
 
 **Rolled rewards** are rewards whose value lives in the roll — item drops are the concrete case. The
 trajectory commits them, and which kills produce them, and how many, is trajectory knowledge:
 foreseeing that reveals a route's throughput, never what any roll contains.
 
-Roll counts are foreseeable, and every rolled reward carries market value for a trade avatar. Density
-is foreseeable where content is not, so it must obey the tail rule: routes may differ modestly in
-rolls per hour — grindy play averages out — but no route is a density jackpot worth scanning
-thousands of futures to find. Density outliers belong in invested content, priced by their
+Roll counts are foreseeable, and every rolled reward carries market value for a trade avatar.
+Density is foreseeable where content is not, so it must obey the tail rule: routes may differ
+modestly in rolls per hour — grindy play averages out — but no route is a density jackpot worth
+scanning thousands of futures to find. Density outliers belong in invested content, priced by their
 cost.
 
 What a roll contains is never client-computable for a trade avatar: content resolves under the
 server-held key, revealed only once its checkpoint is durably appended. A revealed roll can be
 observed before it verifies but cannot leave the account until it does, and re-reaching its
 coordinate means re-appending the path — so early observation yields no tradeable edge. Loot
-therefore drops everywhere — base expeditions, invested expeditions, the offline loop — with full
+therefore drops everywhere — base activities, invested activities, the offline loop — with full
 ordinary variance.
 
 The wider economy design inherits two obligations. First, offline accrual is wall-clock metered and
@@ -95,16 +95,16 @@ while players sleep. The economy-loop note owns both.
 
 ## Juice
 
-Juice is spending to modify an expedition instance. Where its randomness lives follows the tail
-rule, not the mechanic:
+Juice is spending to modify an activity. Where its randomness lives follows the tail rule, not the
+mechanic:
 
-- **Tiers and instance modifiers** — choose a tier, then roll and reroll the instance's flavour
+- **Tiers and activity modifiers** — choose a tier, then roll and reroll the activity's flavour
   modifiers, lock in. Any modifier that scales a market-grade quantity — yield, roll or pack count —
-  is set by the chosen tier at a published scalar, never rolled, so it reveals nothing to select. The
-  modifiers that may be rolled are normalized: bounded scalars, no jackpot combinations, never
+  is set by the chosen tier at a published scalar, never rolled, so it reveals nothing to select.
+  The modifiers that may be rolled are normalized: bounded scalars, no jackpot combinations, never
   coupled to a reward tail. A tail-free distribution is client-trustable and works anywhere, offline
-  included, rerolls and all. Keeping rolled modifiers tail-free is a standing content constraint, the
-  same obligation as roll density.
+  included, rerolls and all. Keeping rolled modifiers tail-free is a standing content constraint,
+  the same obligation as roll density.
 - **Item crafting** — affix rolls are the tail; shaping items is the point. Crafting rolls draw
   sealed server entropy behind the preview flow, online. Self-found avatars craft against their own
   key — nothing is sealed from them, and nothing they make can leave.
@@ -120,21 +120,20 @@ juice mechanics evolve:
   classified by the tail rule like any reward.
 - Difficulty conditions on the chosen tier alone, with flat expected value per cost across tiers.
 - A sealed craft settles all-or-nothing, and a committed craft always resolves — as bailed when
-  abandoned. Bailing forfeits the bundle; under server custody rolled content stays sealed even after
-  the salt releases, so a trade bail selects nothing. A self-found craft has nothing sealed from it,
-  so a bail there can select — priced by the forfeited bundle and confined off-market.
-- Death costs are uniform: the core note's rules apply to juiced and base play alike. Avoiding a
-  foreseen death — routing before a spend, bailing after one — is accepted texture, and the bundle
-  forfeit is the bail's price.
+  abandoned. Bailing forfeits the bundle; under server custody rolled content stays sealed even
+  after the salt releases, so a trade bail selects nothing. A self-found craft has nothing sealed
+  from it, so a bail there can select — priced by the forfeited bundle and confined off-market.
+- Death costs are uniform across juiced and base play. Avoiding a foreseen death — routing before a
+  spend, bailing after one — is accepted texture, and the bundle forfeit is the bail's price.
 
 ## Extraction & Settlement
 
-Progress and yield render instantly; verification is latency, not a gate on play. Extraction — the
-core note's mid-run banking policy — is where the economy's gate sits. Extracted yield joins the
-avatar's holdings immediately, but for a trade avatar it leaves the account (trade, market, guild)
-only once the checkpoints that produced it verify. Opening a trade bumps the player's unverified
-checkpoints to the front of the verification queue, so honest players feel a brief gate exactly when
-they transfer and nowhere else.
+Progress and yield render instantly; verification is latency, not a gate on play. Extraction —
+mid-run banking of yield — is where the economy's gate sits. Extracted yield joins the avatar's
+holdings immediately, but for a trade avatar it leaves the account (trade, market, guild) only once
+the checkpoints that produced it verify. Opening a trade bumps the player's unverified checkpoints
+to the front of the verification queue, so honest players feel a brief gate exactly when they
+transfer and nowhere else.
 
 The verification gate follows value through transformation: an output crafted, salvaged, or combined
 from an unverified input inherits the gate until every contributing input verifies. Item crafting
@@ -142,9 +141,9 @@ that consumes tradeable currency rolls server-side — the tail rule is the same
 and applies exactly once per action.
 
 Experience and levels are never tradeable, render optimistically, and reconcile lazily. Defeat costs
-follow the core note, with one constraint from foresight: survival is trajectory knowledge, so a
-player who plans can avoid nearly every death — death is a texture cost, and the economy never
-relies on it as a sink or a throughput brake.
+carry one constraint from foresight: survival is trajectory knowledge, so a player who plans can
+avoid nearly every death — death is a texture cost, and the economy never relies on it as a sink or
+a throughput brake.
 
 ## Competition
 


### PR DESCRIPTION
## Summary

Revises the activity risk model to a **forward seed chain**: the per-`(avatar, node)` chain advances on every activity end, failure included, so a re-attempt is a fresh continuation rather than a replay. Anti-cheat is re-grounded on equal-expected-value continuations plus steering cost — not replay-identity — which lets failure yield a new fight without reopening reward selection.

## Changes

- `game-entropy.md`: "The anchored seed chain" → "The seed chain" (forward, advances on failure); coordinate `chainIndex` monotonic, restart-stability dropped; reveal safety re-grounded on EV + cost; sealed salt narrowed to a general tail mechanism with item crafting as the worked example (juiced-instances cut — juice is tail-free).
- `game-simulation.md`: new "Activities and encounters" vocabulary (activity / activity type / world map encounter / wave / enemy); "encounter derivation" → "world map encounter derivation"; coordinate no longer "restart-stable"; anchor demoted to a settlement watermark.
- `economy-modes.md`: untouched — already rests on EV-neutrality.

## Review notes

Design-of-record only; no code. An adversarial red-team (chain-steering, coordinate-reroll, tail-in-juice, consistency) runs against these claims; its verdict lands as a PR comment.

Cascades (follow-ups, not this PR): #177 reframed as forward chain + settlement watermark; #129/#469 vocabulary + coordinate; #183 salt scoped to crafting; idle-core `EnemyGroup`→`Wave` / `WorldNode`→`WorldMapEncounter` rename; #169 rework.
