### PR TITLE
feat(#171): add xp curve and level-up settlement

### DIFF
--- a/apps/web/src/routes/-explore-current/explore-current-panel.test.tsx
+++ b/apps/web/src/routes/-explore-current/explore-current-panel.test.tsx
@@ -25,6 +25,7 @@ function buildFakeActivityAppState(id: string): ActivityAppState {
     enemyGroups: [],
     enemyGroupsRemaining: 0,
     id,
+    levelUp: null,
     name: 'World Node',
     rewards: { xp: 0 },
   };

--- a/bun.lock
+++ b/bun.lock
@@ -682,8 +682,10 @@
         "@paralleldrive/cuid2": "catalog:",
         "@vers/contract-activity": "workspace:*",
         "@vers/db": "workspace:*",
+        "@vers/idle-core": "workspace:*",
         "@vers/service-runtime": "workspace:*",
         "kysely": "catalog:",
+        "tiny-invariant": "catalog:",
         "zod": "catalog:",
       },
       "devDependencies": {

--- a/libs/game/idle-client/src/components/activity-info.test.tsx
+++ b/libs/game/idle-client/src/components/activity-info.test.tsx
@@ -28,25 +28,4 @@ test('it renders info about the provided activity', () => {
   expect(enemiesRemaining).toBeInTheDocument();
   expect(enemyGroupsRemaining).toBeInTheDocument();
   expect(xpEarned).toBeInTheDocument();
-  expect(screen.queryByText(nodeHasText('Leveled up'))).not.toBeInTheDocument();
-});
-
-test('it renders a level-up indication when the activity carries one', () => {
-  const activity: ActivityAppState = {
-    currentEnemyGroup: null,
-    elapsed: 0,
-    enemiesRemaining: 20,
-    enemyGroups: [],
-    enemyGroupsRemaining: 4,
-    id: 'test-activity',
-    levelUp: { from: 3, to: 4 },
-    name: 'Test Activity',
-    rewards: { xp: 150 },
-  };
-
-  render(<ActivityInfo activity={activity} />);
-
-  const levelUp = screen.getByText(nodeHasText('Leveled up to 4!'));
-
-  expect(levelUp).toBeInTheDocument();
 });

--- a/libs/game/idle-client/src/components/activity-info.test.tsx
+++ b/libs/game/idle-client/src/components/activity-info.test.tsx
@@ -12,6 +12,7 @@ test('it renders info about the provided activity', () => {
     enemyGroups: [],
     enemyGroupsRemaining: 4,
     id: 'test-activity',
+    levelUp: null,
     name: 'Test Activity',
     rewards: { xp: 150 },
   };
@@ -27,4 +28,25 @@ test('it renders info about the provided activity', () => {
   expect(enemiesRemaining).toBeInTheDocument();
   expect(enemyGroupsRemaining).toBeInTheDocument();
   expect(xpEarned).toBeInTheDocument();
+  expect(screen.queryByText(nodeHasText('Leveled up'))).not.toBeInTheDocument();
+});
+
+test('it renders a level-up indication when the activity carries one', () => {
+  const activity: ActivityAppState = {
+    currentEnemyGroup: null,
+    elapsed: 0,
+    enemiesRemaining: 20,
+    enemyGroups: [],
+    enemyGroupsRemaining: 4,
+    id: 'test-activity',
+    levelUp: { from: 3, to: 4 },
+    name: 'Test Activity',
+    rewards: { xp: 150 },
+  };
+
+  render(<ActivityInfo activity={activity} />);
+
+  const levelUp = screen.getByText(nodeHasText('Leveled up to 4!'));
+
+  expect(levelUp).toBeInTheDocument();
 });

--- a/libs/game/idle-client/src/components/activity-info.tsx
+++ b/libs/game/idle-client/src/components/activity-info.tsx
@@ -24,6 +24,11 @@ export function ActivityInfo(props: Readonly<ActivityInfoProps>) {
       <Text>
         <strong>{props.activity.rewards.xp}</strong> xp earned
       </Text>
+      {props.activity.levelUp && (
+        <Text>
+          Leveled up to <strong>{props.activity.levelUp.to}</strong>!
+        </Text>
+      )}
     </section>
   );
 }

--- a/libs/game/idle-client/src/components/activity-info.tsx
+++ b/libs/game/idle-client/src/components/activity-info.tsx
@@ -24,11 +24,6 @@ export function ActivityInfo(props: Readonly<ActivityInfoProps>) {
       <Text>
         <strong>{props.activity.rewards.xp}</strong> xp earned
       </Text>
-      {props.activity.levelUp && (
-        <Text>
-          Leveled up to <strong>{props.activity.levelUp.to}</strong>!
-        </Text>
-      )}
     </section>
   );
 }

--- a/libs/game/idle-client/src/components/avatar-info.test.tsx
+++ b/libs/game/idle-client/src/components/avatar-info.test.tsx
@@ -30,7 +30,9 @@ test('it renders avatar information', () => {
 
   const avatarName = screen.getByText('Test Avatar');
   const [lifeBar] = screen.getAllByText(nodeHasText('Life: 75 / 100'));
+  const level = screen.getByText(nodeHasText('Level 1'));
 
   expect(avatarName).toBeInTheDocument();
   expect(lifeBar).toBeInTheDocument();
+  expect(level).toBeInTheDocument();
 });

--- a/libs/game/idle-client/src/components/avatar-info.tsx
+++ b/libs/game/idle-client/src/components/avatar-info.tsx
@@ -1,4 +1,4 @@
-import { Heading } from '@vers/design-system';
+import { Heading, Text } from '@vers/design-system';
 import type { AvatarAppState } from '@vers/idle-core';
 import { AttackTimerBar } from './attack-timer-bar';
 import * as styles from './avatar-info.styles';
@@ -18,6 +18,7 @@ export function AvatarInfo(props: Readonly<AvatarInfoProps>) {
       <Heading className={styles.avatarName} level={4}>
         {props.avatar.name}
       </Heading>
+      <Text>Level {props.avatar.level}</Text>
       <LifeBar life={props.avatar.life} maxLife={props.avatar.maxLife} />
       <AttackTimerBar
         isAlive={props.avatar.isAlive}

--- a/libs/game/idle-client/src/state/set-activity.test.ts
+++ b/libs/game/idle-client/src/state/set-activity.test.ts
@@ -12,6 +12,7 @@ test('it updates the activity state', () => {
     enemyGroups: [],
     enemyGroupsRemaining: 4,
     id: '1',
+    levelUp: null,
     name: 'Test Activity',
     rewards: { xp: 0 },
   };
@@ -27,6 +28,7 @@ test('it updates the activity state', () => {
     enemyGroups: [],
     enemyGroupsRemaining: 4,
     id: '1',
+    levelUp: null,
     name: 'Test Activity',
     rewards: { xp: 0 },
   });

--- a/libs/game/idle-client/src/state/use-activity.test.ts
+++ b/libs/game/idle-client/src/state/use-activity.test.ts
@@ -12,6 +12,7 @@ test('it provides activity state', () => {
     enemyGroups: [],
     enemyGroupsRemaining: 4,
     id: 'test-activity',
+    levelUp: null,
     name: 'Test Activity',
     rewards: { xp: 0 },
   };
@@ -27,6 +28,7 @@ test('it provides activity state', () => {
     enemyGroups: [],
     enemyGroupsRemaining: 4,
     id: 'test-activity',
+    levelUp: null,
     name: 'Test Activity',
     rewards: { xp: 0 },
   });

--- a/libs/game/idle-client/src/worker/create-simulation-update-message.test.ts
+++ b/libs/game/idle-client/src/worker/create-simulation-update-message.test.ts
@@ -13,6 +13,7 @@ test('it creates a simulation update message', () => {
       enemyGroups: [],
       enemyGroupsRemaining: 0,
       id: '1',
+      levelUp: null,
       name: 'Test Activity',
       rewards: { xp: 0 },
     },

--- a/libs/game/idle-core/src/core/create-activity.test.ts
+++ b/libs/game/idle-core/src/core/create-activity.test.ts
@@ -42,6 +42,7 @@ test('it returns the expected activity state for a client app', () => {
     enemyGroups: expect.toBeArray(),
     enemyGroupsRemaining: expect.toBeNumber(),
     id: activity.id,
+    levelUp: null,
     name: activity.name,
     rewards: { xp: 0 },
   });
@@ -57,4 +58,25 @@ test('it accrues rewards across multiple calls', () => {
 
   expect(activity.rewards).toStrictEqual({ xp: 15 });
   expect(activity.getAppState().rewards).toStrictEqual({ xp: 15 });
+});
+
+test('it exposes the difficulty carried by its activity data', () => {
+  const ctx = createMockSimulationContext();
+  const activityData = createMockActivityData({ difficulty: 2.5 });
+  const activity = createActivity(activityData, ctx);
+
+  expect(activity.difficulty).toBe(2.5);
+});
+
+test('it records a level-up event and surfaces it on app state', () => {
+  const ctx = createMockSimulationContext();
+  const activityData = createMockActivityData();
+  const activity = createActivity(activityData, ctx);
+
+  expect(activity.levelUp).toBeNull();
+
+  activity.setLevelUp({ from: 1, to: 2 });
+
+  expect(activity.levelUp).toStrictEqual({ from: 1, to: 2 });
+  expect(activity.getAppState().levelUp).toStrictEqual({ from: 1, to: 2 });
 });

--- a/libs/game/idle-core/src/core/create-activity.ts
+++ b/libs/game/idle-core/src/core/create-activity.ts
@@ -2,6 +2,7 @@ import type {
   Activity,
   ActivityAppState,
   ActivityData,
+  ActivityLevelUp,
   ActivityRewards,
   EnemyGroup,
   SimulationContext,
@@ -21,6 +22,7 @@ export function createActivity(
   let elapsed = 0;
   let currentEnemyGroupIdx = 0;
   let rewards: ActivityRewards = { xp: 0 };
+  let levelUp: ActivityLevelUp | null = null;
   const enemyGroups: Array<EnemyGroup> = getEnemyGroups(data, ctx, config);
   const isEnemyGroupsRemaining = () => enemyGroups.some((group) => group.remaining > 0);
 
@@ -36,6 +38,10 @@ export function createActivity(
     rewards = mergeRewards(rewards, delta);
   };
 
+  const setLevelUp = (nextLevelUp: ActivityLevelUp) => {
+    levelUp = nextLevelUp;
+  };
+
   const getAppState = (): ActivityAppState => {
     const currentEnemyGroup = enemyGroups[currentEnemyGroupIdx]?.getAppState() ?? null;
     const enemiesRemaining = enemyGroups.reduce((acc, group) => acc + group.remaining, 0);
@@ -48,6 +54,7 @@ export function createActivity(
       enemyGroups: enemyGroups.map((group) => group.getAppState()),
       enemyGroupsRemaining,
       id: data.id,
+      levelUp,
       name: data.name,
       rewards,
     };
@@ -55,6 +62,7 @@ export function createActivity(
 
   return {
     // meta
+    difficulty: data.difficulty,
     enemyGroups,
     id: data.id,
     name: data.name,
@@ -70,6 +78,9 @@ export function createActivity(
     get isEnemyGroupsRemaining() {
       return isEnemyGroupsRemaining();
     },
+    get levelUp() {
+      return levelUp;
+    },
     get rewards() {
       return rewards;
     },
@@ -81,6 +92,7 @@ export function createActivity(
     updateRewards,
     elapseTime,
     moveToNextEnemyGroup,
+    setLevelUp,
   };
 }
 

--- a/libs/game/idle-core/src/core/run-simulation.test.ts
+++ b/libs/game/idle-core/src/core/run-simulation.test.ts
@@ -45,6 +45,10 @@ test('runs a simulation with default configuration', async () => {
         },
         {
           "hash": "d0100e711451eca4",
+          "levelUp": {
+            "from": 1,
+            "to": 2,
+          },
           "nextSeed": 2866488649,
           "rewards": {
             "xp": 60,
@@ -74,7 +78,7 @@ test('runs a simulation with default configuration', async () => {
           "hash": "0ad2f691a6d94aa0",
           "nextSeed": 4197947599,
           "rewards": {
-            "xp": 0,
+            "xp": 215,
           },
           "time": 57600,
           "type": "completed",

--- a/libs/game/idle-core/src/core/simulate-activity.test.ts
+++ b/libs/game/idle-core/src/core/simulate-activity.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from 'bun:test';
+import invariant from 'tiny-invariant';
 import { createAvatar } from '../entities/create-avatar';
+import { buildCompletionXP, levelForXP } from '../progression';
 import { createMockActivityData } from '../test-utils/create-mock-activity-data';
 import { createMockAvatarData } from '../test-utils/create-mock-avatar-data';
 import { createMockEnemyData } from '../test-utils/create-mock-enemy-data';
@@ -57,7 +59,9 @@ test('it generates enemy group killed checkpoints', async () => {
     },
   });
 
-  const enemyData = createMockEnemyData({ life: 1 });
+  // low enough that two cleared groups stay well under a level threshold — this test is about
+  // checkpoint mechanics, not leveling
+  const enemyData = createMockEnemyData({ life: 1, xp: 1 });
 
   const activityData = createMockActivityData({
     enemies: [enemyData],
@@ -88,7 +92,7 @@ test('it generates enemy group killed checkpoints', async () => {
   expect(secondCheckpoint).toStrictEqual({
     hash: expect.toBeString(),
     nextSeed: expect.toBeNumber(),
-    rewards: { xp: 50 },
+    rewards: { xp: 5 },
     time: expect.toBeNumber(),
     type: ActivityCheckpointType.Progress,
   });
@@ -96,7 +100,7 @@ test('it generates enemy group killed checkpoints', async () => {
   expect(thirdCheckpoint).toStrictEqual({
     hash: expect.toBeString(),
     nextSeed: expect.toBeNumber(),
-    rewards: { xp: 50 },
+    rewards: { xp: 5 },
     time: expect.toBeNumber(),
     type: ActivityCheckpointType.Progress,
   });
@@ -182,7 +186,7 @@ test('it generates a failed checkpoint when the avatar dies', async () => {
   });
 });
 
-test('it returns a completed checkpoint when all enemies are defeated', async () => {
+test('it returns a completed checkpoint that folds in the completion bonus', async () => {
   const weapon: EquipmentWeapon = {
     id: 'test-weapon',
     maxDamage: 9999,
@@ -197,9 +201,10 @@ test('it returns a completed checkpoint when all enemies are defeated', async ()
     },
   });
 
-  const enemyData = createMockEnemyData({ life: 1 });
+  const enemyData = createMockEnemyData({ life: 1, xp: 10 });
 
   const activityData = createMockActivityData({
+    difficulty: 1,
     enemies: [enemyData],
     failureAction: ActivityFailureAction.Retry,
     id: 'world_node_1',
@@ -207,7 +212,7 @@ test('it returns a completed checkpoint when all enemies are defeated', async ()
   });
 
   const ctx = createMockSimulationContext();
-  const activity = createActivity(activityData, ctx);
+  const activity = createActivity(activityData, ctx, { groupCount: 1, groupSize: 1 });
   const avatar = createAvatar(avatarData, ctx);
   const executor = createCombatExecutor(activity, avatar, ctx);
   const generator = simulateActivity(executor, activity, avatar, ctx);
@@ -223,8 +228,145 @@ test('it returns a completed checkpoint when all enemies are defeated', async ()
   expect(checkpoint).toStrictEqual({
     hash: expect.toBeString(),
     nextSeed: expect.toBeNumber(),
-    rewards: { xp: 0 },
+    rewards: { xp: 10 + buildCompletionXP(1) },
     time: expect.toBeNumber(),
     type: ActivityCheckpointType.Completed,
   });
+});
+
+test('it carries a levelUp when a completion bonus crosses a level threshold', async () => {
+  const weapon: EquipmentWeapon = {
+    id: 'test-weapon',
+    maxDamage: 9999,
+    minDamage: 9999,
+    name: 'Test Weapon',
+    speed: 6,
+  };
+
+  const avatarData = createMockAvatarData({
+    paperdoll: {
+      [EquipmentSlot.MainHand]: weapon,
+    },
+    xp: 80,
+  });
+
+  const enemyData = createMockEnemyData({ life: 1, xp: 0 });
+
+  const activityData = createMockActivityData({
+    difficulty: 1,
+    enemies: [enemyData],
+  });
+
+  const ctx = createMockSimulationContext();
+  const activity = createActivity(activityData, ctx, { groupCount: 1, groupSize: 1 });
+  const avatar = createAvatar(avatarData, ctx);
+  const executor = createCombatExecutor(activity, avatar, ctx);
+  const generator = simulateActivity(executor, activity, avatar, ctx);
+
+  let result = await generator.next(1000);
+
+  while (result.done !== true) {
+    result = await generator.next(1000);
+  }
+
+  const checkpoint = result.value;
+
+  expect(checkpoint.type).toBe(ActivityCheckpointType.Completed);
+  expect(checkpoint.levelUp).toStrictEqual({ from: 1, to: 2 });
+});
+
+test('it records a levelUp checkpoint when a group clear crosses a level threshold', async () => {
+  const weapon: EquipmentWeapon = {
+    id: 'test-weapon',
+    maxDamage: 9999,
+    minDamage: 9999,
+    name: 'Test Weapon',
+    speed: 6,
+  };
+
+  const avatarData = createMockAvatarData({
+    paperdoll: {
+      [EquipmentSlot.MainHand]: weapon,
+    },
+    xp: 0,
+  });
+
+  const enemyData = createMockEnemyData({ life: 1, xp: 250 });
+  const activityData = createMockActivityData({ difficulty: 1, enemies: [enemyData] });
+  const ctx = createMockSimulationContext();
+  const activity = createActivity(activityData, ctx, { groupCount: 1, groupSize: 1 });
+  const avatar = createAvatar(avatarData, ctx);
+  const executor = createCombatExecutor(activity, avatar, ctx);
+  const generator = simulateActivity(executor, activity, avatar, ctx);
+
+  // skip the started checkpoint
+  await generator.next(1000);
+
+  const groupClearResult = await generator.next(1000);
+
+  const checkpoint = groupClearResult.value;
+
+  expect(checkpoint?.type).toBe(ActivityCheckpointType.Progress);
+  expect(checkpoint?.levelUp).toStrictEqual({ from: 1, to: 2 });
+});
+
+test('it keeps xp and a level-up earned on the same tick the avatar dies', async () => {
+  const avatarWeapon: EquipmentWeapon = {
+    id: 'test-weapon',
+    maxDamage: 9999,
+    minDamage: 9999,
+    name: 'Test Weapon',
+    speed: 1,
+  };
+
+  const avatarData = createMockAvatarData({
+    life: 5,
+    paperdoll: {
+      [EquipmentSlot.MainHand]: avatarWeapon,
+    },
+    xp: 0,
+  });
+
+  const enemyData = createMockEnemyData({
+    life: 1,
+    primaryAttack: {
+      maxDamage: 9999,
+      minDamage: 9999,
+      speed: 2,
+    },
+    xp: 250,
+  });
+
+  const activityData = createMockActivityData({ difficulty: 1, enemies: [enemyData] });
+  const ctx = createMockSimulationContext();
+  const activity = createActivity(activityData, ctx, { groupCount: 1, groupSize: 1 });
+  const avatar = createAvatar(avatarData, ctx);
+  const executor = createCombatExecutor(activity, avatar, ctx);
+  const generator = simulateActivity(executor, activity, avatar, ctx);
+
+  // skip the started checkpoint
+  await generator.next(1000);
+
+  // the group's only enemy and the avatar both die within this same combat tick
+  const groupClearResult = await generator.next(1000);
+
+  const progressCheckpoint = groupClearResult.value;
+
+  expect(avatar.isAlive).toBeFalse();
+  expect(progressCheckpoint?.type).toBe(ActivityCheckpointType.Progress);
+  expect(progressCheckpoint?.levelUp).toStrictEqual({ from: 1, to: 2 });
+
+  const failedResult = await generator.next(1000);
+
+  invariant(failedResult.done === true, 'the activity must resolve to a failed checkpoint');
+
+  const failedCheckpoint = failedResult.value;
+
+  expect(failedCheckpoint.type).toBe(ActivityCheckpointType.Failed);
+
+  // the failure penalty applies on top of the running total, never dropping xp below the
+  // threshold of the level earned this same tick
+  expect(failedCheckpoint.rewards.xp).toBeGreaterThan(0);
+  expect(failedCheckpoint.rewards.xp).toBeLessThan(250);
+  expect(levelForXP(avatar.xp + failedCheckpoint.rewards.xp)).toBe(2);
 });

--- a/libs/game/idle-core/src/core/simulate-activity.test.ts
+++ b/libs/game/idle-core/src/core/simulate-activity.test.ts
@@ -273,6 +273,7 @@ test('it carries a levelUp when a completion bonus crosses a level threshold', a
 
   expect(checkpoint.type).toBe(ActivityCheckpointType.Completed);
   expect(checkpoint.levelUp).toStrictEqual({ from: 1, to: 2 });
+  expect(avatar.getAppState().level).toBe(2);
 });
 
 test('it records a levelUp checkpoint when a group clear crosses a level threshold', async () => {
@@ -308,6 +309,7 @@ test('it records a levelUp checkpoint when a group clear crosses a level thresho
 
   expect(checkpoint?.type).toBe(ActivityCheckpointType.Progress);
   expect(checkpoint?.levelUp).toStrictEqual({ from: 1, to: 2 });
+  expect(avatar.getAppState().level).toBe(2);
 });
 
 test('it keeps xp and a level-up earned on the same tick the avatar dies', async () => {
@@ -355,6 +357,7 @@ test('it keeps xp and a level-up earned on the same tick the avatar dies', async
   expect(avatar.isAlive).toBeFalse();
   expect(progressCheckpoint?.type).toBe(ActivityCheckpointType.Progress);
   expect(progressCheckpoint?.levelUp).toStrictEqual({ from: 1, to: 2 });
+  expect(avatar.getAppState().level).toBe(2);
 
   const failedResult = await generator.next(1000);
 

--- a/libs/game/idle-core/src/core/simulate-activity.ts
+++ b/libs/game/idle-core/src/core/simulate-activity.ts
@@ -40,6 +40,7 @@ export async function* simulateActivity(
 
       if (checkpoint.levelUp) {
         activity.setLevelUp(checkpoint.levelUp);
+        avatar.updateLevel(checkpoint.levelUp.to);
       }
 
       yield checkpoint;
@@ -61,6 +62,7 @@ export async function* simulateActivity(
 
   if (completedCheckpoint.levelUp) {
     activity.setLevelUp(completedCheckpoint.levelUp);
+    avatar.updateLevel(completedCheckpoint.levelUp.to);
   }
 
   return completedCheckpoint;

--- a/libs/game/idle-core/src/core/simulate-activity.ts
+++ b/libs/game/idle-core/src/core/simulate-activity.ts
@@ -32,10 +32,17 @@ export async function* simulateActivity(
     executor.run(timestep);
 
     if (activity.currentEnemyGroup?.remaining === 0) {
-      const rewards = buildGroupClearRewards(activity.currentEnemyGroup);
+      const rewards = buildGroupClearRewards(activity.currentEnemyGroup, activity.difficulty);
 
       activity.updateRewards(rewards);
-      yield createProgressCheckpoint(activity, ctx, rewards);
+
+      const checkpoint = createProgressCheckpoint(activity, avatar, ctx, rewards);
+
+      if (checkpoint.levelUp) {
+        activity.setLevelUp(checkpoint.levelUp);
+      }
+
+      yield checkpoint;
       logger.debug(`${label} moving to next enemy group`);
 
       // move to the next enemy group
@@ -47,8 +54,14 @@ export async function* simulateActivity(
   }
 
   if (!avatar.isAlive) {
-    return createFailedCheckpoint(activity, ctx);
+    return createFailedCheckpoint(activity, avatar, ctx);
   }
 
-  return createCompletedCheckpoint(activity.elapsed, ctx);
+  const completedCheckpoint = createCompletedCheckpoint(activity, avatar, ctx);
+
+  if (completedCheckpoint.levelUp) {
+    activity.setLevelUp(completedCheckpoint.levelUp);
+  }
+
+  return completedCheckpoint;
 }

--- a/libs/game/idle-core/src/core/utils/build-group-clear-rewards.test.ts
+++ b/libs/game/idle-core/src/core/utils/build-group-clear-rewards.test.ts
@@ -5,13 +5,13 @@ import { createMockSimulationContext } from '../../test-utils/create-mock-simula
 import { buildGroupClearRewards } from './build-group-clear-rewards';
 import { createEnemyGroup } from './create-enemy-group';
 
-test('it sums the xp of every enemy in the group', () => {
+test('it sums the difficulty-scaled xp of every enemy in the group', () => {
   const enemyData = createMockEnemyData({ xp: 10 });
   const activity = createMockActivityData({ enemies: [enemyData] });
   const ctx = createMockSimulationContext();
   const group = createEnemyGroup(activity, ctx, 3);
 
-  expect(buildGroupClearRewards(group)).toStrictEqual({ xp: 30 });
+  expect(buildGroupClearRewards(group, 1)).toStrictEqual({ xp: 30 });
 });
 
 test('it returns zero xp for an empty group', () => {
@@ -19,5 +19,14 @@ test('it returns zero xp for an empty group', () => {
   const ctx = createMockSimulationContext();
   const group = createEnemyGroup(activity, ctx, 0);
 
-  expect(buildGroupClearRewards(group)).toStrictEqual({ xp: 0 });
+  expect(buildGroupClearRewards(group, 1)).toStrictEqual({ xp: 0 });
+});
+
+test('it scales the summed xp by difficulty', () => {
+  const enemyData = createMockEnemyData({ xp: 10 });
+  const activity = createMockActivityData({ enemies: [enemyData] });
+  const ctx = createMockSimulationContext();
+  const group = createEnemyGroup(activity, ctx, 2);
+
+  expect(buildGroupClearRewards(group, 2)).toStrictEqual({ xp: 40 });
 });

--- a/libs/game/idle-core/src/core/utils/build-group-clear-rewards.ts
+++ b/libs/game/idle-core/src/core/utils/build-group-clear-rewards.ts
@@ -1,7 +1,8 @@
+import { buildKillXP } from '../../progression';
 import type { ActivityRewards, EnemyGroup } from '../../types';
 
-export function buildGroupClearRewards(group: EnemyGroup): ActivityRewards {
-  const xp = group.enemies.reduce((total, enemy) => total + enemy.xp, 0);
+export function buildGroupClearRewards(group: EnemyGroup, difficulty: number): ActivityRewards {
+  const xp = group.enemies.reduce((total, enemy) => total + buildKillXP(enemy, difficulty), 0);
 
   return { xp };
 }

--- a/libs/game/idle-core/src/core/utils/create-completed-checkpoint.test.ts
+++ b/libs/game/idle-core/src/core/utils/create-completed-checkpoint.test.ts
@@ -1,17 +1,28 @@
 import { expect, test } from 'bun:test';
+import { createAvatar } from '../../entities/create-avatar';
+import { buildCompletionXP } from '../../progression';
+import { createMockActivityData } from '../../test-utils/create-mock-activity-data';
+import { createMockAvatarData } from '../../test-utils/create-mock-avatar-data';
 import { createMockSimulationContext } from '../../test-utils/create-mock-simulation-context';
 import { ActivityCheckpointType } from '../../types';
 import { hashObject } from '../../utils/hash-object';
+import { createActivity } from '../create-activity';
 import { createCompletedCheckpoint } from './create-completed-checkpoint';
 
-test('it creates a completed checkpoint', () => {
+test('it creates a completed checkpoint with the completion bonus', () => {
   const ctx = createMockSimulationContext();
-  const checkpoint = createCompletedCheckpoint(2500, ctx);
+  const activityData = createMockActivityData({ difficulty: 1 });
+  const activity = createActivity(activityData, ctx);
+  const avatar = createAvatar(createMockAvatarData({ xp: 0 }), ctx);
+
+  activity.elapseTime(2500);
+
+  const checkpoint = createCompletedCheckpoint(activity, avatar, ctx);
 
   expect(checkpoint).toStrictEqual({
     hash: expect.toBeString(),
     nextSeed: expect.toBeNumber(),
-    rewards: { xp: 0 },
+    rewards: { xp: buildCompletionXP(1) },
     time: 2500,
     type: ActivityCheckpointType.Completed,
   });
@@ -19,8 +30,40 @@ test('it creates a completed checkpoint', () => {
 
 test('it includes a hash based on checkpoint data', () => {
   const ctx = createMockSimulationContext();
-  const checkpoint = createCompletedCheckpoint(2500, ctx);
+  const activityData = createMockActivityData();
+  const activity = createActivity(activityData, ctx);
+  const avatar = createAvatar(createMockAvatarData(), ctx);
+
+  activity.elapseTime(2500);
+
+  const checkpoint = createCompletedCheckpoint(activity, avatar, ctx);
   const { hash, rewards, ...hashParts } = checkpoint;
 
   expect(hash).toStrictEqual(hashObject(ctx.hasher, hashParts));
+});
+
+test('it merges the completion bonus with rewards already accrued', () => {
+  const ctx = createMockSimulationContext();
+  const activityData = createMockActivityData();
+  const activity = createActivity(activityData, ctx);
+  const avatar = createAvatar(createMockAvatarData({ xp: 0 }), ctx);
+
+  activity.updateRewards({ xp: 40 });
+
+  const checkpoint = createCompletedCheckpoint(activity, avatar, ctx);
+
+  expect(checkpoint.rewards).toStrictEqual({ xp: 40 + buildCompletionXP(1) });
+});
+
+test('it carries a levelUp when the completion bonus crosses a level threshold', () => {
+  const ctx = createMockSimulationContext();
+  const activityData = createMockActivityData();
+  const activity = createActivity(activityData, ctx);
+  const avatar = createAvatar(createMockAvatarData({ xp: 0 }), ctx);
+
+  activity.updateRewards({ xp: 90 });
+
+  const checkpoint = createCompletedCheckpoint(activity, avatar, ctx);
+
+  expect(checkpoint.levelUp).toStrictEqual({ from: 1, to: 2 });
 });

--- a/libs/game/idle-core/src/core/utils/create-completed-checkpoint.ts
+++ b/libs/game/idle-core/src/core/utils/create-completed-checkpoint.ts
@@ -1,23 +1,36 @@
-import type { ActivityCompletedCheckpoint, ActivityRewards, SimulationContext } from '../../types';
+import { buildCompletionXP, levelForXP } from '../../progression';
+import type {
+  Activity,
+  ActivityCompletedCheckpoint,
+  ActivityLevelUp,
+  ActivityRewards,
+  Avatar,
+  SimulationContext,
+} from '../../types';
 import { ActivityCheckpointType } from '../../types';
 import { hashObject } from '../../utils/hash-object';
 
 export function createCompletedCheckpoint(
-  elapsed: number,
+  activity: Activity,
+  avatar: Avatar,
   ctx: SimulationContext,
 ): ActivityCompletedCheckpoint {
-  // hash chain covers only this frozen subset — rewards ride outside it, verified by server
-  // replay-recompute instead
-  const hashed: Omit<ActivityCompletedCheckpoint, 'hash' | 'rewards'> = {
+  // hash chain covers only this frozen subset — rewards and levelUp ride outside it, verified by
+  // server replay-recompute instead
+  const hashed: Omit<ActivityCompletedCheckpoint, 'hash' | 'levelUp' | 'rewards'> = {
     nextSeed: ctx.rng.generateNewSeed(),
-    time: elapsed,
+    time: activity.elapsed,
     type: ActivityCheckpointType.Completed,
   };
 
   const hash = hashObject(ctx.hasher, hashed);
+  const completionXP = buildCompletionXP(activity.difficulty);
+  const rewards: ActivityRewards = { xp: activity.rewards.xp + completionXP };
+  const previousLevel = levelForXP(avatar.xp + activity.rewards.xp);
+  const currentLevel = levelForXP(avatar.xp + rewards.xp);
 
-  // completion payouts land here once the content layer authors them
-  const rewards: ActivityRewards = { xp: 0 };
+  const levelUp: ActivityLevelUp | undefined =
+    currentLevel > previousLevel ? { from: previousLevel, to: currentLevel } : undefined;
 
-  return { ...hashed, hash, rewards };
+  return { ...hashed, hash, rewards, ...(levelUp && { levelUp }) };
 }

--- a/libs/game/idle-core/src/core/utils/create-failed-checkpoint.test.ts
+++ b/libs/game/idle-core/src/core/utils/create-failed-checkpoint.test.ts
@@ -1,19 +1,23 @@
 import { expect, test } from 'bun:test';
+import { createAvatar } from '../../entities/create-avatar';
+import { buildFailureXPLoss } from '../../progression';
 import { createMockActivityData } from '../../test-utils/create-mock-activity-data';
+import { createMockAvatarData } from '../../test-utils/create-mock-avatar-data';
 import { createMockSimulationContext } from '../../test-utils/create-mock-simulation-context';
 import { ActivityCheckpointType } from '../../types';
 import { hashObject } from '../../utils/hash-object';
 import { createActivity } from '../create-activity';
 import { createFailedCheckpoint } from './create-failed-checkpoint';
 
-test('it creates a failed checkpoint', () => {
+test('it creates a failed checkpoint with no loss at zero accrued xp', () => {
   const ctx = createMockSimulationContext();
   const activityData = createMockActivityData();
   const activity = createActivity(activityData, ctx);
+  const avatar = createAvatar(createMockAvatarData({ xp: 0 }), ctx);
 
   activity.elapseTime(2500);
 
-  const checkpoint = createFailedCheckpoint(activity, ctx);
+  const checkpoint = createFailedCheckpoint(activity, avatar, ctx);
 
   expect(checkpoint).toStrictEqual({
     hash: expect.toBeString(),
@@ -28,8 +32,37 @@ test('it includes a hash based on checkpoint data', () => {
   const ctx = createMockSimulationContext();
   const activityData = createMockActivityData();
   const activity = createActivity(activityData, ctx);
-  const checkpoint = createFailedCheckpoint(activity, ctx);
+  const avatar = createAvatar(createMockAvatarData(), ctx);
+  const checkpoint = createFailedCheckpoint(activity, avatar, ctx);
   const { hash, rewards, ...hashParts } = checkpoint;
 
   expect(hash).toStrictEqual(hashObject(ctx.hasher, hashParts));
+});
+
+test('it subtracts the clamped failure loss from accrued rewards', () => {
+  const ctx = createMockSimulationContext();
+  const activityData = createMockActivityData();
+  const activity = createActivity(activityData, ctx);
+  const avatar = createAvatar(createMockAvatarData({ xp: 0 }), ctx);
+
+  activity.updateRewards({ xp: 40 });
+
+  const checkpoint = createFailedCheckpoint(activity, avatar, ctx);
+  const loss = buildFailureXPLoss(40);
+
+  expect(checkpoint.rewards).toStrictEqual({ xp: 40 - loss });
+  expect(loss).toBeGreaterThan(0);
+});
+
+test('it never carries a levelUp', () => {
+  const ctx = createMockSimulationContext();
+  const activityData = createMockActivityData();
+  const activity = createActivity(activityData, ctx);
+  const avatar = createAvatar(createMockAvatarData({ xp: 0 }), ctx);
+
+  activity.updateRewards({ xp: 100 });
+
+  const checkpoint = createFailedCheckpoint(activity, avatar, ctx);
+
+  expect(checkpoint.levelUp).toBeUndefined();
 });

--- a/libs/game/idle-core/src/core/utils/create-failed-checkpoint.ts
+++ b/libs/game/idle-core/src/core/utils/create-failed-checkpoint.ts
@@ -1,7 +1,9 @@
+import { buildFailureXPLoss } from '../../progression';
 import type {
   Activity,
   ActivityFailedCheckpoint,
   ActivityRewards,
+  Avatar,
   SimulationContext,
 } from '../../types';
 import { ActivityCheckpointType } from '../../types';
@@ -9,6 +11,7 @@ import { hashObject } from '../../utils/hash-object';
 
 export function createFailedCheckpoint(
   activity: Activity,
+  avatar: Avatar,
   ctx: SimulationContext,
 ): ActivityFailedCheckpoint {
   // hash chain covers only this frozen subset — rewards ride outside it, verified by server
@@ -20,9 +23,9 @@ export function createFailedCheckpoint(
   };
 
   const hash = hashObject(ctx.hasher, hashed);
-
-  // defeat cost (negative xp) lands here once the content layer defines its magnitude
-  const rewards: ActivityRewards = { xp: 0 };
+  const runningXP = avatar.xp + activity.rewards.xp;
+  const loss = buildFailureXPLoss(runningXP);
+  const rewards: ActivityRewards = { xp: activity.rewards.xp - loss };
 
   return { ...hashed, hash, rewards };
 }

--- a/libs/game/idle-core/src/core/utils/create-progress-checkpoint.test.ts
+++ b/libs/game/idle-core/src/core/utils/create-progress-checkpoint.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from 'bun:test';
+import { createAvatar } from '../../entities/create-avatar';
 import { createMockActivityData } from '../../test-utils/create-mock-activity-data';
+import { createMockAvatarData } from '../../test-utils/create-mock-avatar-data';
 import { createMockSimulationContext } from '../../test-utils/create-mock-simulation-context';
 import { ActivityCheckpointType } from '../../types';
 import { hashObject } from '../../utils/hash-object';
@@ -10,10 +12,12 @@ test('it creates a progress checkpoint', () => {
   const ctx = createMockSimulationContext();
   const activityData = createMockActivityData();
   const activity = createActivity(activityData, ctx);
+  const avatar = createAvatar(createMockAvatarData(), ctx);
 
   activity.elapseTime(2500);
+  activity.updateRewards({ xp: 15 });
 
-  const checkpoint = createProgressCheckpoint(activity, ctx, { xp: 15 });
+  const checkpoint = createProgressCheckpoint(activity, avatar, ctx, { xp: 15 });
 
   expect(checkpoint).toStrictEqual({
     hash: expect.toBeString(),
@@ -28,10 +32,12 @@ test('it includes a hash based on checkpoint data', () => {
   const ctx = createMockSimulationContext();
   const activityData = createMockActivityData();
   const activity = createActivity(activityData, ctx);
+  const avatar = createAvatar(createMockAvatarData(), ctx);
 
   activity.elapseTime(2500);
+  activity.updateRewards({ xp: 15 });
 
-  const checkpoint = createProgressCheckpoint(activity, ctx, { xp: 15 });
+  const checkpoint = createProgressCheckpoint(activity, avatar, ctx, { xp: 15 });
   const { hash, rewards, ...hashParts } = checkpoint;
 
   expect(hash).toStrictEqual(hashObject(ctx.hasher, hashParts));
@@ -39,21 +45,59 @@ test('it includes a hash based on checkpoint data', () => {
 
 test('it produces the same hash for checkpoints that differ only by rewards', () => {
   const activityData = createMockActivityData();
+  const avatarData = createMockAvatarData();
   const ctxWithNoRewards = createMockSimulationContext();
   const activityWithNoRewards = createActivity(activityData, ctxWithNoRewards);
+  const avatarWithNoRewards = createAvatar(avatarData, ctxWithNoRewards);
 
   activityWithNoRewards.elapseTime(2500);
 
-  const withNoRewards = createProgressCheckpoint(activityWithNoRewards, ctxWithNoRewards, {
-    xp: 0,
-  });
+  const withNoRewards = createProgressCheckpoint(
+    activityWithNoRewards,
+    avatarWithNoRewards,
+    ctxWithNoRewards,
+    { xp: 0 },
+  );
 
   const ctxWithRewards = createMockSimulationContext();
   const activityWithRewards = createActivity(activityData, ctxWithRewards);
+  const avatarWithRewards = createAvatar(avatarData, ctxWithRewards);
 
   activityWithRewards.elapseTime(2500);
+  activityWithRewards.updateRewards({ xp: 15 });
 
-  const withRewards = createProgressCheckpoint(activityWithRewards, ctxWithRewards, { xp: 15 });
+  const withRewards = createProgressCheckpoint(
+    activityWithRewards,
+    avatarWithRewards,
+    ctxWithRewards,
+    { xp: 15 },
+  );
 
   expect(withRewards.hash).toStrictEqual(withNoRewards.hash);
+});
+
+test('it carries a levelUp when the reward delta crosses a level threshold', () => {
+  const ctx = createMockSimulationContext();
+  const activityData = createMockActivityData();
+  const activity = createActivity(activityData, ctx);
+  const avatar = createAvatar(createMockAvatarData({ xp: 0 }), ctx);
+
+  activity.updateRewards({ xp: 100 });
+
+  const checkpoint = createProgressCheckpoint(activity, avatar, ctx, { xp: 100 });
+
+  expect(checkpoint.levelUp).toStrictEqual({ from: 1, to: 2 });
+});
+
+test('it omits levelUp when the reward delta stays within the current level', () => {
+  const ctx = createMockSimulationContext();
+  const activityData = createMockActivityData();
+  const activity = createActivity(activityData, ctx);
+  const avatar = createAvatar(createMockAvatarData({ xp: 0 }), ctx);
+
+  activity.updateRewards({ xp: 1 });
+
+  const checkpoint = createProgressCheckpoint(activity, avatar, ctx, { xp: 1 });
+
+  expect(checkpoint.levelUp).toBeUndefined();
 });

--- a/libs/game/idle-core/src/core/utils/create-progress-checkpoint.ts
+++ b/libs/game/idle-core/src/core/utils/create-progress-checkpoint.ts
@@ -1,26 +1,42 @@
+import { levelForXP } from '../../progression';
 import type {
   Activity,
+  ActivityLevelUp,
   ActivityProgressCheckpoint,
   ActivityRewards,
+  Avatar,
   SimulationContext,
 } from '../../types';
 import { ActivityCheckpointType } from '../../types';
 import { hashObject } from '../../utils/hash-object';
 
+/**
+ * `activity.updateRewards(rewards)` must already have been applied by the caller — `rewards` is
+ * this checkpoint's delta, while `activity.rewards` carries the running total it derives the level
+ * crossing from.
+ */
 export function createProgressCheckpoint(
   activity: Activity,
+  avatar: Avatar,
   ctx: SimulationContext,
   rewards: ActivityRewards,
 ): ActivityProgressCheckpoint {
-  // hash chain covers only this frozen subset — rewards ride outside it, verified by server
-  // replay-recompute instead
-  const hashed: Omit<ActivityProgressCheckpoint, 'hash' | 'rewards'> = {
+  // hash chain covers only this frozen subset — rewards and levelUp ride outside it, verified by
+  // server replay-recompute instead
+  const hashed: Omit<ActivityProgressCheckpoint, 'hash' | 'levelUp' | 'rewards'> = {
     nextSeed: ctx.rng.generateNewSeed(),
     time: activity.elapsed,
     type: ActivityCheckpointType.Progress,
   };
 
   const hash = hashObject(ctx.hasher, hashed);
+  const totalXPAfter = avatar.xp + activity.rewards.xp;
+  const totalXPBefore = totalXPAfter - rewards.xp;
+  const previousLevel = levelForXP(totalXPBefore);
+  const currentLevel = levelForXP(totalXPAfter);
 
-  return { ...hashed, hash, rewards };
+  const levelUp: ActivityLevelUp | undefined =
+    currentLevel > previousLevel ? { from: previousLevel, to: currentLevel } : undefined;
+
+  return { ...hashed, hash, rewards, ...(levelUp && { levelUp }) };
 }

--- a/libs/game/idle-core/src/entities/create-avatar.test.ts
+++ b/libs/game/idle-core/src/entities/create-avatar.test.ts
@@ -26,6 +26,17 @@ test('it creates an avatar with correct initial values', () => {
   expect(avatar.isAlive).toBeTrue();
 });
 
+test('it reflects a level update in the entity and its app state', () => {
+  const ctx = createMockSimulationContext();
+  const data = createMockAvatarData({ level: 1 });
+  const avatar = createAvatar(data, ctx);
+
+  avatar.updateLevel(3);
+
+  expect(avatar.level).toBe(3);
+  expect(avatar.getAppState().level).toBe(3);
+});
+
 test('it exposes a method for setting the avatar state', () => {
   const ctx = createMockSimulationContext();
   const data = createMockAvatarData();

--- a/libs/game/idle-core/src/entities/create-avatar.ts
+++ b/libs/game/idle-core/src/entities/create-avatar.ts
@@ -98,6 +98,7 @@ export function createAvatar(data: AvatarData, ctx: SimulationContext): Avatar {
     id: data.id,
     level: data.level,
     type: EntityType.Avatar,
+    xp: data.xp,
 
     // getters
     get isAlive() {

--- a/libs/game/idle-core/src/entities/create-avatar.ts
+++ b/libs/game/idle-core/src/entities/create-avatar.ts
@@ -27,6 +27,7 @@ interface ResetConfig {
 export function createAvatar(data: AvatarData, ctx: SimulationContext): Avatar {
   const label = createLogLabel('avatar', data.id);
   let state = getInitialState(data);
+  let currentLevel = data.level;
 
   // TODO: pull this out into a util
   const getAppState = (): AvatarAppState => {
@@ -51,7 +52,7 @@ export function createAvatar(data: AvatarData, ctx: SimulationContext): Avatar {
       behaviours: behaviourState,
       id: data.id,
       isAlive: state.status === EntityStatus.Alive,
-      level: data.level,
+      level: currentLevel,
       mainHandAttack,
       name: data.name,
     };
@@ -96,7 +97,6 @@ export function createAvatar(data: AvatarData, ctx: SimulationContext): Avatar {
   const avatar: Avatar = {
     // meta
     id: data.id,
-    level: data.level,
     type: EntityType.Avatar,
     xp: data.xp,
 
@@ -106,6 +106,9 @@ export function createAvatar(data: AvatarData, ctx: SimulationContext): Avatar {
     },
     get life() {
       return state.life;
+    },
+    get level() {
+      return currentLevel;
     },
     get mainHandEquipment() {
       return data.paperdoll[EquipmentSlot.MainHand];
@@ -129,6 +132,9 @@ export function createAvatar(data: AvatarData, ctx: SimulationContext): Avatar {
       logger.debug(`${label} <-- ${amount} damage (${state.life} life remains)`);
     },
     reset,
+    updateLevel: (level: number) => {
+      currentLevel = level;
+    },
   };
 
   DEFAULT_BEHAVIOUR_FACTORIES

--- a/libs/game/idle-core/src/index.ts
+++ b/libs/game/idle-core/src/index.ts
@@ -1,5 +1,6 @@
 export { createSimulation } from './core/create-simulation';
 export { runSimulation } from './core/run-simulation';
+export * from './progression';
 export { createMockActivityData } from './test-utils/create-mock-activity-data';
 export { createMockAvatarData } from './test-utils/create-mock-avatar-data';
 export { createMockEnemyData } from './test-utils/create-mock-enemy-data';

--- a/libs/game/idle-core/src/progression/build-completion-xp.test.ts
+++ b/libs/game/idle-core/src/progression/build-completion-xp.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from 'bun:test';
+import { buildCompletionXP } from './build-completion-xp';
+
+test('it scales up with difficulty', () => {
+  const higher = buildCompletionXP(2);
+  const lower = buildCompletionXP(1);
+
+  expect(higher).toBeGreaterThan(lower);
+});
+
+test('it never returns negative xp for a non-negative difficulty', () => {
+  expect(buildCompletionXP(0)).toBeGreaterThanOrEqual(0);
+});

--- a/libs/game/idle-core/src/progression/build-completion-xp.ts
+++ b/libs/game/idle-core/src/progression/build-completion-xp.ts
@@ -1,0 +1,8 @@
+import { COMPLETION_BASE_XP } from './constants';
+
+/**
+ * Flat activity-completion XP bonus scaled by a node's difficulty multiplier.
+ */
+export function buildCompletionXP(difficulty: number): number {
+  return Math.round(COMPLETION_BASE_XP * difficulty);
+}

--- a/libs/game/idle-core/src/progression/build-failure-xp-loss.test.ts
+++ b/libs/game/idle-core/src/progression/build-failure-xp-loss.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from 'bun:test';
+import { buildFailureXPLoss } from './build-failure-xp-loss';
+import { levelForXP } from './level-for-xp';
+import { xpThreshold } from './xp-threshold';
+
+test('it never returns a negative loss', () => {
+  for (let xp = 0; xp <= 10_000; xp += 173) {
+    expect(buildFailureXPLoss(xp)).toBeGreaterThanOrEqual(0);
+  }
+});
+
+test('it never drops xp below the current level threshold', () => {
+  for (let xp = 0; xp <= 10_000; xp += 173) {
+    const floor = xpThreshold(levelForXP(xp));
+
+    expect(xp - buildFailureXPLoss(xp)).toBeGreaterThanOrEqual(floor);
+  }
+});
+
+test('it returns zero loss exactly at a level threshold', () => {
+  const floor = xpThreshold(5);
+
+  expect(buildFailureXPLoss(floor)).toBe(0);
+});

--- a/libs/game/idle-core/src/progression/build-failure-xp-loss.ts
+++ b/libs/game/idle-core/src/progression/build-failure-xp-loss.ts
@@ -1,0 +1,16 @@
+import { FAILURE_XP_LOSS_FRACTION } from './constants';
+import { levelForXP } from './level-for-xp';
+import { xpThreshold } from './xp-threshold';
+
+/**
+ * XP lost on activity failure: a fraction of an avatar's progress into its current level, clamped
+ * so the loss never crosses that level's threshold — a level already reached is never lost.
+ */
+export function buildFailureXPLoss(runningXP: number): number {
+  const level = levelForXP(runningXP);
+  const floor = xpThreshold(level);
+  const progressIntoLevel = runningXP - floor;
+  const rawLoss = Math.round(progressIntoLevel * FAILURE_XP_LOSS_FRACTION);
+
+  return Math.min(rawLoss, progressIntoLevel);
+}

--- a/libs/game/idle-core/src/progression/build-kill-xp.test.ts
+++ b/libs/game/idle-core/src/progression/build-kill-xp.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from 'bun:test';
+import { buildKillXP } from './build-kill-xp';
+
+test('it returns the enemy base xp at a difficulty of one', () => {
+  expect(buildKillXP({ xp: 42 }, 1)).toBe(42);
+});
+
+test('it scales up with difficulty', () => {
+  const higher = buildKillXP({ xp: 100 }, 2);
+  const lower = buildKillXP({ xp: 100 }, 1);
+
+  expect(higher).toBeGreaterThan(lower);
+});
+
+test('it never returns negative xp for a non-negative difficulty', () => {
+  expect(buildKillXP({ xp: 10 }, 0)).toBeGreaterThanOrEqual(0);
+});

--- a/libs/game/idle-core/src/progression/build-kill-xp.ts
+++ b/libs/game/idle-core/src/progression/build-kill-xp.ts
@@ -1,0 +1,8 @@
+import type { EnemyData } from '../types';
+
+/**
+ * Enemy kill XP scaled by a node's difficulty multiplier.
+ */
+export function buildKillXP(enemy: Readonly<Pick<EnemyData, 'xp'>>, difficulty: number): number {
+  return Math.round(enemy.xp * difficulty);
+}

--- a/libs/game/idle-core/src/progression/constants.ts
+++ b/libs/game/idle-core/src/progression/constants.ts
@@ -1,0 +1,16 @@
+/**
+ * Tunable inputs for the XP and leveling curve. Values here are a placeholder shape standing in
+ * for a designed curve — callers depend on the functions built from them, never these numbers
+ * directly.
+ */
+export const XP_THRESHOLD_BASE = 100;
+
+/**
+ * Flat XP granted for completing an activity, before difficulty scaling.
+ */
+export const COMPLETION_BASE_XP = 25;
+
+/**
+ * Fraction of an avatar's progress into its current level lost on activity failure.
+ */
+export const FAILURE_XP_LOSS_FRACTION = 0.1;

--- a/libs/game/idle-core/src/progression/index.ts
+++ b/libs/game/idle-core/src/progression/index.ts
@@ -1,0 +1,5 @@
+export { buildCompletionXP } from './build-completion-xp';
+export { buildFailureXPLoss } from './build-failure-xp-loss';
+export { buildKillXP } from './build-kill-xp';
+export { levelForXP } from './level-for-xp';
+export { xpThreshold } from './xp-threshold';

--- a/libs/game/idle-core/src/progression/level-for-xp.test.ts
+++ b/libs/game/idle-core/src/progression/level-for-xp.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from 'bun:test';
+import { levelForXP } from './level-for-xp';
+import { xpThreshold } from './xp-threshold';
+
+test('it returns level one for zero xp', () => {
+  expect(levelForXP(0)).toBe(1);
+});
+
+test('it inverts xpThreshold across a range of levels', () => {
+  for (let level = 1; level <= 50; level++) {
+    expect(levelForXP(xpThreshold(level))).toBe(level);
+  }
+});
+
+test('it is monotonic as xp grows', () => {
+  let previousLevel = levelForXP(0);
+
+  for (let xp = 0; xp <= 100_000; xp += 137) {
+    const level = levelForXP(xp);
+
+    expect(level).toBeGreaterThanOrEqual(previousLevel);
+
+    previousLevel = level;
+  }
+});

--- a/libs/game/idle-core/src/progression/level-for-xp.ts
+++ b/libs/game/idle-core/src/progression/level-for-xp.ts
@@ -1,0 +1,10 @@
+import { XP_THRESHOLD_BASE } from './constants';
+
+const FLOAT_EPSILON = 1e-9;
+
+/**
+ * The level a cumulative XP total falls into — the inverse of `xpThreshold`.
+ */
+export function levelForXP(xp: number): number {
+  return 1 + Math.floor(Math.sqrt(xp / XP_THRESHOLD_BASE) + FLOAT_EPSILON);
+}

--- a/libs/game/idle-core/src/progression/xp-threshold.test.ts
+++ b/libs/game/idle-core/src/progression/xp-threshold.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from 'bun:test';
+import { xpThreshold } from './xp-threshold';
+
+test('it returns zero xp for level one', () => {
+  expect(xpThreshold(1)).toBe(0);
+});
+
+test('it strictly increases as level increases', () => {
+  const thresholds = Array.from({ length: 30 }, (_, index) => xpThreshold(index + 1));
+
+  for (let index = 1; index < thresholds.length; index++) {
+    expect(thresholds[index]).toBeGreaterThan(thresholds[index - 1]!);
+  }
+});

--- a/libs/game/idle-core/src/progression/xp-threshold.ts
+++ b/libs/game/idle-core/src/progression/xp-threshold.ts
@@ -1,0 +1,9 @@
+import { XP_THRESHOLD_BASE } from './constants';
+
+/**
+ * Cumulative XP required to reach a level. A placeholder quadratic curve standing in for a
+ * designed one; `xpThreshold(1)` is always zero.
+ */
+export function xpThreshold(level: number): number {
+  return XP_THRESHOLD_BASE * (level - 1) ** 2;
+}

--- a/libs/game/idle-core/src/test-utils/create-mock-activity-data.test.ts
+++ b/libs/game/idle-core/src/test-utils/create-mock-activity-data.test.ts
@@ -7,6 +7,7 @@ test('it creates activity data with expected properties', () => {
   const activity = createMockActivityData();
 
   expect(activity).toStrictEqual({
+    difficulty: 1,
     enemies: [
       {
         level: 1,
@@ -41,6 +42,7 @@ test('it creates activity data with custom properties', () => {
   });
 
   expect(activity).toStrictEqual({
+    difficulty: 1,
     enemies: [enemy],
     failureAction: ActivityFailureAction.Abort,
     id: 'custom-activity',

--- a/libs/game/idle-core/src/test-utils/create-mock-activity-data.ts
+++ b/libs/game/idle-core/src/test-utils/create-mock-activity-data.ts
@@ -6,6 +6,7 @@ import { createMockEnemyData } from './create-mock-enemy-data';
 // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- a Partial of the mutable activity seed, whose nested enemies array has no readonly form; spread into the returned seed, never mutated
 export function createMockActivityData(overrides: Partial<ActivityData> = {}): ActivityData {
   const activity: ActivityData = {
+    difficulty: 1,
     enemies: [createMockEnemyData()],
     failureAction: ActivityFailureAction.Retry,
     id: createId(),

--- a/libs/game/idle-core/src/test-utils/create-mock-avatar-data.test.ts
+++ b/libs/game/idle-core/src/test-utils/create-mock-avatar-data.test.ts
@@ -19,6 +19,7 @@ test('it creates avatar data with expected properties', () => {
         speed: 0.8,
       },
     },
+    xp: 0,
   });
 });
 
@@ -53,5 +54,6 @@ test('it creates avatar data with custom properties', () => {
         speed: 1,
       },
     },
+    xp: 0,
   });
 });

--- a/libs/game/idle-core/src/test-utils/create-mock-avatar-data.ts
+++ b/libs/game/idle-core/src/test-utils/create-mock-avatar-data.ts
@@ -9,6 +9,7 @@ export function createMockAvatarData(overrides: Partial<AvatarData> = {}): Avata
     level: 1,
     life: 200,
     name: 'Test Avatar',
+    xp: 0,
     ...overrides,
     paperdoll: {
       [EquipmentSlot.MainHand]: {

--- a/libs/game/idle-core/src/types/activity.ts
+++ b/libs/game/idle-core/src/types/activity.ts
@@ -1,6 +1,7 @@
 import type { EnemyData, EnemyGroup, EnemyGroupAppState } from './entities';
 
 interface IActivityData {
+  difficulty: number;
   failureAction: ActivityFailureAction;
   id: string;
   name: string;
@@ -32,6 +33,14 @@ export interface ActivityRewards {
   readonly xp: number;
 }
 
+/**
+ * A level crossing recorded on the checkpoint (or activity attempt) that caused it.
+ */
+export interface ActivityLevelUp {
+  readonly from: number;
+  readonly to: number;
+}
+
 export interface ActivityAppState {
   readonly currentEnemyGroup: EnemyGroupAppState | null;
   readonly elapsed: number;
@@ -39,12 +48,14 @@ export interface ActivityAppState {
   readonly enemyGroups: Array<EnemyGroupAppState>;
   readonly enemyGroupsRemaining: number;
   readonly id: string;
+  readonly levelUp: ActivityLevelUp | null;
   readonly name: string;
   readonly rewards: ActivityRewards;
 }
 
 export interface Activity {
   // meta
+  readonly difficulty: number;
   readonly enemyGroups: Array<EnemyGroup>;
   readonly id: string;
   readonly name: string;
@@ -54,6 +65,7 @@ export interface Activity {
   get currentEnemyGroup(): EnemyGroup | null;
   get elapsed(): number;
   get isEnemyGroupsRemaining(): boolean;
+  get levelUp(): ActivityLevelUp | null;
   get rewards(): ActivityRewards;
 
   // utils
@@ -61,6 +73,7 @@ export interface Activity {
   elapseTime: (time: number) => void;
   getAppState: () => ActivityAppState;
   moveToNextEnemyGroup: () => void;
+  setLevelUp: (levelUp: ActivityLevelUp) => void;
 }
 
 export type ActivityCheckpointGenerator = AsyncGenerator<
@@ -71,6 +84,7 @@ export type ActivityCheckpointGenerator = AsyncGenerator<
 
 interface IActivityCheckpoint {
   readonly hash: string;
+  readonly levelUp?: ActivityLevelUp;
   readonly rewards: ActivityRewards;
   readonly time: number;
   readonly type: ActivityCheckpointType;

--- a/libs/game/idle-core/src/types/entities.ts
+++ b/libs/game/idle-core/src/types/entities.ts
@@ -9,6 +9,7 @@ export interface AvatarData {
   level: number;
   life: number;
   name: string;
+  xp: number;
 
   // TODO: implement this as a map? type? where we use a record to enforce equipment type e.g. 1h/2h weapons = weapons, etc
   paperdoll: {
@@ -82,6 +83,7 @@ export interface AvatarAppState {
 export interface Avatar extends IEntity<AvatarState, AvatarAppState> {
   // meta
   readonly type: EntityType.Avatar;
+  readonly xp: number;
 
   // getters
   get mainHandEquipment(): EquipmentWeapon | null;

--- a/libs/game/idle-core/src/types/entities.ts
+++ b/libs/game/idle-core/src/types/entities.ts
@@ -95,6 +95,7 @@ export interface Avatar extends IEntity<AvatarState, AvatarAppState> {
   // utils
   calcAttackDamage: () => number;
   reset: (config?: ResetConfig) => void;
+  updateLevel: (level: number) => void;
 }
 
 export interface EnemyState {

--- a/services/activity/package.json
+++ b/services/activity/package.json
@@ -16,8 +16,10 @@
     "@paralleldrive/cuid2": "catalog:",
     "@vers/contract-activity": "workspace:*",
     "@vers/db": "workspace:*",
+    "@vers/idle-core": "workspace:*",
     "@vers/service-runtime": "workspace:*",
     "kysely": "catalog:",
+    "tiny-invariant": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/services/activity/src/handlers/track-activity-progress.test.ts
+++ b/services/activity/src/handlers/track-activity-progress.test.ts
@@ -292,6 +292,15 @@ test('it settles avatar xp and level from a completed terminal checkpoint', asyn
 
   expect(updated.xp).toBe(rewardsXP);
   expect(updated.level).toBe(levelForXP(rewardsXP));
+
+  const updatedActivity = await ctx.db
+    .selectFrom('activities')
+    .selectAll()
+    .where('id', '=', started.id)
+    .executeTakeFirstOrThrow();
+
+  expect(updatedActivity.status).toBe('stopped');
+  expect(updatedActivity.stoppedAt).not.toBeNil();
 });
 
 test('it settles a clamped xp loss from a failed terminal checkpoint', async () => {

--- a/services/activity/src/handlers/track-activity-progress.test.ts
+++ b/services/activity/src/handlers/track-activity-progress.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'bun:test';
 import type { ActivityContract } from '@vers/contract-activity';
+import { buildFailureXPLoss, levelForXP } from '@vers/idle-core';
 import { createAnonymousViewer, createTestDB, createViewer } from '@vers/service-test-utils/bun';
 import { buildRPCTestClient } from '@vers/test-utils';
 import { createActivityService } from '../create-activity-service';
@@ -257,4 +258,117 @@ test('it rejects an anonymous acting user with UNAUTHORIZED', async () => {
   expect(
     client.trackActivityProgress({ activityID: 'act_1', checkpoints: [], expectedHead: 0 }),
   ).rejects.toMatchObject({ code: 'UNAUTHORIZED', data: { reason: 'missing-session' } });
+});
+
+test('it settles avatar xp and level from a completed terminal checkpoint', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id, xp: 0 });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({ avatarID: avatar.id, nodeID: 'node_1' });
+
+  const rewardsXP = 150;
+
+  const batch = createMockCheckpointBatch({
+    finalPayloadOverrides: { rewards: { xp: rewardsXP }, type: 'completed' },
+    startPrevHash: started.startHash,
+    startVersion: 1,
+  });
+
+  await client.trackActivityProgress({
+    activityID: started.id,
+    checkpoints: batch,
+    expectedHead: 0,
+  });
+
+  const updated = await ctx.db
+    .selectFrom('avatars')
+    .selectAll()
+    .where('id', '=', avatar.id)
+    .executeTakeFirstOrThrow();
+
+  expect(updated.xp).toBe(rewardsXP);
+  expect(updated.level).toBe(levelForXP(rewardsXP));
+});
+
+test('it settles a clamped xp loss from a failed terminal checkpoint', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+
+  // partway into a level, so the failure loss is nonzero but the ratchet still holds
+  const startingXP = 150;
+
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id, xp: startingXP });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({ avatarID: avatar.id, nodeID: 'node_1' });
+
+  const loss = buildFailureXPLoss(startingXP);
+  const rewardsXP = -loss;
+
+  const batch = createMockCheckpointBatch({
+    finalPayloadOverrides: { rewards: { xp: rewardsXP }, type: 'failed' },
+    startPrevHash: started.startHash,
+    startVersion: 1,
+  });
+
+  await client.trackActivityProgress({
+    activityID: started.id,
+    checkpoints: batch,
+    expectedHead: 0,
+  });
+
+  const updated = await ctx.db
+    .selectFrom('avatars')
+    .selectAll()
+    .where('id', '=', avatar.id)
+    .executeTakeFirstOrThrow();
+
+  expect(loss).toBeGreaterThan(0);
+  expect(updated.xp).toBe(startingXP + rewardsXP);
+  expect(updated.level).toBe(levelForXP(startingXP + rewardsXP));
+});
+
+test('it does not double-apply xp on a duplicate terminal submission', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id, xp: 0 });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({ avatarID: avatar.id, nodeID: 'node_1' });
+
+  const batch = createMockCheckpointBatch({
+    finalPayloadOverrides: { rewards: { xp: 150 }, type: 'completed' },
+    startPrevHash: started.startHash,
+    startVersion: 1,
+  });
+
+  await client.trackActivityProgress({
+    activityID: started.id,
+    checkpoints: batch,
+    expectedHead: 0,
+  });
+
+  expect(
+    client.trackActivityProgress({
+      activityID: started.id,
+      checkpoints: batch,
+      expectedHead: 0,
+    }),
+  ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+  const updated = await ctx.db
+    .selectFrom('avatars')
+    .selectAll()
+    .where('id', '=', avatar.id)
+    .executeTakeFirstOrThrow();
+
+  expect(updated.xp).toBe(150);
 });

--- a/services/activity/src/handlers/track-activity-progress.ts
+++ b/services/activity/src/handlers/track-activity-progress.ts
@@ -82,7 +82,10 @@ export async function trackActivityProgress(
         appendedAt: sql`now()`,
         appendedHead: newHead,
         lastHash: newLastHash,
-        ...(terminalRewardsXP !== undefined && { status: 'stopped' as const }),
+        ...(terminalRewardsXP !== undefined && {
+          status: 'stopped' as const,
+          stoppedAt: sql`now()`,
+        }),
       })
       .where('id', '=', opts.input.activityID)
       .where('appendedHead', '=', opts.input.expectedHead)

--- a/services/activity/src/handlers/track-activity-progress.ts
+++ b/services/activity/src/handlers/track-activity-progress.ts
@@ -1,8 +1,11 @@
-import type { CheckpointBatchEntry } from '@vers/contract-activity';
+import type { CheckpointBatchEntry, CheckpointPayload } from '@vers/contract-activity';
 import { buildCheckpointHash } from '@vers/contract-activity';
 import type { DB, Json } from '@vers/db';
+import { levelForXP } from '@vers/idle-core';
 import { sql } from 'kysely';
 import type { Kysely } from 'kysely';
+import invariant from 'tiny-invariant';
+import * as z from 'zod';
 import type {
   CheckpointInvalidPayload,
   EmptyErrorPayload,
@@ -33,7 +36,10 @@ interface TrackActivityProgressOpts {
  * contiguity and hash chain are validated up front; the head-row compare-and-swap inside the
  * transaction is the actual serialization point — a losing race re-reads the current head and
  * reports NOT_FOUND (activity gone or no longer active) or CONFLICT (a retryable stale head) as
- * appropriate.
+ * appropriate. When the batch's last checkpoint is terminal (completed or failed), the same
+ * transaction claims the activity's terminal transition and settles the avatar's xp/level from
+ * that checkpoint's final rewards total — the claim guards against a duplicate terminal
+ * resubmission double-applying.
  */
 export async function trackActivityProgress(
   db: Kysely<DB>,
@@ -48,7 +54,7 @@ export async function trackActivityProgress(
   const head = await db
     .selectFrom('activities')
     .innerJoin('avatars', 'avatars.id', 'activities.avatarId')
-    .select(['activities.appendedHead', 'activities.lastHash'])
+    .select(['activities.appendedHead', 'activities.avatarId', 'activities.lastHash', 'avatars.xp'])
     .where('activities.id', '=', opts.input.activityID)
     .where('avatars.userId', '=', actingUserID)
     .where('activities.status', '=', 'active')
@@ -67,11 +73,17 @@ export async function trackActivityProgress(
   const lastCheckpoint = opts.input.checkpoints.at(-1);
   const newHead = lastCheckpoint?.version ?? opts.input.expectedHead;
   const newLastHash = lastCheckpoint?.hash ?? head.lastHash;
+  const terminalRewardsXP = lastCheckpoint && findTerminalRewardsXP(lastCheckpoint.payload);
 
   const appendedHead = await db.transaction().execute(async (trx) => {
     const updated = await trx
       .updateTable('activities')
-      .set({ appendedAt: sql`now()`, appendedHead: newHead, lastHash: newLastHash })
+      .set({
+        appendedAt: sql`now()`,
+        appendedHead: newHead,
+        lastHash: newLastHash,
+        ...(terminalRewardsXP !== undefined && { status: 'stopped' as const }),
+      })
       .where('id', '=', opts.input.activityID)
       .where('appendedHead', '=', opts.input.expectedHead)
       .where('status', '=', 'active')
@@ -106,6 +118,19 @@ export async function trackActivityProgress(
           })),
         )
         .execute();
+    }
+
+    if (terminalRewardsXP !== undefined) {
+      const newXP = Math.max(0, Math.round(head.xp + terminalRewardsXP));
+
+      const settled = await trx
+        .updateTable('avatars')
+        .set({ level: levelForXP(newXP), xp: newXP })
+        .where('id', '=', head.avatarId)
+        .where('xp', '=', head.xp)
+        .executeTakeFirst();
+
+      invariant(settled.numUpdatedRows > 0n, 'avatar settlement must apply exactly once');
     }
 
     return updated.appendedHead;
@@ -171,4 +196,27 @@ function findInvalidReason(
   }
 
   return undefined;
+}
+
+/**
+ * Checkpoint types whose `rewards.xp` is a final running total the avatar row settles against.
+ */
+const TERMINAL_CHECKPOINT_TYPES = new Set(['completed', 'failed']);
+
+const TerminalRewardsSchema = z.object({ xp: z.number() });
+
+/**
+ * The final rewards total a terminal checkpoint's payload carries, or `undefined` when the
+ * checkpoint isn't terminal or its `rewards` shape doesn't parse — the latter settles no xp rather
+ * than throwing, since the hash chain doesn't cover `rewards` and a malformed value isn't
+ * distinguishable here from a stale or non-terminal client payload.
+ */
+function findTerminalRewardsXP(payload: Readonly<CheckpointPayload>): number | undefined {
+  if (!TERMINAL_CHECKPOINT_TYPES.has(payload.type)) {
+    return undefined;
+  }
+
+  const parsed = TerminalRewardsSchema.safeParse(payload['rewards']);
+
+  return parsed.success ? parsed.data.xp : undefined;
 }

--- a/services/activity/src/test-utils/factories/create-mock-checkpoint-batch.test.ts
+++ b/services/activity/src/test-utils/factories/create-mock-checkpoint-batch.test.ts
@@ -45,3 +45,37 @@ test('it defaults entropySource to chain', () => {
 
   expect(entry?.payload.entropySource).toBe('chain');
 });
+
+test('it merges finalPayloadOverrides into only the last entry', () => {
+  const batch = createMockCheckpointBatch({
+    count: 2,
+    finalPayloadOverrides: { rewards: { xp: 10 }, type: 'completed' },
+    startPrevHash: 'hash_0',
+    startVersion: 1,
+  });
+
+  expect(batch[0]?.payload).toMatchObject({ type: 'tick' });
+  expect(batch[1]?.payload).toMatchObject({ rewards: { xp: 10 }, type: 'completed' });
+});
+
+test('it keeps the last entry chain-valid after the payload override', () => {
+  const batch = createMockCheckpointBatch({
+    finalPayloadOverrides: { rewards: { xp: 10 }, type: 'completed' },
+    startPrevHash: 'hash_0',
+    startVersion: 1,
+  });
+
+  const [entry] = batch;
+
+  expect(entry?.hash).toBe(
+    buildCheckpointHash({
+      entropySource: entry?.payload.entropySource ?? '',
+      nextSeed: entry?.payload.nextSeed ?? '',
+      prevHash: entry?.prevHash ?? '',
+      seed: entry?.payload.seed ?? '',
+      time: entry?.payload.time ?? 0,
+      type: entry?.payload.type ?? '',
+      version: entry?.version ?? 0,
+    }),
+  );
+});

--- a/services/activity/src/test-utils/factories/create-mock-checkpoint-batch.ts
+++ b/services/activity/src/test-utils/factories/create-mock-checkpoint-batch.ts
@@ -9,6 +9,12 @@ interface CreateMockCheckpointBatchConfig {
   readonly count?: number;
 
   /**
+   * Extra fields merged into the last entry's payload — `type`/`rewards` for a batch ending in a
+   * terminal checkpoint. Ignored by `buildCheckpointHash`, so the chain stays valid.
+   */
+  readonly finalPayloadOverrides?: Readonly<Record<string, unknown>>;
+
+  /**
    * The hash the batch's first entry links onto — the activity's current `lastHash` for a batch
    * that will apply cleanly.
    */
@@ -34,6 +40,7 @@ export function createMockCheckpointBatch(
 
   for (let index = 0; index < count; index += 1) {
     const version = config.startVersion + index;
+    const isLast = index === count - 1;
 
     const payload = {
       entropySource: 'chain',
@@ -41,6 +48,7 @@ export function createMockCheckpointBatch(
       seed: faker.string.alphanumeric({ casing: 'lower', length: 16 }),
       time: version * 1000,
       type: 'tick',
+      ...(isLast && config.finalPayloadOverrides),
     };
 
     const hash = buildCheckpointHash({ ...payload, prevHash, version });


### PR DESCRIPTION
## Description

Closes #171

Adds an XP curve and level derivation to idle-core, wires it through activity rewards and checkpoints, settles avatar xp/level on activity completion in the service layer, and surfaces level and level-up in the idle client.

- `libs/game/idle-core/src/progression/`: `xpThreshold`/`levelForXP` (inverse pair), `buildKillXP`, `buildCompletionXP`, `buildFailureXPLoss`, on a placeholder quadratic curve in `constants.ts`
- `difficulty` added to activity data, `xp` to avatar data; new `ActivityLevelUp` type carried on checkpoints, `Activity`, and `ActivityAppState`
- checkpoint builders compute level crossings via `levelForXP`; `simulate-activity.ts` preserves the invariant that group-clear XP and any level-up apply before death resolution
- `services/activity`: `trackActivityProgress` detects a terminal checkpoint in the batch and settles the avatar's xp/level with a single conditional `UPDATE` inside the existing transactional head-row CAS, guarding against duplicate terminal resubmission
- `idle-client`: `ActivityInfo` shows a level-up line, `AvatarInfo` shows the avatar's level

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
