### PR TITLE
docs: add the seed-chain architecture doc

### DIFF
--- a/docs/architecture/game-entropy.md
+++ b/docs/architecture/game-entropy.md
@@ -26,7 +26,8 @@ reproduces byte-for-byte. Deriving from an appended-but-unverified checkpoint is
 settlement trusts only the verified prefix and claws back any rejected suffix. The chain is
 client-computable — offline simulation depends on it — and every activity advances it, a failed or
 abandoned attempt exactly as a completed one. The attempt after a failure is a fresh continuation,
-never a replay of the one that failed.
+never a replay of the one that failed. The [seed chain](./seed-chain.md) holds this state in a
+per-pair row of two anchors and fixes the transitions that advance and rewind them.
 
 The chain seeds the trajectory only — enemies, timing, survival, experience, and which kills commit
 rolled rewards — and rolled content resolves separately, at a coordinate fixed by the kill that

--- a/docs/architecture/game-simulation.md
+++ b/docs/architecture/game-simulation.md
@@ -29,7 +29,7 @@ decide whether to trust what the client submitted.
 
 `startActivity` is a server action that owns every simulation input: it mints the seed for a node's
 first activity and derives each continuation's seed from the previous activity's appended checkpoint
-(see [game entropy](./game-entropy.md)), resolves the node's enemy content, snapshots the avatar's
+(see [the seed chain](./seed-chain.md)), resolves the node's enemy content, snapshots the avatar's
 build (equipment, passives, level) from server truth, and stamps the engine and content versions.
 Client-submitted activity and avatar payloads are display hints, and a continuation's seed is a
 client computation the verifier reproduces from the appended chain — online and offline alike, never

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -60,6 +60,9 @@ is playing. Provisioning, connection rules, and where the secrets live: [databas
   compare-and-swap backing the checkpoint hash chain. The table carries no inbound foreign keys and
   no global uniqueness constraint, so time-range partitioning with a retention window that
   cold-archives verified streams to object storage is a storage change, not a schema change.
+- **Seed chain state** — one `activity_chains` row per `(avatar_id, node_id)`, holding the chain's
+  genesis seed and its appended and verified anchors, from which each activity at the node draws its
+  seed. See [the seed chain](./seed-chain.md).
 
 ## Game layer
 

--- a/docs/architecture/seed-chain.md
+++ b/docs/architecture/seed-chain.md
@@ -1,0 +1,103 @@
+# The seed chain
+
+Every `(avatar, node)` pair owns one forward, append-only seed chain. Each activity at the node
+draws its seed from the chain's current position and advances it, so the next activity continues
+from where the last one left off — a completed, failed, or abandoned attempt all advance it alike. A
+re-attempt is a fresh continuation, never a replay. Why the chain takes this shape, and how its
+flatness prices look-ahead, is the [entropy model](./game-entropy.md#the-seed-chain); this document
+is the data model and lifecycle.
+
+## The chain row
+
+`activity_chains`, keyed `(avatar_id, node_id)`, holds the chain's state as two cursors:
+
+- The **appended anchor** (`appended_next_seed`, `appended_chain_index`) is the derivation source. A
+  new activity seeds from it. It moves the instant an activity's tail is written, ahead of
+  verification, so offline play never waits on the verifier.
+- The **verified anchor** (`verified_next_seed`, `verified_chain_index`) is the settlement watermark
+  and the rollback target. Settlement trusts positions at or below it.
+
+`genesis_seed` records the origin seed. The row carries no `updated_at` column and no on-update
+trigger, so a reveal that self-assigns `genesis_seed` to keep the mint idempotent bumps no timestamp
+and writes no logical change.
+
+The chain row spans a node's activities. A
+[checkpoint stream](./game-simulation.md#checkpoint-streams) and its head-row cursors span a single
+activity.
+
+## Seeds and chainIndex
+
+A seed is a 128-bit xoroshiro128+ state carried as a 32-character hex string. A continuation seed is
+the previous activity's final checkpoint `nextSeed`, copied verbatim — the derivation is identity,
+and the verifier reproduces it from the appended chain rather than trusting a submitted value.
+
+`chainIndex` counts checkpoints along the whole chain, monotonic across activities so a failed
+attempt's positions are spent, never reused. An activity carries `start_chain_index`, stamped at
+start from the chain's appended cursor; a checkpoint's `chainIndex` is
+`start_chain_index + version`, where `version` is its 1-based position in the activity's stream. The
+`Started` checkpoint sits at `start_chain_index + 1`. Reward coordinates and sealed-salt positions
+key on this value, so its base is fixed here.
+
+`chainIndex` is a field of the checkpoint's frozen hashed subset, so replay reproduces every
+coordinate and the server validates each checkpoint's `chainIndex` against
+`start_chain_index + version`.
+
+## Genesis
+
+A node's genesis seed is a server CSPRNG mint — sixteen random bytes as hex, re-rolled off the
+degenerate all-zero xoroshiro state — written to the chain row when the row is first created for the
+pair. It needs no re-derivation: the verifier reads the stored value and a restored device fetches
+it. A client cannot compute it and cannot steer it, since the cell coordinate and the avatar are
+both fixed before the mint.
+
+## Advancing the chain
+
+The chain advances on an activity's transition out of `active`. Which cursor moves depends on
+whether the appended tail is trustworthy.
+
+### Forward exits
+
+A terminal checkpoint (completed or failed), a user stop, and an offline cap all leave honest
+progress. The request path advances `appended_next_seed` and `appended_chain_index` from the last
+appended checkpoint, guarded by a compare-and-swap on the activity's `start_chain_index` so a
+duplicate transition moves nothing. An activity that appended nothing, or whose only checkpoint is
+`Started` — whose `nextSeed` equals the seed, so nothing was consumed — leaves the anchor untouched.
+
+### Adverse exits
+
+Reproducible divergence rejects a stream; repeated ambiguity quarantines it. The appended tail is
+then suspect and never advances the appended anchor.
+
+A rejection rewinds the appended anchor to the verified anchor in one self-referential statement,
+setting `appended_next_seed = verified_next_seed` and `appended_chain_index = verified_chain_index`
+from the row's own columns. A successor that already rooted past the verified point
+(`start_chain_index > verified_chain_index`) is void: its forward-advance compare-and-swap can no
+longer match, and settlement clears its optimistic rewards. A quarantine blocks new activity starts
+on the pair; every other node proceeds.
+
+Session eviction changes the writer, not the activity. The activity stays `active`, a new session
+resumes it from the verified anchor, and its tail is adjudicated on its own merits — eviction
+advances nothing.
+
+## Settlement and reveal
+
+Identity settlement and rolled-reward reveal gate on the verified anchor, never on the appended
+head, so a suspect tail that later rejects settles nothing to claw back. A synced but unverified
+reward holds as a pending item on the client until the verifier settles it.
+
+## Concurrency
+
+- The verifier serializes a chain's activities on the chain row, adjudicating one at a time in
+  order, so a continuation never confirms against a predecessor that later rejects.
+- The request-path forward-advance and the verifier both acquire the chain row before the activity
+  row, a single ordering that admits no cycle.
+- The rejection rewind reads the verified columns inline in its update statement, never through a
+  prior select, so a concurrent confirm cannot slip between the read and the write.
+
+## Provenance
+
+Every checkpoint's frozen hashed subset carries an `entropySource` tag naming which source rolled
+its outcomes, present from the first row written and covered by the hash. Verification stamps an
+outcome's provenance from server records and this tag, and tradeability keys on the source's
+security property rather than on the delivery channel — the
+[provenance rules](./game-entropy.md#provenance) own that distinction.


### PR DESCRIPTION
Promotes the forward seed chain's implementation design out of a closed-issue comment into a durable, versioned doc.

- New `docs/architecture/seed-chain.md` — the `activity_chains` data model, the appended/verified anchors, the forward-advance and adverse-rewind lifecycle, the concurrency contract, and the `chainIndex = startChainIndex + version` convention.
- Cross-linked from `game-entropy.md`, `game-simulation.md`, and the `overview.md` data map.

Every downstream ticket points at the doc instead of the #177 comment.