### PR TITLE
fix: disable sentry client reports on server sdks

### DIFF
--- a/apps/web/src/server/init-sentry-node.ts
+++ b/apps/web/src/server/init-sentry-node.ts
@@ -19,5 +19,9 @@ export function initSentryNode(): void {
 
     // tracing lives on the OpenTelemetry path; the error backend drops transaction envelopes
     tracesSampleRate: 0,
+
+    // the error backend discards client reports, and their 60s flush keeps otherwise idle
+    // infrastructure awake
+    sendClientReports: false,
   });
 }

--- a/libs/service/service-runtime/src/create-service.ts
+++ b/libs/service/service-runtime/src/create-service.ts
@@ -165,8 +165,15 @@ async function createLogShipper(serviceName: string): Promise<OTLPLogStream> {
 async function createErrorReporter(dsn: string): Promise<(error: unknown) => void> {
   const sentry = await import('@sentry/bun');
 
-  // tracing lives on the OpenTelemetry path; the error backend drops transaction envelopes
-  sentry.init({ dsn, dataCollection: { userInfo: true }, tracesSampleRate: 0 });
+  // tracing lives on the OpenTelemetry path; the error backend drops transaction envelopes.
+  // Client reports are off: the error backend discards them, and their 60s flush keeps
+  // otherwise idle infrastructure awake.
+  sentry.init({
+    dsn,
+    dataCollection: { userInfo: true },
+    tracesSampleRate: 0,
+    sendClientReports: false,
+  });
 
   return (error) => {
     sentry.withScope((scope) => {


### PR DESCRIPTION
## Description

Disables `sendClientReports` in the two server-side Sentry inits (app-web node SDK, service-runtime bun SDK). Their 60-second client-report flush was hitting Bugsink around the clock, and each POST's DSN lookup kept the Neon compute from ever reaching its 5-minute suspend window — compute has been pinned active since 2026-07-12.

- Client reports carry only drop-count telemetry, which Bugsink discards as unsupported — no error-reporting behaviour changes.
- Browser SDK left as-is: a tab only sends while open, so it can't keep infrastructure awake.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality (config-only change)