### PR TITLE
feat(#177): add activity_chains table

### DIFF
--- a/libs/data/db/migrations/1783900000000_activity_chains.ts
+++ b/libs/data/db/migrations/1783900000000_activity_chains.ts
@@ -1,0 +1,39 @@
+import type { Kysely } from 'kysely';
+import { sql } from 'kysely';
+
+/**
+ * Creates `activity_chains`, one row per (avatar, node) holding the genesis seed and the two
+ * derivation anchors: `appended_*` is the source for the next activity's seed derivation,
+ * `verified_*` is the settlement watermark it advances to once outcomes are confirmed.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable('activity_chains')
+    .addColumn('avatar_id', 'text', (col) => col.notNull())
+    .addColumn('node_id', 'text', (col) => col.notNull())
+    .addColumn('genesis_seed', 'text', (col) => col.notNull())
+    .addColumn('appended_next_seed', 'text', (col) => col.notNull())
+    .addColumn('appended_chain_index', 'integer', (col) => col.notNull().defaultTo(0))
+    .addColumn('verified_next_seed', 'text', (col) => col.notNull())
+    .addColumn('verified_chain_index', 'integer', (col) => col.notNull().defaultTo(0))
+
+    // Deliberately no `updated_at` column and no on-update trigger — a later reveal upsert
+    // self-assigns `genesis_seed` and must not bump a timestamp.
+    .addColumn('created_at', 'timestamp', (col) => col.notNull().defaultTo(sql`now()`))
+
+    // Deliberately no `mode` column yet — economy-mode key custody is added with the economy
+    // modes work (#472).
+    .addPrimaryKeyConstraint('activity_chains_pk', ['avatar_id', 'node_id'])
+    .addForeignKeyConstraint(
+      'activity_chains_avatar_id_avatars_id_fk',
+      ['avatar_id'],
+      'avatars',
+      ['id'],
+      (fk) => fk.onDelete('cascade').onUpdate('cascade'),
+    )
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable('activity_chains').execute();
+}

--- a/libs/data/db/migrations/1783900000000_activity_chains.ts
+++ b/libs/data/db/migrations/1783900000000_activity_chains.ts
@@ -21,8 +21,8 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     // self-assigns `genesis_seed` and must not bump a timestamp.
     .addColumn('created_at', 'timestamp', (col) => col.notNull().defaultTo(sql`now()`))
 
-    // Deliberately no `mode` column yet — economy-mode key custody is added with the economy
-    // modes work (#472).
+    // Deliberately no `mode` column — economy-mode key custody is a separate concern, owned by
+    // the economy-mode partitioning rather than the seed chain.
     .addPrimaryKeyConstraint('activity_chains_pk', ['avatar_id', 'node_id'])
     .addForeignKeyConstraint(
       'activity_chains_avatar_id_avatars_id_fk',

--- a/libs/data/db/src/index.ts
+++ b/libs/data/db/src/index.ts
@@ -3,6 +3,7 @@ export { migrateToLatest, migrationsFolder } from './migrate-to-latest';
 
 export type {
   Activities,
+  ActivityChains,
   ActivityCheckpoints,
   Avatars,
   ConsumedTransactionTokens,

--- a/libs/data/db/src/schema.generated.ts
+++ b/libs/data/db/src/schema.generated.ts
@@ -49,6 +49,17 @@ export interface Activities {
   verifiedHead: Generated<number>;
 }
 
+export interface ActivityChains {
+  appendedChainIndex: Generated<number>;
+  appendedNextSeed: string;
+  avatarId: string;
+  createdAt: Generated<Timestamp>;
+  genesisSeed: string;
+  nodeId: string;
+  verifiedChainIndex: Generated<number>;
+  verifiedNextSeed: string;
+}
+
 export interface ActivityCheckpoints {
   activityId: string;
   appendedAt: Generated<Timestamp>;
@@ -128,6 +139,7 @@ export interface Verifications {
 
 export interface DB {
   activities: Activities;
+  activityChains: ActivityChains;
   activityCheckpoints: ActivityCheckpoints;
   avatars: Avatars;
   consumedTransactionTokens: ConsumedTransactionTokens;

--- a/services/activity/src/activity-chains-schema.test.ts
+++ b/services/activity/src/activity-chains-schema.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from 'bun:test';
+import { faker } from '@faker-js/faker';
+import { createTestDB, createTestUser } from '@vers/service-test-utils/bun';
+import { createAvatarRow } from './test-utils/create-avatar-row';
+
+test('it round-trips an activity_chains row', async () => {
+  await using db = await createTestDB();
+
+  const testUser = await createTestUser(db.db);
+  const avatar = await createAvatarRow(db.db, { userId: testUser.user.id });
+
+  const genesisSeed = faker.string.hexadecimal({ casing: 'lower', length: 32, prefix: '' });
+  const appendedNextSeed = faker.string.hexadecimal({ casing: 'lower', length: 32, prefix: '' });
+  const verifiedNextSeed = faker.string.hexadecimal({ casing: 'lower', length: 32, prefix: '' });
+
+  const inserted = await db.db
+    .insertInto('activityChains')
+    .values({
+      appendedNextSeed,
+      avatarId: avatar.id,
+      genesisSeed,
+      nodeId: 'node_1',
+      verifiedNextSeed,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
+
+  const selected = await db.db
+    .selectFrom('activityChains')
+    .selectAll()
+    .where('avatarId', '=', avatar.id)
+    .where('nodeId', '=', 'node_1')
+    .executeTakeFirstOrThrow();
+
+  expect(selected).toStrictEqual(inserted);
+  expect(selected.appendedChainIndex).toBe(0);
+  expect(selected.verifiedChainIndex).toBe(0);
+  expect(selected.genesisSeed).toBe(genesisSeed);
+  expect(selected.appendedNextSeed).toBe(appendedNextSeed);
+  expect(selected.verifiedNextSeed).toBe(verifiedNextSeed);
+  expect(selected.createdAt).toBeInstanceOf(Date);
+});


### PR DESCRIPTION
## Description

Adds the `activity_chains` table (slice 3 of 5 for #177): one row per avatar/node holding the genesis seed and the appended/verified derivation anchors for the forward seed chain.

- composite PK on `(avatar_id, node_id)`, FK to `avatars(id)` cascading on delete/update
- no `updated_at`/trigger and no `mode` column yet, with comments explaining why
- `schema.generated.ts` and the `index.ts` type barrel updated by hand to match `kysely-codegen` conventions
- real-database round-trip test inserts and selects a row, asserting field equality and the zero chain-index defaults
- no handler or contract reads/writes the table yet — out of scope for this slice

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
