### PR TITLE
feat(#181): add the replay pipeline primitives and append guards

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -99,6 +99,8 @@
         "ignoreInferredTypes": true,
         "allow": [
           { "from": "package", "name": "Kysely", "package": "kysely" },
+          // a live kysely transaction handle: same mutable connection state as Kysely above
+          { "from": "package", "name": "Transaction", "package": "kysely" },
           // a live pg-boss client handle: connection pool and event emitter state, no readonly form
           { "from": "package", "name": "PgBoss", "package": "pg-boss" },
           // structurally a single method signature, which the rule's default settings treat as

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -314,6 +314,14 @@
   },
   "overrides": [
     {
+      "files": ["**/schema.generated.ts"],
+      // kysely-codegen column overrides emit inline `import()` type annotations; the file is
+      // generated, so the style rule has nothing to teach it
+      "rules": {
+        "typescript/consistent-type-imports": "off"
+      }
+    },
+    {
       "files": ["**/*.test.ts", "**/*.test.tsx"],
       // ergonomics for every co-located suite, whichever runner it targets: one
       // suite per module with inline test data means file length scales with

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,8 @@ Overused jargon a plainer word covers; applies to all prose — docs, comments, 
 text.
 
 - `bites` (figurative) — "applies", "takes effect", or name the consequence.
+- `CAS` (the acronym) — "compare-and-swap" spelled out, or name the behaviour: a guarded update
+  that applies only if the cursor still holds its expected value.
 - `load-bearing` — "required", "essential", or name what breaks without it.
 - `seam` — "boundary", "join", "integration point".
 - `surface` — noun: "area", "API", the concrete thing itself; verb: "show", "raise", "report".

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,9 @@ text.
 - `bites` (figurative) — "applies", "takes effect", or name the consequence.
 - `CAS` (the acronym) — "compare-and-swap" spelled out, or name the behaviour: a guarded update that
   applies only if the cursor still holds its expected value.
+- `fence` / `fencing` (the distributed-systems metaphor) — state the rule it enforces: "each
+  activity has a single writer", "an append from any other session is rejected". A markdown code
+  fence is a different word and stays.
 - `load-bearing` — "required", "essential", or name what breaks without it.
 - `seam` — "boundary", "join", "integration point".
 - `surface` — noun: "area", "API", the concrete thing itself; verb: "show", "raise", "report".

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,8 +205,8 @@ Overused jargon a plainer word covers; applies to all prose — docs, comments, 
 text.
 
 - `bites` (figurative) — "applies", "takes effect", or name the consequence.
-- `CAS` (the acronym) — "compare-and-swap" spelled out, or name the behaviour: a guarded update
-  that applies only if the cursor still holds its expected value.
+- `CAS` (the acronym) — "compare-and-swap" spelled out, or name the behaviour: a guarded update that
+  applies only if the cursor still holds its expected value.
 - `load-bearing` — "required", "essential", or name what breaks without it.
 - `seam` — "boundary", "join", "integration point".
 - `surface` — noun: "area", "API", the concrete thing itself; verb: "show", "raise", "report".

--- a/agents/project.md
+++ b/agents/project.md
@@ -54,6 +54,8 @@ Overused jargon a plainer word covers; applies to all prose — docs, comments, 
 text.
 
 - `bites` (figurative) — "applies", "takes effect", or name the consequence.
+- `CAS` (the acronym) — "compare-and-swap" spelled out, or name the behaviour: a guarded update that
+  applies only if the cursor still holds its expected value.
 - `load-bearing` — "required", "essential", or name what breaks without it.
 - `seam` — "boundary", "join", "integration point".
 - `surface` — noun: "area", "API", the concrete thing itself; verb: "show", "raise", "report".

--- a/agents/project.md
+++ b/agents/project.md
@@ -56,6 +56,9 @@ text.
 - `bites` (figurative) — "applies", "takes effect", or name the consequence.
 - `CAS` (the acronym) — "compare-and-swap" spelled out, or name the behaviour: a guarded update that
   applies only if the cursor still holds its expected value.
+- `fence` / `fencing` (the distributed-systems metaphor) — state the rule it enforces: "each
+  activity has a single writer", "an append from any other session is rejected". A markdown code
+  fence is a different word and stays.
 - `load-bearing` — "required", "essential", or name what breaks without it.
 - `seam` — "boundary", "join", "integration point".
 - `surface` — noun: "area", "API", the concrete thing itself; verb: "show", "raise", "report".

--- a/apps/web/src/lib/proxy/send-rpc-request.ts
+++ b/apps/web/src/lib/proxy/send-rpc-request.ts
@@ -25,8 +25,13 @@ export async function sendRPCRequest(request: Request, service: ServiceName): Pr
 
   const headers = new Headers(request.headers);
 
-  const actingUserID = await loadSessionActor();
-  const token = await createEdgeServiceToken({ actingUserID, audience: service });
+  const actor = await loadSessionActor();
+
+  const token = await createEdgeServiceToken({
+    actingSessionID: actor?.sessionID ?? null,
+    actingUserID: actor?.userID ?? null,
+    audience: service,
+  });
 
   headers.set('authorization', `Bearer ${token}`);
 

--- a/apps/web/src/lib/rpc/build-service-link.ts
+++ b/apps/web/src/lib/rpc/build-service-link.ts
@@ -32,12 +32,21 @@ export function buildServiceLink(service: ServiceName): RPCLink<ServiceLinkConte
       () =>
         new RPCLink<ServiceLinkContext>({
           headers: async (options) => {
+            // an explicit acting user (login, force-logout) has no cookie session to name, so the
+            // token carries no `sid` claim on that path
+            const actor =
+              options.context.actingUserID === undefined ? await loadSessionActor() : null;
+
             const actingUserID =
               options.context.actingUserID === undefined
-                ? await loadSessionActor()
+                ? (actor?.userID ?? null)
                 : options.context.actingUserID;
 
-            const token = await createEdgeServiceToken({ actingUserID, audience: service });
+            const token = await createEdgeServiceToken({
+              actingSessionID: actor?.sessionID ?? null,
+              actingUserID,
+              audience: service,
+            });
 
             const trace = createTraceContext(findAmbientTrace());
 

--- a/apps/web/src/lib/rpc/create-edge-service-token.ts
+++ b/apps/web/src/lib/rpc/create-edge-service-token.ts
@@ -14,7 +14,8 @@ interface CreateEdgeServiceTokenOptions {
 /**
  * Mints the s2s token every outbound service call carries, signed with this app's edge key.
  * `actingUserID` becomes the token's `sub` claim; `null` mints a verified-anonymous token instead.
- * `actingSessionID` becomes the `sid` (writer-fence) claim; flows holding no live session omit it.
+ * `actingSessionID` becomes the `sid` (writer-identity) claim; flows holding no live session omit
+ * it.
  */
 export async function createEdgeServiceToken(
   options: Readonly<CreateEdgeServiceTokenOptions>,

--- a/apps/web/src/lib/rpc/create-edge-service-token.ts
+++ b/apps/web/src/lib/rpc/create-edge-service-token.ts
@@ -6,6 +6,7 @@ import { env } from '../../server/env';
 const privateKey = parseServicePrivateKey(env.SERVICE_AUTH_PRIVATE_KEY);
 
 interface CreateEdgeServiceTokenOptions {
+  readonly actingSessionID?: string | null;
   readonly actingUserID: string | null;
   readonly audience: ServiceName;
 }
@@ -13,6 +14,7 @@ interface CreateEdgeServiceTokenOptions {
 /**
  * Mints the s2s token every outbound service call carries, signed with this app's edge key.
  * `actingUserID` becomes the token's `sub` claim; `null` mints a verified-anonymous token instead.
+ * `actingSessionID` becomes the `sid` (writer-fence) claim; flows holding no live session omit it.
  */
 export async function createEdgeServiceToken(
   options: Readonly<CreateEdgeServiceTokenOptions>,
@@ -21,5 +23,7 @@ export async function createEdgeServiceToken(
     audience: options.audience,
     privateKey: await privateKey,
     ...(options.actingUserID !== null && { actingUserId: options.actingUserID }),
+    ...(options.actingSessionID !== null &&
+      options.actingSessionID !== undefined && { actingSessionId: options.actingSessionID }),
   });
 }

--- a/apps/web/src/lib/rpc/load-session-actor.test.ts
+++ b/apps/web/src/lib/rpc/load-session-actor.test.ts
@@ -34,7 +34,7 @@ test('it returns the cookie userID unchanged for a fresh access token whose sess
     () => loadSessionActor(),
   );
 
-  expect(outcome.value).toBe(session.userID);
+  expect(outcome.value).toStrictEqual({ sessionID: session.id, userID: session.userID });
   expect(outcome.cookies['en_session']).toContainEntry(['accessToken', accessToken]);
 });
 
@@ -95,7 +95,9 @@ test('it hits getSession at most once per request for a fresh access token', asy
     () => Promise.all([loadSessionActor(), loadSessionActor()]),
   );
 
-  expect(outcome.value).toStrictEqual([session.userID, session.userID]);
+  const actor = { sessionID: session.id, userID: session.userID };
+
+  expect(outcome.value).toStrictEqual([actor, actor]);
   expect(callCount).toBe(1);
 });
 
@@ -151,7 +153,7 @@ test('it refreshes a stale access token once, updates the cookie, and returns th
     () => loadSessionActor(),
   );
 
-  expect(outcome.value).toBe(session.userID);
+  expect(outcome.value).toStrictEqual({ sessionID: session.id, userID: session.userID });
   expect(outcome.cookies['en_session']).not.toContainEntry(['accessToken', staleAccessToken]);
   expect(outcome.cookies['en_session']).not.toContainEntry(['refreshToken', 'refresh-1']);
 });
@@ -228,7 +230,9 @@ test('it single-flights concurrent refreshes for the same session', async () => 
     Promise.all([loadSessionActor(), loadSessionActor()]),
   );
 
-  expect(outcome.value).toStrictEqual([session.userID, session.userID]);
+  const actor = { sessionID: session.id, userID: session.userID };
+
+  expect(outcome.value).toStrictEqual([actor, actor]);
 
   // if the two calls raced instead of sharing one refresh, the mock service's reuse detection
   // would revoke the session on the second rotation

--- a/apps/web/src/lib/rpc/load-session-actor.ts
+++ b/apps/web/src/lib/rpc/load-session-actor.ts
@@ -25,7 +25,16 @@ interface RefreshedTokens {
 const inFlightRefreshes = new Map<string, Promise<RefreshedTokens | undefined>>();
 
 /**
- * Loads the acting user id for a cookie-derived service call, proactively re-validating a
+ * The validated identity pair a cookie-derived service call acts as: the user for the token's
+ * `sub` claim, the session for its `sid` (writer-fence) claim.
+ */
+export interface SessionActor {
+  readonly sessionID: string;
+  readonly userID: string;
+}
+
+/**
+ * Loads the acting user and session ids for a cookie-derived service call, proactively re-validating a
  * near-expired session first: services no longer see the caller's own access token, so nothing
  * else re-checks the underlying session's existence, expiry, or revocation before its identity is
  * trusted to mint an s2s token. Even a fresh access token no longer settles that on its own — this
@@ -37,7 +46,7 @@ const inFlightRefreshes = new Map<string, Promise<RefreshedTokens | undefined>>(
  * reached at all fails the call instead: an unreachable service is never grounds to trust the
  * token or to destroy the cookie.
  */
-export async function loadSessionActor(): Promise<string | null> {
+export async function loadSessionActor(): Promise<SessionActor | null> {
   const session = await getAuthSession();
 
   if (
@@ -58,7 +67,7 @@ export async function loadSessionActor(): Promise<string | null> {
       return null;
     }
 
-    return session.userID;
+    return { sessionID: session.sessionID, userID: session.userID };
   }
 
   const tokens = await resolveRefreshedTokens(session.sessionID, session.refreshToken);
@@ -71,7 +80,7 @@ export async function loadSessionActor(): Promise<string | null> {
 
   await updateAuthSession({ accessToken: tokens.accessToken, refreshToken: tokens.refreshToken });
 
-  return session.userID;
+  return { sessionID: session.sessionID, userID: session.userID };
 }
 
 function isAccessTokenStale(accessToken: string): boolean {

--- a/apps/web/src/lib/rpc/load-session-actor.ts
+++ b/apps/web/src/lib/rpc/load-session-actor.ts
@@ -26,7 +26,8 @@ const inFlightRefreshes = new Map<string, Promise<RefreshedTokens | undefined>>(
 
 /**
  * The validated identity pair a cookie-derived service call acts as: the user for the token's
- * `sub` claim, the session for its `sid` (writer-fence) claim.
+ * `sub` claim, the session for its `sid` claim (the writer identity activity appends are checked
+ * against).
  */
 export interface SessionActor {
   readonly sessionID: string;

--- a/bun.lock
+++ b/bun.lock
@@ -759,6 +759,25 @@
         "typescript": "catalog:",
       },
     },
+    "services/replay": {
+      "name": "@vers/service-replay",
+      "version": "0.0.0",
+      "dependencies": {
+        "@vers/db": "workspace:*",
+        "@vers/idle-core": "workspace:*",
+        "kysely": "catalog:",
+      },
+      "devDependencies": {
+        "@faker-js/faker": "catalog:",
+        "@paralleldrive/cuid2": "catalog:",
+        "@types/bun": "catalog:",
+        "@types/node": "catalog:",
+        "@vers/service-test-utils": "workspace:*",
+        "@vers/test-utils": "workspace:*",
+        "@zgeoff/bun-test-extended": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
     "services/session": {
       "name": "@vers/service-session",
       "version": "0.0.0",
@@ -2265,6 +2284,8 @@
     "@vers/service-avatar": ["@vers/service-avatar@workspace:services/avatar"],
 
     "@vers/service-email": ["@vers/service-email@workspace:services/email"],
+
+    "@vers/service-replay": ["@vers/service-replay@workspace:services/replay"],
 
     "@vers/service-runtime": ["@vers/service-runtime@workspace:libs/service/service-runtime"],
 

--- a/contracts/activity/src/activity-contract.test.ts
+++ b/contracts/activity/src/activity-contract.test.ts
@@ -10,10 +10,11 @@ test('it declares UNAUTHORIZED and FORBIDDEN on every owner-scoped procedure', (
   ]);
 });
 
-test('it declares CONFLICT and NOT_FOUND on startActivity', () => {
+test('it declares CONFLICT, NOT_FOUND, and CHAIN_QUARANTINED on startActivity', () => {
   expect(activityContract.startActivity['~orpc'].errorMap).toContainAllKeys([
     'UNAUTHORIZED',
     'FORBIDDEN',
+    'CHAIN_QUARANTINED',
     'CONFLICT',
     'NOT_FOUND',
   ]);
@@ -24,6 +25,14 @@ test('it declares a bespoke CHECKPOINT_INVALID with an explicit status on trackA
 
   expect(errorMap).toContainKey('CHECKPOINT_INVALID');
   expect(errorMap.CHECKPOINT_INVALID?.status).toBe(422);
+});
+
+test('it declares the writer-fence errors with explicit statuses on trackActivityProgress', () => {
+  const errorMap = activityContract.trackActivityProgress['~orpc'].errorMap;
+
+  expect(errorMap).toContainKeys(['ACTIVITY_TERMINAL', 'SESSION_EVICTED']);
+  expect(errorMap.ACTIVITY_TERMINAL?.status).toBe(409);
+  expect(errorMap.SESSION_EVICTED?.status).toBe(403);
 });
 
 test('it generates a valid OpenAPI document from the activity contract', async () => {

--- a/contracts/activity/src/activity-contract.test.ts
+++ b/contracts/activity/src/activity-contract.test.ts
@@ -27,7 +27,7 @@ test('it declares a bespoke CHECKPOINT_INVALID with an explicit status on trackA
   expect(errorMap.CHECKPOINT_INVALID?.status).toBe(422);
 });
 
-test('it declares the writer-fence errors with explicit statuses on trackActivityProgress', () => {
+test('it declares the single-writer errors with explicit statuses on trackActivityProgress', () => {
   const errorMap = activityContract.trackActivityProgress['~orpc'].errorMap;
 
   expect(errorMap).toContainKeys(['ACTIVITY_TERMINAL', 'SESSION_EVICTED']);

--- a/contracts/activity/src/activity-contract.ts
+++ b/contracts/activity/src/activity-contract.ts
@@ -1,11 +1,13 @@
 import { authedRoute, defineErrors } from '@vers/contract-base';
 import * as z from 'zod';
 import { ActivityDataSchema } from './activity-data-schema';
+import { ActivityStatusSchema } from './activity-status-schema';
 import { CheckpointBatchEntrySchema } from './checkpoint-batch-entry-schema';
 import { CheckpointSchema } from './checkpoint-schema';
 
 const CheckpointInvalidDataSchema = z.object({ reason: z.string() });
 const StaleHeadDataSchema = z.object({ appendedHead: z.int() });
+const TerminalStatusDataSchema = z.object({ status: ActivityStatusSchema });
 
 /**
  * The activities service's API: every procedure is authed and owner-scoped through the caller's
@@ -42,6 +44,20 @@ export const activityContract = {
       }),
     ),
 
+  resumeActivity: authedRoute
+    .route({
+      method: 'POST',
+      path: '/activities/{activityID}/resume',
+      summary: "Take over as an active activity's writer session",
+    })
+    .input(z.object({ activityID: z.string() }))
+    .output(ActivityDataSchema)
+    .errors(
+      defineErrors({
+        NOT_FOUND: { data: z.object({}), message: 'No active activity with that id' },
+      }),
+    ),
+
   startActivity: authedRoute
     .route({
       method: 'POST',
@@ -52,6 +68,11 @@ export const activityContract = {
     .output(ActivityDataSchema)
     .errors(
       defineErrors({
+        CHAIN_QUARANTINED: {
+          data: z.object({}),
+          message: 'The chain is quarantined pending replay adjudication',
+          status: 409,
+        },
         CONFLICT: {
           data: z.object({ activity: ActivityDataSchema }),
           message: 'An activity is already active for this avatar',
@@ -90,6 +111,11 @@ export const activityContract = {
     .output(z.object({ appendedHead: z.int() }))
     .errors(
       defineErrors({
+        ACTIVITY_TERMINAL: {
+          data: TerminalStatusDataSchema,
+          message: 'The activity has reached a terminal status and accepts no further appends',
+          status: 409,
+        },
         CHECKPOINT_INVALID: {
           data: CheckpointInvalidDataSchema,
           message: 'Checkpoint batch failed structural validation',
@@ -99,7 +125,12 @@ export const activityContract = {
           data: StaleHeadDataSchema,
           message: "Checkpoint batch is stale for the activity's current head",
         },
-        NOT_FOUND: { data: z.object({}), message: 'No active activity with that id' },
+        NOT_FOUND: { data: z.object({}), message: 'No activity with that id' },
+        SESSION_EVICTED: {
+          data: z.object({}),
+          message: "The submitting session is no longer the activity's writer",
+          status: 403,
+        },
       }),
     ),
 };

--- a/docs/architecture/error-handling.md
+++ b/docs/architecture/error-handling.md
@@ -55,7 +55,10 @@ Status assignment follows the failure's nature:
 
 | Domain       | Code                   | Status | Meaning                                                                                    | data         |
 | ------------ | ---------------------- | ------ | ------------------------------------------------------------------------------------------ | ------------ |
+| activity     | `ACTIVITY_TERMINAL`    | 409    | Append against a terminal activity status — fatal for the stream, the client discards      | `{ status }` |
+| activity     | `CHAIN_QUARANTINED`    | 409    | New start refused while the chain's replay frontier is quarantined                         | —            |
 | activity     | `CHECKPOINT_INVALID`   | 422    | Checkpoint batch fails structural validation (contiguity, chainIndex, chain link, or hash) | `{ reason }` |
+| activity     | `SESSION_EVICTED`      | 403    | Append from a session that is no longer the activity's writer — fatal, the client discards | —            |
 | user         | `INVALID_RESET_TOKEN`  | 422    | Reset token doesn't match the one on record                                                | —            |
 | user         | `PASSWORD_NOT_SET`     | 409    | Operation presumes a password; the account has none                                        | —            |
 | user         | `RESET_TOKEN_EXPIRED`  | 410    | Reset token was valid but its window has passed                                            | —            |

--- a/docs/architecture/game-simulation.md
+++ b/docs/architecture/game-simulation.md
@@ -65,11 +65,11 @@ replayed) — the last chain hash, and the activity status.
   carrying the current head, and the client resends the tail. Resubmission is a free dedupe —
   `UNIQUE(activity_id, version)` plus deterministic checkpoint content — and dedupe runs before
   elapsed-time accounting, so replays never inflate duration.
-- A writer fence rejects appends from evicted sessions as fatal: the head row stamps the one session
-  allowed to append, and resuming on a new session takes the writer over, so a displaced writer's
-  in-flight submissions fail rather than interleave. Terminal statuses (stopped, rejected, capped,
-  quarantined) reject any later append. Together these resolve every race between logout, forced
-  logout, stop, rejection, and cap.
+- Each activity has a single writer: the head row stamps the session allowed to append, and resuming
+  on a new session takes the writer over. An append from any other session fails fatally, so a
+  displaced writer's in-flight submissions die rather than interleave. Terminal statuses (stopped,
+  rejected, capped, quarantined) reject any later append. Together these resolve every race between
+  logout, forced logout, stop, rejection, and cap.
 
 ## Replay
 

--- a/docs/architecture/game-simulation.md
+++ b/docs/architecture/game-simulation.md
@@ -65,9 +65,11 @@ replayed) — the last chain hash, and the activity status.
   carrying the current head, and the client resends the tail. Resubmission is a free dedupe —
   `UNIQUE(activity_id, version)` plus deterministic checkpoint content — and dedupe runs before
   elapsed-time accounting, so replays never inflate duration.
-- A session-epoch fence rejects appends from evicted sessions as fatal. Terminal statuses (stopped,
-  rejected, capped, quarantined) reject any later append. Together these resolve every race between
-  logout, forced logout, stop, rejection, and cap.
+- A writer fence rejects appends from evicted sessions as fatal: the head row stamps the one session
+  allowed to append, and resuming on a new session takes the writer over, so a displaced writer's
+  in-flight submissions fail rather than interleave. Terminal statuses (stopped, rejected, capped,
+  quarantined) reject any later append. Together these resolve every race between logout, forced
+  logout, stop, rejection, and cap.
 
 ## Replay
 
@@ -98,8 +100,8 @@ cheating wave.
 
 Verified deltas apply exactly once through a cursor-guarded transaction: advance `verified_head`
 with a compare-and-swap — the update applies only if the cursor still holds its expected value —
-then apply the delta to identity state and append the outcome event, all in one local transaction. A
-crashed worker retries idempotently.
+then apply the delta to identity state and append the settlement's economic-ledger entry, all in one
+local transaction. A crashed worker retries idempotently.
 
 - First-clears, achievements, and other one-shot grants insert into a unique-keyed grant table with
   `ON CONFLICT DO NOTHING` inside the same transaction — idempotent across re-farms and replays.

--- a/knip.json
+++ b/knip.json
@@ -51,6 +51,9 @@
       "entry": ["src/serve.ts", "src/sweep.ts"],
       "ignoreDependencies": ["@orpc/contract"]
     },
+    "services/replay": {
+      "entry": []
+    },
     "libs/service/service-utils": {
       "ignoreDependencies": ["pino-pretty"]
     },

--- a/libs/data/db/.kysely-codegenrc.json
+++ b/libs/data/db/.kysely-codegenrc.json
@@ -1,0 +1,8 @@
+{
+  "overrides": {
+    "columns": {
+      "activities.build_snapshot": "import('./types').Json",
+      "activity_checkpoints.payload": "import('./types').Json"
+    }
+  }
+}

--- a/libs/data/db/migrations/1783957774984_replay_pipeline.ts
+++ b/libs/data/db/migrations/1783957774984_replay_pipeline.ts
@@ -2,8 +2,8 @@ import type { Kysely } from 'kysely';
 import { sql } from 'kysely';
 
 /**
- * Adds the replay pipeline's schema: the activity head row gains the writer-fence column
- * (`writer_session_id`, the session allowed to append) and the poison-pill attempt counter, the
+ * Adds the replay pipeline's schema: the activity head row gains the single-writer column
+ * (`writer_session_id`, the one session allowed to append) and the poison-pill attempt counter, the
  * chain row gains the claim priority, and `avatar_grants` records one-shot grants (first-clears,
  * achievements, meta-unlocks) whose primary key is the grant-once rule itself. The partial index
  * serves the replay claim's pending-work scan (`appended_head > verified_head`).

--- a/libs/data/db/migrations/1783957774984_replay_pipeline.ts
+++ b/libs/data/db/migrations/1783957774984_replay_pipeline.ts
@@ -1,0 +1,54 @@
+import type { Kysely } from 'kysely';
+import { sql } from 'kysely';
+
+/**
+ * Adds the replay pipeline's schema: the activity head row gains the writer-fence column
+ * (`writer_session_id`, the session allowed to append) and the poison-pill attempt counter, the
+ * chain row gains the claim priority, and `avatar_grants` records one-shot grants (first-clears,
+ * achievements, meta-unlocks) whose primary key is the grant-once rule itself. The partial index
+ * serves the replay claim's pending-work scan (`appended_head > verified_head`).
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema.alterTable('activities').addColumn('writer_session_id', 'text').execute();
+
+  await db.schema
+    .alterTable('activities')
+    .addColumn('replay_attempts', 'integer', (col) => col.notNull().defaultTo(0))
+    .execute();
+
+  await db.schema
+    .alterTable('activity_chains')
+    .addColumn('priority', 'integer', (col) => col.notNull().defaultTo(0))
+    .execute();
+
+  await db.schema
+    .createTable('avatar_grants')
+    .addColumn('avatar_id', 'text', (col) => col.notNull())
+    .addColumn('kind', 'text', (col) => col.notNull())
+    .addColumn('key', 'text', (col) => col.notNull())
+    .addColumn('created_at', 'timestamp', (col) => col.notNull().defaultTo(sql`now()`))
+    .addPrimaryKeyConstraint('avatar_grants_pk', ['avatar_id', 'kind', 'key'])
+    .addForeignKeyConstraint(
+      'avatar_grants_avatar_id_avatars_id_fk',
+      ['avatar_id'],
+      'avatars',
+      ['id'],
+      (fk) => fk.onDelete('cascade').onUpdate('cascade'),
+    )
+    .execute();
+
+  await db.schema
+    .createIndex('activities_replay_pending_idx')
+    .on('activities')
+    .columns(['avatar_id', 'scope_type', 'scope_id', 'start_chain_index'])
+    .where(sql.ref('appended_head'), '>', sql.ref('verified_head'))
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropIndex('activities_replay_pending_idx').execute();
+  await db.schema.dropTable('avatar_grants').execute();
+  await db.schema.alterTable('activity_chains').dropColumn('priority').execute();
+  await db.schema.alterTable('activities').dropColumn('replay_attempts').execute();
+  await db.schema.alterTable('activities').dropColumn('writer_session_id').execute();
+}

--- a/libs/data/db/src/index.ts
+++ b/libs/data/db/src/index.ts
@@ -10,9 +10,10 @@ export type {
   Avatars,
   ConsumedTransactionTokens,
   DB,
-  Json,
   PendingTransactions,
   Sessions,
   Users,
   Verifications,
 } from './schema.generated';
+
+export type { Json } from './types';

--- a/libs/data/db/src/index.ts
+++ b/libs/data/db/src/index.ts
@@ -5,6 +5,8 @@ export type {
   Activities,
   ActivityChains,
   ActivityCheckpoints,
+  ActivityStatus,
+  AvatarGrants,
   Avatars,
   ConsumedTransactionTokens,
   DB,

--- a/libs/data/db/src/schema.generated.ts
+++ b/libs/data/db/src/schema.generated.ts
@@ -12,18 +12,6 @@ export type Generated<T> =
     ? ColumnType<S, I | undefined, U>
     : ColumnType<T, T | undefined, T>;
 
-export type Json = JsonValue;
-
-export type JsonArray = Array<JsonValue>;
-
-export interface JsonObject {
-  [x: string]: JsonValue | undefined;
-}
-
-export type JsonPrimitive = boolean | number | string | null;
-
-export type JsonValue = JsonArray | JsonObject | JsonPrimitive;
-
 export type Timestamp = ColumnType<Date, Date | string, Date | string>;
 
 export type VerificationType = '2fa' | '2fa-setup' | 'change-email' | 'onboarding';
@@ -32,7 +20,7 @@ export interface Activities {
   appendedAt: Timestamp | null;
   appendedHead: Generated<number>;
   avatarId: string;
-  buildSnapshot: Json;
+  buildSnapshot: import('./types').Json;
   contentVersion: string;
   createdAt: Generated<Timestamp>;
   id: string;
@@ -70,7 +58,7 @@ export interface ActivityCheckpoints {
   activityId: string;
   appendedAt: Generated<Timestamp>;
   hash: string;
-  payload: Json;
+  payload: import('./types').Json;
   prevHash: string;
   version: number;
 }

--- a/libs/data/db/src/schema.generated.ts
+++ b/libs/data/db/src/schema.generated.ts
@@ -37,6 +37,7 @@ export interface Activities {
   createdAt: Generated<Timestamp>;
   id: string;
   lastHash: string;
+  replayAttempts: Generated<number>;
   scopeId: string;
   scopeType: string;
   seed: string;
@@ -49,6 +50,7 @@ export interface Activities {
   updatedAt: Generated<Timestamp>;
   verifiedAt: Timestamp | null;
   verifiedHead: Generated<number>;
+  writerSessionId: string | null;
 }
 
 export interface ActivityChains {
@@ -57,6 +59,7 @@ export interface ActivityChains {
   avatarId: string;
   createdAt: Generated<Timestamp>;
   genesisSeed: string;
+  priority: Generated<number>;
   scopeId: string;
   scopeType: string;
   verifiedChainIndex: Generated<number>;
@@ -70,6 +73,13 @@ export interface ActivityCheckpoints {
   payload: Json;
   prevHash: string;
   version: number;
+}
+
+export interface AvatarGrants {
+  avatarId: string;
+  createdAt: Generated<Timestamp>;
+  key: string;
+  kind: string;
 }
 
 export interface Avatars {
@@ -144,6 +154,7 @@ export interface DB {
   activities: Activities;
   activityChains: ActivityChains;
   activityCheckpoints: ActivityCheckpoints;
+  avatarGrants: AvatarGrants;
   avatars: Avatars;
   consumedTransactionTokens: ConsumedTransactionTokens;
   pendingTransactions: PendingTransactions;

--- a/libs/data/db/src/types.ts
+++ b/libs/data/db/src/types.ts
@@ -1,0 +1,15 @@
+/**
+ * The deep-readonly JSON value every jsonb column types as, via the codegen column overrides in
+ * `.kysely-codegenrc.json`. Readonly because a row's jsonb payload is never mutated in place —
+ * writes construct fresh values — and a mutable recursive union would force every function taking
+ * a row to opt out of readonly-parameter linting. Plain mutable values remain assignable.
+ */
+export type Json = JsonArray | JsonObject | JsonPrimitive;
+
+type JsonArray = ReadonlyArray<Json>;
+
+interface JsonObject {
+  readonly [key: string]: Json | undefined;
+}
+
+type JsonPrimitive = boolean | number | string | null;

--- a/libs/service/service-auth/src/create-service-token.ts
+++ b/libs/service/service-auth/src/create-service-token.ts
@@ -15,8 +15,8 @@ export interface CreateServiceTokenOptions {
 /**
  * Mints the s2s token every outbound service call carries. `actingUserId` becomes the token's
  * `sub` claim; omitting it mints a verified-anonymous token instead. `actingSessionId` becomes the
- * `sid` claim naming the caller's underlying session — the writer identity fenced procedures
- * compare against; flows holding no live session omit it.
+ * `sid` claim naming the caller's underlying session — the writer identity activity appends are
+ * checked against; flows holding no live session omit it.
  */
 export function createServiceToken(options: Readonly<CreateServiceTokenOptions>): Promise<string> {
   const claims = {

--- a/libs/service/service-auth/src/create-service-token.ts
+++ b/libs/service/service-auth/src/create-service-token.ts
@@ -5,6 +5,7 @@ import { TOKEN_ALGORITHM, TOKEN_ISSUER } from './token-claims';
 import type { ServiceName } from './types';
 
 export interface CreateServiceTokenOptions {
+  readonly actingSessionId?: string;
   readonly actingUserId?: string;
   readonly audience: ServiceName;
   readonly expiresIn?: string;
@@ -13,10 +14,15 @@ export interface CreateServiceTokenOptions {
 
 /**
  * Mints the s2s token every outbound service call carries. `actingUserId` becomes the token's
- * `sub` claim; omitting it mints a verified-anonymous token instead.
+ * `sub` claim; omitting it mints a verified-anonymous token instead. `actingSessionId` becomes the
+ * `sid` claim naming the caller's underlying session — the writer identity fenced procedures
+ * compare against; flows holding no live session omit it.
  */
 export function createServiceToken(options: Readonly<CreateServiceTokenOptions>): Promise<string> {
-  const claims = options.actingUserId === undefined ? {} : { sub: options.actingUserId };
+  const claims = {
+    ...(options.actingUserId !== undefined && { sub: options.actingUserId }),
+    ...(options.actingSessionId !== undefined && { sid: options.actingSessionId }),
+  };
 
   const jwt = new jose.SignJWT(claims)
     .setProtectedHeader({ alg: TOKEN_ALGORITHM })

--- a/libs/service/service-auth/src/parse-service-token.test.ts
+++ b/libs/service/service-auth/src/parse-service-token.test.ts
@@ -23,7 +23,29 @@ test('it resolves the acting user from a token minted for the matching audience'
     publicKey: keyPair.publicKey,
   });
 
-  expect(resolution).toStrictEqual({ actingUserId: 'user-1' });
+  expect(resolution).toStrictEqual({ actingSessionId: null, actingUserId: 'user-1' });
+});
+
+test('it resolves the acting session from a token minted with an actingSessionId', async () => {
+  const keyPair = await jose.generateKeyPair(TOKEN_ALGORITHM);
+
+  const token = await createServiceToken({
+    actingSessionId: 'session-1',
+    actingUserId: 'user-1',
+    audience: 'avatar',
+    privateKey: keyPair.privateKey,
+  });
+
+  const request = new Request('http://test.local', {
+    headers: { authorization: `Bearer ${token}` },
+  });
+
+  const resolution = await parseServiceToken(request, {
+    audience: buildServiceAudience('avatar'),
+    publicKey: keyPair.publicKey,
+  });
+
+  expect(resolution).toStrictEqual({ actingSessionId: 'session-1', actingUserId: 'user-1' });
 });
 
 test('it resolves a null acting user from a token minted with no actingUserId', async () => {
@@ -43,7 +65,7 @@ test('it resolves a null acting user from a token minted with no actingUserId', 
     publicKey: keyPair.publicKey,
   });
 
-  expect(resolution).toStrictEqual({ actingUserId: null });
+  expect(resolution).toStrictEqual({ actingSessionId: null, actingUserId: null });
 });
 
 test('it rejects a token minted for a different audience', async () => {

--- a/libs/service/service-auth/src/parse-service-token.ts
+++ b/libs/service/service-auth/src/parse-service-token.ts
@@ -3,7 +3,7 @@ import * as jose from 'jose';
 import { TOKEN_ALGORITHM, TOKEN_ISSUER } from './token-claims';
 
 export type ServiceTokenResolution =
-  | { actingUserId: null | string }
+  | { actingSessionId: null | string; actingUserId: null | string }
   | { failure: 'invalid-service-token' };
 
 interface ParseServiceTokenOptions {
@@ -37,6 +37,8 @@ export async function parseServiceToken(
     });
 
     return {
+      actingSessionId:
+        typeof verification.payload['sid'] === 'string' ? verification.payload['sid'] : null,
       actingUserId: typeof verification.payload.sub === 'string' ? verification.payload.sub : null,
     };
   } catch {

--- a/libs/service/service-runtime/src/create-service.ts
+++ b/libs/service/service-runtime/src/create-service.ts
@@ -229,6 +229,7 @@ function mountORPCHandler(
 
         const handled = await handler.handle(context.request, {
           context: {
+            actingSessionId: resolution.actingSessionId,
             actingUserId: resolution.actingUserId,
             logger: deps.logger,
             traceID: trace.traceID,

--- a/libs/service/service-runtime/src/types.ts
+++ b/libs/service/service-runtime/src/types.ts
@@ -5,6 +5,12 @@ import type pino from 'pino';
  */
 export interface ServiceContext {
   /**
+   * Session named by the verified service token's `sid` claim — the writer identity fenced
+   * procedures compare against; null when the call holds no live session.
+   */
+  actingSessionId: null | string;
+
+  /**
    * Acting user named by the verified service token; null for verified anonymous calls.
    */
   actingUserId: null | string;

--- a/libs/service/service-runtime/src/types.ts
+++ b/libs/service/service-runtime/src/types.ts
@@ -5,8 +5,8 @@ import type pino from 'pino';
  */
 export interface ServiceContext {
   /**
-   * Session named by the verified service token's `sid` claim — the writer identity fenced
-   * procedures compare against; null when the call holds no live session.
+   * Session named by the verified service token's `sid` claim — compared against an activity's
+   * stamped writer before an append is accepted; null when the call holds no live session.
    */
   actingSessionId: null | string;
 

--- a/libs/testing/service-test-utils/src/bun/composites/create-viewer.ts
+++ b/libs/testing/service-test-utils/src/bun/composites/create-viewer.ts
@@ -7,11 +7,14 @@ import { getTestServiceKeyPair } from '../get-test-service-key-pair';
 interface CreateViewerConfig {
   readonly audience: string;
   readonly db: Kysely<DB>;
+  readonly sessionID?: string;
   readonly user?: Partial<Insertable<Users>>;
 }
 
 /**
- * A persisted, s2s-authenticated acting user: a token and the user it was minted for.
+ * A persisted, s2s-authenticated acting user: a token and the user it was minted for. Passing
+ * `sessionID` mints the token's `sid` (writer-fence) claim; omitting it mints a session-less
+ * token, matching flows that hold no live session.
  */
 export async function createViewer(
   config: Readonly<CreateViewerConfig>,
@@ -23,6 +26,7 @@ export async function createViewer(
     actingUserId: created.user.id,
     audience: config.audience,
     privateKey: keyPair.privateKey,
+    ...(config.sessionID !== undefined && { actingSessionId: config.sessionID }),
   });
 
   return { token, user: created.user };

--- a/libs/testing/service-test-utils/src/bun/composites/create-viewer.ts
+++ b/libs/testing/service-test-utils/src/bun/composites/create-viewer.ts
@@ -13,8 +13,8 @@ interface CreateViewerConfig {
 
 /**
  * A persisted, s2s-authenticated acting user: a token and the user it was minted for. Passing
- * `sessionID` mints the token's `sid` (writer-fence) claim; omitting it mints a session-less
- * token, matching flows that hold no live session.
+ * `sessionID` mints the token's `sid` claim — the writer identity activity appends are checked
+ * against; omitting it mints a session-less token, matching flows that hold no live session.
  */
 export async function createViewer(
   config: Readonly<CreateViewerConfig>,

--- a/libs/testing/service-test-utils/src/bun/create-service-token.ts
+++ b/libs/testing/service-test-utils/src/bun/create-service-token.ts
@@ -3,6 +3,7 @@ import type { CryptoKey } from 'jose';
 import * as jose from 'jose';
 
 interface CreateServiceTokenOptions {
+  readonly actingSessionId?: string;
   readonly actingUserId?: string;
   readonly audience: string;
   readonly expiresIn?: string;
@@ -13,7 +14,10 @@ interface CreateServiceTokenOptions {
  * Signs a short-lived s2s token carrying the shared claim vocabulary, for tests to send as `Authorization: Bearer <token>`.
  */
 export function createServiceToken(options: CreateServiceTokenOptions): Promise<string> {
-  const claims = options.actingUserId === undefined ? {} : { sub: options.actingUserId };
+  const claims = {
+    ...(options.actingUserId !== undefined && { sub: options.actingUserId }),
+    ...(options.actingSessionId !== undefined && { sid: options.actingSessionId }),
+  };
 
   const jwt = new jose.SignJWT(claims)
     .setProtectedHeader({ alg: TOKEN_ALGORITHM })

--- a/services/activity/src/build-router.ts
+++ b/services/activity/src/build-router.ts
@@ -5,6 +5,7 @@ import type { ServiceContext } from '@vers/service-runtime';
 import type { Kysely } from 'kysely';
 import { getCurrentActivity } from './handlers/get-current-activity';
 import { getLatestActivityProgress } from './handlers/get-latest-activity-progress';
+import { resumeActivity } from './handlers/resume-activity';
 import { startActivity } from './handlers/start-activity';
 import { stopActivity } from './handlers/stop-activity';
 import { trackActivityProgress } from './handlers/track-activity-progress';
@@ -27,6 +28,7 @@ export function buildActivityRouter(deps: BuildActivityRouterDeps) {
     getLatestActivityProgress: os.getLatestActivityProgress.handler((opts) =>
       getLatestActivityProgress(deps.db, opts),
     ),
+    resumeActivity: os.resumeActivity.handler((opts) => resumeActivity(deps.db, opts)),
     startActivity: os.startActivity.handler((opts) => startActivity(deps, opts)),
     stopActivity: os.stopActivity.handler((opts) => stopActivity(deps.db, opts)),
     trackActivityProgress: os.trackActivityProgress.handler((opts) =>

--- a/services/activity/src/handlers/resume-activity.test.ts
+++ b/services/activity/src/handlers/resume-activity.test.ts
@@ -1,0 +1,138 @@
+import { expect, test } from 'bun:test';
+import type { ActivityContract } from '@vers/contract-activity';
+import {
+  createServiceToken,
+  createTestDB,
+  createViewer,
+  getTestServiceKeyPair,
+} from '@vers/service-test-utils/bun';
+import { buildRPCTestClient } from '@vers/test-utils';
+import { createActivityService } from '../create-activity-service';
+import { createAvatarRow } from '../test-utils/create-avatar-row';
+
+async function setupTest() {
+  const db = await createTestDB();
+  const service = await createActivityService({ db: db.db });
+
+  return { app: service.app, db: db.db, [Symbol.asyncDispose]: db[Symbol.asyncDispose] };
+}
+
+test('it stamps the acting session as the writer', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({
+    audience: 'service-activity',
+    db: ctx.db,
+    sessionID: 'session-a',
+  });
+
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'node_1',
+    scopeType: 'world_map_node',
+  });
+
+  const keyPair = await getTestServiceKeyPair();
+
+  const tokenB = await createServiceToken({
+    actingSessionId: 'session-b',
+    actingUserId: viewer.user.id,
+    audience: 'service-activity',
+    privateKey: keyPair.privateKey,
+  });
+
+  const clientB = buildRPCTestClient<ActivityContract>(ctx.app, { token: tokenB });
+
+  const resumed = await clientB.resumeActivity({ activityID: started.id });
+
+  expect(resumed).toMatchObject({ id: started.id, status: 'active' });
+
+  const row = await ctx.db
+    .selectFrom('activities')
+    .select('writerSessionId')
+    .where('id', '=', started.id)
+    .executeTakeFirstOrThrow();
+
+  expect(row.writerSessionId).toBe('session-b');
+});
+
+test('it reports NOT_FOUND for a stopped activity', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({
+    audience: 'service-activity',
+    db: ctx.db,
+    sessionID: 'session-a',
+  });
+
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'node_1',
+    scopeType: 'world_map_node',
+  });
+
+  await client.stopActivity({ avatarID: avatar.id });
+
+  expect(client.resumeActivity({ activityID: started.id })).rejects.toMatchObject({
+    code: 'NOT_FOUND',
+  });
+});
+
+test("it reports NOT_FOUND for another user's activity", async () => {
+  await using ctx = await setupTest();
+
+  const owner = await createViewer({
+    audience: 'service-activity',
+    db: ctx.db,
+    sessionID: 'session-a',
+  });
+
+  const avatar = await createAvatarRow(ctx.db, { userId: owner.user.id });
+
+  const ownerClient = buildRPCTestClient<ActivityContract>(ctx.app, { token: owner.token });
+
+  const started = await ownerClient.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'node_1',
+    scopeType: 'world_map_node',
+  });
+
+  const intruder = await createViewer({
+    audience: 'service-activity',
+    db: ctx.db,
+    sessionID: 'session-b',
+  });
+
+  const intruderClient = buildRPCTestClient<ActivityContract>(ctx.app, { token: intruder.token });
+
+  expect(intruderClient.resumeActivity({ activityID: started.id })).rejects.toMatchObject({
+    code: 'NOT_FOUND',
+  });
+});
+
+test('it rejects a session-less caller with UNAUTHORIZED', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'node_1',
+    scopeType: 'world_map_node',
+  });
+
+  expect(client.resumeActivity({ activityID: started.id })).rejects.toMatchObject({
+    code: 'UNAUTHORIZED',
+  });
+});

--- a/services/activity/src/handlers/resume-activity.ts
+++ b/services/activity/src/handlers/resume-activity.ts
@@ -21,7 +21,7 @@ interface ResumeActivityOpts {
 
 /**
  * Takes over as an active activity's writer session: after this call the acting session is the
- * only one whose appends pass the writer fence, and the displaced writer's in-flight submissions
+ * only one whose appends are accepted, and the displaced writer's in-flight submissions
  * fail fatally. Taking the writer is the whole of resuming server-side — the caller rebuilds its
  * simulation from the verified anchor and appends from the current head. The ownership check
  * folds into the same statement, so a foreign or missing activity is the same NOT_FOUND as a

--- a/services/activity/src/handlers/resume-activity.ts
+++ b/services/activity/src/handlers/resume-activity.ts
@@ -1,0 +1,57 @@
+import type { ActivityData } from '@vers/contract-activity';
+import type { DB } from '@vers/db';
+import type { Kysely } from 'kysely';
+import type { EmptyErrorPayload, MissingSessionPayload } from '../types';
+import { toActivityData } from './to-activity-data';
+
+/**
+ * oRPC handler opts for the authed `resumeActivity` procedure.
+ */
+interface ResumeActivityOpts {
+  readonly context: {
+    readonly actingSessionId: null | string;
+    readonly actingUserId: null | string;
+  };
+  readonly errors: {
+    readonly NOT_FOUND: (payload: EmptyErrorPayload) => Error;
+    readonly UNAUTHORIZED: (payload: MissingSessionPayload) => Error;
+  };
+  readonly input: { readonly activityID: string };
+}
+
+/**
+ * Takes over as an active activity's writer session: after this call the acting session is the
+ * only one whose appends pass the writer fence, and the displaced writer's in-flight submissions
+ * fail fatally. Taking the writer is the whole of resuming server-side — the caller rebuilds its
+ * simulation from the verified anchor and appends from the current head. The ownership check
+ * folds into the same statement, so a foreign or missing activity is the same NOT_FOUND as a
+ * terminal one.
+ */
+export async function resumeActivity(
+  db: Kysely<DB>,
+  opts: ResumeActivityOpts,
+): Promise<ActivityData> {
+  const actingUserID = opts.context.actingUserId;
+  const actingSessionID = opts.context.actingSessionId;
+
+  if (actingUserID === null || actingSessionID === null) {
+    throw opts.errors.UNAUTHORIZED({ data: { reason: 'missing-session' } });
+  }
+
+  const row = await db
+    .updateTable('activities')
+    .set({ writerSessionId: actingSessionID })
+    .where('id', '=', opts.input.activityID)
+    .where('status', '=', 'active')
+    .where('avatarId', 'in', (subquery) =>
+      subquery.selectFrom('avatars').select('id').where('userId', '=', actingUserID),
+    )
+    .returningAll()
+    .executeTakeFirst();
+
+  if (row === undefined) {
+    throw opts.errors.NOT_FOUND({ data: {} });
+  }
+
+  return toActivityData(row);
+}

--- a/services/activity/src/handlers/start-activity.test.ts
+++ b/services/activity/src/handlers/start-activity.test.ts
@@ -208,3 +208,56 @@ test('it rejects an anonymous acting user with UNAUTHORIZED', async () => {
     data: { reason: 'missing-session' },
   });
 });
+
+test('it blocks a new start while the chain is quarantined', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'node_1',
+    scopeType: 'world_map_node',
+  });
+
+  await ctx.db
+    .updateTable('activities')
+    .set({ status: 'quarantined' })
+    .where('id', '=', started.id)
+    .execute();
+
+  expect(
+    client.startActivity({ avatarID: avatar.id, scopeID: 'node_1', scopeType: 'world_map_node' }),
+  ).rejects.toMatchObject({ code: 'CHAIN_QUARANTINED' });
+});
+
+test('it stamps the acting session as the new activity writer', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({
+    audience: 'service-activity',
+    db: ctx.db,
+    sessionID: 'session-a',
+  });
+
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'node_1',
+    scopeType: 'world_map_node',
+  });
+
+  const row = await ctx.db
+    .selectFrom('activities')
+    .select('writerSessionId')
+    .where('id', '=', started.id)
+    .executeTakeFirstOrThrow();
+
+  expect(row.writerSessionId).toBe('session-a');
+});

--- a/services/activity/src/handlers/start-activity.ts
+++ b/services/activity/src/handlers/start-activity.ts
@@ -23,8 +23,12 @@ interface StartActivityDeps {
  * oRPC handler opts for the authed `startActivity` procedure.
  */
 interface StartActivityOpts {
-  readonly context: { readonly actingUserId: null | string };
+  readonly context: {
+    readonly actingSessionId: null | string;
+    readonly actingUserId: null | string;
+  };
   readonly errors: {
+    readonly CHAIN_QUARANTINED: (payload: EmptyErrorPayload) => Error;
     readonly CONFLICT: (payload: ActiveActivityConflictPayload) => Error;
     readonly NOT_FOUND: (payload: EmptyErrorPayload) => Error;
     readonly UNAUTHORIZED: (payload: MissingSessionPayload) => Error;
@@ -38,9 +42,10 @@ interface StartActivityOpts {
 
 /**
  * Starts an activity for an avatar owned by the acting user, snapshotting the avatar's current
- * progression as the build the stream plays against. Throws CONFLICT with the avatar's existing
- * activity when one is already active — the partial unique index is the serialization point, this
- * handler just reports what it caught.
+ * progression as the build the stream plays against, and stamping the acting session as the
+ * stream's writer. Throws CONFLICT with the avatar's existing activity when one is already active
+ * — the partial unique index is the serialization point, this handler just reports what it caught.
+ * A chain whose replay frontier is quarantined admits no new starts until it is adjudicated.
  */
 export async function startActivity(
   deps: StartActivityDeps,
@@ -61,6 +66,19 @@ export async function startActivity(
 
   if (avatar === undefined) {
     throw opts.errors.NOT_FOUND({ data: {} });
+  }
+
+  const quarantined = await deps.db
+    .selectFrom('activities')
+    .select('id')
+    .where('avatarId', '=', opts.input.avatarID)
+    .where('scopeType', '=', opts.input.scopeType)
+    .where('scopeId', '=', opts.input.scopeID)
+    .where('status', '=', 'quarantined')
+    .executeTakeFirst();
+
+  if (quarantined !== undefined) {
+    throw opts.errors.CHAIN_QUARANTINED({ data: {} });
   }
 
   const id = `act_${createId()}`;
@@ -109,6 +127,7 @@ export async function startActivity(
         simVersion: deps.simVersion,
         startChainIndex: chain.appendedChainIndex,
         startHash,
+        writerSessionId: opts.context.actingSessionId,
       })
       .returningAll()
       .executeTakeFirstOrThrow();

--- a/services/activity/src/handlers/to-activity-data.ts
+++ b/services/activity/src/handlers/to-activity-data.ts
@@ -9,7 +9,6 @@ import type { Selectable } from 'kysely';
  * boundary — oRPC validates handler output against the contract's output schema and fails the
  * request on mismatch.
  */
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- the row's jsonb `buildSnapshot` field types as the generated `Json` union, which nests a mutable `JsonValue[]` branch with no readonly form
 export function toActivityData(row: Readonly<Selectable<Activities>>): ActivityData {
   return {
     appendedAt: row.appendedAt,

--- a/services/activity/src/handlers/to-checkpoint-data.ts
+++ b/services/activity/src/handlers/to-checkpoint-data.ts
@@ -8,7 +8,6 @@ import type { Selectable } from 'kysely';
  * contract input, and the cast cannot smuggle a drifted row past the RPC boundary — oRPC validates
  * handler output against the contract's output schema and fails the request on mismatch.
  */
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- the row's jsonb `payload` field types as the generated `Json` union, which nests a mutable `JsonValue[]` branch with no readonly form
 export function toCheckpointData(row: Readonly<Selectable<ActivityCheckpoints>>): Checkpoint {
   return {
     appendedAt: row.appendedAt,

--- a/services/activity/src/handlers/track-activity-progress.test.ts
+++ b/services/activity/src/handlers/track-activity-progress.test.ts
@@ -1,7 +1,13 @@
 import { expect, test } from 'bun:test';
 import type { ActivityContract } from '@vers/contract-activity';
 import { buildFailureXPLoss, levelForXP } from '@vers/idle-core';
-import { createAnonymousViewer, createTestDB, createViewer } from '@vers/service-test-utils/bun';
+import {
+  createAnonymousViewer,
+  createServiceToken,
+  createTestDB,
+  createViewer,
+  getTestServiceKeyPair,
+} from '@vers/service-test-utils/bun';
 import { buildRPCTestClient } from '@vers/test-utils';
 import { createActivityService } from '../create-activity-service';
 import { createAvatarRow } from '../test-utils/create-avatar-row';
@@ -245,7 +251,7 @@ test('it rejects a hash that does not match its payload with CHECKPOINT_INVALID'
   ).rejects.toMatchObject({ code: 'CHECKPOINT_INVALID', data: { reason: 'hash-mismatch' } });
 });
 
-test('it rejects appending to a stopped activity with NOT_FOUND', async () => {
+test('it rejects appending to a stopped activity with ACTIVITY_TERMINAL', async () => {
   await using ctx = await setupTest();
 
   const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
@@ -265,7 +271,7 @@ test('it rejects appending to a stopped activity with NOT_FOUND', async () => {
 
   expect(
     client.trackActivityProgress({ activityID: started.id, checkpoints: batch, expectedHead: 0 }),
-  ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  ).rejects.toMatchObject({ code: 'ACTIVITY_TERMINAL', data: { status: 'stopped' } });
 });
 
 test('it rejects a foreign or missing activity id with NOT_FOUND', async () => {
@@ -644,7 +650,7 @@ test('it advances the chain anchor exactly once across a duplicate terminal subm
       checkpoints: batch,
       expectedHead: 0,
     }),
-  ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  ).rejects.toMatchObject({ code: 'ACTIVITY_TERMINAL', data: { status: 'stopped' } });
 
   const chainAfterSecond = await ctx.db
     .selectFrom('activityChains')
@@ -689,7 +695,7 @@ test('it does not double-apply xp on a duplicate terminal submission', async () 
       checkpoints: batch,
       expectedHead: 0,
     }),
-  ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  ).rejects.toMatchObject({ code: 'ACTIVITY_TERMINAL', data: { status: 'stopped' } });
 
   const updated = await ctx.db
     .selectFrom('avatars')
@@ -698,4 +704,109 @@ test('it does not double-apply xp on a duplicate terminal submission', async () 
     .executeTakeFirstOrThrow();
 
   expect(updated.xp).toBe(150);
+});
+
+test('it fences an append from a displaced writer session with SESSION_EVICTED', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({
+    audience: 'service-activity',
+    db: ctx.db,
+    sessionID: 'session-a',
+  });
+
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  const clientA = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await clientA.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'node_1',
+    scopeType: 'world_map_node',
+  });
+
+  const keyPair = await getTestServiceKeyPair();
+
+  const tokenB = await createServiceToken({
+    actingSessionId: 'session-b',
+    actingUserId: viewer.user.id,
+    audience: 'service-activity',
+    privateKey: keyPair.privateKey,
+  });
+
+  const clientB = buildRPCTestClient<ActivityContract>(ctx.app, { token: tokenB });
+
+  await clientB.resumeActivity({ activityID: started.id });
+
+  const batch = createMockCheckpointBatch({ startPrevHash: started.startHash, startVersion: 1 });
+
+  expect(
+    clientA.trackActivityProgress({ activityID: started.id, checkpoints: batch, expectedHead: 0 }),
+  ).rejects.toMatchObject({ code: 'SESSION_EVICTED' });
+
+  const result = await clientB.trackActivityProgress({
+    activityID: started.id,
+    checkpoints: batch,
+    expectedHead: 0,
+  });
+
+  expect(result).toStrictEqual({ appendedHead: 1 });
+});
+
+test('it lets the first appending session claim an unstamped stream', async () => {
+  await using ctx = await setupTest();
+
+  // a session-less viewer starts the activity, leaving the writer unstamped
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  const sessionlessClient = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await sessionlessClient.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'node_1',
+    scopeType: 'world_map_node',
+  });
+
+  const keyPair = await getTestServiceKeyPair();
+
+  const tokenA = await createServiceToken({
+    actingSessionId: 'session-a',
+    actingUserId: viewer.user.id,
+    audience: 'service-activity',
+    privateKey: keyPair.privateKey,
+  });
+
+  const clientA = buildRPCTestClient<ActivityContract>(ctx.app, { token: tokenA });
+  const batch = createMockCheckpointBatch({ startPrevHash: started.startHash, startVersion: 1 });
+
+  const result = await clientA.trackActivityProgress({
+    activityID: started.id,
+    checkpoints: batch,
+    expectedHead: 0,
+  });
+
+  expect(result).toStrictEqual({ appendedHead: 1 });
+
+  const tokenB = await createServiceToken({
+    actingSessionId: 'session-b',
+    actingUserId: viewer.user.id,
+    audience: 'service-activity',
+    privateKey: keyPair.privateKey,
+  });
+
+  const clientB = buildRPCTestClient<ActivityContract>(ctx.app, { token: tokenB });
+
+  const nextBatch = createMockCheckpointBatch({
+    startPrevHash: batch[0]?.hash ?? '',
+    startVersion: 2,
+  });
+
+  expect(
+    clientB.trackActivityProgress({
+      activityID: started.id,
+      checkpoints: nextBatch,
+      expectedHead: 1,
+    }),
+  ).rejects.toMatchObject({ code: 'SESSION_EVICTED' });
 });

--- a/services/activity/src/handlers/track-activity-progress.test.ts
+++ b/services/activity/src/handlers/track-activity-progress.test.ts
@@ -706,7 +706,7 @@ test('it does not double-apply xp on a duplicate terminal submission', async () 
   expect(updated.xp).toBe(150);
 });
 
-test('it fences an append from a displaced writer session with SESSION_EVICTED', async () => {
+test('it rejects an append from a displaced writer session with SESSION_EVICTED', async () => {
   await using ctx = await setupTest();
 
   const viewer = await createViewer({

--- a/services/activity/src/handlers/track-activity-progress.test.ts
+++ b/services/activity/src/handlers/track-activity-progress.test.ts
@@ -14,7 +14,7 @@ import { createAvatarRow } from '../test-utils/create-avatar-row';
 import { createMockCheckpointBatch } from '../test-utils/factories/create-mock-checkpoint-batch';
 
 /**
- * `trackActivityProgress` opens its own `db.transaction()` for the head-row CAS, which can't nest
+ * `trackActivityProgress` opens its own `db.transaction()` for the head-row compare-and-swap, which can't nest
  * under the default rollback-on-dispose isolation — this suite runs against a real, committed
  * schema clone instead.
  */

--- a/services/activity/src/handlers/track-activity-progress.ts
+++ b/services/activity/src/handlers/track-activity-progress.ts
@@ -43,8 +43,8 @@ interface TrackActivityProgressOpts {
  * transaction is the actual serialization point — a losing race re-reads the current head and
  * reports NOT_FOUND (activity gone), ACTIVITY_TERMINAL (a terminal status accepts no appends),
  * SESSION_EVICTED (another session took over as the writer — fatal, the caller discards its
- * pending queue), or CONFLICT (a retryable stale head). The writer fence admits only the stamped
- * writer session; an unstamped activity is claimed by the first appending session. When the
+ * pending queue), or CONFLICT (a retryable stale head). Only the activity's stamped writer session
+ * may append; an unstamped activity is claimed by the first appending session. When the
  * batch's last checkpoint is terminal (completed or failed), the same transaction claims the
  * activity's terminal transition and settles the avatar's xp/level from that checkpoint's final
  * rewards total — the claim guards against a duplicate terminal resubmission double-applying.

--- a/services/activity/src/handlers/track-activity-progress.ts
+++ b/services/activity/src/handlers/track-activity-progress.ts
@@ -11,17 +11,23 @@ import type {
   EmptyErrorPayload,
   MissingSessionPayload,
   StaleHeadPayload,
+  TerminalStatusPayload,
 } from '../types';
 
 /**
  * oRPC handler opts for the authed `trackActivityProgress` procedure.
  */
 interface TrackActivityProgressOpts {
-  readonly context: { readonly actingUserId: null | string };
+  readonly context: {
+    readonly actingSessionId: null | string;
+    readonly actingUserId: null | string;
+  };
   readonly errors: {
+    readonly ACTIVITY_TERMINAL: (payload: TerminalStatusPayload) => Error;
     readonly CHECKPOINT_INVALID: (payload: CheckpointInvalidPayload) => Error;
     readonly CONFLICT: (payload: StaleHeadPayload) => Error;
     readonly NOT_FOUND: (payload: EmptyErrorPayload) => Error;
+    readonly SESSION_EVICTED: (payload: EmptyErrorPayload) => Error;
     readonly UNAUTHORIZED: (payload: MissingSessionPayload) => Error;
   };
   readonly input: {
@@ -35,11 +41,13 @@ interface TrackActivityProgressOpts {
  * Appends a checkpoint batch to an active activity owned by the acting user. The batch's internal
  * contiguity and hash chain are validated up front; the head-row compare-and-swap inside the
  * transaction is the actual serialization point — a losing race re-reads the current head and
- * reports NOT_FOUND (activity gone or no longer active) or CONFLICT (a retryable stale head) as
- * appropriate. When the batch's last checkpoint is terminal (completed or failed), the same
- * transaction claims the activity's terminal transition and settles the avatar's xp/level from
- * that checkpoint's final rewards total — the claim guards against a duplicate terminal
- * resubmission double-applying.
+ * reports NOT_FOUND (activity gone), ACTIVITY_TERMINAL (a terminal status accepts no appends),
+ * SESSION_EVICTED (another session took over as the writer — fatal, the caller discards its
+ * pending queue), or CONFLICT (a retryable stale head). The writer fence admits only the stamped
+ * writer session; an unstamped activity is claimed by the first appending session. When the
+ * batch's last checkpoint is terminal (completed or failed), the same transaction claims the
+ * activity's terminal transition and settles the avatar's xp/level from that checkpoint's final
+ * rewards total — the claim guards against a duplicate terminal resubmission double-applying.
  */
 export async function trackActivityProgress(
   db: Kysely<DB>,
@@ -51,6 +59,8 @@ export async function trackActivityProgress(
     throw opts.errors.UNAUTHORIZED({ data: { reason: 'missing-session' } });
   }
 
+  const actingSessionID = opts.context.actingSessionId;
+
   const head = await db
     .selectFrom('activities')
     .innerJoin('avatars', 'avatars.id', 'activities.avatarId')
@@ -61,15 +71,24 @@ export async function trackActivityProgress(
       'activities.scopeId',
       'activities.scopeType',
       'activities.startChainIndex',
+      'activities.status',
+      'activities.writerSessionId',
       'avatars.xp',
     ])
     .where('activities.id', '=', opts.input.activityID)
     .where('avatars.userId', '=', actingUserID)
-    .where('activities.status', '=', 'active')
     .executeTakeFirst();
 
   if (head === undefined) {
     throw opts.errors.NOT_FOUND({ data: {} });
+  }
+
+  if (head.status !== 'active') {
+    throw opts.errors.ACTIVITY_TERMINAL({ data: { status: head.status } });
+  }
+
+  if (head.writerSessionId !== null && head.writerSessionId !== actingSessionID) {
+    throw opts.errors.SESSION_EVICTED({ data: {} });
   }
 
   const reason = findInvalidReason(opts.input, head);
@@ -90,6 +109,7 @@ export async function trackActivityProgress(
         appendedAt: sql`now()`,
         appendedHead: newHead,
         lastHash: newLastHash,
+        ...(actingSessionID !== null && { writerSessionId: actingSessionID }),
         ...(terminalRewardsXP !== undefined && {
           status: 'stopped' as const,
           stoppedAt: sql`now()`,
@@ -98,18 +118,29 @@ export async function trackActivityProgress(
       .where('id', '=', opts.input.activityID)
       .where('appendedHead', '=', opts.input.expectedHead)
       .where('status', '=', 'active')
+      .where((eb) =>
+        eb.or([eb('writerSessionId', 'is', null), eb('writerSessionId', '=', actingSessionID)]),
+      )
       .returning('appendedHead')
       .executeTakeFirst();
 
     if (updated === undefined) {
       const current = await trx
         .selectFrom('activities')
-        .select(['appendedHead', 'status'])
+        .select(['appendedHead', 'status', 'writerSessionId'])
         .where('id', '=', opts.input.activityID)
         .executeTakeFirst();
 
-      if (current === undefined || current.status !== 'active') {
+      if (current === undefined) {
         throw opts.errors.NOT_FOUND({ data: {} });
+      }
+
+      if (current.status !== 'active') {
+        throw opts.errors.ACTIVITY_TERMINAL({ data: { status: current.status } });
+      }
+
+      if (current.writerSessionId !== null && current.writerSessionId !== actingSessionID) {
+        throw opts.errors.SESSION_EVICTED({ data: {} });
       }
 
       throw opts.errors.CONFLICT({ data: { appendedHead: current.appendedHead } });

--- a/services/activity/src/handlers/track-activity-progress.ts
+++ b/services/activity/src/handlers/track-activity-progress.ts
@@ -207,7 +207,7 @@ interface TrackActivityProgressHead {
 }
 
 /**
- * Validates a checkpoint batch's internal shape ahead of the transactional head-row CAS: version
+ * Validates a checkpoint batch's internal shape ahead of the transactional head-row compare-and-swap: version
  * contiguity from `expectedHead + 1`, each entry's `chainIndex` continuity from
  * `head.startChainIndex`, each entry's hash against its own payload, each entry's chain link to
  * the previous one, and — only when `expectedHead` still matches the head row, since a stale

--- a/services/activity/src/test-utils/factories/create-mock-activity.ts
+++ b/services/activity/src/test-utils/factories/create-mock-activity.ts
@@ -11,8 +11,7 @@ import type { Insertable } from 'kysely';
  * correctly with `createMockCheckpointBatch`.
  */
 export function createMockActivity(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- Activities' jsonb `buildSnapshot` field types as the generated `Json` union, which nests a mutable `JsonValue[]` branch with no readonly form
-  overrides: Partial<Insertable<Activities>> = {},
+  overrides: Readonly<Partial<Insertable<Activities>>> = {},
 ): Insertable<Activities> {
   const id = overrides.id ?? `act_${createId()}`;
   const seed = overrides.seed ?? faker.string.alphanumeric({ casing: 'lower', length: 32 });

--- a/services/activity/src/types.ts
+++ b/services/activity/src/types.ts
@@ -1,4 +1,4 @@
-import type { ActivityData } from '@vers/contract-activity';
+import type { ActivityData, ActivityStatus } from '@vers/contract-activity';
 
 /**
  * Payload shape for an authed procedure's UNAUTHORIZED error when no acting user is present.
@@ -34,4 +34,12 @@ export interface StaleHeadPayload {
  */
 export interface CheckpointInvalidPayload {
   readonly data: { readonly reason: string };
+}
+
+/**
+ * Payload shape for `trackActivityProgress`'s ACTIVITY_TERMINAL: the terminal status that rejects
+ * the append.
+ */
+export interface TerminalStatusPayload {
+  readonly data: { readonly status: ActivityStatus };
 }

--- a/services/replay/bunfig.toml
+++ b/services/replay/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./test-setup.ts"]

--- a/services/replay/package.json
+++ b/services/replay/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@vers/service-replay",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@vers/db": "workspace:*",
+    "@vers/idle-core": "workspace:*",
+    "kysely": "catalog:"
+  },
+  "devDependencies": {
+    "@faker-js/faker": "catalog:",
+    "@paralleldrive/cuid2": "catalog:",
+    "@types/bun": "catalog:",
+    "@types/node": "catalog:",
+    "@vers/service-test-utils": "workspace:*",
+    "@vers/test-utils": "workspace:*",
+    "@zgeoff/bun-test-extended": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/services/replay/src/apply/apply-verified-segment.test.ts
+++ b/services/replay/src/apply/apply-verified-segment.test.ts
@@ -1,0 +1,233 @@
+import { expect, test } from 'bun:test';
+import { createTestDB } from '@vers/service-test-utils/bun';
+import { createActivityRow } from '../test-utils/create-activity-row';
+import { createAvatarRow } from '../test-utils/create-avatar-row';
+import { createChainRow } from '../test-utils/create-chain-row';
+import { applyVerifiedSegment } from './apply-verified-segment';
+
+/**
+ * `applyVerifiedSegment` opens its own `db.transaction()` when handed a non-transaction handle,
+ * which can't nest under the default rollback-on-dispose isolation — this suite runs against a
+ * real, committed schema clone instead.
+ */
+async function setupTest() {
+  const db = await createTestDB({ isolation: 'schema' });
+
+  return { db: db.db, [Symbol.asyncDispose]: db[Symbol.asyncDispose] };
+}
+
+test('it applies a duplicate segment exactly once', async () => {
+  await using ctx = await setupTest();
+
+  const avatar = await createAvatarRow(ctx.db, { xp: 100 });
+
+  const activity = await createActivityRow(ctx.db, {
+    appendedHead: 5,
+    avatarId: avatar.id,
+  });
+
+  const first = await applyVerifiedSegment(ctx.db, {
+    activityID: activity.id,
+    avatarID: avatar.id,
+    expectedVerifiedHead: 0,
+    verifiedHead: 5,
+    xpDelta: 50,
+  });
+
+  const second = await applyVerifiedSegment(ctx.db, {
+    activityID: activity.id,
+    avatarID: avatar.id,
+    expectedVerifiedHead: 0,
+    verifiedHead: 5,
+    xpDelta: 50,
+  });
+
+  expect(first).toStrictEqual({ applied: true, granted: [] });
+  expect(second).toStrictEqual({ applied: false });
+
+  const settled = await ctx.db
+    .selectFrom('avatars')
+    .select(['level', 'xp'])
+    .where('id', '=', avatar.id)
+    .executeTakeFirstOrThrow();
+
+  expect(settled.xp).toBe(150);
+
+  const cursor = await ctx.db
+    .selectFrom('activities')
+    .select(['verifiedAt', 'verifiedHead'])
+    .where('id', '=', activity.id)
+    .executeTakeFirstOrThrow();
+
+  expect(cursor.verifiedHead).toBe(5);
+  expect(cursor.verifiedAt).toBeValidDate();
+});
+
+test('it grants a one-shot reward exactly once across re-farms', async () => {
+  await using ctx = await setupTest();
+
+  const avatar = await createAvatarRow(ctx.db);
+
+  const firstRun = await createActivityRow(ctx.db, {
+    appendedHead: 3,
+    avatarId: avatar.id,
+    status: 'stopped',
+  });
+
+  const secondRun = await createActivityRow(ctx.db, {
+    appendedHead: 3,
+    avatarId: avatar.id,
+    scopeId: firstRun.scopeId,
+    startChainIndex: 3,
+  });
+
+  const grant = { key: 'node_1', kind: 'first_clear' };
+
+  const first = await applyVerifiedSegment(ctx.db, {
+    activityID: firstRun.id,
+    avatarID: avatar.id,
+    expectedVerifiedHead: 0,
+    grants: [grant],
+    verifiedHead: 3,
+  });
+
+  const second = await applyVerifiedSegment(ctx.db, {
+    activityID: secondRun.id,
+    avatarID: avatar.id,
+    expectedVerifiedHead: 0,
+    grants: [grant],
+    verifiedHead: 3,
+  });
+
+  expect(first).toStrictEqual({ applied: true, granted: [grant] });
+  expect(second).toStrictEqual({ applied: true, granted: [] });
+
+  const rows = await ctx.db
+    .selectFrom('avatarGrants')
+    .selectAll()
+    .where('avatarId', '=', avatar.id)
+    .execute();
+
+  expect(rows).toHaveLength(1);
+});
+
+test('it advances the chain anchor forward only', async () => {
+  await using ctx = await setupTest();
+
+  const avatar = await createAvatarRow(ctx.db);
+
+  const chain = await createChainRow(ctx.db, {
+    avatarId: avatar.id,
+    verifiedChainIndex: 10,
+    verifiedNextSeed: 'aa'.repeat(16),
+  });
+
+  const activity = await createActivityRow(ctx.db, {
+    appendedHead: 2,
+    avatarId: avatar.id,
+    scopeId: chain.scopeId,
+    scopeType: chain.scopeType,
+  });
+
+  const stale = await applyVerifiedSegment(ctx.db, {
+    activityID: activity.id,
+    avatarID: avatar.id,
+    chain: {
+      chainIndex: 4,
+      nextSeed: 'bb'.repeat(16),
+      scopeID: chain.scopeId,
+      scopeType: chain.scopeType,
+    },
+    expectedVerifiedHead: 0,
+    verifiedHead: 1,
+  });
+
+  expect(stale).toStrictEqual({ applied: true, granted: [] });
+
+  const afterStale = await ctx.db
+    .selectFrom('activityChains')
+    .select(['verifiedChainIndex', 'verifiedNextSeed'])
+    .where('avatarId', '=', avatar.id)
+    .where('scopeId', '=', chain.scopeId)
+    .executeTakeFirstOrThrow();
+
+  expect(afterStale).toStrictEqual({
+    verifiedChainIndex: 10,
+    verifiedNextSeed: 'aa'.repeat(16),
+  });
+
+  await applyVerifiedSegment(ctx.db, {
+    activityID: activity.id,
+    avatarID: avatar.id,
+    chain: {
+      chainIndex: 12,
+      nextSeed: 'cc'.repeat(16),
+      scopeID: chain.scopeId,
+      scopeType: chain.scopeType,
+    },
+    expectedVerifiedHead: 1,
+    verifiedHead: 2,
+  });
+
+  const afterAdvance = await ctx.db
+    .selectFrom('activityChains')
+    .select(['verifiedChainIndex', 'verifiedNextSeed'])
+    .where('avatarId', '=', avatar.id)
+    .where('scopeId', '=', chain.scopeId)
+    .executeTakeFirstOrThrow();
+
+  expect(afterAdvance).toStrictEqual({
+    verifiedChainIndex: 12,
+    verifiedNextSeed: 'cc'.repeat(16),
+  });
+});
+
+test('it floors xp at zero on an adverse delta', async () => {
+  await using ctx = await setupTest();
+
+  const avatar = await createAvatarRow(ctx.db, { xp: 10 });
+  const activity = await createActivityRow(ctx.db, { appendedHead: 1, avatarId: avatar.id });
+
+  await applyVerifiedSegment(ctx.db, {
+    activityID: activity.id,
+    avatarID: avatar.id,
+    expectedVerifiedHead: 0,
+    verifiedHead: 1,
+    xpDelta: -50,
+  });
+
+  const settled = await ctx.db
+    .selectFrom('avatars')
+    .select('xp')
+    .where('id', '=', avatar.id)
+    .executeTakeFirstOrThrow();
+
+  expect(settled.xp).toBe(0);
+});
+
+test('it resets the attempt counter on a successful apply', async () => {
+  await using ctx = await setupTest();
+
+  const avatar = await createAvatarRow(ctx.db);
+
+  const activity = await createActivityRow(ctx.db, {
+    appendedHead: 1,
+    avatarId: avatar.id,
+    replayAttempts: 3,
+  });
+
+  await applyVerifiedSegment(ctx.db, {
+    activityID: activity.id,
+    avatarID: avatar.id,
+    expectedVerifiedHead: 0,
+    verifiedHead: 1,
+  });
+
+  const row = await ctx.db
+    .selectFrom('activities')
+    .select('replayAttempts')
+    .where('id', '=', activity.id)
+    .executeTakeFirstOrThrow();
+
+  expect(row.replayAttempts).toBe(0);
+});

--- a/services/replay/src/apply/apply-verified-segment.ts
+++ b/services/replay/src/apply/apply-verified-segment.ts
@@ -1,0 +1,123 @@
+import type { DB } from '@vers/db';
+import { levelForXP } from '@vers/idle-core';
+import { sql } from 'kysely';
+import type { Kysely } from 'kysely';
+import type { GrantOnce } from '../types';
+
+interface ChainAdvance {
+  readonly chainIndex: number;
+  readonly nextSeed: string;
+  readonly scopeID: string;
+  readonly scopeType: string;
+}
+
+interface ApplyVerifiedSegmentInput {
+  readonly activityID: string;
+  readonly avatarID: string;
+
+  /**
+   * Advances the chain row's verified anchor alongside the cursor, for a segment that ends an
+   * adjudicated activity. Guarded forward-only — a stale advance moves nothing.
+   */
+  readonly chain?: ChainAdvance;
+  readonly expectedVerifiedHead: number;
+  readonly grants?: ReadonlyArray<GrantOnce>;
+  readonly verifiedHead: number;
+
+  /**
+   * Signed delta added to the avatar's xp (`xp = xp + delta`, floored at zero) — never an absolute
+   * value, so a concurrent grant is never overwritten.
+   */
+  readonly xpDelta?: number;
+}
+
+type ApplyVerifiedSegmentResult =
+  | { readonly applied: false }
+  | { readonly applied: true; readonly granted: ReadonlyArray<GrantOnce> };
+
+/**
+ * Applies one replayed segment's verified outcome exactly once. The cursor guard is the whole
+ * mechanism: `verified_head` advances only if it still holds the expected value, and every other
+ * write — the identity delta, the chain-anchor advance, the grant-once inserts — commits in the
+ * same local transaction behind it, so a duplicate or crashed-and-retried apply either lands whole
+ * or not at all (`applied: false`, nothing to roll back). One-shot grants insert with
+ * `ON CONFLICT DO NOTHING`; `granted` reports which of them actually landed, so a first-clear
+ * bonus attaches only on the apply that won the insert. A successful apply resets the poison-pill
+ * attempt counter. Runs inside the caller's transaction when given one (composing with a held
+ * chain claim), or opens its own otherwise.
+ */
+export function applyVerifiedSegment(
+  db: Kysely<DB>,
+  input: Readonly<ApplyVerifiedSegmentInput>,
+): Promise<ApplyVerifiedSegmentResult> {
+  if (db.isTransaction) {
+    return applySegmentWrites(db, input);
+  }
+
+  return db.transaction().execute((trx) => applySegmentWrites(trx, input));
+}
+
+async function applySegmentWrites(
+  trx: Kysely<DB>,
+  input: Readonly<ApplyVerifiedSegmentInput>,
+): Promise<ApplyVerifiedSegmentResult> {
+  const advanced = await trx
+    .updateTable('activities')
+    .set({ replayAttempts: 0, verifiedAt: sql`now()`, verifiedHead: input.verifiedHead })
+    .where('id', '=', input.activityID)
+    .where('verifiedHead', '=', input.expectedVerifiedHead)
+    .returning('verifiedHead')
+    .executeTakeFirst();
+
+  if (advanced === undefined) {
+    return { applied: false };
+  }
+
+  if (input.xpDelta !== undefined && input.xpDelta !== 0) {
+    const settled = await trx
+      .updateTable('avatars')
+      .set({ xp: sql`GREATEST(0, xp + ${input.xpDelta})` })
+      .where('id', '=', input.avatarID)
+      .returning('xp')
+      .executeTakeFirstOrThrow();
+
+    await trx
+      .updateTable('avatars')
+      .set({ level: levelForXP(settled.xp) })
+      .where('id', '=', input.avatarID)
+      .execute();
+  }
+
+  if (input.chain !== undefined) {
+    await trx
+      .updateTable('activityChains')
+      .set({
+        verifiedChainIndex: input.chain.chainIndex,
+        verifiedNextSeed: input.chain.nextSeed,
+      })
+      .where('avatarId', '=', input.avatarID)
+      .where('scopeType', '=', input.chain.scopeType)
+      .where('scopeId', '=', input.chain.scopeID)
+      .where('verifiedChainIndex', '<', input.chain.chainIndex)
+      .execute();
+  }
+
+  if (input.grants === undefined || input.grants.length === 0) {
+    return { applied: true, granted: [] };
+  }
+
+  const granted = await trx
+    .insertInto('avatarGrants')
+    .values(
+      input.grants.map((grant) => ({
+        avatarId: input.avatarID,
+        key: grant.key,
+        kind: grant.kind,
+      })),
+    )
+    .onConflict((oc) => oc.doNothing())
+    .returning(['key', 'kind'])
+    .execute();
+
+  return { applied: true, granted };
+}

--- a/services/replay/src/index.ts
+++ b/services/replay/src/index.ts
@@ -1,0 +1,5 @@
+export { applyVerifiedSegment } from './apply/apply-verified-segment';
+export { claimNextChain } from './queue/claim-next-chain';
+export { findReplayFrontier } from './queue/find-replay-frontier';
+export { MAX_REPLAY_ATTEMPTS, updateReplayAttempts } from './queue/update-replay-attempts';
+export type { ChainKey, ClaimedChain, GrantOnce, ReplayFrontier } from './types';

--- a/services/replay/src/queue/claim-next-chain.test.ts
+++ b/services/replay/src/queue/claim-next-chain.test.ts
@@ -1,0 +1,125 @@
+import { expect, test } from 'bun:test';
+import { createTestDB } from '@vers/service-test-utils/bun';
+import { createActivityRow } from '../test-utils/create-activity-row';
+import { createChainRow } from '../test-utils/create-chain-row';
+import { claimNextChain } from './claim-next-chain';
+
+/**
+ * The claim is a `FOR UPDATE SKIP LOCKED` row lock held across concurrent transactions, which
+ * needs real committed rows and independent connections — this suite runs against a real,
+ * committed schema clone.
+ */
+async function setupTest() {
+  const db = await createTestDB({ isolation: 'schema' });
+
+  return { db: db.db, [Symbol.asyncDispose]: db[Symbol.asyncDispose] };
+}
+
+test('it claims a chain with appends past the verified cursor', async () => {
+  await using ctx = await setupTest();
+
+  const chain = await createChainRow(ctx.db);
+
+  await createActivityRow(ctx.db, {
+    appendedHead: 3,
+    avatarId: chain.avatarId,
+    scopeId: chain.scopeId,
+  });
+
+  const claimed = await ctx.db.transaction().execute((trx) => claimNextChain(trx));
+
+  expect(claimed).toStrictEqual({
+    avatarID: chain.avatarId,
+    priority: 0,
+    scopeID: chain.scopeId,
+    scopeType: chain.scopeType,
+  });
+});
+
+test('it reports an empty queue as undefined', async () => {
+  await using ctx = await setupTest();
+
+  const chain = await createChainRow(ctx.db);
+
+  await createActivityRow(ctx.db, {
+    appendedHead: 3,
+    avatarId: chain.avatarId,
+    scopeId: chain.scopeId,
+    verifiedHead: 3,
+  });
+
+  const claimed = await ctx.db.transaction().execute((trx) => claimNextChain(trx));
+
+  expect(claimed).toBeUndefined();
+});
+
+test('it claims the highest-priority chain first', async () => {
+  await using ctx = await setupTest();
+
+  const routine = await createChainRow(ctx.db);
+
+  await createActivityRow(ctx.db, {
+    appendedHead: 1,
+    avatarId: routine.avatarId,
+    scopeId: routine.scopeId,
+  });
+
+  const bumped = await createChainRow(ctx.db, { priority: 10 });
+
+  await createActivityRow(ctx.db, {
+    appendedHead: 1,
+    avatarId: bumped.avatarId,
+    scopeId: bumped.scopeId,
+  });
+
+  const claimed = await ctx.db.transaction().execute((trx) => claimNextChain(trx));
+
+  expect(claimed).toMatchObject({ avatarID: bumped.avatarId, priority: 10 });
+});
+
+test('it skips a chain another worker holds', async () => {
+  await using ctx = await setupTest();
+
+  const chain = await createChainRow(ctx.db);
+
+  await createActivityRow(ctx.db, {
+    appendedHead: 3,
+    avatarId: chain.avatarId,
+    scopeId: chain.scopeId,
+  });
+
+  const outcome = await ctx.db.transaction().execute(async (holder) => {
+    const held = await claimNextChain(holder);
+    const contender = await ctx.db.transaction().execute((trx) => claimNextChain(trx));
+
+    return { contender, held };
+  });
+
+  expect(outcome.held).toMatchObject({ avatarID: chain.avatarId });
+  expect(outcome.contender).toBeUndefined();
+});
+
+test('it skips a chain whose replay frontier is quarantined', async () => {
+  await using ctx = await setupTest();
+
+  const chain = await createChainRow(ctx.db);
+
+  await createActivityRow(ctx.db, {
+    appendedHead: 3,
+    avatarId: chain.avatarId,
+    scopeId: chain.scopeId,
+    startChainIndex: 0,
+    status: 'quarantined',
+  });
+
+  await createActivityRow(ctx.db, {
+    appendedHead: 2,
+    avatarId: chain.avatarId,
+    scopeId: chain.scopeId,
+    startChainIndex: 3,
+  });
+
+  const claimed = await ctx.db.transaction().execute((trx) => claimNextChain(trx));
+
+  expect(claimed).toBeUndefined();
+});

--- a/services/replay/src/queue/claim-next-chain.ts
+++ b/services/replay/src/queue/claim-next-chain.ts
@@ -1,0 +1,50 @@
+import type { DB } from '@vers/db';
+import type { Transaction } from 'kysely';
+import type { ClaimedChain } from '../types';
+
+/**
+ * Claims the next chain with replay work: highest priority first, locked with
+ * `FOR UPDATE SKIP LOCKED` so concurrent workers each claim a different chain without waiting. A
+ * chain has work when any of its activities has appends past its verified cursor; a chain whose
+ * replay frontier is quarantined is unclaimable, since per-chain FIFO forbids replaying anything
+ * behind it. Must run inside the caller's transaction — the claim is the row lock, and it releases
+ * on commit or rollback. The lock only prevents duplicated effort: exactly-once application is the
+ * verified-cursor guard's job, not this lock's.
+ */
+export async function claimNextChain(trx: Transaction<DB>): Promise<ClaimedChain | undefined> {
+  const row = await trx
+    .selectFrom('activityChains as chain')
+    .innerJoinLateral(
+      (eb) =>
+        eb
+          .selectFrom('activities')
+          .select('activities.status')
+          .whereRef('activities.avatarId', '=', 'chain.avatarId')
+          .whereRef('activities.scopeType', '=', 'chain.scopeType')
+          .whereRef('activities.scopeId', '=', 'chain.scopeId')
+          .whereRef('activities.appendedHead', '>', 'activities.verifiedHead')
+          .orderBy('activities.startChainIndex')
+          .limit(1)
+          .as('frontier'),
+      (join) => join.onTrue(),
+    )
+    .select(['chain.avatarId', 'chain.priority', 'chain.scopeId', 'chain.scopeType'])
+    .where('frontier.status', '!=', 'quarantined')
+    .orderBy('chain.priority', 'desc')
+    .orderBy('chain.createdAt')
+    .limit(1)
+    .forUpdate('chain')
+    .skipLocked()
+    .executeTakeFirst();
+
+  if (row === undefined) {
+    return undefined;
+  }
+
+  return {
+    avatarID: row.avatarId,
+    priority: row.priority,
+    scopeID: row.scopeId,
+    scopeType: row.scopeType,
+  };
+}

--- a/services/replay/src/queue/find-replay-frontier.test.ts
+++ b/services/replay/src/queue/find-replay-frontier.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from 'bun:test';
+import { createTestDB } from '@vers/service-test-utils/bun';
+import { createActivityRow } from '../test-utils/create-activity-row';
+import { createChainRow } from '../test-utils/create-chain-row';
+import { findReplayFrontier } from './find-replay-frontier';
+
+async function setupTest() {
+  const db = await createTestDB();
+
+  return { db: db.db, [Symbol.asyncDispose]: db[Symbol.asyncDispose] };
+}
+
+test('it returns the oldest pending activity on the chain', async () => {
+  await using ctx = await setupTest();
+
+  const chain = await createChainRow(ctx.db);
+
+  const chainKey = {
+    avatarID: chain.avatarId,
+    scopeID: chain.scopeId,
+    scopeType: chain.scopeType,
+  };
+
+  const older = await createActivityRow(ctx.db, {
+    appendedHead: 4,
+    avatarId: chain.avatarId,
+    scopeId: chain.scopeId,
+    startChainIndex: 0,
+    status: 'stopped',
+    verifiedHead: 2,
+  });
+
+  await createActivityRow(ctx.db, {
+    appendedHead: 3,
+    avatarId: chain.avatarId,
+    scopeId: chain.scopeId,
+    startChainIndex: 4,
+  });
+
+  const frontier = await findReplayFrontier(ctx.db, chainKey);
+
+  expect(frontier).toStrictEqual({
+    activityID: older.id,
+    appendedHead: 4,
+    replayAttempts: 0,
+    startChainIndex: 0,
+    status: 'stopped',
+    verifiedHead: 2,
+  });
+});
+
+test('it reports a fully replayed chain as undefined', async () => {
+  await using ctx = await setupTest();
+
+  const chain = await createChainRow(ctx.db);
+
+  await createActivityRow(ctx.db, {
+    appendedHead: 3,
+    avatarId: chain.avatarId,
+    scopeId: chain.scopeId,
+    verifiedHead: 3,
+  });
+
+  const frontier = await findReplayFrontier(ctx.db, {
+    avatarID: chain.avatarId,
+    scopeID: chain.scopeId,
+    scopeType: chain.scopeType,
+  });
+
+  expect(frontier).toBeUndefined();
+});

--- a/services/replay/src/queue/find-replay-frontier.ts
+++ b/services/replay/src/queue/find-replay-frontier.ts
@@ -1,0 +1,38 @@
+import type { DB } from '@vers/db';
+import type { Kysely } from 'kysely';
+import type { ChainKey, ReplayFrontier } from '../types';
+
+/**
+ * The chain's oldest activity with appends past its verified cursor, in `start_chain_index` order
+ * — the next unit of replay work. Undefined when the chain is fully replayed. Per-chain FIFO means
+ * the frontier is the only activity a worker may replay; its status is the caller's to inspect (a
+ * quarantined frontier blocks the chain).
+ */
+export async function findReplayFrontier(
+  db: Kysely<DB>,
+  chain: Readonly<ChainKey>,
+): Promise<ReplayFrontier | undefined> {
+  const row = await db
+    .selectFrom('activities')
+    .select(['appendedHead', 'id', 'replayAttempts', 'startChainIndex', 'status', 'verifiedHead'])
+    .where('avatarId', '=', chain.avatarID)
+    .where('scopeType', '=', chain.scopeType)
+    .where('scopeId', '=', chain.scopeID)
+    .where((eb) => eb('appendedHead', '>', eb.ref('verifiedHead')))
+    .orderBy('startChainIndex')
+    .limit(1)
+    .executeTakeFirst();
+
+  if (row === undefined) {
+    return undefined;
+  }
+
+  return {
+    activityID: row.id,
+    appendedHead: row.appendedHead,
+    replayAttempts: row.replayAttempts,
+    startChainIndex: row.startChainIndex,
+    status: row.status,
+    verifiedHead: row.verifiedHead,
+  };
+}

--- a/services/replay/src/queue/update-replay-attempts.test.ts
+++ b/services/replay/src/queue/update-replay-attempts.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from 'bun:test';
+import { createTestDB } from '@vers/service-test-utils/bun';
+import { createActivityRow } from '../test-utils/create-activity-row';
+import { updateReplayAttempts } from './update-replay-attempts';
+
+async function setupTest() {
+  const db = await createTestDB();
+
+  return { db: db.db, [Symbol.asyncDispose]: db[Symbol.asyncDispose] };
+}
+
+test('it counts a failed replay against the activity', async () => {
+  await using ctx = await setupTest();
+
+  const activity = await createActivityRow(ctx.db, { appendedHead: 1 });
+  const result = await updateReplayAttempts(ctx.db, { activityID: activity.id });
+
+  expect(result).toStrictEqual({ attempts: 1, quarantined: false });
+});
+
+test('it quarantines the activity at max attempts', async () => {
+  await using ctx = await setupTest();
+
+  const activity = await createActivityRow(ctx.db, { appendedHead: 1, replayAttempts: 2 });
+  const result = await updateReplayAttempts(ctx.db, { activityID: activity.id, maxAttempts: 3 });
+
+  expect(result).toStrictEqual({ attempts: 3, quarantined: true });
+
+  const row = await ctx.db
+    .selectFrom('activities')
+    .select('status')
+    .where('id', '=', activity.id)
+    .executeTakeFirstOrThrow();
+
+  expect(row.status).toBe('quarantined');
+});
+
+test('it reports a missing activity as undefined', async () => {
+  await using ctx = await setupTest();
+
+  const result = await updateReplayAttempts(ctx.db, { activityID: 'act_missing' });
+
+  expect(result).toBeUndefined();
+});

--- a/services/replay/src/queue/update-replay-attempts.ts
+++ b/services/replay/src/queue/update-replay-attempts.ts
@@ -1,0 +1,47 @@
+import type { ActivityStatus, DB } from '@vers/db';
+import { sql } from 'kysely';
+import type { Kysely } from 'kysely';
+
+/**
+ * How many failed replays an activity survives before it quarantines.
+ */
+export const MAX_REPLAY_ATTEMPTS = 5;
+
+interface UpdateReplayAttemptsInput {
+  readonly activityID: string;
+  readonly maxAttempts?: number;
+}
+
+interface UpdateReplayAttemptsResult {
+  readonly attempts: number;
+  readonly quarantined: boolean;
+}
+
+/**
+ * Counts one failed replay against the activity in a single statement: the attempt counter
+ * increments, and crossing `maxAttempts` transitions the status to `quarantined` in the same
+ * update — the poison-pill exit that takes the chain out of the claim queue. The caller owns
+ * alerting on a `quarantined: true` result; a successful apply resets the counter.
+ */
+export async function updateReplayAttempts(
+  db: Kysely<DB>,
+  input: Readonly<UpdateReplayAttemptsInput>,
+): Promise<UpdateReplayAttemptsResult | undefined> {
+  const maxAttempts = input.maxAttempts ?? MAX_REPLAY_ATTEMPTS;
+
+  const row = await db
+    .updateTable('activities')
+    .set((eb) => ({
+      replayAttempts: eb('replayAttempts', '+', 1),
+      status: sql<ActivityStatus>`CASE WHEN replay_attempts + 1 >= ${maxAttempts} THEN 'quarantined'::activity_status ELSE status END`,
+    }))
+    .where('id', '=', input.activityID)
+    .returning(['replayAttempts', 'status'])
+    .executeTakeFirst();
+
+  if (row === undefined) {
+    return undefined;
+  }
+
+  return { attempts: row.replayAttempts, quarantined: row.status === 'quarantined' };
+}

--- a/services/replay/src/test-utils/create-activity-row.ts
+++ b/services/replay/src/test-utils/create-activity-row.ts
@@ -1,0 +1,28 @@
+import type { Activities, DB } from '@vers/db';
+import type { Insertable, Kysely, Selectable } from 'kysely';
+import { createAvatarRow } from './create-avatar-row';
+import { createMockActivityRow } from './factories/create-mock-activity-row';
+
+/**
+ * Persists an activity head row sourced from the factory's defaults, creating an owning avatar
+ * when `avatarId` is omitted — the head row's foreign key needs a real one.
+ */
+export async function createActivityRow(
+  db: Kysely<DB>,
+  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- Activities' jsonb `buildSnapshot` field types as the generated `Json` union, which nests a mutable `JsonValue[]` branch with no readonly form
+  overrides: Partial<Insertable<Activities>> = {},
+): Promise<Selectable<Activities>> {
+  let avatarId = overrides.avatarId;
+
+  if (avatarId === undefined) {
+    const avatar = await createAvatarRow(db);
+
+    avatarId = avatar.id;
+  }
+
+  return db
+    .insertInto('activities')
+    .values(createMockActivityRow({ ...overrides, avatarId }))
+    .returningAll()
+    .executeTakeFirstOrThrow();
+}

--- a/services/replay/src/test-utils/create-activity-row.ts
+++ b/services/replay/src/test-utils/create-activity-row.ts
@@ -9,8 +9,7 @@ import { createMockActivityRow } from './factories/create-mock-activity-row';
  */
 export async function createActivityRow(
   db: Kysely<DB>,
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- Activities' jsonb `buildSnapshot` field types as the generated `Json` union, which nests a mutable `JsonValue[]` branch with no readonly form
-  overrides: Partial<Insertable<Activities>> = {},
+  overrides: Readonly<Partial<Insertable<Activities>>> = {},
 ): Promise<Selectable<Activities>> {
   let avatarId = overrides.avatarId;
 

--- a/services/replay/src/test-utils/create-avatar-row.ts
+++ b/services/replay/src/test-utils/create-avatar-row.ts
@@ -1,0 +1,34 @@
+import { faker } from '@faker-js/faker';
+import { createId } from '@paralleldrive/cuid2';
+import type { Avatars, DB } from '@vers/db';
+import { createTestUser } from '@vers/service-test-utils/bun';
+import type { Insertable, Kysely, Selectable } from 'kysely';
+
+/**
+ * Inserts an avatar row (and, when `userId` is omitted, an owning user) via kysely — the apply
+ * primitives need a real avatar for the grant table's foreign key, and this service doesn't own
+ * the avatar domain.
+ */
+export async function createAvatarRow(
+  db: Kysely<DB>,
+  data: Readonly<Partial<Insertable<Avatars>>> = {},
+): Promise<Selectable<Avatars>> {
+  let userId = data.userId;
+
+  if (userId === undefined) {
+    const created = await createTestUser(db);
+
+    userId = created.user.id;
+  }
+
+  return db
+    .insertInto('avatars')
+    .values({
+      id: createId(),
+      name: faker.string.alpha({ casing: 'lower', length: { max: 12, min: 6 } }),
+      ...data,
+      userId,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
+}

--- a/services/replay/src/test-utils/create-chain-row.ts
+++ b/services/replay/src/test-utils/create-chain-row.ts
@@ -1,0 +1,27 @@
+import type { ActivityChains, DB } from '@vers/db';
+import type { Insertable, Kysely, Selectable } from 'kysely';
+import { createAvatarRow } from './create-avatar-row';
+import { createMockChainRow } from './factories/create-mock-chain-row';
+
+/**
+ * Persists a chain row sourced from the factory's defaults, creating an owning avatar when
+ * `avatarId` is omitted — the chain table's foreign key needs a real one.
+ */
+export async function createChainRow(
+  db: Kysely<DB>,
+  overrides: Readonly<Partial<Insertable<ActivityChains>>> = {},
+): Promise<Selectable<ActivityChains>> {
+  let avatarId = overrides.avatarId;
+
+  if (avatarId === undefined) {
+    const avatar = await createAvatarRow(db);
+
+    avatarId = avatar.id;
+  }
+
+  return db
+    .insertInto('activityChains')
+    .values(createMockChainRow({ ...overrides, avatarId }))
+    .returningAll()
+    .executeTakeFirstOrThrow();
+}

--- a/services/replay/src/test-utils/factories/create-mock-activity-row.test.ts
+++ b/services/replay/src/test-utils/factories/create-mock-activity-row.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from 'bun:test';
+import { createMockActivityRow } from './create-mock-activity-row';
+
+test('it builds a row with generated identity and matching hash defaults', () => {
+  const row = createMockActivityRow();
+
+  expect(row.id).toStartWith('act_');
+  expect(row.lastHash).toBe(row.startHash);
+  expect(row.seed).toHaveLength(32);
+});
+
+test('it keeps explicit overrides', () => {
+  const row = createMockActivityRow({ avatarId: 'avatar-1', scopeId: 'node_9' });
+
+  expect(row).toMatchObject({ avatarId: 'avatar-1', scopeId: 'node_9' });
+});

--- a/services/replay/src/test-utils/factories/create-mock-activity-row.ts
+++ b/services/replay/src/test-utils/factories/create-mock-activity-row.ts
@@ -1,0 +1,30 @@
+import { faker } from '@faker-js/faker';
+import { createId } from '@paralleldrive/cuid2';
+import type { Activities } from '@vers/db';
+import type { Insertable } from 'kysely';
+
+/**
+ * A plain, unpersisted activity head row with faker-generated defaults. Never requires a parent —
+ * `avatarId` defaults to a random id, not a real avatar's. Hash fields default to opaque strings:
+ * the replay primitives read cursors and status, never the hash chain.
+ */
+export function createMockActivityRow(
+  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- Activities' jsonb `buildSnapshot` field types as the generated `Json` union, which nests a mutable `JsonValue[]` branch with no readonly form
+  overrides: Partial<Insertable<Activities>> = {},
+): Insertable<Activities> {
+  const startHash = faker.string.hexadecimal({ casing: 'lower', length: 64, prefix: '' });
+
+  return {
+    avatarId: createId(),
+    buildSnapshot: { level: 1, xp: 0 },
+    contentVersion: '0.0.0-dev',
+    id: `act_${createId()}`,
+    lastHash: startHash,
+    scopeId: faker.string.alphanumeric({ casing: 'lower', length: 8 }),
+    scopeType: 'world_map_node',
+    seed: faker.string.hexadecimal({ casing: 'lower', length: 32, prefix: '' }),
+    simVersion: '0.0.0-dev',
+    startHash,
+    ...overrides,
+  };
+}

--- a/services/replay/src/test-utils/factories/create-mock-activity-row.ts
+++ b/services/replay/src/test-utils/factories/create-mock-activity-row.ts
@@ -9,8 +9,7 @@ import type { Insertable } from 'kysely';
  * the replay primitives read cursors and status, never the hash chain.
  */
 export function createMockActivityRow(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- Activities' jsonb `buildSnapshot` field types as the generated `Json` union, which nests a mutable `JsonValue[]` branch with no readonly form
-  overrides: Partial<Insertable<Activities>> = {},
+  overrides: Readonly<Partial<Insertable<Activities>>> = {},
 ): Insertable<Activities> {
   const startHash = faker.string.hexadecimal({ casing: 'lower', length: 64, prefix: '' });
 

--- a/services/replay/src/test-utils/factories/create-mock-chain-row.test.ts
+++ b/services/replay/src/test-utils/factories/create-mock-chain-row.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'bun:test';
+import { createMockChainRow } from './create-mock-chain-row';
+
+test('it builds a chain whose anchors both start at the genesis seed', () => {
+  const row = createMockChainRow();
+
+  expect(row.appendedNextSeed).toBe(row.genesisSeed);
+  expect(row.verifiedNextSeed).toBe(row.genesisSeed);
+});
+
+test('it keeps explicit overrides', () => {
+  const row = createMockChainRow({ appendedNextSeed: 'ff00', avatarId: 'avatar-1' });
+
+  expect(row).toMatchObject({ appendedNextSeed: 'ff00', avatarId: 'avatar-1' });
+});

--- a/services/replay/src/test-utils/factories/create-mock-chain-row.ts
+++ b/services/replay/src/test-utils/factories/create-mock-chain-row.ts
@@ -1,0 +1,25 @@
+import { faker } from '@faker-js/faker';
+import { createId } from '@paralleldrive/cuid2';
+import type { ActivityChains } from '@vers/db';
+import type { Insertable } from 'kysely';
+
+/**
+ * A plain, unpersisted chain row with faker-generated defaults. Never requires a parent —
+ * `avatarId` defaults to a random id, not a real avatar's. Both anchors default to the genesis
+ * seed at index zero, a chain no activity has drawn from yet.
+ */
+export function createMockChainRow(
+  overrides: Readonly<Partial<Insertable<ActivityChains>>> = {},
+): Insertable<ActivityChains> {
+  const genesisSeed = faker.string.hexadecimal({ casing: 'lower', length: 32, prefix: '' });
+
+  return {
+    appendedNextSeed: genesisSeed,
+    avatarId: createId(),
+    genesisSeed,
+    scopeId: faker.string.alphanumeric({ casing: 'lower', length: 8 }),
+    scopeType: 'world_map_node',
+    verifiedNextSeed: genesisSeed,
+    ...overrides,
+  };
+}

--- a/services/replay/src/types.ts
+++ b/services/replay/src/types.ts
@@ -1,0 +1,41 @@
+import type { ActivityStatus } from '@vers/db';
+
+/**
+ * The identity of one `(avatar, chain scope)` seed chain — the unit the replay queue claims and
+ * serializes on.
+ */
+export interface ChainKey {
+  readonly avatarID: string;
+  readonly scopeID: string;
+  readonly scopeType: string;
+}
+
+/**
+ * A chain claimed for replay: its key plus the queue priority it was picked at. The claim is a row
+ * lock — it lasts until the claiming transaction commits or rolls back.
+ */
+export interface ClaimedChain extends ChainKey {
+  readonly priority: number;
+}
+
+/**
+ * A chain's replay frontier: the oldest activity with appends not yet replayed, and the segment
+ * bounds (`verifiedHead + 1 … appendedHead`) the next replay covers.
+ */
+export interface ReplayFrontier {
+  readonly activityID: string;
+  readonly appendedHead: number;
+  readonly replayAttempts: number;
+  readonly startChainIndex: number;
+  readonly status: ActivityStatus;
+  readonly verifiedHead: number;
+}
+
+/**
+ * One one-shot grant coordinate: `kind` namespaces the rule (first-clear, achievement,
+ * meta-unlock), `key` names the target within it.
+ */
+export interface GrantOnce {
+  readonly key: string;
+  readonly kind: string;
+}

--- a/services/replay/test-setup.ts
+++ b/services/replay/test-setup.ts
@@ -1,0 +1,7 @@
+import '@zgeoff/bun-test-extended';
+import { setupBunTestDB } from '@vers/service-test-utils/bun';
+import { registerBunTestCleanup } from '@vers/test-utils/bun';
+
+await setupBunTestDB();
+
+registerBunTestCleanup();

--- a/services/replay/tsconfig.json
+++ b/services/replay/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "types": ["node", "bun", "@zgeoff/bun-test-extended"] },
+  "files": [],
+  "include": ["test-setup.ts", "src/**/*.ts"],
+  "exclude": []
+}

--- a/services/replay/turbo.json
+++ b/services/replay/turbo.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["//"],
+  "tags": ["service"]
+}


### PR DESCRIPTION
## Description

Closes #181. Lands the replay pipeline's primitives and append guards: the cursor-poll queue and exactly-once apply as internal modules of a stub `services/replay`, and the single-writer rule on the append path.

- queue is the schema: `appended_head > verified_head` is pending work; `claimNextChain` takes a chain with `FOR UPDATE SKIP LOCKED`, priority-ordered, quarantined frontier unclaimable
- `applyVerifiedSegment`: cursor-guarded transaction — verified-head advance, xp delta add, forward-only chain-anchor advance, grant-once inserts (`avatar_grants`, unique `(avatar_id, kind, key)`)
- the single-writer rule needs a session identity server-side, so the s2s token gains a `sid` claim minted from the validated cookie session
- `SESSION_EVICTED` 403 / `ACTIVITY_TERMINAL` 409 / `CHAIN_QUARANTINED` 409, registry rows included; `resumeActivity` is the writer takeover
- no process scaffolding — #130's worker adds serve/Dockerfile/deploy
- docs: single-writer wording replaces the session-epoch fence; "outcome event" reads as the #179 ledger entry; `CAS` and `fence` banned

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality

## Context

Append guards and apply are driven end-to-end in the real-postgres suites through the real service app (RPC client → elysia → postgres), including concurrent `SKIP LOCKED` claims and duplicate-apply idempotence. The `updateReplayAttempts` name (issue says "record-replay-failure") follows the closed verb list — `record` isn't in it.