### PR TITLE
docs: encode specialization node/tier authoring rules

### DIFF
--- a/docs/game-design/base-class-template.md
+++ b/docs/game-design/base-class-template.md
@@ -26,12 +26,16 @@ Per specialization:
 - **Name** — working name.
 - **System drawn on** — the universal system it interlocks with (a resource pool, a defensive layer,
   the beat cadence) or the mechanic itself. Never a damage type or a build archetype.
-- **Tier 1** — the choices offered, one exclusive pick.
-- **Tier 2** — the choices offered, one exclusive pick.
-- **Tier 3** — the choices offered, one exclusive pick.
+- **Tier 1 / Tier 2 / Tier 3** — two or three nodes each; the avatar takes one per tier. For every
+  node, state its effect and the **edge** it holds: the build, region, or encounter shape it is
+  strongest in. Nodes in a tier point in different directions — that divergence is the choice.
 
-The tiers may follow any internal framework. One example runs output, then fuel, then fusion: what
-the mechanic drives, then how it scales, then how it and the coupled system become one engine.
+Check the specialization as a set of paths, not tier by tier:
+
+- No node erases the value of an earlier one; a node bound to a durable quantity survives a capstone
+  that a node bound to a transient state does not.
+- No node wins in every context — each holds a different edge, or the tier collapses to one pick.
+- A capstone that reshapes the mechanic leaves no earlier node orphaned.
 
 ## Open Questions
 

--- a/docs/game-design/base-classes.md
+++ b/docs/game-design/base-classes.md
@@ -51,15 +51,31 @@ Any system a specialization draws on is universal — a resource pool, a defensi
 cadence — never a build archetype. Drawing on a damage type would smuggle a build back into the
 class layer and break the generic-or-transformative law at the specialization level.
 
-A specialization is a small branching structure of three tiers, one exclusive choice per tier. Each
-is free, and encouraged, to build its own internal framework rather than fill a fixed template. One
-example runs output, then fuel, then fusion: the first tier steers what the mechanic drives, the
-second steers how it accrues and scales, and the third fuses the mechanic with a coupled system into
-one engine.
+A specialization is three tiers. Each tier offers two or three nodes, and the avatar takes one. The
+nodes in a tier diverge — they pull the mechanic in different directions, and choosing among them is
+the decision the tier exists to pose. A tier is a fork, not a themed step dressed with
+interchangeable options.
 
-Choosing a specialization is a one-time commitment, re-chooseable with investment. The three tier
-choices within a chosen specialization respec freely, like passive allocation. A specialization
-unlocks through progression.
+Choosing a specialization is a one-time commitment, re-chooseable with investment. The node taken in
+each tier respecs freely, like passive allocation. A specialization unlocks through progression.
+
+## Authoring a Specialization
+
+Nodes are chosen in combination across the three tiers, so a specialization is designed as the set
+of paths through it, not tier by tier.
+
+- **Nodes compose without self-nullifying.** No node erases the value of one an avatar already took.
+  A node keyed to a durable quantity survives a later node that a node keyed to a transient state
+  does not — anchor a node's scaling to something no later node can remove.
+- **No node wins unconditionally.** Each node in a tier is strongest in a different build, region,
+  or encounter shape; nodes separated only by magnitude collapse into one obvious pick. The design
+  states the edge each node is meant to hold, and a balance pass confirms no path dominates.
+- **Off-path nodes stay tempting.** Along any path, the node that extends it is usually right but
+  never automatic — a node from another direction is defensible in some builds, or the tier choices
+  reduce to autopilot and only the first fork was real.
+- **A capstone that reshapes the mechanic cannot orphan its earlier nodes.** When a later tier can
+  replace or transform the mechanic, earlier nodes bound to the old form die with it. Bind early
+  nodes to the class's own resource, not to a structure a capstone might remove.
 
 ## Worked Example
 
@@ -69,11 +85,11 @@ Take a base class whose mechanic is a resource that accrues as the avatar acts a
 output. That resource, how it accrues, and what it amplifies are the entire base class, and it plays
 on its own.
 
-One of its specializations routes that resource through another universal system across three tiers:
-
-- **Tier 1 — output.** The resource additionally drives one of a small set of chosen effects.
-- **Tier 2 — fuel.** The resource's ceiling or accrual scales with the coupled system.
-- **Tier 3 — fusion.** The resource and the coupled system feed each other into a single engine.
+One of its specializations routes that resource through another universal system. Each of its three
+tiers is a fork: at one tier the avatar takes either a node that scales the resource's ceiling with
+the coupled system or a node that converts the coupled system's recovery into resource gain — nodes
+that pull toward different builds, so the pick commits a direction rather than stacking a number.
+Later tiers deepen that direction without deleting the earlier node.
 
 Its sibling specializations express the same resource differently — routing it through other
 systems, or scaling it through itself — each a distinct read on the one mechanic.


### PR DESCRIPTION
## Description

Encode the specialization authoring rules surfaced while speccing the first base class, so the model carries them before the class content lands.

- Add **node** as the term for a per-tier option: a tier offers two or three nodes, the avatar takes one, and the nodes diverge — a tier is a fork, not a themed step.
- New "Authoring a Specialization" section: nodes compose without self-nullifying, no node wins unconditionally (each holds a different edge), off-path nodes stay tempting, and a transformative capstone must not orphan earlier nodes.
- Drop the output→fuel→fusion framing that read as "one theme per tier"; rework the worked example around the fork/node model.
- Template gains a per-node **edge** field and the composition checklist.

## Testing

Docs-only — no code paths. `format:check` is the relevant gate.

## Context

Closes #506. Refines the base-class model (#228); feeds the first base class design (#490), which stays open.
