### PR TITLE
feat: add read-only Neon MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -4,6 +4,10 @@
       "type": "http",
       "url": "https://mcp.axiom.co/mcp"
     },
+    "neon": {
+      "type": "http",
+      "url": "https://mcp.neon.tech/mcp?readonly=true"
+    },
     "bugsink": {
       "command": "sh",
       "args": [


### PR DESCRIPTION
## Description

Add Neon's hosted MCP server to `.mcp.json` so agents can inspect the Neon project (branches, monitoring, usage, SQL) without leaving the session. Wired read-only.

- Uses the hosted endpoint `https://mcp.neon.tech/mcp?readonly=true`, matching the `axiom` http/OAuth pattern — no API key to mint or store, no service-account sprawl.
- `?readonly=true` refuses writes (branch creation, migrations) while keeping project/branch/monitoring reads and schema/SQL inspection; branch management stays with `neonctl`, as today.
- Complements the existing `postgres` MCP (SQL against prod/dev) with Neon control-plane visibility — the gap felt while diagnosing the recent outbound-traffic spike.

## Testing

- [x] `bun run format:check` passes
- [ ] N/A — config only

## Context

Drop `?readonly=true` later if agent-driven branch management is wanted. Companion PR vendors the Neon agent skills (#494).