### PR TITLE
feat(bugsink): schedule monthly vacuum_files

### DIFF
--- a/.github/workflows/bugsink-vacuum.yml
+++ b/.github/workflows/bugsink-vacuum.yml
@@ -1,0 +1,31 @@
+# Monthly housekeeping for the self-hosted Bugsink error tracker: drop unused
+# sourcemap File/Chunk rows so they don't accumulate in the shared Neon database.
+# vacuum_files enqueues a snappea background task and returns immediately, so the
+# job just triggers it. Runs in the production environment for the Fly token.
+name: Bugsink vacuum
+
+on:
+  schedule:
+    # 03:17 UTC on the 1st of each month — off the hour to dodge cron congestion
+    - cron: '17 3 1 * *'
+  workflow_dispatch:
+
+concurrency:
+  group: bugsink-vacuum
+  cancel-in-progress: false
+
+jobs:
+  vacuum:
+    name: Vacuum sourcemap files
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 10
+    steps:
+      - name: Setup flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # 1.6
+
+      - name: Enqueue vacuum_files
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        # --user bugsink: snappea refuses to enqueue as any other uid
+        run: flyctl ssh console --app vers-bugsink --user bugsink -C 'bugsink-manage vacuum_files'

--- a/apps/bugsink/README.md
+++ b/apps/bugsink/README.md
@@ -34,6 +34,12 @@ move across with `bugsink-manage migrate_to_current_objectstorage`.
 The R2 credentials also live on the `bugsink-r2` item in the `vers` 1Password vault. Unset the four
 `R2_*` secrets and Bugsink falls back to storing files in the database.
 
+## Housekeeping
+
+The `.github/workflows/bugsink-vacuum.yml` workflow runs `bugsink-manage vacuum_files` monthly (and
+on manual dispatch) to drop unused sourcemap `File`/`Chunk` rows before they accumulate in the
+shared Neon database. It enqueues a snappea background task, so the run returns immediately.
+
 ## API tokens
 
 Tokens are minted in the Bugsink UI or with `bugsink-manage create_auth_token` over


### PR DESCRIPTION
## Description

Add a monthly (and manual-dispatch) workflow that runs `bugsink-manage vacuum_files` over `fly ssh`, dropping unused sourcemap `File`/`Chunk` rows before they accumulate in the shared Neon database. Follows the R2 file migration — vacuum is now storage hygiene, not urgent.

- Runs in the `production` environment for `FLY_API_TOKEN`; `--user bugsink` because snappea refuses to enqueue as another uid.
- `vacuum_files` enqueues a snappea background task and returns immediately.

## Testing

- [x] `bun run format:check` passes
- [ ] First scheduled/dispatch run exercises it end-to-end

## Context

If the `production` environment has required-reviewer protection, the monthly run will wait for approval — move `FLY_API_TOKEN` to a non-gated environment if unattended runs are wanted. Default `vacuum_files` removes orphans only; add `file_max_days` later for access-based eviction.