### PR TITLE
chore: ignore all secret .env files anywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,13 +55,13 @@ Thumbs.db
 # secrets & keys
 privkey.pem
 pubkey.crt
-services/*/.env.production
-apps/web-e2e/.env
-apps/**/.env*.local
-services/**/.env*.local
-contracts/**/.env*.local
-libs/**/.env*.local
-infra/.env*.local
+# Env files anywhere: only .env.example, .env.development, and .env.test are committed
+.env
+.env.*
+!.env.example
+!.env.*.example
+!.env.development
+!.env.test
 
 # cursor context files
 memory.md


### PR DESCRIPTION
## Description

The `.gitignore` env rules were narrow per-directory `.env*.local` patterns, leaving root `.env`, `.env.production`, and ad-hoc names like `.env.cloudflare` trackable — a secret-leak gap. Replace them with a repo-wide rule.

- Ignore every `.env` file at any depth, re-including only the committed `.env.example`, `.env.development`, and `.env.test`.
- Verified: all secret patterns now ignored; every currently-tracked env file stays tracked; no tracked file flipped to ignored.

## Testing

- [x] `git check-ignore` matrix over secret vs committed env paths
- [x] `git ls-files | git check-ignore --stdin` empty (no tracked file newly ignored)

## Context

Prompted by `.env.cloudflare` (transient R2 creds) slipping the ignore during the bugsink R2 work.