### PR TITLE
feat(#178): add the pure replay entrypoint and canonical engine hash

### DIFF
--- a/libs/game/idle-core/package.json
+++ b/libs/game/idle-core/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./replay": "./src/replay.ts"
   },
   "scripts": {
     "test": "bun test",

--- a/libs/game/idle-core/src/replay.ts
+++ b/libs/game/idle-core/src/replay.ts
@@ -1,0 +1,10 @@
+/**
+ * The pure replay entrypoint: its transitive closure is the versioned
+ * simulation behaviour. The deploy pipeline hashes a bundle built from this
+ * entrypoint, so the hash changes whenever a module it reaches changes and
+ * stays stable otherwise. Excludes `src/test-utils`, which pulls in
+ * `@faker-js/faker`, a devDependency with no place in a shipped bundle.
+ */
+export { createSimulation } from './core/create-simulation';
+export { runSimulation } from './core/run-simulation';
+export type * from './types';

--- a/scripts/src/bin/deploy.ts
+++ b/scripts/src/bin/deploy.ts
@@ -5,6 +5,7 @@ import { applyScheduledMachineActions } from '../deploy/apply-scheduled-machine-
 import { checkTarget } from '../deploy/check-target';
 import { findStaleReason } from '../deploy/find-stale-reason';
 import { loadDeployManifest } from '../deploy/load-deploy-manifest';
+import { loadEngineHash } from '../deploy/load-engine-hash';
 import { planScheduledMachineActions } from '../deploy/plan-scheduled-machine-actions';
 import { readAppState } from '../deploy/read-app-state';
 import { readChangesSince } from '../deploy/read-changes-since';
@@ -42,6 +43,15 @@ program
     const manifest = await loadDeployManifest();
 
     console.log(JSON.stringify(manifest.apps.map((target) => target.app)));
+  });
+
+program
+  .command('engine-hash')
+  .description('print the canonical sim engine bundle hash')
+  .action(async () => {
+    const hash = await loadEngineHash();
+
+    console.log(hash);
   });
 
 await program.parseAsync();

--- a/scripts/src/deploy/load-engine-hash.test.ts
+++ b/scripts/src/deploy/load-engine-hash.test.ts
@@ -45,7 +45,7 @@ test('it excludes test utilities and faker from the bundle', async () => {
  * already-resolved node_modules, so a build from the copy resolves the same
  * package specifiers as the real entrypoint without a workspace install.
  */
-async function copyEngineSourceToTempDir(): Promise<string> {
+async function createEngineSourceTempDir(): Promise<string> {
   const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'idle-core-hash-'));
 
   onTestFinished(async () => {
@@ -64,7 +64,7 @@ async function copyEngineSourceToTempDir(): Promise<string> {
 }
 
 test('it changes the hash when the engine source changes', async () => {
-  const copiedEntrypoint = await copyEngineSourceToTempDir();
+  const copiedEntrypoint = await createEngineSourceTempDir();
   const before = await loadEngineHash(copiedEntrypoint);
 
   const constantsPath = path.join(path.dirname(copiedEntrypoint), 'progression/constants.ts');

--- a/scripts/src/deploy/load-engine-hash.test.ts
+++ b/scripts/src/deploy/load-engine-hash.test.ts
@@ -1,0 +1,82 @@
+import { expect, onTestFinished, test } from 'bun:test';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { PINNED_BUN_VERSION, loadEngineHash } from './load-engine-hash';
+
+const REPLAY_ENTRYPOINT = path.resolve(
+  import.meta.dirname,
+  '../../../libs/game/idle-core/src/replay.ts',
+);
+
+const IDLE_CORE_DIR = path.resolve(import.meta.dirname, '../../../libs/game/idle-core');
+
+test('it is pinned to the bun version this process is running', () => {
+  expect(PINNED_BUN_VERSION).toBe(Bun.version);
+});
+
+test('it produces the same hash across two consecutive builds', async () => {
+  const first = await loadEngineHash();
+  const second = await loadEngineHash();
+
+  expect(first).toBe(second);
+});
+
+test('it excludes test utilities and faker from the bundle', async () => {
+  const result = await Bun.build({
+    entrypoints: [REPLAY_ENTRYPOINT],
+    minify: false,
+    sourcemap: 'none',
+    target: 'bun',
+  });
+
+  expect(result.success).toBe(true);
+
+  const texts = await Promise.all(result.outputs.map((output) => output.text()));
+
+  const bundle = texts.join('\n');
+
+  expect(bundle).not.toInclude('test-utils/');
+  expect(bundle).not.toInclude('@faker-js/faker');
+});
+
+/**
+ * Copies the real engine source tree into an mkdtemp dir and symlinks in its
+ * already-resolved node_modules, so a build from the copy resolves the same
+ * package specifiers as the real entrypoint without a workspace install.
+ */
+async function copyEngineSourceToTempDir(): Promise<string> {
+  const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'idle-core-hash-'));
+
+  onTestFinished(async () => {
+    await fs.rm(tmpRoot, { force: true, recursive: true });
+  });
+
+  await fs.cp(path.join(IDLE_CORE_DIR, 'src'), path.join(tmpRoot, 'src'), { recursive: true });
+
+  await fs.symlink(
+    path.join(IDLE_CORE_DIR, 'node_modules'),
+    path.join(tmpRoot, 'node_modules'),
+    'dir',
+  );
+
+  return path.join(tmpRoot, 'src', 'replay.ts');
+}
+
+test('it changes the hash when the engine source changes', async () => {
+  const copiedEntrypoint = await copyEngineSourceToTempDir();
+  const before = await loadEngineHash(copiedEntrypoint);
+
+  const constantsPath = path.join(path.dirname(copiedEntrypoint), 'progression/constants.ts');
+
+  const constantsSource = await fs.readFile(constantsPath, 'utf8');
+
+  await fs.writeFile(
+    constantsPath,
+    constantsSource.replace('COMPLETION_BASE_XP = 25', 'COMPLETION_BASE_XP = 26'),
+  );
+
+  const after = await loadEngineHash(copiedEntrypoint);
+
+  expect(before).not.toBe(after);
+});

--- a/scripts/src/deploy/load-engine-hash.ts
+++ b/scripts/src/deploy/load-engine-hash.ts
@@ -1,0 +1,63 @@
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+
+/**
+ * Matches `ARG BUN_VERSION` in every service Dockerfile — the runtime the
+ * hashed bundle is deployed to. A hash built under a different Bun version
+ * isn't comparable across environments, so `loadEngineHash` refuses to run
+ * under any other version.
+ */
+export const PINNED_BUN_VERSION = '1.3.10';
+
+const DEFAULT_ENTRYPOINT = path.resolve(
+  import.meta.dirname,
+  '../../../libs/game/idle-core/src/replay.ts',
+);
+
+/**
+ * The sim version identity: a sha256 hex digest over the pure replay
+ * entrypoint's bundled output plus the pinned Bun version, so any change to
+ * the engine's transitive closure or its build runtime changes the hash. The
+ * bundle build is deterministic (`target: 'bun'`, unminified, no sourcemap)
+ * so two builds of the same closure agree.
+ */
+export async function loadEngineHash(entrypoint: string = DEFAULT_ENTRYPOINT): Promise<string> {
+  requirePinnedBunVersion();
+
+  const result = await Bun.build({
+    entrypoints: [entrypoint],
+    minify: false,
+    sourcemap: 'none',
+    target: 'bun',
+  });
+
+  if (!result.success) {
+    const messages = result.logs.map((log) => log.message).join('\n');
+
+    throw new Error(`failed to build the engine bundle for hashing:\n${messages}`);
+  }
+
+  const outputs = await Promise.all(
+    result.outputs.map(async (output) => ({ path: output.path, text: await output.text() })),
+  );
+
+  outputs.sort((a, b) => a.path.localeCompare(b.path));
+
+  const hash = createHash('sha256');
+
+  for (const output of outputs) {
+    hash.update(output.text);
+  }
+
+  hash.update(`\nbun:${PINNED_BUN_VERSION}`);
+
+  return hash.digest('hex');
+}
+
+function requirePinnedBunVersion(): void {
+  if (Bun.version !== PINNED_BUN_VERSION) {
+    throw new Error(
+      `the engine hash requires bun ${PINNED_BUN_VERSION} to be comparable across environments, but this process is running bun ${Bun.version}`,
+    );
+  }
+}


### PR DESCRIPTION
## Description

Part of #178 (Stage 1).

Adds a deterministic engine-hash pipeline so deploys can detect when the sim engine's behaviour actually changed. A pure `replay.ts` entrypoint re-exports the versioned simulation closure, and `loadEngineHash` builds it with `Bun.build` and sha256-hashes the sorted output plus the pinned Bun version.

- `libs/game/idle-core` gains a `./replay` export excluding `test-utils` (and its `@faker-js/faker` dependency) from the hashed closure
- `loadEngineHash` throws if the running Bun version doesn't match `PINNED_BUN_VERSION`, since a hash built under a different runtime isn't comparable
- `deploy engine-hash` subcommand prints the hash as plain hex
- tests cover hash stability, exclusion of test utilities, sensitivity to a source edit, and the version pin

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality

