### PR TITLE
feat(#177): add chainIndex to the checkpoint hashed subset

### DIFF
--- a/apps/web-e2e/src/checkpoint-hash-parity.spec.ts
+++ b/apps/web-e2e/src/checkpoint-hash-parity.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from '@playwright/test';
 import { buildCheckpointHash } from '@vers/contract-activity';
 
-const FROZEN_DIGEST = '6079d244605014de9d91fcd80080ddad169ab684fccbcbd1d5523bcd512e30d6';
-const CANONICAL_JSON = JSON.stringify(['hash_0', 1, 'seed_0', 'seed_1', 12, 'tick', 'chain']);
+const FROZEN_DIGEST = 'a2a741f37fd2cffb06c6b5e1ad737106670c1203d89206040b5260de4b632408';
+const CANONICAL_JSON = JSON.stringify(['hash_0', 1, 1, 'seed_0', 'seed_1', 12, 'tick', 'chain']);
 
 /**
  * Every party on the checkpoint hash chain — service, verifier, browser client — must derive
@@ -14,6 +14,7 @@ test('it derives the same frozen digest from the contract call and from browser 
 }) => {
   expect(
     buildCheckpointHash({
+      chainIndex: 1,
       entropySource: 'chain',
       nextSeed: 'seed_1',
       prevHash: 'hash_0',

--- a/contracts/activity/src/build-checkpoint-hash.test.ts
+++ b/contracts/activity/src/build-checkpoint-hash.test.ts
@@ -3,6 +3,7 @@ import { buildCheckpointHash } from './build-checkpoint-hash';
 
 test('it builds a deterministic hex digest for a given input', () => {
   const input = {
+    chainIndex: 1,
     entropySource: 'chain',
     nextSeed: 'seed_1',
     prevHash: 'hash_0',
@@ -18,6 +19,7 @@ test('it builds a deterministic hex digest for a given input', () => {
 
 test('it produces different hashes for different versions', () => {
   const input = {
+    chainIndex: 1,
     entropySource: 'chain',
     nextSeed: 'seed_1',
     prevHash: 'hash_0',
@@ -31,8 +33,25 @@ test('it produces different hashes for different versions', () => {
   );
 });
 
+test('it produces different hashes for different chain indices', () => {
+  const input = {
+    entropySource: 'chain',
+    nextSeed: 'seed_1',
+    prevHash: 'hash_0',
+    seed: 'seed_0',
+    time: 12,
+    type: 'tick',
+    version: 1,
+  };
+
+  expect(buildCheckpointHash({ ...input, chainIndex: 1 })).not.toBe(
+    buildCheckpointHash({ ...input, chainIndex: 2 }),
+  );
+});
+
 test('it produces different hashes for different entropy sources', () => {
   const input = {
+    chainIndex: 1,
     nextSeed: 'seed_1',
     prevHash: 'hash_0',
     seed: 'seed_0',
@@ -48,6 +67,7 @@ test('it produces different hashes for different entropy sources', () => {
 
 test('it produces a 64-character hex digest', () => {
   const hash = buildCheckpointHash({
+    chainIndex: 1,
     entropySource: 'chain',
     nextSeed: 'seed_1',
     prevHash: 'hash_0',
@@ -62,6 +82,7 @@ test('it produces a 64-character hex digest', () => {
 
 test('it derives the frozen canonical digest for a known input', () => {
   const hash = buildCheckpointHash({
+    chainIndex: 1,
     entropySource: 'chain',
     nextSeed: 'seed_1',
     prevHash: 'hash_0',
@@ -71,5 +92,5 @@ test('it derives the frozen canonical digest for a known input', () => {
     version: 1,
   });
 
-  expect(hash).toBe('6079d244605014de9d91fcd80080ddad169ab684fccbcbd1d5523bcd512e30d6');
+  expect(hash).toBe('a2a741f37fd2cffb06c6b5e1ad737106670c1203d89206040b5260de4b632408');
 });

--- a/contracts/activity/src/build-checkpoint-hash.ts
+++ b/contracts/activity/src/build-checkpoint-hash.ts
@@ -2,6 +2,7 @@ import { sha256 } from '@noble/hashes/sha2.js';
 import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils.js';
 
 interface BuildCheckpointHashInput {
+  readonly chainIndex: number;
   readonly entropySource: string;
   readonly nextSeed: string;
   readonly prevHash: string;
@@ -13,14 +14,15 @@ interface BuildCheckpointHashInput {
 
 /**
  * The checkpoint hash chain's link function: a sha256 hex digest over the canonical field order
- * `[prevHash, version, seed, nextSeed, time, type, entropySource]`. Shared by the contract, the
- * service, and (via this package) the client, so every party derives the same hash from the same
- * fields.
+ * `[prevHash, version, chainIndex, seed, nextSeed, time, type, entropySource]`. Shared by the
+ * contract, the service, and (via this package) the client, so every party derives the same hash
+ * from the same fields.
  */
 export function buildCheckpointHash(input: Readonly<BuildCheckpointHashInput>): string {
   const canonical = JSON.stringify([
     input.prevHash,
     input.version,
+    input.chainIndex,
     input.seed,
     input.nextSeed,
     input.time,

--- a/contracts/activity/src/checkpoint-batch-entry-schema.test.ts
+++ b/contracts/activity/src/checkpoint-batch-entry-schema.test.ts
@@ -4,7 +4,14 @@ import { CheckpointBatchEntrySchema } from './checkpoint-batch-entry-schema';
 test('it accepts a well-formed batch entry', () => {
   const result = CheckpointBatchEntrySchema.safeParse({
     hash: 'hash_1',
-    payload: { entropySource: 'chain', nextSeed: 'seed_1', seed: 'seed_0', time: 12, type: 'tick' },
+    payload: {
+      chainIndex: 1,
+      entropySource: 'chain',
+      nextSeed: 'seed_1',
+      seed: 'seed_0',
+      time: 12,
+      type: 'tick',
+    },
     prevHash: 'hash_0',
     version: 1,
   });
@@ -15,7 +22,14 @@ test('it accepts a well-formed batch entry', () => {
 test('it rejects a negative version', () => {
   const result = CheckpointBatchEntrySchema.safeParse({
     hash: 'hash_1',
-    payload: { entropySource: 'chain', nextSeed: 'seed_1', seed: 'seed_0', time: 12, type: 'tick' },
+    payload: {
+      chainIndex: 1,
+      entropySource: 'chain',
+      nextSeed: 'seed_1',
+      seed: 'seed_0',
+      time: 12,
+      type: 'tick',
+    },
     prevHash: 'hash_0',
     version: -1,
   });

--- a/contracts/activity/src/checkpoint-payload-schema.test.ts
+++ b/contracts/activity/src/checkpoint-payload-schema.test.ts
@@ -3,6 +3,7 @@ import { CheckpointPayloadSchema } from './checkpoint-payload-schema';
 
 test('it accepts the hashed subset with no extra fields', () => {
   const result = CheckpointPayloadSchema.safeParse({
+    chainIndex: 1,
     entropySource: 'chain',
     nextSeed: 'seed_1',
     seed: 'seed_0',
@@ -15,6 +16,7 @@ test('it accepts the hashed subset with no extra fields', () => {
 
 test('it accepts extra fields beyond the hashed subset', () => {
   const result = CheckpointPayloadSchema.safeParse({
+    chainIndex: 1,
     combatLog: ['hit', 'crit'],
     entropySource: 'chain',
     nextSeed: 'seed_1',
@@ -28,6 +30,7 @@ test('it accepts extra fields beyond the hashed subset', () => {
 
 test('it rejects a payload missing a hashed field', () => {
   const result = CheckpointPayloadSchema.safeParse({
+    chainIndex: 1,
     entropySource: 'chain',
     nextSeed: 'seed_1',
     time: 12,
@@ -39,6 +42,32 @@ test('it rejects a payload missing a hashed field', () => {
 
 test('it rejects a payload missing the entropy-source tag', () => {
   const result = CheckpointPayloadSchema.safeParse({
+    chainIndex: 1,
+    nextSeed: 'seed_1',
+    seed: 'seed_0',
+    time: 12,
+    type: 'tick',
+  });
+
+  expect(result.success).toBeFalse();
+});
+
+test('it rejects a payload missing chainIndex', () => {
+  const result = CheckpointPayloadSchema.safeParse({
+    entropySource: 'chain',
+    nextSeed: 'seed_1',
+    seed: 'seed_0',
+    time: 12,
+    type: 'tick',
+  });
+
+  expect(result.success).toBeFalse();
+});
+
+test('it rejects a negative chainIndex', () => {
+  const result = CheckpointPayloadSchema.safeParse({
+    chainIndex: -1,
+    entropySource: 'chain',
     nextSeed: 'seed_1',
     seed: 'seed_0',
     time: 12,

--- a/contracts/activity/src/checkpoint-payload-schema.ts
+++ b/contracts/activity/src/checkpoint-payload-schema.ts
@@ -7,6 +7,7 @@ import * as z from 'zod';
  */
 export const CheckpointPayloadSchema = z
   .looseObject({
+    chainIndex: z.int().min(0),
     entropySource: z.string(),
     nextSeed: z.string(),
     seed: z.string(),

--- a/contracts/activity/src/checkpoint-schema.test.ts
+++ b/contracts/activity/src/checkpoint-schema.test.ts
@@ -5,7 +5,14 @@ test('it accepts a well-formed checkpoint', () => {
   const result = CheckpointSchema.safeParse({
     appendedAt: new Date(),
     hash: 'hash_1',
-    payload: { entropySource: 'chain', nextSeed: 'seed_1', seed: 'seed_0', time: 12, type: 'tick' },
+    payload: {
+      chainIndex: 1,
+      entropySource: 'chain',
+      nextSeed: 'seed_1',
+      seed: 'seed_0',
+      time: 12,
+      type: 'tick',
+    },
     prevHash: 'hash_0',
     version: 1,
   });
@@ -16,7 +23,14 @@ test('it accepts a well-formed checkpoint', () => {
 test('it rejects a checkpoint missing appendedAt', () => {
   const result = CheckpointSchema.safeParse({
     hash: 'hash_1',
-    payload: { entropySource: 'chain', nextSeed: 'seed_1', seed: 'seed_0', time: 12, type: 'tick' },
+    payload: {
+      chainIndex: 1,
+      entropySource: 'chain',
+      nextSeed: 'seed_1',
+      seed: 'seed_0',
+      time: 12,
+      type: 'tick',
+    },
     prevHash: 'hash_0',
     version: 1,
   });

--- a/services/activity/src/handlers/track-activity-progress.ts
+++ b/services/activity/src/handlers/track-activity-progress.ts
@@ -184,6 +184,7 @@ function findInvalidReason(
     }
 
     const expectedHash = buildCheckpointHash({
+      chainIndex: checkpoint.payload.chainIndex,
       entropySource: checkpoint.payload.entropySource,
       nextSeed: checkpoint.payload.nextSeed,
       prevHash: checkpoint.prevHash,

--- a/services/activity/src/test-utils/factories/create-mock-checkpoint-batch.test.ts
+++ b/services/activity/src/test-utils/factories/create-mock-checkpoint-batch.test.ts
@@ -15,6 +15,12 @@ test('it builds a chain of the requested length with contiguous versions', () =>
   expect(batch.map((entry) => entry.version)).toStrictEqual([1, 2, 3]);
 });
 
+test('it defaults chainIndex to the checkpoint version', () => {
+  const batch = createMockCheckpointBatch({ count: 3, startPrevHash: 'hash_0', startVersion: 1 });
+
+  expect(batch.map((entry) => entry.payload.chainIndex)).toStrictEqual([1, 2, 3]);
+});
+
 test('it chains each entry onto the previous one', () => {
   const batch = createMockCheckpointBatch({ count: 3, startPrevHash: 'hash_0', startVersion: 1 });
 
@@ -29,6 +35,7 @@ test('it computes each hash via buildCheckpointHash', () => {
 
   expect(entry?.hash).toBe(
     buildCheckpointHash({
+      chainIndex: entry?.payload.chainIndex ?? 0,
       entropySource: entry?.payload.entropySource ?? '',
       nextSeed: entry?.payload.nextSeed ?? '',
       prevHash: entry?.prevHash ?? '',
@@ -69,6 +76,7 @@ test('it keeps the last entry chain-valid after the payload override', () => {
 
   expect(entry?.hash).toBe(
     buildCheckpointHash({
+      chainIndex: entry?.payload.chainIndex ?? 0,
       entropySource: entry?.payload.entropySource ?? '',
       nextSeed: entry?.payload.nextSeed ?? '',
       prevHash: entry?.prevHash ?? '',

--- a/services/activity/src/test-utils/factories/create-mock-checkpoint-batch.ts
+++ b/services/activity/src/test-utils/factories/create-mock-checkpoint-batch.ts
@@ -43,6 +43,7 @@ export function createMockCheckpointBatch(
     const isLast = index === count - 1;
 
     const payload = {
+      chainIndex: version,
       entropySource: 'chain',
       nextSeed: faker.string.alphanumeric({ casing: 'lower', length: 16 }),
       seed: faker.string.alphanumeric({ casing: 'lower', length: 16 }),


### PR DESCRIPTION
## Description

Adds `chainIndex` to the checkpoint's frozen hashed subset, slice 2 of 5 for the forward seed chain (#177). Contract and service layers only; `@vers/idle-core` is untouched by design.

- `buildCheckpointHash` takes `chainIndex: number` and folds it into the canonical array right after `version`, so the frozen digest changes for any checkpoint sharing this code path.
- `CheckpointPayloadSchema` requires a non-negative `chainIndex`.
- `track-activity-progress`'s recomputation now passes the checkpoint's own `chainIndex` through; no chain-index continuity validation yet (slice 5).
- The checkpoint-batch test factory defaults `chainIndex` to the checkpoint's own version.
- The e2e hash-parity spec's canonical JSON and frozen digest are recomputed with `chainIndex: 1`.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
