### PR TITLE
fix(bugsink): use repo-root-relative COPY paths in Dockerfile

### DIFF
--- a/apps/bugsink/Dockerfile
+++ b/apps/bugsink/Dockerfile
@@ -10,8 +10,8 @@ USER root
 RUN pip install --no-cache-dir boto3==1.43.46
 
 RUN cp /app/bugsink_conf.py /app/bugsink_conf_base.py
-COPY r2_storage.py /app/r2_storage.py
-COPY bugsink_conf.py /app/bugsink_conf.py
+COPY apps/bugsink/r2_storage.py /app/r2_storage.py
+COPY apps/bugsink/bugsink_conf.py /app/bugsink_conf.py
 RUN chown bugsink /app/bugsink_conf_base.py /app/r2_storage.py /app/bugsink_conf.py
 
 USER bugsink


### PR DESCRIPTION
## Description

The bugsink R2 image (#497) failed to deploy: the deploy pipeline runs `flyctl deploy` from the repo root, so the Docker build context is the repo root, not `apps/bugsink`, and `COPY r2_storage.py` / `COPY bugsink_conf.py` resolved to nothing. Prefix both with `apps/bugsink/`, matching every service Dockerfile (context = repo root).

- Validated with a local `docker build` against the root context, plus an in-image import check of `boto3` + `r2_storage` and the conf's R2 fallback.

## Testing

- [x] `bun run format:check` passes
- [x] Local `docker build` succeeds; image imports the adapter and loads the conf

## Context

bugsink stayed up on the prior stock image (Fly keeps last-good on deploy failure). Scoped R2 credentials are staged as Fly secrets; this deploy activates them, after which the file migration runs.