### PR TITLE
feat(#177): advance chain anchor on terminal checkpoint

### DIFF
--- a/docs/architecture/error-handling.md
+++ b/docs/architecture/error-handling.md
@@ -53,18 +53,18 @@ Status assignment follows the failure's nature:
 - **401 Unauthorized** — a failure of authentication state.
 - **409 Conflict** — an operation whose precondition the resource's current state contradicts.
 
-| Domain       | Code                   | Status | Meaning                                                                        | data         |
-| ------------ | ---------------------- | ------ | ------------------------------------------------------------------------------ | ------------ |
-| activity     | `CHECKPOINT_INVALID`   | 422    | Checkpoint batch fails structural validation (contiguity, chain link, or hash) | `{ reason }` |
-| user         | `INVALID_RESET_TOKEN`  | 422    | Reset token doesn't match the one on record                                    | —            |
-| user         | `PASSWORD_NOT_SET`     | 409    | Operation presumes a password; the account has none                            | —            |
-| user         | `RESET_TOKEN_EXPIRED`  | 410    | Reset token was valid but its window has passed                                | —            |
-| session      | `REFRESH_TOKEN_REUSED` | 401    | Refresh token replayed — rotation-theft signal, session revoked                | —            |
-| session      | `SESSION_EXPIRED`      | 401    | Session exists but its lifetime has passed                                     | —            |
-| session      | `TRANSACTION_MISMATCH` | 422    | Step-up consume request doesn't match the pending transaction                  | `{ field }`  |
-| verification | `CODE_ALREADY_USED`    | 410    | One-time code already consumed                                                 | —            |
-| verification | `CODE_EXPIRED`         | 410    | Code was valid but its window has passed                                       | —            |
-| verification | `INVALID_CODE`         | 422    | Code doesn't verify against the secret                                         | —            |
+| Domain       | Code                   | Status | Meaning                                                                                    | data         |
+| ------------ | ---------------------- | ------ | ------------------------------------------------------------------------------------------ | ------------ |
+| activity     | `CHECKPOINT_INVALID`   | 422    | Checkpoint batch fails structural validation (contiguity, chainIndex, chain link, or hash) | `{ reason }` |
+| user         | `INVALID_RESET_TOKEN`  | 422    | Reset token doesn't match the one on record                                                | —            |
+| user         | `PASSWORD_NOT_SET`     | 409    | Operation presumes a password; the account has none                                        | —            |
+| user         | `RESET_TOKEN_EXPIRED`  | 410    | Reset token was valid but its window has passed                                            | —            |
+| session      | `REFRESH_TOKEN_REUSED` | 401    | Refresh token replayed — rotation-theft signal, session revoked                            | —            |
+| session      | `SESSION_EXPIRED`      | 401    | Session exists but its lifetime has passed                                                 | —            |
+| session      | `TRANSACTION_MISMATCH` | 422    | Step-up consume request doesn't match the pending transaction                              | `{ field }`  |
+| verification | `CODE_ALREADY_USED`    | 410    | One-time code already consumed                                                             | —            |
+| verification | `CODE_EXPIRED`         | 410    | Code was valid but its window has passed                                                   | —            |
+| verification | `INVALID_CODE`         | 422    | Code doesn't verify against the secret                                                     | —            |
 
 ## Service layer
 

--- a/services/activity/src/handlers/track-activity-progress.test.ts
+++ b/services/activity/src/handlers/track-activity-progress.test.ts
@@ -343,6 +343,241 @@ test('it settles a clamped xp loss from a failed terminal checkpoint', async () 
   expect(updated.level).toBe(levelForXP(startingXP + rewardsXP));
 });
 
+test('it advances the chain anchor to the terminal checkpoint on a completed batch', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({ avatarID: avatar.id, nodeID: 'node_1' });
+
+  const batch = createMockCheckpointBatch({
+    finalPayloadOverrides: { rewards: { xp: 100 }, type: 'completed' },
+    startPrevHash: started.startHash,
+    startVersion: 1,
+  });
+
+  await client.trackActivityProgress({
+    activityID: started.id,
+    checkpoints: batch,
+    expectedHead: 0,
+  });
+
+  const terminal = batch[0]!;
+
+  const chain = await ctx.db
+    .selectFrom('activityChains')
+    .selectAll()
+    .where('avatarId', '=', avatar.id)
+    .where('nodeId', '=', 'node_1')
+    .executeTakeFirstOrThrow();
+
+  expect(chain.appendedNextSeed).toBe(terminal.payload.nextSeed);
+  expect(chain.appendedChainIndex).toBe(terminal.payload.chainIndex);
+});
+
+test('it advances the chain anchor to the terminal checkpoint on a failed batch', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({ avatarID: avatar.id, nodeID: 'node_1' });
+
+  const batch = createMockCheckpointBatch({
+    finalPayloadOverrides: { rewards: { xp: -10 }, type: 'failed' },
+    startPrevHash: started.startHash,
+    startVersion: 1,
+  });
+
+  await client.trackActivityProgress({
+    activityID: started.id,
+    checkpoints: batch,
+    expectedHead: 0,
+  });
+
+  const terminal = batch[0]!;
+
+  const chain = await ctx.db
+    .selectFrom('activityChains')
+    .selectAll()
+    .where('avatarId', '=', avatar.id)
+    .where('nodeId', '=', 'node_1')
+    .executeTakeFirstOrThrow();
+
+  expect(chain.appendedNextSeed).toBe(terminal.payload.nextSeed);
+  expect(chain.appendedChainIndex).toBe(terminal.payload.chainIndex);
+});
+
+test('it continues the next activity on the same node from the previous terminal checkpoint', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const firstStarted = await client.startActivity({ avatarID: avatar.id, nodeID: 'node_1' });
+
+  const firstBatch = createMockCheckpointBatch({
+    finalPayloadOverrides: { rewards: { xp: 100 }, type: 'completed' },
+    startPrevHash: firstStarted.startHash,
+    startVersion: 1,
+  });
+
+  await client.trackActivityProgress({
+    activityID: firstStarted.id,
+    checkpoints: firstBatch,
+    expectedHead: 0,
+  });
+
+  const terminal = firstBatch[0]!;
+
+  const secondStarted = await client.startActivity({ avatarID: avatar.id, nodeID: 'node_1' });
+
+  expect(secondStarted.seed).toBe(terminal.payload.nextSeed);
+  expect(secondStarted.startChainIndex).toBe(terminal.payload.chainIndex);
+});
+
+test('it moves nothing when a stale terminal replays the compare-and-swap at an anchor the chain has already passed', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const firstStarted = await client.startActivity({ avatarID: avatar.id, nodeID: 'node_1' });
+
+  const firstBatch = createMockCheckpointBatch({
+    finalPayloadOverrides: { rewards: { xp: 100 }, type: 'completed' },
+    startPrevHash: firstStarted.startHash,
+    startVersion: 1,
+  });
+
+  await client.trackActivityProgress({
+    activityID: firstStarted.id,
+    checkpoints: firstBatch,
+    expectedHead: 0,
+  });
+
+  const secondStarted = await client.startActivity({ avatarID: avatar.id, nodeID: 'node_1' });
+
+  const secondBatch = createMockCheckpointBatch({
+    finalPayloadOverrides: { rewards: { xp: 100 }, type: 'completed' },
+    startChainIndex: secondStarted.startChainIndex,
+    startPrevHash: secondStarted.startHash,
+    startVersion: 1,
+  });
+
+  await client.trackActivityProgress({
+    activityID: secondStarted.id,
+    checkpoints: secondBatch,
+    expectedHead: 0,
+  });
+
+  const anchorAfterSecond = await ctx.db
+    .selectFrom('activityChains')
+    .selectAll()
+    .where('avatarId', '=', avatar.id)
+    .where('nodeId', '=', 'node_1')
+    .executeTakeFirstOrThrow();
+
+  // replays the first activity's own compare-and-swap, which the chain has already moved past
+  await ctx.db
+    .updateTable('activityChains')
+    .set({ appendedChainIndex: 999, appendedNextSeed: 'replayed-seed' })
+    .where('avatarId', '=', avatar.id)
+    .where('nodeId', '=', 'node_1')
+    .where('appendedChainIndex', '=', firstStarted.startChainIndex)
+    .execute();
+
+  const anchorAfterReplay = await ctx.db
+    .selectFrom('activityChains')
+    .selectAll()
+    .where('avatarId', '=', avatar.id)
+    .where('nodeId', '=', 'node_1')
+    .executeTakeFirstOrThrow();
+
+  expect(anchorAfterReplay).toStrictEqual(anchorAfterSecond);
+});
+
+test('it rejects a chainIndex that is not startChainIndex plus version with CHECKPOINT_INVALID', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({ avatarID: avatar.id, nodeID: 'node_1' });
+
+  const batch = createMockCheckpointBatch({ startPrevHash: started.startHash, startVersion: 1 });
+  const tampered = [{ ...batch[0]!, payload: { ...batch[0]!.payload, chainIndex: 99 } }];
+
+  expect(
+    client.trackActivityProgress({
+      activityID: started.id,
+      checkpoints: tampered,
+      expectedHead: 0,
+    }),
+  ).rejects.toMatchObject({
+    code: 'CHECKPOINT_INVALID',
+    data: { reason: 'non-contiguous-chain-index' },
+  });
+});
+
+test('it advances the chain anchor exactly once across a duplicate terminal submission', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({ avatarID: avatar.id, nodeID: 'node_1' });
+
+  const batch = createMockCheckpointBatch({
+    finalPayloadOverrides: { rewards: { xp: 100 }, type: 'completed' },
+    startPrevHash: started.startHash,
+    startVersion: 1,
+  });
+
+  await client.trackActivityProgress({
+    activityID: started.id,
+    checkpoints: batch,
+    expectedHead: 0,
+  });
+
+  const chainAfterFirst = await ctx.db
+    .selectFrom('activityChains')
+    .selectAll()
+    .where('avatarId', '=', avatar.id)
+    .where('nodeId', '=', 'node_1')
+    .executeTakeFirstOrThrow();
+
+  expect(
+    client.trackActivityProgress({
+      activityID: started.id,
+      checkpoints: batch,
+      expectedHead: 0,
+    }),
+  ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+  const chainAfterSecond = await ctx.db
+    .selectFrom('activityChains')
+    .selectAll()
+    .where('avatarId', '=', avatar.id)
+    .where('nodeId', '=', 'node_1')
+    .executeTakeFirstOrThrow();
+
+  expect(chainAfterSecond).toStrictEqual(chainAfterFirst);
+});
+
 test('it does not double-apply xp on a duplicate terminal submission', async () => {
   await using ctx = await setupTest();
 

--- a/services/activity/src/handlers/track-activity-progress.ts
+++ b/services/activity/src/handlers/track-activity-progress.ts
@@ -54,7 +54,14 @@ export async function trackActivityProgress(
   const head = await db
     .selectFrom('activities')
     .innerJoin('avatars', 'avatars.id', 'activities.avatarId')
-    .select(['activities.appendedHead', 'activities.avatarId', 'activities.lastHash', 'avatars.xp'])
+    .select([
+      'activities.appendedHead',
+      'activities.avatarId',
+      'activities.lastHash',
+      'activities.nodeId',
+      'activities.startChainIndex',
+      'avatars.xp',
+    ])
     .where('activities.id', '=', opts.input.activityID)
     .where('avatars.userId', '=', actingUserID)
     .where('activities.status', '=', 'active')
@@ -123,7 +130,18 @@ export async function trackActivityProgress(
         .execute();
     }
 
-    if (terminalRewardsXP !== undefined) {
+    if (terminalRewardsXP !== undefined && lastCheckpoint !== undefined) {
+      await trx
+        .updateTable('activityChains')
+        .set({
+          appendedChainIndex: lastCheckpoint.payload.chainIndex,
+          appendedNextSeed: lastCheckpoint.payload.nextSeed,
+        })
+        .where('avatarId', '=', head.avatarId)
+        .where('nodeId', '=', head.nodeId)
+        .where('appendedChainIndex', '=', head.startChainIndex)
+        .execute();
+
       const newXP = Math.max(0, Math.round(head.xp + terminalRewardsXP));
 
       const settled = await trx
@@ -150,13 +168,15 @@ interface CheckpointBatchInput {
 interface TrackActivityProgressHead {
   readonly appendedHead: number;
   readonly lastHash: string;
+  readonly startChainIndex: number;
 }
 
 /**
  * Validates a checkpoint batch's internal shape ahead of the transactional head-row CAS: version
- * contiguity from `expectedHead + 1`, each entry's hash against its own payload, each entry's
- * chain link to the previous one, and — only when `expectedHead` still matches the head row, since
- * a stale batch's chain has nothing to link onto — the first entry's link onto the current head.
+ * contiguity from `expectedHead + 1`, each entry's `chainIndex` continuity from
+ * `head.startChainIndex`, each entry's hash against its own payload, each entry's chain link to
+ * the previous one, and — only when `expectedHead` still matches the head row, since a stale
+ * batch's chain has nothing to link onto — the first entry's link onto the current head.
  */
 function findInvalidReason(
   input: Readonly<CheckpointBatchInput>,
@@ -169,6 +189,10 @@ function findInvalidReason(
 
     if (checkpoint.version !== expectedVersion) {
       return 'non-contiguous-versions';
+    }
+
+    if (checkpoint.payload.chainIndex !== head.startChainIndex + checkpoint.version) {
+      return 'non-contiguous-chain-index';
     }
 
     let previousHash: string | undefined;

--- a/services/activity/src/test-utils/factories/create-mock-checkpoint-batch.test.ts
+++ b/services/activity/src/test-utils/factories/create-mock-checkpoint-batch.test.ts
@@ -21,6 +21,17 @@ test('it defaults chainIndex to the checkpoint version', () => {
   expect(batch.map((entry) => entry.payload.chainIndex)).toStrictEqual([1, 2, 3]);
 });
 
+test('it offsets chainIndex by startChainIndex when given', () => {
+  const batch = createMockCheckpointBatch({
+    count: 3,
+    startChainIndex: 10,
+    startPrevHash: 'hash_0',
+    startVersion: 1,
+  });
+
+  expect(batch.map((entry) => entry.payload.chainIndex)).toStrictEqual([11, 12, 13]);
+});
+
 test('it chains each entry onto the previous one', () => {
   const batch = createMockCheckpointBatch({ count: 3, startPrevHash: 'hash_0', startVersion: 1 });
 

--- a/services/activity/src/test-utils/factories/create-mock-checkpoint-batch.ts
+++ b/services/activity/src/test-utils/factories/create-mock-checkpoint-batch.ts
@@ -21,6 +21,11 @@ interface CreateMockCheckpointBatchConfig {
   readonly startPrevHash: string;
 
   /**
+   * The activity's `startChainIndex` each entry's `chainIndex` is offset from. Default 0.
+   */
+  readonly startChainIndex?: number;
+
+  /**
    * The batch's first entry version — the activity's current `appendedHead + 1` for a batch that
    * will apply cleanly.
    */
@@ -35,6 +40,7 @@ export function createMockCheckpointBatch(
   config: Readonly<CreateMockCheckpointBatchConfig>,
 ): Array<CheckpointBatchEntry> {
   const count = config.count ?? 1;
+  const startChainIndex = config.startChainIndex ?? 0;
   const entries: Array<CheckpointBatchEntry> = [];
   let prevHash = config.startPrevHash;
 
@@ -43,7 +49,7 @@ export function createMockCheckpointBatch(
     const isLast = index === count - 1;
 
     const payload = {
-      chainIndex: version,
+      chainIndex: startChainIndex + version,
       entropySource: 'chain',
       nextSeed: faker.string.alphanumeric({ casing: 'lower', length: 16 }),
       seed: faker.string.alphanumeric({ casing: 'lower', length: 16 }),


### PR DESCRIPTION
## Description

Completes the forward seed chain (#177): a terminal checkpoint batch now advances its node's chain anchor, and each checkpoint's `chainIndex` is validated against that anchor before it's accepted.

- `track-activity-progress`'s head select now also pulls `activities.nodeId` and `activities.startChainIndex`
- `findInvalidReason` rejects a checkpoint whose `payload.chainIndex` isn't `startChainIndex + version`, returning `CHECKPOINT_INVALID` / `non-contiguous-chain-index`
- on a terminal batch, the handler advances the `activityChains` row's `appendedNextSeed`/`appendedChainIndex` from the terminal checkpoint's payload, via a compare-and-swap on the prior `appendedChainIndex`, inside the same transaction as xp settlement
- `createMockCheckpointBatch` takes an optional `startChainIndex` offset for building chained batches
- `error-handling.md`'s `CHECKPOINT_INVALID` registry row now documents the `chainIndex` check

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
