### PR TITLE
feat(#177): replace rng numeric seed with 128-bit state currency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -411,6 +411,7 @@
       "version": "0.0.0",
       "dependencies": {
         "pure-rand": "catalog:",
+        "tiny-invariant": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:",

--- a/libs/game/game-utils/package.json
+++ b/libs/game/game-utils/package.json
@@ -11,7 +11,8 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "pure-rand": "catalog:"
+    "pure-rand": "catalog:",
+    "tiny-invariant": "catalog:"
   },
   "devDependencies": {
     "@types/bun": "catalog:",

--- a/libs/game/game-utils/src/create-rng.test.ts
+++ b/libs/game/game-utils/src/create-rng.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from 'bun:test';
-import { createRNG } from './create-rng';
+import { createRNG, stateFromSeed } from './create-rng';
 
 test('it generates a deterministic sequence of integers with the given seed', () => {
-  const rng = createRNG(35_131_234);
+  const rng = createRNG(stateFromSeed(35_131_234));
 
   expect(rng.getInt(0, 100)).toMatchInlineSnapshot(`33`);
   expect(rng.getInt(0, 100)).toMatchInlineSnapshot(`33`);
@@ -13,9 +13,58 @@ test('it generates a deterministic sequence of integers with the given seed', ()
 });
 
 test('it generates a deterministic array of integers with the given seed', () => {
-  const rng = createRNG(35_131_234);
+  const rng = createRNG(stateFromSeed(35_131_234));
   const series = rng.getSeries(0, 100, 20);
 
   expect(series).toHaveLength(20);
   expect(series).toSatisfyAll((value: number) => typeof value === 'number');
+});
+
+test('it round-trips a snapshotted state back to the identical string', () => {
+  const rng = createRNG(stateFromSeed(1234));
+
+  rng.getInt(0, 100);
+  rng.getInt(0, 100);
+
+  const snapshot = rng.getState();
+
+  expect(createRNG(snapshot).getState()).toBe(snapshot);
+});
+
+test('it resumes a mid-stream snapshot with the exact subsequent draw sequence', () => {
+  const original = createRNG(stateFromSeed(4_242_424_242));
+
+  original.getInt(0, 1000);
+  original.getInt(0, 1000);
+
+  const midStreamState = original.getState();
+  const expectedContinuation = original.getSeries(0, 1000, 10);
+  const resumed = createRNG(midStreamState);
+  const actualContinuation = resumed.getSeries(0, 1000, 10);
+
+  expect(actualContinuation).toStrictEqual(expectedContinuation);
+});
+
+test('it rejects an all-zero state', () => {
+  expect(() => createRNG('0'.repeat(32))).toThrow();
+});
+
+test('it rejects a state of the wrong length', () => {
+  expect(() => createRNG('abcd')).toThrow();
+});
+
+test('it rejects a non-hex state', () => {
+  expect(() => createRNG('z'.repeat(32))).toThrow();
+});
+
+test('it derives a deterministic state from a numeric seed', () => {
+  expect(stateFromSeed(999)).toBe(stateFromSeed(999));
+  expect(stateFromSeed(999)).not.toBe(stateFromSeed(1000));
+});
+
+test('it produces a reproducible draw sequence from a seed-derived state', () => {
+  const first = createRNG(stateFromSeed(555));
+  const second = createRNG(stateFromSeed(555));
+
+  expect(first.getSeries(0, 100, 10)).toStrictEqual(second.getSeries(0, 100, 10));
 });

--- a/libs/game/game-utils/src/create-rng.ts
+++ b/libs/game/game-utils/src/create-rng.ts
@@ -1,35 +1,75 @@
 import { uniformInt } from 'pure-rand/distribution/uniformInt';
-import { xoroshiro128plus } from 'pure-rand/generator/xoroshiro128plus';
+import { xoroshiro128plus, xoroshiro128plusFromState } from 'pure-rand/generator/xoroshiro128plus';
+import invariant from 'tiny-invariant';
 import type { RNG } from './types';
+
+const STATE_HEX_PATTERN = /^[0-9a-f]{32}$/;
+const STATE_ALL_ZERO = '0'.repeat(32);
+const STATE_WORD_COUNT = 4;
+const STATE_WORD_HEX_CHARS = 8;
 
 /**
  * thin wrapper around pure-rand as it's interface is verbose and we don't need
  * most of it
  *
- * @param seed - the seed to create the rng with
+ * @param state - the 128-bit xoroshiro128+ state to rehydrate, as a 32-character hex string
  * @returns a thin wrapper around pure-rand
  */
-export function createRNG(initialSeed: number): RNG {
-  let seed = initialSeed;
-  let rng = xoroshiro128plus(seed);
-  const getInt = (min: number, max: number) => uniformInt(rng, min, max);
-
-  const generateNewSeed = () => {
-    seed = getInt(0, 0x100000000);
-    rng = xoroshiro128plus(seed);
-
-    return seed;
-  };
+export function createRNG(state: string): RNG {
+  const gen = xoroshiro128plusFromState(decodeState(state));
+  const getInt = (min: number, max: number) => uniformInt(gen, min, max);
 
   const getSeries = (min: number, max: number, count: number) =>
     Array.from({ length: count }, () => getInt(min, max));
 
   return {
-    generateNewSeed,
     getInt,
     getSeries,
-    get seed() {
-      return seed;
-    },
+    getState: () => encodeState(gen.getState()),
   };
+}
+
+/**
+ * Decodes a 32-character hex string into the four 32-bit words xoroshiro128+ carries as state.
+ * Round-trips `encodeState` exactly — word order is preserved, never interpreted. Throws on a
+ * malformed string or the all-zero state, xoroshiro128+'s degenerate fixed point.
+ */
+export function decodeState(hex: string): Array<number> {
+  invariant(STATE_HEX_PATTERN.test(hex), 'rng state must be a 32-character lowercase hex string');
+
+  invariant(
+    hex !== STATE_ALL_ZERO,
+    'rng state must not be the all-zero xoroshiro128plus fixed point',
+  );
+
+  return Array.from({ length: STATE_WORD_COUNT }, (_, index) => {
+    const chunk = hex.slice(index * STATE_WORD_HEX_CHARS, (index + 1) * STATE_WORD_HEX_CHARS);
+
+    // oxlint-disable-next-line unicorn/prefer-math-trunc -- reinterprets the unsigned hex value as a signed 32-bit int; Math.trunc only drops a fractional part, it doesn't wrap the high bit
+    return parseInt(chunk, 16) | 0;
+  });
+}
+
+/**
+ * Encodes xoroshiro128+'s four 32-bit state words into a 32-character hex string, one
+ * 8-character chunk per word in the order given.
+ */
+export function encodeState(words: ReadonlyArray<number>): string {
+  return words
+    .map((word) => {
+      // oxlint-disable-next-line unicorn/prefer-math-trunc -- reinterprets a signed 32-bit int as unsigned; Math.trunc only drops a fractional part, it doesn't clear the sign bit
+      const unsigned = word >>> 0;
+
+      return unsigned.toString(16).padStart(8, '0');
+    })
+    .join('');
+}
+
+/**
+ * Derives a 128-bit rng state from a plain numeric seed, for callers that legitimately seed from a
+ * number (a world map node's stored seed, an initial placeholder state, tests). Seed `0` scrambles
+ * to a valid non-zero state.
+ */
+export function stateFromSeed(seed: number): string {
+  return encodeState(xoroshiro128plus(seed).getState());
 }

--- a/libs/game/game-utils/src/index.ts
+++ b/libs/game/game-utils/src/index.ts
@@ -1,4 +1,4 @@
 export { combineSeeds } from './combine-seeds';
-export { createRNG } from './create-rng';
+export { createRNG, decodeState, encodeState, stateFromSeed } from './create-rng';
 export { createSeed } from './create-seed';
 export type * from './types';

--- a/libs/game/game-utils/src/types.ts
+++ b/libs/game/game-utils/src/types.ts
@@ -1,6 +1,5 @@
 export interface RNG {
-  generateNewSeed: () => number;
   getInt: (min: number, max: number) => number;
   getSeries: (min: number, max: number, count: number) => Array<number>;
-  get seed(): number;
+  getState: () => string;
 }

--- a/libs/game/idle-core/src/core/create-simulation.test.ts
+++ b/libs/game/idle-core/src/core/create-simulation.test.ts
@@ -120,7 +120,7 @@ test('it runs an activity and returns checkpoints', async () => {
   expect(firstCheckpoint).toStrictEqual({
     hash: expect.toBeString(),
     rewards: { xp: 0 },
-    seed: expect.toBeNumber(),
+    seed: expect.toBeString(),
     time: 0,
     type: ActivityCheckpointType.Started,
   });
@@ -129,7 +129,7 @@ test('it runs an activity and returns checkpoints', async () => {
 
   expect(secondCheckpoint).toStrictEqual({
     hash: expect.toBeString(),
-    nextSeed: expect.toBeNumber(),
+    nextSeed: expect.toBeString(),
     rewards: expect.toBeObject(),
     time: expect.toBeNumber(),
     type: ActivityCheckpointType.Progress,

--- a/libs/game/idle-core/src/core/create-simulation.ts
+++ b/libs/game/idle-core/src/core/create-simulation.ts
@@ -1,4 +1,4 @@
-import { createRNG } from '@vers/game-utils';
+import { createRNG, stateFromSeed } from '@vers/game-utils';
 import { deepEqual } from 'fast-equals';
 import invariant from 'tiny-invariant';
 import type { XXHashAPI } from 'xxhash-wasm';
@@ -24,7 +24,7 @@ import { simulateActivity } from './simulate-activity';
 import { getAppState } from './utils/get-app-state';
 
 export function createSimulation(hasher: XXHashAPI): Simulation {
-  let _rng = createRNG(0);
+  let _rng = createRNG(stateFromSeed(0));
   let _avatar: Avatar | null = null;
   let _activityData: ActivityData | null = null;
   let _activity: Activity | null = null;
@@ -185,8 +185,8 @@ export function createSimulation(hasher: XXHashAPI): Simulation {
     get failureAction(): ActivityFailureAction {
       return state.failureAction;
     },
-    get seed(): number {
-      return _rng.seed;
+    get rngState(): string {
+      return _rng.getState();
     },
     get state() {
       return state;

--- a/libs/game/idle-core/src/core/run-simulation.test.ts
+++ b/libs/game/idle-core/src/core/run-simulation.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'bun:test';
+import { stateFromSeed } from '@vers/game-utils';
 import { createMockActivityData } from '../test-utils/create-mock-activity-data';
 import { createMockAvatarData } from '../test-utils/create-mock-avatar-data';
 import { createMockEnemyData } from '../test-utils/create-mock-enemy-data';
@@ -12,7 +13,7 @@ test('runs a simulation with default configuration', async () => {
     enemies: [createMockEnemyData()],
     failureAction: ActivityFailureAction.Retry,
     id: 'world_map_encounter_1',
-    seed: 3_047_525_658,
+    seed: stateFromSeed(3_047_525_658),
     type: ActivityType.WorldMapEncounter,
   });
 
@@ -26,17 +27,17 @@ test('runs a simulation with default configuration', async () => {
     {
       "checkpoints": [
         {
-          "hash": "cbd6cc9427a79b1e",
+          "hash": "407d7906bdd4db82",
           "rewards": {
             "xp": 0,
           },
-          "seed": 3047525658,
+          "seed": "63298078c2177576c07e0321584c2a05",
           "time": 0,
           "type": "started",
         },
         {
-          "hash": "611b08f1de148c51",
-          "nextSeed": 685112472,
+          "hash": "d1ace45dda64f2ef",
+          "nextSeed": "20c0dac3c8da96ee1a82332c38c2e8ae",
           "rewards": {
             "xp": 60,
           },
@@ -44,61 +45,61 @@ test('runs a simulation with default configuration', async () => {
           "type": "progress",
         },
         {
-          "hash": "d0100e711451eca4",
+          "hash": "17c6aebfd6dfea7c",
           "levelUp": {
             "from": 1,
             "to": 2,
           },
-          "nextSeed": 2866488649,
+          "nextSeed": "651b7bac24e8282ac2345557ee733dc5",
           "rewards": {
             "xp": 60,
           },
-          "time": 36300,
+          "time": 33800,
           "type": "progress",
         },
         {
-          "hash": "754e2d41cc9f551d",
-          "nextSeed": 2249575321,
+          "hash": "6967c8efdd0347d2",
+          "nextSeed": "183a8b662f0c22f40b637a9f83c410ca",
           "rewards": {
             "xp": 30,
           },
-          "time": 46300,
+          "time": 43800,
           "type": "progress",
         },
         {
-          "hash": "e9f8306aa299f8cc",
-          "nextSeed": 3183217100,
+          "hash": "05509deb38464e85",
+          "nextSeed": "0d1c5f2ed8a45260129c426ab502cbb3",
           "rewards": {
             "xp": 40,
           },
-          "time": 57600,
+          "time": 56300,
           "type": "progress",
         },
         {
-          "hash": "0ad2f691a6d94aa0",
-          "nextSeed": 4197947599,
+          "hash": "6a6629b7772afe49",
+          "nextSeed": "0d1c5f2ed8a45260129c426ab502cbb3",
           "rewards": {
             "xp": 215,
           },
-          "time": 57600,
+          "time": 56300,
           "type": "completed",
         },
         {
-          "hash": "f1dd0c3fcae677d9",
+          "hash": "d1e97ebd0eb2c79b",
           "rewards": {
             "xp": 0,
           },
-          "seed": 4197947599,
+          "seed": "664be6d955fc249bfe89a1dbcdfd99cc",
           "time": 0,
           "type": "started",
         },
         {
-          "hash": "18975faf33fdc719",
-          "nextSeed": 2381219441,
+          "hash": "580d0847a0d4356d",
+          "nextSeed": "dd5a3353a7f6c0c6afcb296684176982",
           "rewards": {
-            "xp": 60,
+            "xp": 40,
           },
-          "time": 18800,
+          "time": 13800,
           "type": "progress",
         },
       ],
@@ -114,7 +115,7 @@ test('it respects duration limit and stops the simulation accordingly', async ()
     enemies: [createMockEnemyData()],
     failureAction: ActivityFailureAction.Retry,
     id: 'world_map_encounter_1',
-    seed: 3_047_525_658,
+    seed: stateFromSeed(3_047_525_658),
     type: ActivityType.WorldMapEncounter,
   });
 
@@ -130,7 +131,7 @@ test('it respects duration limit and stops the simulation accordingly', async ()
   expect(result.elapsed).toBe(10_000);
 });
 
-test('it stops at the specified seed if provided', async () => {
+test('it stops at the specified rng state if provided', async () => {
   const avatar = createMockAvatarData();
   const enemy = createMockEnemyData();
 
@@ -138,7 +139,7 @@ test('it stops at the specified seed if provided', async () => {
     enemies: [enemy],
     failureAction: ActivityFailureAction.Retry,
     id: 'world_map_encounter_1',
-    seed: 3_047_525_658,
+    seed: stateFromSeed(3_047_525_658),
     type: ActivityType.WorldMapEncounter,
   });
 
@@ -146,9 +147,9 @@ test('it stops at the specified seed if provided', async () => {
     // set a long duration so we always reach the right value
     duration: 200_000,
 
-    // when our algo changes, can just pull this seed to something valid from our
+    // when our algo changes, can just pull this state to something valid from our
     // happy path snapshot test ouput
-    stopAtSeed: 4_197_947_599,
+    stopAtState: '20c0dac3c8da96ee1a82332c38c2e8ae',
   };
 
   const result = await runSimulation(activity, avatar, config);
@@ -157,10 +158,10 @@ test('it stops at the specified seed if provided', async () => {
 
   expect(finalCheckpoint).toStrictEqual({
     hash: expect.toBeString(),
-    nextSeed: config.stopAtSeed,
+    nextSeed: config.stopAtState,
     rewards: expect.toBeObject(),
     time: expect.toBeNumber(),
-    type: ActivityCheckpointType.Completed,
+    type: ActivityCheckpointType.Progress,
   });
 });
 
@@ -173,7 +174,7 @@ test('it aborts on failure if failure action is set to abort', async () => {
     enemies: [enemy],
     failureAction: ActivityFailureAction.Abort,
     id: 'world_map_encounter_1',
-    seed: 3_047_525_658,
+    seed: stateFromSeed(3_047_525_658),
     type: ActivityType.WorldMapEncounter,
   });
 
@@ -193,7 +194,7 @@ test('it aborts on failure if failure action is set to abort', async () => {
 
   expect(lastCheckpoint).toStrictEqual({
     hash: expect.toBeString(),
-    nextSeed: expect.toBeNumber(),
+    nextSeed: expect.toBeString(),
     rewards: { xp: 0 },
     time: expect.toBeNumber(),
     type: ActivityCheckpointType.Failed,
@@ -209,7 +210,7 @@ test('it retries when failure action is set to retry', async () => {
     enemies: [enemy],
     failureAction: ActivityFailureAction.Retry,
     id: 'world_map_encounter_1',
-    seed: 3_047_525_658,
+    seed: stateFromSeed(3_047_525_658),
     type: ActivityType.WorldMapEncounter,
   });
 

--- a/libs/game/idle-core/src/core/run-simulation.ts
+++ b/libs/game/idle-core/src/core/run-simulation.ts
@@ -12,12 +12,12 @@ import { createSimulation } from './create-simulation';
 /**
  * @property duration - how long to run the simulation for. derive from the checkpoint data submitted by the
  * cient, or if simulating offline progress the duration since the last checkpoint (if any)
- * @property stopAtSeed - if a final seed is provided we will stop processing once we've reached it. useful for
+ * @property stopAtState - if a final rng state is provided we will stop processing once we've reached it. useful for
  * verifying client progress.
  */
 interface SimulationConfig {
   readonly duration: number;
-  readonly stopAtSeed?: number;
+  readonly stopAtState?: string;
 }
 
 interface SimulationOutput {
@@ -45,9 +45,9 @@ export async function runSimulation(
   const checkpoints: Array<ActivityCheckpoint> = [];
 
   while (simulation.elapsed < config.duration) {
-    // bail out if we've reached our desired seed
-    if (simulation.seed === config.stopAtSeed) {
-      logger.debug(`${label} stopping at seed ${simulation.seed}`);
+    // bail out if we've reached our desired rng state
+    if (simulation.rngState === config.stopAtState) {
+      logger.debug(`${label} stopping at rng state ${simulation.rngState}`);
       break;
     }
 

--- a/libs/game/idle-core/src/core/simulate-activity.test.ts
+++ b/libs/game/idle-core/src/core/simulate-activity.test.ts
@@ -38,7 +38,7 @@ test('it immediately generates a started checkpoint', async () => {
   expect(firstCheckpoint).toStrictEqual({
     hash: expect.toBeString(),
     rewards: { xp: 0 },
-    seed: 999_999_999,
+    seed: expect.toBeString(),
     time: 0,
     type: ActivityCheckpointType.Started,
   });
@@ -91,7 +91,7 @@ test('it generates wave killed checkpoints', async () => {
 
   expect(secondCheckpoint).toStrictEqual({
     hash: expect.toBeString(),
-    nextSeed: expect.toBeNumber(),
+    nextSeed: expect.toBeString(),
     rewards: { xp: 5 },
     time: expect.toBeNumber(),
     type: ActivityCheckpointType.Progress,
@@ -99,7 +99,7 @@ test('it generates wave killed checkpoints', async () => {
 
   expect(thirdCheckpoint).toStrictEqual({
     hash: expect.toBeString(),
-    nextSeed: expect.toBeNumber(),
+    nextSeed: expect.toBeString(),
     rewards: { xp: 5 },
     time: expect.toBeNumber(),
     type: ActivityCheckpointType.Progress,
@@ -179,7 +179,7 @@ test('it generates a failed checkpoint when the avatar dies', async () => {
 
   expect(checkpoint).toStrictEqual({
     hash: expect.toBeString(),
-    nextSeed: expect.toBeNumber(),
+    nextSeed: expect.toBeString(),
     rewards: { xp: 0 },
     time: expect.toBeNumber(),
     type: ActivityCheckpointType.Failed,
@@ -227,7 +227,7 @@ test('it returns a completed checkpoint that folds in the completion bonus', asy
 
   expect(checkpoint).toStrictEqual({
     hash: expect.toBeString(),
-    nextSeed: expect.toBeNumber(),
+    nextSeed: expect.toBeString(),
     rewards: { xp: 10 + buildCompletionXP(1) },
     time: expect.toBeNumber(),
     type: ActivityCheckpointType.Completed,

--- a/libs/game/idle-core/src/core/utils/create-completed-checkpoint.test.ts
+++ b/libs/game/idle-core/src/core/utils/create-completed-checkpoint.test.ts
@@ -21,7 +21,7 @@ test('it creates a completed checkpoint with the completion bonus', () => {
 
   expect(checkpoint).toStrictEqual({
     hash: expect.toBeString(),
-    nextSeed: expect.toBeNumber(),
+    nextSeed: expect.toBeString(),
     rewards: { xp: buildCompletionXP(1) },
     time: 2500,
     type: ActivityCheckpointType.Completed,

--- a/libs/game/idle-core/src/core/utils/create-completed-checkpoint.ts
+++ b/libs/game/idle-core/src/core/utils/create-completed-checkpoint.ts
@@ -18,7 +18,7 @@ export function createCompletedCheckpoint(
   // hash chain covers only this frozen subset — rewards and levelUp ride outside it, verified by
   // server replay-recompute instead
   const hashed: Omit<ActivityCompletedCheckpoint, 'hash' | 'levelUp' | 'rewards'> = {
-    nextSeed: ctx.rng.generateNewSeed(),
+    nextSeed: ctx.rng.getState(),
     time: activity.elapsed,
     type: ActivityCheckpointType.Completed,
   };

--- a/libs/game/idle-core/src/core/utils/create-failed-checkpoint.test.ts
+++ b/libs/game/idle-core/src/core/utils/create-failed-checkpoint.test.ts
@@ -21,7 +21,7 @@ test('it creates a failed checkpoint with no loss at zero accrued xp', () => {
 
   expect(checkpoint).toStrictEqual({
     hash: expect.toBeString(),
-    nextSeed: expect.toBeNumber(),
+    nextSeed: expect.toBeString(),
     rewards: { xp: 0 },
     time: 2500,
     type: ActivityCheckpointType.Failed,

--- a/libs/game/idle-core/src/core/utils/create-failed-checkpoint.ts
+++ b/libs/game/idle-core/src/core/utils/create-failed-checkpoint.ts
@@ -17,7 +17,7 @@ export function createFailedCheckpoint(
   // hash chain covers only this frozen subset — rewards ride outside it, verified by server
   // replay-recompute instead
   const hashed: Omit<ActivityFailedCheckpoint, 'hash' | 'rewards'> = {
-    nextSeed: ctx.rng.generateNewSeed(),
+    nextSeed: ctx.rng.getState(),
     time: activity.elapsed,
     type: ActivityCheckpointType.Failed,
   };

--- a/libs/game/idle-core/src/core/utils/create-progress-checkpoint.test.ts
+++ b/libs/game/idle-core/src/core/utils/create-progress-checkpoint.test.ts
@@ -21,7 +21,7 @@ test('it creates a progress checkpoint', () => {
 
   expect(checkpoint).toStrictEqual({
     hash: expect.toBeString(),
-    nextSeed: expect.toBeNumber(),
+    nextSeed: expect.toBeString(),
     rewards: { xp: 15 },
     time: 2500,
     type: ActivityCheckpointType.Progress,

--- a/libs/game/idle-core/src/core/utils/create-progress-checkpoint.ts
+++ b/libs/game/idle-core/src/core/utils/create-progress-checkpoint.ts
@@ -24,7 +24,7 @@ export function createProgressCheckpoint(
   // hash chain covers only this frozen subset — rewards and levelUp ride outside it, verified by
   // server replay-recompute instead
   const hashed: Omit<ActivityProgressCheckpoint, 'hash' | 'levelUp' | 'rewards'> = {
-    nextSeed: ctx.rng.generateNewSeed(),
+    nextSeed: ctx.rng.getState(),
     time: activity.elapsed,
     type: ActivityCheckpointType.Progress,
   };

--- a/libs/game/idle-core/src/core/utils/create-started-checkpoint.test.ts
+++ b/libs/game/idle-core/src/core/utils/create-started-checkpoint.test.ts
@@ -11,7 +11,7 @@ test('it creates a started checkpoint', () => {
   expect(checkpoint).toStrictEqual({
     hash: expect.toBeString(),
     rewards: { xp: 0 },
-    seed: ctx.rng.seed,
+    seed: ctx.rng.getState(),
     time: 0,
     type: ActivityCheckpointType.Started,
   });

--- a/libs/game/idle-core/src/core/utils/create-started-checkpoint.ts
+++ b/libs/game/idle-core/src/core/utils/create-started-checkpoint.ts
@@ -6,7 +6,7 @@ export function createStartedCheckpoint(ctx: SimulationContext): ActivityStarted
   // hash chain covers only this frozen subset — rewards ride outside it, verified by server
   // replay-recompute instead
   const hashed: Omit<ActivityStartedCheckpoint, 'hash' | 'rewards'> = {
-    seed: ctx.rng.seed,
+    seed: ctx.rng.getState(),
     time: 0,
     type: ActivityCheckpointType.Started,
   };

--- a/libs/game/idle-core/src/test-utils/create-mock-activity-data.test.ts
+++ b/libs/game/idle-core/src/test-utils/create-mock-activity-data.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'bun:test';
+import { stateFromSeed } from '@vers/game-utils';
 import { ActivityFailureAction, ActivityType } from '../types';
 import { createMockActivityData } from './create-mock-activity-data';
 import { createMockEnemyData } from './create-mock-enemy-data';
@@ -24,7 +25,7 @@ test('it creates activity data with expected properties', () => {
     failureAction: ActivityFailureAction.Retry,
     id: expect.toBeString(),
     name: 'World Map Encounter',
-    seed: expect.toBeNumber(),
+    seed: expect.toBeString(),
     type: ActivityType.WorldMapEncounter,
   });
 });
@@ -37,7 +38,7 @@ test('it creates activity data with custom properties', () => {
     failureAction: ActivityFailureAction.Abort,
     id: 'custom-activity',
     name: 'Custom Activity',
-    seed: 123,
+    seed: stateFromSeed(123),
     type: ActivityType.WorldMapEncounter,
   });
 
@@ -47,7 +48,7 @@ test('it creates activity data with custom properties', () => {
     failureAction: ActivityFailureAction.Abort,
     id: 'custom-activity',
     name: 'Custom Activity',
-    seed: 123,
+    seed: stateFromSeed(123),
     type: ActivityType.WorldMapEncounter,
   });
 });

--- a/libs/game/idle-core/src/test-utils/create-mock-activity-data.ts
+++ b/libs/game/idle-core/src/test-utils/create-mock-activity-data.ts
@@ -1,4 +1,5 @@
 import { createId } from '@paralleldrive/cuid2';
+import { stateFromSeed } from '@vers/game-utils';
 import type { ActivityData } from '../types';
 import { ActivityFailureAction, ActivityType } from '../types';
 import { createMockEnemyData } from './create-mock-enemy-data';
@@ -11,7 +12,7 @@ export function createMockActivityData(overrides: Partial<ActivityData> = {}): A
     failureAction: ActivityFailureAction.Retry,
     id: createId(),
     name: 'World Map Encounter',
-    seed: 1,
+    seed: stateFromSeed(1),
     type: ActivityType.WorldMapEncounter,
     ...overrides,
   };

--- a/libs/game/idle-core/src/test-utils/create-mock-simulation-context.test.ts
+++ b/libs/game/idle-core/src/test-utils/create-mock-simulation-context.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'bun:test';
-import { createRNG } from '@vers/game-utils';
+import { createRNG, stateFromSeed } from '@vers/game-utils';
 import { createMockSimulationContext } from './create-mock-simulation-context';
 
 test('it creates a simulation context with expected properties', () => {
@@ -13,7 +13,7 @@ test('it creates a simulation context with expected properties', () => {
 });
 
 test('it creates a simulation context with custom properties', () => {
-  const rng = createRNG(999_999_999);
+  const rng = createRNG(stateFromSeed(999_999_999));
 
   const ctx = createMockSimulationContext({
     elapsed: 100,

--- a/libs/game/idle-core/src/test-utils/create-mock-simulation-context.ts
+++ b/libs/game/idle-core/src/test-utils/create-mock-simulation-context.ts
@@ -1,4 +1,4 @@
-import { createRNG } from '@vers/game-utils';
+import { createRNG, stateFromSeed } from '@vers/game-utils';
 import xxhash from 'xxhash-wasm';
 import type { SimulationContext } from '../types';
 
@@ -10,7 +10,7 @@ export function createMockSimulationContext(overrides: Overrides = {}): Simulati
   const ctx: SimulationContext = {
     elapsed: 0,
     hasher,
-    rng: createRNG(999_999_999),
+    rng: createRNG(stateFromSeed(999_999_999)),
     ...overrides,
   };
 

--- a/libs/game/idle-core/src/types/activity.ts
+++ b/libs/game/idle-core/src/types/activity.ts
@@ -19,7 +19,7 @@ export enum ActivityFailureAction {
 
 export interface WorldMapEncounterActivityData extends IActivityData {
   enemies: Array<EnemyData>;
-  seed: number;
+  seed: string;
   type: ActivityType.WorldMapEncounter;
 }
 
@@ -98,22 +98,22 @@ export enum ActivityCheckpointType {
 }
 
 export interface ActivityStartedCheckpoint extends IActivityCheckpoint {
-  readonly seed: number;
+  readonly seed: string;
   readonly type: ActivityCheckpointType.Started;
 }
 
 export interface ActivityFailedCheckpoint extends IActivityCheckpoint {
-  readonly nextSeed: number;
+  readonly nextSeed: string;
   readonly type: ActivityCheckpointType.Failed;
 }
 
 export interface ActivityCompletedCheckpoint extends IActivityCheckpoint {
-  readonly nextSeed: number;
+  readonly nextSeed: string;
   readonly type: ActivityCheckpointType.Completed;
 }
 
 export interface ActivityProgressCheckpoint extends IActivityCheckpoint {
-  readonly nextSeed: number;
+  readonly nextSeed: string;
   readonly type: ActivityCheckpointType.Progress;
 }
 

--- a/libs/game/idle-core/src/types/simulation.ts
+++ b/libs/game/idle-core/src/types/simulation.ts
@@ -37,7 +37,7 @@ export interface Simulation {
   get ctx(): SimulationContext;
   get elapsed(): number;
   get failureAction(): ActivityFailureAction;
-  get seed(): number;
+  get rngState(): string;
   get state(): SimulationState;
 
   // utils

--- a/libs/game/idle-core/src/utils/is-completed-checkpoint.test.ts
+++ b/libs/game/idle-core/src/utils/is-completed-checkpoint.test.ts
@@ -11,7 +11,7 @@ import { isCompletedCheckpoint } from './is-completed-checkpoint';
 test('returns true for completed checkpoints', () => {
   const completedCheckpoint: ActivityCompletedCheckpoint = {
     hash: 'abc123',
-    nextSeed: 12_345,
+    nextSeed: '12345',
     rewards: { xp: 0 },
     time: 1000,
     type: ActivityCheckpointType.Completed,
@@ -23,7 +23,7 @@ test('returns true for completed checkpoints', () => {
 test('returns false for non-completed checkpoints', () => {
   const startedCheckpoint: ActivityStartedCheckpoint = {
     hash: 'def456',
-    seed: 54_321,
+    seed: '54321',
     rewards: { xp: 0 },
     time: 0,
     type: ActivityCheckpointType.Started,
@@ -31,7 +31,7 @@ test('returns false for non-completed checkpoints', () => {
 
   const failedCheckpoint: ActivityFailedCheckpoint = {
     hash: 'ghi789',
-    nextSeed: 98_765,
+    nextSeed: '98765',
     rewards: { xp: 0 },
     time: 500,
     type: ActivityCheckpointType.Failed,
@@ -39,7 +39,7 @@ test('returns false for non-completed checkpoints', () => {
 
   const progressCheckpoint: ActivityProgressCheckpoint = {
     hash: 'jkl012',
-    nextSeed: 24_680,
+    nextSeed: '24680',
     rewards: { xp: 0 },
     time: 300,
     type: ActivityCheckpointType.Progress,

--- a/libs/game/idle-core/src/utils/is-failed-checkpoint.test.ts
+++ b/libs/game/idle-core/src/utils/is-failed-checkpoint.test.ts
@@ -11,7 +11,7 @@ import { isFailedCheckpoint } from './is-failed-checkpoint';
 test('returns true for failed checkpoints', () => {
   const failedCheckpoint: ActivityFailedCheckpoint = {
     hash: 'abc123',
-    nextSeed: 12_345,
+    nextSeed: '12345',
     rewards: { xp: 0 },
     time: 500,
     type: ActivityCheckpointType.Failed,
@@ -23,7 +23,7 @@ test('returns true for failed checkpoints', () => {
 test('returns false for non-failed checkpoints', () => {
   const startedCheckpoint: ActivityStartedCheckpoint = {
     hash: 'def456',
-    seed: 54_321,
+    seed: '54321',
     rewards: { xp: 0 },
     time: 0,
     type: ActivityCheckpointType.Started,
@@ -31,7 +31,7 @@ test('returns false for non-failed checkpoints', () => {
 
   const completedCheckpoint: ActivityCompletedCheckpoint = {
     hash: 'ghi789',
-    nextSeed: 98_765,
+    nextSeed: '98765',
     rewards: { xp: 0 },
     time: 1000,
     type: ActivityCheckpointType.Completed,
@@ -39,7 +39,7 @@ test('returns false for non-failed checkpoints', () => {
 
   const progressCheckpoint: ActivityProgressCheckpoint = {
     hash: 'jkl012',
-    nextSeed: 24_680,
+    nextSeed: '24680',
     rewards: { xp: 0 },
     time: 300,
     type: ActivityCheckpointType.Progress,

--- a/libs/game/idle-core/src/utils/is-progress-checkpoint.test.ts
+++ b/libs/game/idle-core/src/utils/is-progress-checkpoint.test.ts
@@ -11,7 +11,7 @@ import { isProgressCheckpoint } from './is-progress-checkpoint';
 test('returns true for progress checkpoints', () => {
   const progressCheckpoint: ActivityProgressCheckpoint = {
     hash: 'abc123',
-    nextSeed: 12_345,
+    nextSeed: '12345',
     rewards: { xp: 0 },
     time: 300,
     type: ActivityCheckpointType.Progress,
@@ -23,7 +23,7 @@ test('returns true for progress checkpoints', () => {
 test('returns false for non-progress checkpoints', () => {
   const startedCheckpoint: ActivityStartedCheckpoint = {
     hash: 'def456',
-    seed: 54_321,
+    seed: '54321',
     rewards: { xp: 0 },
     time: 0,
     type: ActivityCheckpointType.Started,
@@ -31,7 +31,7 @@ test('returns false for non-progress checkpoints', () => {
 
   const completedCheckpoint: ActivityCompletedCheckpoint = {
     hash: 'ghi789',
-    nextSeed: 98_765,
+    nextSeed: '98765',
     rewards: { xp: 0 },
     time: 1000,
     type: ActivityCheckpointType.Completed,
@@ -39,7 +39,7 @@ test('returns false for non-progress checkpoints', () => {
 
   const failedCheckpoint: ActivityFailedCheckpoint = {
     hash: 'jkl012',
-    nextSeed: 24_680,
+    nextSeed: '24680',
     rewards: { xp: 0 },
     time: 500,
     type: ActivityCheckpointType.Failed,

--- a/libs/game/idle-core/src/utils/is-started-checkpoint.test.ts
+++ b/libs/game/idle-core/src/utils/is-started-checkpoint.test.ts
@@ -11,7 +11,7 @@ import { isStartedCheckpoint } from './is-started-checkpoint';
 test('returns true for started checkpoints', () => {
   const startedCheckpoint: ActivityStartedCheckpoint = {
     hash: 'abc123',
-    seed: 12_345,
+    seed: '12345',
     rewards: { xp: 0 },
     time: 0,
     type: ActivityCheckpointType.Started,
@@ -23,7 +23,7 @@ test('returns true for started checkpoints', () => {
 test('returns false for non-started checkpoints', () => {
   const completedCheckpoint: ActivityCompletedCheckpoint = {
     hash: 'def456',
-    nextSeed: 54_321,
+    nextSeed: '54321',
     rewards: { xp: 0 },
     time: 1000,
     type: ActivityCheckpointType.Completed,
@@ -31,7 +31,7 @@ test('returns false for non-started checkpoints', () => {
 
   const failedCheckpoint: ActivityFailedCheckpoint = {
     hash: 'ghi789',
-    nextSeed: 98_765,
+    nextSeed: '98765',
     rewards: { xp: 0 },
     time: 500,
     type: ActivityCheckpointType.Failed,
@@ -39,7 +39,7 @@ test('returns false for non-started checkpoints', () => {
 
   const progressCheckpoint: ActivityProgressCheckpoint = {
     hash: 'jkl012',
-    nextSeed: 24_680,
+    nextSeed: '24680',
     rewards: { xp: 0 },
     time: 300,
     type: ActivityCheckpointType.Progress,

--- a/libs/game/worldmap-core/src/get-randomized-position.test.ts
+++ b/libs/game/worldmap-core/src/get-randomized-position.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from 'bun:test';
-import { createRNG } from '@vers/game-utils';
+import { createRNG, stateFromSeed } from '@vers/game-utils';
 import { getRandomizedPosition } from './get-randomized-position';
 
 test('it returns a position within the expected range', () => {
-  const rng = createRNG(12_345);
+  const rng = createRNG(stateFromSeed(12_345));
   const position = getRandomizedPosition([0, 0], rng);
 
   expect(position).toMatchInlineSnapshot(`

--- a/libs/game/worldmap-core/src/get-world-map-node-map.ts
+++ b/libs/game/worldmap-core/src/get-world-map-node-map.ts
@@ -1,4 +1,4 @@
-import { createRNG } from '@vers/game-utils';
+import { createRNG, stateFromSeed } from '@vers/game-utils';
 import { getRandomizedPosition } from './get-randomized-position';
 import type { CompressedWorldMapNode, WorldMapNode, WorldMapNodeMap } from './types';
 
@@ -8,7 +8,7 @@ export function getWorldMapNodeMap(
   const nodes: Record<string, WorldMapNode> = {};
 
   for (const node of compressedNodes) {
-    const rng = createRNG(node.s);
+    const rng = createRNG(stateFromSeed(node.s));
 
     const worldMapNode: WorldMapNode = {
       connections: node.c,


### PR DESCRIPTION
## Description

Part of #177. Replaces the RNG's 32-bit numeric reseed with a 128-bit xoroshiro128+ state carried as a fixed-width 32-char hex string, so activity seed currency is a byte-identical snapshot of engine state rather than a derived number.

- `RNG` now exposes `getState(): string`; `generateNewSeed`/`seed` are gone.
- `createRNG` takes the state string directly and rehydrates via `xoroshiro128plusFromState`; `encodeState`/`decodeState` (the pinned codec, guarding hex format and the all-zero degenerate state) and `stateFromSeed(seed)` are exported for numeric-seed callers.
- idle-core's `ActivityData.seed` and all checkpoint seed/nextSeed fields are now `string`; checkpoint builders call `ctx.rng.getState()`.
- `Simulation` exposes `rngState` (not `state`, which already means `SimulationState`); `runSimulation`'s `stopAtSeed` becomes `stopAtState`.
- worldmap-core wraps its stored numeric node seed with `stateFromSeed()` before calling `createRNG`; draws are byte-identical to the prior numeric path.
- Instantaneous checkpoints (e.g. progress and completed at the same tick) now share an identical `nextSeed`, since the RNG no longer reseeds per checkpoint.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality

## Context

Slice 1 of 5 for the forward seed chain (#177).
