### PR TITLE
feat(bugsink): store sourcemap files in R2 instead of Neon

### DIFF
--- a/apps/bugsink/Dockerfile
+++ b/apps/bugsink/Dockerfile
@@ -1,0 +1,17 @@
+# Bugsink with an R2 object-storage backend for uploaded files. Extends the
+# pinned stock image with boto3 and our sourcemap-to-R2 wiring; upgrading Bugsink
+# is still a tag bump on the FROM line. The base image's config template is kept
+# as bugsink_conf_base so our bugsink_conf.py inherits it and overrides only the
+# file object storage.
+FROM bugsink/bugsink:2.4.0
+
+USER root
+
+RUN pip install --no-cache-dir boto3==1.43.46
+
+RUN cp /app/bugsink_conf.py /app/bugsink_conf_base.py
+COPY r2_storage.py /app/r2_storage.py
+COPY bugsink_conf.py /app/bugsink_conf.py
+RUN chown bugsink /app/bugsink_conf_base.py /app/r2_storage.py /app/bugsink_conf.py
+
+USER bugsink

--- a/apps/bugsink/README.md
+++ b/apps/bugsink/README.md
@@ -4,24 +4,35 @@ Self-hosted [Bugsink](https://www.bugsink.com) error tracker, deployed on Fly as
 Browser and server exceptions ingest here over the Sentry protocol: each vers app has its own
 Bugsink project, and that project's DSN is the only wiring an app carries.
 
-This directory holds Fly config only — no workspace package, nothing to build. The app runs the
-pinned stock `bugsink/bugsink` image; a merge to `main` touching this directory redeploys it, so
-upgrading Bugsink is a tag bump in `fly.toml`. A manual roll is
-`fly deploy --config apps/bugsink/fly.toml`.
+This directory holds Fly config plus a thin image (`Dockerfile`) over the pinned stock
+`bugsink/bugsink`, adding boto3 and the R2 storage backend below. A merge to `main` touching this
+directory redeploys it, and upgrading Bugsink is a tag bump on the `Dockerfile` `FROM` line. A
+manual roll is `fly deploy --config apps/bugsink/fly.toml`. `bugsink_conf.py` imports the stock
+image's config and overrides only the file object storage, so the rest of Bugsink's env-driven
+settings stay upstream's.
 
 ## Storage
 
 Event data lives in a dedicated database in the shared Neon project (`DATABASE_URL` secret) — no app
-runs its own database, the machine keeps no volume, and Bugsink's SQLite-on-Docker-volume warning
-never applies.
+runs its own database and the machine keeps no volume. Uploaded files (sourcemap artifact bundles),
+which Bugsink stores in the database by default, go to the Cloudflare R2 bucket `vers-bugsink-files`
+via `r2_storage.py` instead, keeping those blobs and their read traffic off Neon. Existing files
+move across with `bugsink-manage migrate_to_current_objectstorage`.
 
 ## Secrets
 
-| Secret             | Value                                              |
-| ------------------ | -------------------------------------------------- |
-| `SECRET_KEY`       | `openssl rand -base64 50`                          |
-| `DATABASE_URL`     | the Neon `bugsink` database, pooled connection URL |
-| `CREATE_SUPERUSER` | `email:password` — first boot only, unset after    |
+| Secret                 | Value                                                      |
+| ---------------------- | ---------------------------------------------------------- |
+| `SECRET_KEY`           | `openssl rand -base64 50`                                  |
+| `DATABASE_URL`         | the Neon `bugsink` database, pooled connection URL         |
+| `CREATE_SUPERUSER`     | `email:password` — first boot only, unset after            |
+| `R2_ENDPOINT_URL`      | `https://<cloudflare-account-id>.r2.cloudflarestorage.com` |
+| `R2_BUCKET`            | `vers-bugsink-files`                                       |
+| `R2_ACCESS_KEY_ID`     | R2 S3 access key id                                        |
+| `R2_SECRET_ACCESS_KEY` | R2 S3 secret access key                                    |
+
+The R2 credentials also live on the `bugsink-r2` item in the `vers` 1Password vault. Unset the four
+`R2_*` secrets and Bugsink falls back to storing files in the database.
 
 ## API tokens
 

--- a/apps/bugsink/bugsink_conf.py
+++ b/apps/bugsink/bugsink_conf.py
@@ -1,0 +1,27 @@
+"""
+Bugsink settings for the vers deployment: the stock Docker config plus one
+override. The base image ships its Docker config template at
+/app/bugsink_conf.py; our Dockerfile preserves it as bugsink_conf_base so we
+inherit every env-driven setting and only add R2 as the ``file`` write storage.
+Keeping the base by import (not copy) means a bugsink bump needs no edit here.
+
+When R2_BUCKET is set, uploaded files (sourcemap artifact bundles) are written
+to Cloudflare R2 instead of the Postgres row, keeping the shared Neon database
+free of large blobs. Without it, the image falls back to the stock DB storage.
+"""
+
+import os
+
+from bugsink_conf_base import *  # noqa: F401,F403
+from bugsink_conf_base import BUGSINK
+
+if os.getenv("R2_BUCKET"):
+    BUGSINK["OBJECT_STORAGES"] = {
+        "file": {
+            "r2": {
+                "STORAGE": "r2_storage.R2ObjectStorage",
+                "OPTIONS": {},
+                "USE_FOR_WRITE": True,
+            },
+        },
+    }

--- a/apps/bugsink/fly.toml
+++ b/apps/bugsink/fly.toml
@@ -1,12 +1,13 @@
 # Self-hosted Bugsink error tracker. Public because browsers post error envelopes
-# directly to it; every other client is a server SDK. Runs the pinned stock image —
-# no build — and a merge to main touching this directory redeploys it, so upgrading
-# Bugsink is a tag bump here.
+# directly to it; every other client is a server SDK. Builds a thin image over the
+# pinned stock Bugsink that adds an R2 object-storage backend for uploaded files; a
+# merge to main touching this directory redeploys it, and upgrading Bugsink is a tag
+# bump on the Dockerfile's FROM line.
 app = 'vers-bugsink'
 primary_region = 'syd'
 
 [build]
-image = 'bugsink/bugsink:2.4.0'
+dockerfile = 'Dockerfile'
 
 [http_service]
 internal_port = 8000

--- a/apps/bugsink/r2_storage.py
+++ b/apps/bugsink/r2_storage.py
@@ -1,0 +1,76 @@
+"""
+Bugsink object-storage backend that keeps uploaded files (sourcemap artifact
+bundles) in Cloudflare R2 over its S3-compatible API, instead of the Postgres
+row. Registered as the ``file`` object kind's write storage in bugsink_conf.py.
+
+Bugsink resolves this class by dotted path and constructs it as
+``R2ObjectStorage(name, object_kind=..., **OPTIONS)``; credentials and target
+bucket come from the R2_* environment (Fly secrets) so no secret is baked in.
+The four methods below are Bugsink's ObjectStorage contract: open() is a context
+manager yielding a readable ('rb') or writable ('wb') file object.
+"""
+
+import os
+from contextlib import contextmanager
+from io import BytesIO
+
+import boto3
+from botocore.config import Config
+
+from files.storage import ObjectStorage
+
+
+class R2ObjectStorage(ObjectStorage):
+    def __init__(
+        self,
+        name,
+        object_kind,
+        bucket=None,
+        endpoint_url=None,
+        access_key_id=None,
+        secret_access_key=None,
+        **kwargs,
+    ):
+        super().__init__(name, object_kind, **kwargs)
+        self.bucket = bucket or os.environ["R2_BUCKET"]
+        self._client = boto3.client(
+            "s3",
+            endpoint_url=endpoint_url or os.environ["R2_ENDPOINT_URL"],
+            aws_access_key_id=access_key_id or os.environ["R2_ACCESS_KEY_ID"],
+            aws_secret_access_key=secret_access_key or os.environ["R2_SECRET_ACCESS_KEY"],
+            region_name="auto",
+            config=Config(signature_version="s3v4"),
+        )
+
+    def exists(self, key):
+        try:
+            self._client.head_object(Bucket=self.bucket, Key=str(key))
+            return True
+        except self._client.exceptions.ClientError as exc:
+            if exc.response["Error"]["Code"] in ("404", "NoSuchKey", "NotFound"):
+                return False
+            raise
+
+    def delete(self, key):
+        self._client.delete_object(Bucket=self.bucket, Key=str(key))
+
+    @contextmanager
+    def open(self, key, mode="rb"):
+        if mode == "rb":
+            body = self._client.get_object(Bucket=self.bucket, Key=str(key))["Body"]
+            try:
+                yield body
+            finally:
+                body.close()
+        elif mode == "wb":
+            buffer = BytesIO()
+            yield buffer
+            self._client.put_object(Bucket=self.bucket, Key=str(key), Body=buffer.getvalue())
+        else:
+            raise ValueError("ObjectStorage.open() mode must be 'rb' or 'wb'")
+
+    def list(self):
+        paginator = self._client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=self.bucket):
+            for obj in page.get("Contents", []):
+                yield obj["Key"]


### PR DESCRIPTION
## Description

Uploaded files (sourcemap artifact bundles) currently sit in the shared Neon `bugsink` database — 201 MB of blob that Bugsink reassembles by reading back out of Neon on every deploy, the bulk of the project's outbound traffic. This routes those files to the Cloudflare R2 bucket `vers-bugsink-files` instead; the event database stays on Neon.

- Thin image over pinned `bugsink/bugsink:2.4.0` adds `boto3` + an R2 `ObjectStorage` backend (`r2_storage.py`); Bugsink upgrade stays a `FROM`-line tag bump.
- `bugsink_conf.py` imports the stock image config and overrides only file storage — nothing copied from upstream, so bumps need no edit here. Without `R2_*` env it falls back to database storage.
- Adapter exercised end-to-end against the real bucket (write/exists/read/list/delete).
- `fly.toml` switches from stock `image` to `[build]`.

## Testing

- [x] `bun run format:check` passes
- [x] R2 adapter round-trip verified against `vers-bugsink-files`
- [ ] Post-deploy: `migrate_to_current_objectstorage`, confirm symbolication + Neon egress drop

## Context

R2 bucket created; creds land in Fly secrets + the `vers` vault. `apps/bugsink` is not a workspace package, so CI's turbo graph doesn't cover it — the adapter's coverage is the real-R2 round-trip plus the post-deploy symbolication check.