### PR TITLE
refactor(game-utils): split rng module into one file per export

### DIFF
--- a/libs/game/game-utils/src/build-state-from-seed.test.ts
+++ b/libs/game/game-utils/src/build-state-from-seed.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from 'bun:test';
+import { buildStateFromSeed } from './build-state-from-seed';
+import { createRNG } from './create-rng';
+
+test('it derives a deterministic state from a numeric seed', () => {
+  expect(buildStateFromSeed(999)).toBe(buildStateFromSeed(999));
+  expect(buildStateFromSeed(999)).not.toBe(buildStateFromSeed(1000));
+});
+
+test('it produces a reproducible draw sequence from a seed-derived state', () => {
+  const first = createRNG(buildStateFromSeed(555));
+  const second = createRNG(buildStateFromSeed(555));
+
+  expect(first.getSeries(0, 100, 10)).toStrictEqual(second.getSeries(0, 100, 10));
+});
+
+test('it scrambles seed zero to a valid non-zero state', () => {
+  expect(buildStateFromSeed(0)).not.toBe('0'.repeat(32));
+  expect(() => createRNG(buildStateFromSeed(0))).not.toThrow();
+});

--- a/libs/game/game-utils/src/build-state-from-seed.ts
+++ b/libs/game/game-utils/src/build-state-from-seed.ts
@@ -1,0 +1,11 @@
+import { xoroshiro128plus } from 'pure-rand/generator/xoroshiro128plus';
+import { encodeState } from './encode-state';
+
+/**
+ * Derives a 128-bit rng state from a plain numeric seed, for callers that legitimately seed from a
+ * number (a world map node's stored seed, an initial placeholder state, tests). Seed `0` scrambles
+ * to a valid non-zero state.
+ */
+export function buildStateFromSeed(seed: number): string {
+  return encodeState(xoroshiro128plus(seed).getState());
+}

--- a/libs/game/game-utils/src/create-rng.test.ts
+++ b/libs/game/game-utils/src/create-rng.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from 'bun:test';
-import { createRNG, stateFromSeed } from './create-rng';
+import { buildStateFromSeed } from './build-state-from-seed';
+import { createRNG } from './create-rng';
 
 test('it generates a deterministic sequence of integers with the given seed', () => {
-  const rng = createRNG(stateFromSeed(35_131_234));
+  const rng = createRNG(buildStateFromSeed(35_131_234));
 
   expect(rng.getInt(0, 100)).toMatchInlineSnapshot(`33`);
   expect(rng.getInt(0, 100)).toMatchInlineSnapshot(`33`);
@@ -13,7 +14,7 @@ test('it generates a deterministic sequence of integers with the given seed', ()
 });
 
 test('it generates a deterministic array of integers with the given seed', () => {
-  const rng = createRNG(stateFromSeed(35_131_234));
+  const rng = createRNG(buildStateFromSeed(35_131_234));
   const series = rng.getSeries(0, 100, 20);
 
   expect(series).toHaveLength(20);
@@ -21,7 +22,7 @@ test('it generates a deterministic array of integers with the given seed', () =>
 });
 
 test('it round-trips a snapshotted state back to the identical string', () => {
-  const rng = createRNG(stateFromSeed(1234));
+  const rng = createRNG(buildStateFromSeed(1234));
 
   rng.getInt(0, 100);
   rng.getInt(0, 100);
@@ -32,7 +33,7 @@ test('it round-trips a snapshotted state back to the identical string', () => {
 });
 
 test('it resumes a mid-stream snapshot with the exact subsequent draw sequence', () => {
-  const original = createRNG(stateFromSeed(4_242_424_242));
+  const original = createRNG(buildStateFromSeed(4_242_424_242));
 
   original.getInt(0, 1000);
   original.getInt(0, 1000);
@@ -55,16 +56,4 @@ test('it rejects a state of the wrong length', () => {
 
 test('it rejects a non-hex state', () => {
   expect(() => createRNG('z'.repeat(32))).toThrow();
-});
-
-test('it derives a deterministic state from a numeric seed', () => {
-  expect(stateFromSeed(999)).toBe(stateFromSeed(999));
-  expect(stateFromSeed(999)).not.toBe(stateFromSeed(1000));
-});
-
-test('it produces a reproducible draw sequence from a seed-derived state', () => {
-  const first = createRNG(stateFromSeed(555));
-  const second = createRNG(stateFromSeed(555));
-
-  expect(first.getSeries(0, 100, 10)).toStrictEqual(second.getSeries(0, 100, 10));
 });

--- a/libs/game/game-utils/src/create-rng.ts
+++ b/libs/game/game-utils/src/create-rng.ts
@@ -1,12 +1,8 @@
 import { uniformInt } from 'pure-rand/distribution/uniformInt';
-import { xoroshiro128plus, xoroshiro128plusFromState } from 'pure-rand/generator/xoroshiro128plus';
-import invariant from 'tiny-invariant';
+import { xoroshiro128plusFromState } from 'pure-rand/generator/xoroshiro128plus';
+import { decodeState } from './decode-state';
+import { encodeState } from './encode-state';
 import type { RNG } from './types';
-
-const STATE_HEX_PATTERN = /^[0-9a-f]{32}$/;
-const STATE_ALL_ZERO = '0'.repeat(32);
-const STATE_WORD_COUNT = 4;
-const STATE_WORD_HEX_CHARS = 8;
 
 /**
  * thin wrapper around pure-rand as it's interface is verbose and we don't need
@@ -27,49 +23,4 @@ export function createRNG(state: string): RNG {
     getSeries,
     getState: () => encodeState(gen.getState()),
   };
-}
-
-/**
- * Decodes a 32-character hex string into the four 32-bit words xoroshiro128+ carries as state.
- * Round-trips `encodeState` exactly — word order is preserved, never interpreted. Throws on a
- * malformed string or the all-zero state, xoroshiro128+'s degenerate fixed point.
- */
-export function decodeState(hex: string): Array<number> {
-  invariant(STATE_HEX_PATTERN.test(hex), 'rng state must be a 32-character lowercase hex string');
-
-  invariant(
-    hex !== STATE_ALL_ZERO,
-    'rng state must not be the all-zero xoroshiro128plus fixed point',
-  );
-
-  return Array.from({ length: STATE_WORD_COUNT }, (_, index) => {
-    const chunk = hex.slice(index * STATE_WORD_HEX_CHARS, (index + 1) * STATE_WORD_HEX_CHARS);
-
-    // oxlint-disable-next-line unicorn/prefer-math-trunc -- reinterprets the unsigned hex value as a signed 32-bit int; Math.trunc only drops a fractional part, it doesn't wrap the high bit
-    return parseInt(chunk, 16) | 0;
-  });
-}
-
-/**
- * Encodes xoroshiro128+'s four 32-bit state words into a 32-character hex string, one
- * 8-character chunk per word in the order given.
- */
-export function encodeState(words: ReadonlyArray<number>): string {
-  return words
-    .map((word) => {
-      // oxlint-disable-next-line unicorn/prefer-math-trunc -- reinterprets a signed 32-bit int as unsigned; Math.trunc only drops a fractional part, it doesn't clear the sign bit
-      const unsigned = word >>> 0;
-
-      return unsigned.toString(16).padStart(8, '0');
-    })
-    .join('');
-}
-
-/**
- * Derives a 128-bit rng state from a plain numeric seed, for callers that legitimately seed from a
- * number (a world map node's stored seed, an initial placeholder state, tests). Seed `0` scrambles
- * to a valid non-zero state.
- */
-export function stateFromSeed(seed: number): string {
-  return encodeState(xoroshiro128plus(seed).getState());
 }

--- a/libs/game/game-utils/src/decode-state.test.ts
+++ b/libs/game/game-utils/src/decode-state.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from 'bun:test';
+import { decodeState } from './decode-state';
+
+test('it decodes each 8-character chunk into a signed 32-bit word', () => {
+  expect(decodeState('00000001000000027fffffffffffffff')).toStrictEqual([1, 2, 2_147_483_647, -1]);
+});
+
+test('it rejects an all-zero state', () => {
+  expect(() => decodeState('0'.repeat(32))).toThrow();
+});
+
+test('it rejects a state of the wrong length', () => {
+  expect(() => decodeState('abcd')).toThrow();
+});
+
+test('it rejects a non-hex state', () => {
+  expect(() => decodeState('z'.repeat(32))).toThrow();
+});
+
+test('it rejects uppercase hex', () => {
+  expect(() => decodeState('A'.repeat(32))).toThrow();
+});

--- a/libs/game/game-utils/src/decode-state.ts
+++ b/libs/game/game-utils/src/decode-state.ts
@@ -1,0 +1,27 @@
+import invariant from 'tiny-invariant';
+
+const STATE_HEX_PATTERN = /^[0-9a-f]{32}$/;
+const STATE_ALL_ZERO = '0'.repeat(32);
+const STATE_WORD_COUNT = 4;
+const STATE_WORD_HEX_CHARS = 8;
+
+/**
+ * Decodes a 32-character hex string into the four 32-bit words xoroshiro128+ carries as state.
+ * Round-trips `encodeState` exactly — word order is preserved, never interpreted. Throws on a
+ * malformed string or the all-zero state, xoroshiro128+'s degenerate fixed point.
+ */
+export function decodeState(hex: string): Array<number> {
+  invariant(STATE_HEX_PATTERN.test(hex), 'rng state must be a 32-character lowercase hex string');
+
+  invariant(
+    hex !== STATE_ALL_ZERO,
+    'rng state must not be the all-zero xoroshiro128plus fixed point',
+  );
+
+  return Array.from({ length: STATE_WORD_COUNT }, (_, index) => {
+    const chunk = hex.slice(index * STATE_WORD_HEX_CHARS, (index + 1) * STATE_WORD_HEX_CHARS);
+
+    // oxlint-disable-next-line unicorn/prefer-math-trunc -- reinterprets the unsigned hex value as a signed 32-bit int; Math.trunc only drops a fractional part, it doesn't wrap the high bit
+    return parseInt(chunk, 16) | 0;
+  });
+}

--- a/libs/game/game-utils/src/encode-state.test.ts
+++ b/libs/game/game-utils/src/encode-state.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from 'bun:test';
+import { decodeState } from './decode-state';
+import { encodeState } from './encode-state';
+
+test('it encodes each word as an 8-character unsigned hex chunk in order', () => {
+  expect(encodeState([1, 2, 2_147_483_647, -1])).toBe('00000001000000027fffffffffffffff');
+});
+
+test('it round-trips through the decoder exactly', () => {
+  const hex = '0123456789abcdeffedcba9876543210';
+
+  expect(encodeState(decodeState(hex))).toBe(hex);
+});

--- a/libs/game/game-utils/src/encode-state.ts
+++ b/libs/game/game-utils/src/encode-state.ts
@@ -1,0 +1,14 @@
+/**
+ * Encodes xoroshiro128+'s four 32-bit state words into a 32-character hex string, one
+ * 8-character chunk per word in the order given.
+ */
+export function encodeState(words: ReadonlyArray<number>): string {
+  return words
+    .map((word) => {
+      // oxlint-disable-next-line unicorn/prefer-math-trunc -- reinterprets a signed 32-bit int as unsigned; Math.trunc only drops a fractional part, it doesn't clear the sign bit
+      const unsigned = word >>> 0;
+
+      return unsigned.toString(16).padStart(8, '0');
+    })
+    .join('');
+}

--- a/libs/game/game-utils/src/index.ts
+++ b/libs/game/game-utils/src/index.ts
@@ -1,4 +1,7 @@
+export { buildStateFromSeed } from './build-state-from-seed';
 export { combineSeeds } from './combine-seeds';
-export { createRNG, decodeState, encodeState, stateFromSeed } from './create-rng';
+export { createRNG } from './create-rng';
 export { createSeed } from './create-seed';
+export { decodeState } from './decode-state';
+export { encodeState } from './encode-state';
 export type * from './types';

--- a/libs/game/idle-core/src/core/create-simulation.ts
+++ b/libs/game/idle-core/src/core/create-simulation.ts
@@ -1,4 +1,4 @@
-import { createRNG, stateFromSeed } from '@vers/game-utils';
+import { buildStateFromSeed, createRNG } from '@vers/game-utils';
 import { deepEqual } from 'fast-equals';
 import invariant from 'tiny-invariant';
 import type { XXHashAPI } from 'xxhash-wasm';
@@ -24,7 +24,7 @@ import { simulateActivity } from './simulate-activity';
 import { getAppState } from './utils/get-app-state';
 
 export function createSimulation(hasher: XXHashAPI): Simulation {
-  let _rng = createRNG(stateFromSeed(0));
+  let _rng = createRNG(buildStateFromSeed(0));
   let _avatar: Avatar | null = null;
   let _activityData: ActivityData | null = null;
   let _activity: Activity | null = null;

--- a/libs/game/idle-core/src/core/run-simulation.test.ts
+++ b/libs/game/idle-core/src/core/run-simulation.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'bun:test';
-import { stateFromSeed } from '@vers/game-utils';
+import { buildStateFromSeed } from '@vers/game-utils';
 import { createMockActivityData } from '../test-utils/create-mock-activity-data';
 import { createMockAvatarData } from '../test-utils/create-mock-avatar-data';
 import { createMockEnemyData } from '../test-utils/create-mock-enemy-data';
@@ -13,7 +13,7 @@ test('runs a simulation with default configuration', async () => {
     enemies: [createMockEnemyData()],
     failureAction: ActivityFailureAction.Retry,
     id: 'world_map_encounter_1',
-    seed: stateFromSeed(3_047_525_658),
+    seed: buildStateFromSeed(3_047_525_658),
     type: ActivityType.WorldMapEncounter,
   });
 
@@ -115,7 +115,7 @@ test('it respects duration limit and stops the simulation accordingly', async ()
     enemies: [createMockEnemyData()],
     failureAction: ActivityFailureAction.Retry,
     id: 'world_map_encounter_1',
-    seed: stateFromSeed(3_047_525_658),
+    seed: buildStateFromSeed(3_047_525_658),
     type: ActivityType.WorldMapEncounter,
   });
 
@@ -139,7 +139,7 @@ test('it stops at the specified rng state if provided', async () => {
     enemies: [enemy],
     failureAction: ActivityFailureAction.Retry,
     id: 'world_map_encounter_1',
-    seed: stateFromSeed(3_047_525_658),
+    seed: buildStateFromSeed(3_047_525_658),
     type: ActivityType.WorldMapEncounter,
   });
 
@@ -174,7 +174,7 @@ test('it aborts on failure if failure action is set to abort', async () => {
     enemies: [enemy],
     failureAction: ActivityFailureAction.Abort,
     id: 'world_map_encounter_1',
-    seed: stateFromSeed(3_047_525_658),
+    seed: buildStateFromSeed(3_047_525_658),
     type: ActivityType.WorldMapEncounter,
   });
 
@@ -210,7 +210,7 @@ test('it retries when failure action is set to retry', async () => {
     enemies: [enemy],
     failureAction: ActivityFailureAction.Retry,
     id: 'world_map_encounter_1',
-    seed: stateFromSeed(3_047_525_658),
+    seed: buildStateFromSeed(3_047_525_658),
     type: ActivityType.WorldMapEncounter,
   });
 

--- a/libs/game/idle-core/src/test-utils/create-mock-activity-data.test.ts
+++ b/libs/game/idle-core/src/test-utils/create-mock-activity-data.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'bun:test';
-import { stateFromSeed } from '@vers/game-utils';
+import { buildStateFromSeed } from '@vers/game-utils';
 import { ActivityFailureAction, ActivityType } from '../types';
 import { createMockActivityData } from './create-mock-activity-data';
 import { createMockEnemyData } from './create-mock-enemy-data';
@@ -38,7 +38,7 @@ test('it creates activity data with custom properties', () => {
     failureAction: ActivityFailureAction.Abort,
     id: 'custom-activity',
     name: 'Custom Activity',
-    seed: stateFromSeed(123),
+    seed: buildStateFromSeed(123),
     type: ActivityType.WorldMapEncounter,
   });
 
@@ -48,7 +48,7 @@ test('it creates activity data with custom properties', () => {
     failureAction: ActivityFailureAction.Abort,
     id: 'custom-activity',
     name: 'Custom Activity',
-    seed: stateFromSeed(123),
+    seed: buildStateFromSeed(123),
     type: ActivityType.WorldMapEncounter,
   });
 });

--- a/libs/game/idle-core/src/test-utils/create-mock-activity-data.ts
+++ b/libs/game/idle-core/src/test-utils/create-mock-activity-data.ts
@@ -1,5 +1,5 @@
 import { createId } from '@paralleldrive/cuid2';
-import { stateFromSeed } from '@vers/game-utils';
+import { buildStateFromSeed } from '@vers/game-utils';
 import type { ActivityData } from '../types';
 import { ActivityFailureAction, ActivityType } from '../types';
 import { createMockEnemyData } from './create-mock-enemy-data';
@@ -12,7 +12,7 @@ export function createMockActivityData(overrides: Partial<ActivityData> = {}): A
     failureAction: ActivityFailureAction.Retry,
     id: createId(),
     name: 'World Map Encounter',
-    seed: stateFromSeed(1),
+    seed: buildStateFromSeed(1),
     type: ActivityType.WorldMapEncounter,
     ...overrides,
   };

--- a/libs/game/idle-core/src/test-utils/create-mock-simulation-context.test.ts
+++ b/libs/game/idle-core/src/test-utils/create-mock-simulation-context.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'bun:test';
-import { createRNG, stateFromSeed } from '@vers/game-utils';
+import { buildStateFromSeed, createRNG } from '@vers/game-utils';
 import { createMockSimulationContext } from './create-mock-simulation-context';
 
 test('it creates a simulation context with expected properties', () => {
@@ -13,7 +13,7 @@ test('it creates a simulation context with expected properties', () => {
 });
 
 test('it creates a simulation context with custom properties', () => {
-  const rng = createRNG(stateFromSeed(999_999_999));
+  const rng = createRNG(buildStateFromSeed(999_999_999));
 
   const ctx = createMockSimulationContext({
     elapsed: 100,

--- a/libs/game/idle-core/src/test-utils/create-mock-simulation-context.ts
+++ b/libs/game/idle-core/src/test-utils/create-mock-simulation-context.ts
@@ -1,4 +1,4 @@
-import { createRNG, stateFromSeed } from '@vers/game-utils';
+import { buildStateFromSeed, createRNG } from '@vers/game-utils';
 import xxhash from 'xxhash-wasm';
 import type { SimulationContext } from '../types';
 
@@ -10,7 +10,7 @@ export function createMockSimulationContext(overrides: Overrides = {}): Simulati
   const ctx: SimulationContext = {
     elapsed: 0,
     hasher,
-    rng: createRNG(stateFromSeed(999_999_999)),
+    rng: createRNG(buildStateFromSeed(999_999_999)),
     ...overrides,
   };
 

--- a/libs/game/worldmap-core/src/get-randomized-position.test.ts
+++ b/libs/game/worldmap-core/src/get-randomized-position.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from 'bun:test';
-import { createRNG, stateFromSeed } from '@vers/game-utils';
+import { buildStateFromSeed, createRNG } from '@vers/game-utils';
 import { getRandomizedPosition } from './get-randomized-position';
 
 test('it returns a position within the expected range', () => {
-  const rng = createRNG(stateFromSeed(12_345));
+  const rng = createRNG(buildStateFromSeed(12_345));
   const position = getRandomizedPosition([0, 0], rng);
 
   expect(position).toMatchInlineSnapshot(`

--- a/libs/game/worldmap-core/src/get-world-map-node-map.ts
+++ b/libs/game/worldmap-core/src/get-world-map-node-map.ts
@@ -1,4 +1,4 @@
-import { createRNG, stateFromSeed } from '@vers/game-utils';
+import { buildStateFromSeed, createRNG } from '@vers/game-utils';
 import { getRandomizedPosition } from './get-randomized-position';
 import type { CompressedWorldMapNode, WorldMapNode, WorldMapNodeMap } from './types';
 
@@ -8,7 +8,7 @@ export function getWorldMapNodeMap(
   const nodes: Record<string, WorldMapNode> = {};
 
   for (const node of compressedNodes) {
-    const rng = createRNG(stateFromSeed(node.s));
+    const rng = createRNG(buildStateFromSeed(node.s));
 
     const worldMapNode: WorldMapNode = {
       connections: node.c,


### PR DESCRIPTION
## Description

Splits `create-rng.ts` into one module per export and renames `stateFromSeed` to `buildStateFromSeed`, bringing the overnight RNG work in line with the one-export-per-file and function-naming conventions.

- `decodeState`, `encodeState`, and `buildStateFromSeed` each get their own module and co-located test file
- Rejection tests stay on `createRNG` (its contract) and are also asserted directly on `decodeState`
- Rename propagated to idle-core and worldmap-core callers; no behaviour change

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality