### PR TITLE
docs: lock replay, combat, chain-scope, and passive vocabulary

### DIFF
--- a/docs/architecture/game-entropy.md
+++ b/docs/architecture/game-entropy.md
@@ -160,9 +160,9 @@ Every checkpoint's hashed subset carries an entropy-source tag identifying which
 outcomes, present from the first row ever written. The subset is frozen, so the tag cannot be added
 later. The two sources it distinguishes today are server-custody and device-custody rolls, and the
 tag is what lets further sources — a verifiable-randomness beacon, a rotated key generation — join
-without a migration. Replay validates the tag against the avatar's server-recorded mode; a
-mismatch is divergence. Settlement stamps an outcome's provenance from server records and the tag —
-never from a client claim.
+without a migration. Replay validates the tag against the avatar's server-recorded mode; a mismatch
+is divergence. Settlement stamps an outcome's provenance from server records and the tag — never
+from a client claim.
 
 Tradeability keys on the security property: entropy unpredictable at the moment the outcome was
 committed, and provably tied to the party that minted it. Server-custody rolls and sealed salt have

--- a/docs/architecture/game-entropy.md
+++ b/docs/architecture/game-entropy.md
@@ -160,7 +160,7 @@ Every checkpoint's hashed subset carries an entropy-source tag identifying which
 outcomes, present from the first row ever written. The subset is frozen, so the tag cannot be added
 later. The two sources it distinguishes today are server-custody and device-custody rolls, and the
 tag is what lets further sources — a verifiable-randomness beacon, a rotated key generation — join
-without a migration. Verification validates the tag against the avatar's server-recorded mode; a
+without a migration. Replay validates the tag against the avatar's server-recorded mode; a
 mismatch is divergence. Settlement stamps an outcome's provenance from server records and the tag —
 never from a client claim.
 

--- a/docs/architecture/game-simulation.md
+++ b/docs/architecture/game-simulation.md
@@ -7,17 +7,24 @@ replay.
 
 An **activity** is one attempt at a piece of content, recorded as a single append-only checkpoint
 stream and verified as a unit. Every activity has a type. A **world map encounter** is the type
-where an avatar fights through a node's enemies, arranged in **waves** — ordered groups the avatar
-clears one at a time. `@vers/idle-core` runs any activity type; `@vers/game-utils` derives a world
-map encounter's waves, enemies, and timing from `(node, seed, content)` as a pure function.
+where an avatar fights through a map node's enemies, arranged in **waves** — ordered groups the
+avatar clears one at a time. **Combat** is how an encounter resolves: each tick, the engine's combat
+executor advances the avatar and the current wave's enemies and dispatches their attack events.
+`@vers/idle-core` runs any activity type; `@vers/game-utils` derives a world map encounter's waves,
+enemies, and timing from `(node, seed, content)` as a pure function.
+
+Activities at the same target chain together: each `(avatar, chain scope)` pair owns one append-only
+[seed chain](./seed-chain.md), where a **chain scope** is a `(scope_type, scope_id)` pair naming a
+stable, returnable target. A world map encounter's chain scope is its map node (`world_map_node`) —
+the activity type says what the avatar does, the scope type says where it returns to.
 
 ## The deterministic core
 
 The simulation is a pure function: a server-authored input snapshot plus a seed stream fully
 determine every tick. The engine (`@vers/idle-core`) and world map encounter derivation
-(`@vers/game-utils`) are shared libraries, so the client worker and the verification worker — the
-server process that replays submitted checkpoints — import the same code and compute byte-identical
-results from the same inputs.
+(`@vers/game-utils`) are shared libraries, so the client worker and the verifier — the server
+process that replays submitted checkpoints — import the same code and compute byte-identical results
+from the same inputs.
 
 The client does all real-time simulation. One writer per browser profile runs the fixed-timestep
 loop — a SharedWorker, with leader election where SharedWorker is unavailable — and other tabs are
@@ -59,18 +66,18 @@ replayed) — the last chain hash, and the activity status.
   rejected, capped, quarantined) reject any later append. Together these resolve every race between
   logout, forced logout, stop, rejection, and cap.
 
-## Verification
+## Replay
 
-A queue-fed worker replays submitted checkpoint batches and compares results. Verification is
-per-stream FIFO — version N+1 never verifies before N, because the seed chain would break — and the
-worker replays from the `Started` snapshot under the engine version stamped into it, dispatched
-through a provider registry so old segments replay under the code and content that produced them.
+A queue-fed verifier replays submitted checkpoint batches and compares results. Replay is per-stream
+FIFO — version N+1 never verifies before N, because the seed chain would break — and the verifier
+replays from the `Started` snapshot under the engine version stamped into it, dispatched through a
+provider registry so old segments replay under the code and content that produced them.
 
 Ambiguity parks, it never rejects: a version mismatch, an unknown engine, or a timeout is held as an
 operational state, not judged as a cheat signal. Only reproducible divergence under a matched
 version and snapshot, on repetition, is treated as cheating, and enforcement lands at a session
-boundary — never mid-session. A stream that fails verification repeatedly is quarantined and alerted
-on rather than retried forever.
+boundary — never mid-session. A stream that fails replay repeatedly is quarantined and alerted on
+rather than retried forever.
 
 Replay divergence is not the only cheat signal. Because every attempt at a node is a link in the
 append-only, server-verified chain, reroll-scanning leaves a record: an avatar whose results ride
@@ -80,7 +87,7 @@ or by completing and discarding them. This is a behavioural signal, not a diverg
 scored with the same restraint: a soft consequence before a hard one, always at a session boundary.
 Honest grinders swing too, and a false accusation costs more than the edge it denies.
 
-The primary health gauge is verification lag: the oldest unverified append across all streams.
+The primary health gauge is replay lag: the oldest unverified append across all streams.
 Rejection rates are tracked split by cause — an integrity-mismatch spike is almost always a bad
 deploy, not a cheating wave.
 

--- a/docs/architecture/game-simulation.md
+++ b/docs/architecture/game-simulation.md
@@ -87,9 +87,9 @@ or by completing and discarding them. This is a behavioural signal, not a diverg
 scored with the same restraint: a soft consequence before a hard one, always at a session boundary.
 Honest grinders swing too, and a false accusation costs more than the edge it denies.
 
-The primary health gauge is replay lag: the oldest unverified append across all streams.
-Rejection rates are tracked split by cause — an integrity-mismatch spike is almost always a bad
-deploy, not a cheating wave.
+The primary health gauge is replay lag: the oldest unverified append across all streams. Rejection
+rates are tracked split by cause — an integrity-mismatch spike is almost always a bad deploy, not a
+cheating wave.
 
 ## Applying verified progress
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -44,7 +44,7 @@ Each service is its own Fly deployment, scale-to-zero, reachable only on the pri
 - `service-activity` — owns the game's event store: activity streams of simulation checkpoint
   batches, and the "current activity" / "latest progress" reads the client resumes from.
 - `service-verifier` (in build) — queue-fed checkpoint-replay worker. Replaying a simulation is
-  CPU-bound, so verification runs off the request path with its own scaling profile.
+  CPU-bound, so replay runs off the request path with its own scaling profile.
 
 ## Data
 
@@ -56,7 +56,7 @@ is playing. Provisioning, connection rules, and where the secrets live: [databas
 - **Activity checkpoints** — an append-only table keyed by `(activity_id, version)`, one row per
   checkpoint batch, alongside a per-activity head row carrying the appended and verified cursors.
   The workload is append-heavy submissions, point reads for "latest progress" off the head row, and
-  full-stream replays during verification — a natural fit for indexed Postgres, with the head row's
+  full-stream replays by the verifier — a natural fit for indexed Postgres, with the head row's
   compare-and-swap backing the checkpoint hash chain. The table carries no inbound foreign keys and
   no global uniqueness constraint, so time-range partitioning with a retention window that
   cold-archives verified streams to object storage is a storage change, not a schema change.

--- a/docs/architecture/seed-chain.md
+++ b/docs/architecture/seed-chain.md
@@ -99,7 +99,7 @@ reward holds as a pending item on the client until the verifier settles it.
 ## Provenance
 
 Every checkpoint's frozen hashed subset carries an `entropySource` tag naming which source rolled
-its outcomes, present from the first row written and covered by the hash. Verification stamps an
+its outcomes, present from the first row written and covered by the hash. Replay stamps an
 outcome's provenance from server records and this tag, and tradeability keys on the source's
 security property rather than on the delivery channel — the
 [provenance rules](./game-entropy.md#provenance) own that distinction.

--- a/docs/architecture/seed-chain.md
+++ b/docs/architecture/seed-chain.md
@@ -99,7 +99,7 @@ reward holds as a pending item on the client until the verifier settles it.
 ## Provenance
 
 Every checkpoint's frozen hashed subset carries an `entropySource` tag naming which source rolled
-its outcomes, present from the first row written and covered by the hash. Replay stamps an
-outcome's provenance from server records and this tag, and tradeability keys on the source's
-security property rather than on the delivery channel — the
-[provenance rules](./game-entropy.md#provenance) own that distinction.
+its outcomes, present from the first row written and covered by the hash. Replay stamps an outcome's
+provenance from server records and this tag, and tradeability keys on the source's security property
+rather than on the delivery channel — the [provenance rules](./game-entropy.md#provenance) own that
+distinction.

--- a/docs/game-design/base-class-template.md
+++ b/docs/game-design/base-class-template.md
@@ -26,16 +26,17 @@ Per specialization:
 - **Name** — working name.
 - **System drawn on** — the universal system it interlocks with (a resource pool, a defensive layer,
   the beat cadence) or the mechanic itself. Never a damage type or a build archetype.
-- **Tier 1 / Tier 2 / Tier 3** — two or three nodes each; the avatar takes one per tier. For every
-  node, state its effect and the **edge** it holds: the build, region, or encounter shape it is
-  strongest in. Nodes in a tier point in different directions — that divergence is the choice.
+- **Tier 1 / Tier 2 / Tier 3** — two or three passives each; the avatar takes one per tier. For
+  every passive, state its effect and the **edge** it holds: the build, region, or encounter shape
+  it is strongest in. Passives in a tier point in different directions — that divergence is the
+  choice.
 
 Check the specialization as a set of paths, not tier by tier:
 
-- No node erases the value of an earlier one; a node bound to a durable quantity survives a capstone
-  that a node bound to a transient state does not.
-- No node wins in every context — each holds a different edge, or the tier collapses to one pick.
-- A capstone that reshapes the mechanic leaves no earlier node orphaned.
+- No passive erases the value of an earlier one; a passive bound to a durable quantity survives a
+  capstone that a passive bound to a transient state does not.
+- No passive wins in every context — each holds a different edge, or the tier collapses to one pick.
+- A capstone that reshapes the mechanic leaves no earlier passive orphaned.
 
 ## Open Questions
 

--- a/docs/game-design/base-classes.md
+++ b/docs/game-design/base-classes.md
@@ -51,31 +51,32 @@ Any system a specialization draws on is universal — a resource pool, a defensi
 cadence — never a build archetype. Drawing on a damage type would smuggle a build back into the
 class layer and break the generic-or-transformative law at the specialization level.
 
-A specialization is three tiers. Each tier offers two or three nodes, and the avatar takes one. The
-nodes in a tier diverge — they pull the mechanic in different directions, and choosing among them is
-the decision the tier exists to pose. A tier is a fork, not a themed step dressed with
+A specialization is three tiers. Each tier offers two or three passives, and the avatar takes one.
+The passives in a tier diverge — they pull the mechanic in different directions, and choosing among
+them is the decision the tier exists to pose. A tier is a fork, not a themed step dressed with
 interchangeable options.
 
-Choosing a specialization is a one-time commitment, re-chooseable with investment. The node taken in
-each tier respecs freely, like passive allocation. A specialization unlocks through progression.
+Choosing a specialization is a one-time commitment, re-chooseable with investment. The passive taken
+in each tier respecs freely, like tree allocation. A specialization unlocks through progression.
 
 ## Authoring a Specialization
 
-Nodes are chosen in combination across the three tiers, so a specialization is designed as the set
-of paths through it, not tier by tier.
+Passives are chosen in combination across the three tiers, so a specialization is designed as the
+set of paths through it, not tier by tier.
 
-- **Nodes compose without self-nullifying.** No node erases the value of one an avatar already took.
-  A node keyed to a durable quantity survives a later node that a node keyed to a transient state
-  does not — anchor a node's scaling to something no later node can remove.
-- **No node wins unconditionally.** Each node in a tier is strongest in a different build, region,
-  or encounter shape; nodes separated only by magnitude collapse into one obvious pick. The design
-  states the edge each node is meant to hold, and a balance pass confirms no path dominates.
-- **Off-path nodes stay tempting.** Along any path, the node that extends it is usually right but
-  never automatic — a node from another direction is defensible in some builds, or the tier choices
-  reduce to autopilot and only the first fork was real.
-- **A capstone that reshapes the mechanic cannot orphan its earlier nodes.** When a later tier can
-  replace or transform the mechanic, earlier nodes bound to the old form die with it. Bind early
-  nodes to the class's own resource, not to a structure a capstone might remove.
+- **Passives compose without self-nullifying.** No passive erases the value of one an avatar already
+  took. A passive keyed to a durable quantity survives a later passive that a passive keyed to a
+  transient state does not — anchor a passive's scaling to something no later passive can remove.
+- **No passive wins unconditionally.** Each passive in a tier is strongest in a different build,
+  region, or encounter shape; passives separated only by magnitude collapse into one obvious pick.
+  The design states the edge each passive is meant to hold, and a balance pass confirms no path
+  dominates.
+- **Off-path passives stay tempting.** Along any path, the passive that extends it is usually right
+  but never automatic — a passive from another direction is defensible in some builds, or the tier
+  choices reduce to autopilot and only the first fork was real.
+- **A capstone that reshapes the mechanic cannot orphan its earlier passives.** When a later tier
+  can replace or transform the mechanic, earlier passives bound to the old form die with it. Bind
+  early passives to the class's own resource, not to a structure a capstone might remove.
 
 ## Worked Example
 
@@ -86,10 +87,10 @@ output. That resource, how it accrues, and what it amplifies are the entire base
 on its own.
 
 One of its specializations routes that resource through another universal system. Each of its three
-tiers is a fork: at one tier the avatar takes either a node that scales the resource's ceiling with
-the coupled system or a node that converts the coupled system's recovery into resource gain — nodes
-that pull toward different builds, so the pick commits a direction rather than stacking a number.
-Later tiers deepen that direction without deleting the earlier node.
+tiers is a fork: at one tier the avatar takes either a passive that scales the resource's ceiling
+with the coupled system or a passive that converts the coupled system's recovery into resource gain
+— passives that pull toward different builds, so the pick commits a direction rather than stacking a
+number. Later tiers deepen that direction without deleting the earlier passive.
 
 Its sibling specializations express the same resource differently — routing it through other
 systems, or scaling it through itself — each a distinct read on the one mechanic.


### PR DESCRIPTION
## Description

Applies the prose-only terminology decisions from #522. Code renames land separately; every term here describes the tree as it stands.

- Checkpoint-replay vocabulary: the process is replay, the worker is the verifier — "verification" belongs to the identity service (game-simulation.md heading, overview, seed-chain, game-entropy).
- Specialization tier picks are **passives**, never "nodes" — bare "node" is reserved for technical senses; tier-pick respec now reads "like tree allocation" to avoid circularity (base-classes, base-class-template).
- Glossary gains **combat** (how an encounter resolves, via the combat executor) and **chain scope** (`scope_type`/`scope_id`, with the activity-type ↔ scope-type relationship), and qualifies "map node" on first use.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [ ] New tests added for new functionality

## Context

Part of the #522 cleanup pass; the companion code PR carries the identifier renames and their glossary entries.