### PR TITLE
feat(#170): single-attempt runner and submitter cap handling

### DIFF
--- a/libs/game/idle-client/src/submission/create-checkpoint-submitter.test.ts
+++ b/libs/game/idle-client/src/submission/create-checkpoint-submitter.test.ts
@@ -18,10 +18,12 @@ function setupTest(
   const link = new RPCLink({ url: `${ACTIVITY_SERVICE_URL}/rpc` });
 
   const client: ActivityServiceClient = createORPCClient(link);
+  const onAcked = mock<(activityID: string, appendedHead: number) => void>();
+  const onCapped = mock<(activityID: string, appendedHead: number) => void>();
   const onInvalid = mock<(activityID: string, reason: string) => void>();
-  const submitter = createCheckpointSubmitter({ client, onInvalid, ...config });
+  const submitter = createCheckpointSubmitter({ client, onAcked, onCapped, onInvalid, ...config });
 
-  return { onInvalid, submitter };
+  return { onAcked, onCapped, onInvalid, submitter };
 }
 
 test('it flushes immediately on a terminal checkpoint and confirms the queue on success', async () => {
@@ -273,4 +275,143 @@ test('it defers a non-terminal checkpoint to the shared progress window', async 
   await capturedFlush?.();
 
   expect(track).toHaveBeenCalledOnce();
+});
+
+test('it reports each acknowledged head after a successful flush', async () => {
+  const ctx = setupTest();
+
+  server.use(mockActivityService.trackActivityProgress.handler(() => ({ appendedHead: 2 })));
+
+  await ctx.submitter.attach({
+    activityID: 'acked-activity',
+    appendedHead: 0,
+    lastHash: 'start_hash',
+    startChainIndex: 0,
+  });
+
+  await ctx.submitter.submit('acked-activity', createMockStartedCheckpoint());
+  await ctx.submitter.submit('acked-activity', createMockCompletedCheckpoint());
+
+  expect(ctx.onAcked).toHaveBeenCalledExactlyOnceWith('acked-activity', 2);
+});
+
+test('it stops the stream, discards the queue, and reports the stop index when the server caps the batch', async () => {
+  const ctx = setupTest();
+  const track = mock<(input: unknown) => void>();
+
+  server.use(
+    mockActivityService.trackActivityProgress.handler((opts) => {
+      track(opts.input);
+      throw opts.errors.ACTIVITY_CAPPED({ data: { appendedHead: 0 } });
+    }),
+  );
+
+  await ctx.submitter.attach({
+    activityID: 'capped-activity',
+    appendedHead: 0,
+    lastHash: 'start_hash',
+    startChainIndex: 0,
+  });
+
+  await ctx.submitter.submit('capped-activity', createMockStartedCheckpoint());
+  await ctx.submitter.submit('capped-activity', createMockCompletedCheckpoint());
+
+  expect(ctx.onCapped).toHaveBeenCalledExactlyOnceWith('capped-activity', 0);
+  expect(track).toHaveBeenCalledOnce();
+
+  const remaining = await readQueuedCheckpoints('capped-activity');
+
+  expect(remaining).toStrictEqual([]);
+
+  // a checkpoint produced after the stream stopped is silently dropped, not queued
+  await ctx.submitter.submit('capped-activity', createMockProgressCheckpoint());
+
+  const stillEmpty = await readQueuedCheckpoints('capped-activity');
+
+  expect(stillEmpty).toStrictEqual([]);
+});
+
+test('it discards the queue and stops the stream on a stopped terminal status', async () => {
+  const ctx = setupTest();
+  const track = mock<(input: unknown) => void>();
+
+  server.use(
+    mockActivityService.trackActivityProgress.handler((opts) => {
+      track(opts.input);
+      throw opts.errors.ACTIVITY_TERMINAL({ data: { appendedHead: 3, status: 'stopped' } });
+    }),
+  );
+
+  await ctx.submitter.attach({
+    activityID: 'terminal-activity',
+    appendedHead: 0,
+    lastHash: 'start_hash',
+    startChainIndex: 0,
+  });
+
+  await ctx.submitter.submit('terminal-activity', createMockStartedCheckpoint());
+  await ctx.submitter.submit('terminal-activity', createMockCompletedCheckpoint());
+
+  expect(ctx.onCapped).not.toHaveBeenCalled();
+  expect(track).toHaveBeenCalledOnce();
+
+  const remaining = await readQueuedCheckpoints('terminal-activity');
+
+  expect(remaining).toStrictEqual([]);
+});
+
+test('it reports the stop index when a resend answers with the already-capped status', async () => {
+  const ctx = setupTest();
+
+  server.use(
+    mockActivityService.trackActivityProgress.handler((opts) => {
+      throw opts.errors.ACTIVITY_TERMINAL({ data: { appendedHead: 4, status: 'capped' } });
+    }),
+  );
+
+  await ctx.submitter.attach({
+    activityID: 'already-capped-activity',
+    appendedHead: 4,
+    lastHash: 'head_hash',
+    startChainIndex: 0,
+  });
+
+  await ctx.submitter.submit('already-capped-activity', createMockCompletedCheckpoint());
+
+  expect(ctx.onCapped).toHaveBeenCalledExactlyOnceWith('already-capped-activity', 4);
+});
+
+test('it discards the queue and stops the stream on SESSION_EVICTED', async () => {
+  const ctx = setupTest();
+  const track = mock<(input: unknown) => void>();
+
+  server.use(
+    mockActivityService.trackActivityProgress.handler((opts) => {
+      track(opts.input);
+      throw opts.errors.SESSION_EVICTED({ data: {} });
+    }),
+  );
+
+  await ctx.submitter.attach({
+    activityID: 'evicted-activity',
+    appendedHead: 0,
+    lastHash: 'start_hash',
+    startChainIndex: 0,
+  });
+
+  await ctx.submitter.submit('evicted-activity', createMockStartedCheckpoint());
+  await ctx.submitter.submit('evicted-activity', createMockCompletedCheckpoint());
+
+  expect(track).toHaveBeenCalledOnce();
+
+  const remaining = await readQueuedCheckpoints('evicted-activity');
+
+  expect(remaining).toStrictEqual([]);
+
+  // a checkpoint produced after the stream stopped is silently dropped, not queued
+  await ctx.submitter.submit('evicted-activity', createMockProgressCheckpoint());
+
+  const stillEmpty = await readQueuedCheckpoints('evicted-activity');
+
+  expect(stillEmpty).toStrictEqual([]);
 });

--- a/libs/game/idle-client/src/submission/create-checkpoint-submitter.ts
+++ b/libs/game/idle-client/src/submission/create-checkpoint-submitter.ts
@@ -45,6 +45,19 @@ interface CreateCheckpointSubmitterOptions {
   readonly client: Pick<ActivityServiceClient, 'trackActivityProgress'>;
 
   /**
+   * Called after every successful flush with the server's fresh appended head — the caller's
+   * authoritative last-contact signal, anchoring its view of the offline-progress budget.
+   */
+  readonly onAcked?: (activityID: string, appendedHead: number) => void;
+
+  /**
+   * Called once the server caps an activity, with the exact head the stream stopped at — the
+   * index the caller rebases from after a resync. Fires whether this submitter's own batch
+   * tripped the cap or a resend answered with the already-capped status.
+   */
+  readonly onCapped?: (activityID: string, appendedHead: number) => void;
+
+  /**
    * Called once a `CHECKPOINT_INVALID` response stops an activity's stream, so the caller can
    * notify connected tabs and report the rejection.
    */
@@ -63,8 +76,9 @@ interface CreateCheckpointSubmitterOptions {
  * in-flight batch per activity. Response handling follows the activity service's response
  * contract: a fresh head on success or `CONFLICT` advances the cursor and confirms the queue up to
  * it; `CHECKPOINT_INVALID` and `NOT_FOUND` stop the stream (keeping and discarding its queue rows,
- * respectively); anything else — `UNAUTHORIZED` or a transport failure — holds the queue untouched
- * for the next flush tick.
+ * respectively); `ACTIVITY_CAPPED`, `ACTIVITY_TERMINAL`, and `SESSION_EVICTED` stop the stream and
+ * discard its rows — the server accepts nothing further for it; anything else — `UNAUTHORIZED` or
+ * a transport failure — holds the queue untouched for the next flush tick.
  */
 export function createCheckpointSubmitter(
   options: Readonly<CreateCheckpointSubmitterOptions>,
@@ -113,11 +127,42 @@ export function createCheckpointSubmitter(
         await removeConfirmedCheckpoints(activityID, result.appendedHead);
 
         state.expectedHead = result.appendedHead;
+        options.onAcked?.(activityID, result.appendedHead);
 
         return;
       }
 
       if (!isDefinedError(error)) {
+        return;
+      }
+
+      if (error.code === 'ACTIVITY_CAPPED') {
+        state.invalid = true;
+
+        await removeQueuedCheckpoints(activityID);
+
+        options.onCapped?.(activityID, error.data.appendedHead);
+
+        return;
+      }
+
+      if (error.code === 'ACTIVITY_TERMINAL') {
+        state.invalid = true;
+
+        await removeQueuedCheckpoints(activityID);
+
+        if (error.data.status === 'capped') {
+          options.onCapped?.(activityID, error.data.appendedHead);
+        }
+
+        return;
+      }
+
+      if (error.code === 'SESSION_EVICTED') {
+        state.invalid = true;
+
+        await removeQueuedCheckpoints(activityID);
+
         return;
       }
 

--- a/libs/game/idle-client/src/worker/create-worker-runtime.ts
+++ b/libs/game/idle-client/src/worker/create-worker-runtime.ts
@@ -1,4 +1,5 @@
 import type { Simulation } from '@vers/idle-core';
+import { SIMULATION_TIMESTEP_MS } from '@vers/idle-core';
 import invariant from 'tiny-invariant';
 import { createActivityServiceClient } from '../submission/create-activity-service-client';
 import { createCheckpointSubmitter } from '../submission/create-checkpoint-submitter';
@@ -7,10 +8,6 @@ import { createCheckpointStreamInvalidMessage } from './create-checkpoint-stream
 import { handleClientMessage } from './handle-client-message';
 import { runSimulation } from './run-simulation';
 import type { WorkerContext } from './types';
-
-// 20 updates per second = 50ms batches
-const targetUpdatesPerSecond = 20;
-const defaultTimestep = 1000 / targetUpdatesPerSecond;
 
 export interface WorkerRuntime {
   readonly connections: ReadonlySet<MessagePort>;
@@ -28,7 +25,7 @@ interface CreateWorkerRuntimeOptions {
  * one-simulation-per-worker invariant.
  */
 export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): WorkerRuntime {
-  const timestep = options.timestep ?? defaultTimestep;
+  const timestep = options.timestep ?? SIMULATION_TIMESTEP_MS;
 
   const connections = new Set<MessagePort>();
 

--- a/libs/game/idle-core/src/core/run-attempt.test.ts
+++ b/libs/game/idle-core/src/core/run-attempt.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from 'bun:test';
+import { buildStateFromSeed } from '@vers/game-utils';
+import { createMockActivityInput } from '../test-utils/create-mock-activity-input';
+import { createMockAvatarData } from '../test-utils/create-mock-avatar-data';
+import { createMockEnemyData } from '../test-utils/create-mock-enemy-data';
+import { ActivityCheckpointType, ActivityFailureAction, ActivityType } from '../types';
+import { runAttempt } from './run-attempt';
+
+test('it commits a stream that starts and ends on a terminal checkpoint', async () => {
+  const avatar = createMockAvatarData();
+
+  const activity = createMockActivityInput({
+    enemies: [createMockEnemyData()],
+    id: 'world_map_encounter_1',
+    seed: buildStateFromSeed(3_047_525_658),
+    type: ActivityType.WorldMapEncounter,
+  });
+
+  const result = await runAttempt(activity, avatar, { maxDurationMs: 120_000 });
+
+  expect(result.outcome).toBe('completed');
+  expect(result.checkpoints[0]?.type).toBe(ActivityCheckpointType.Started);
+  expect(result.checkpoints.at(-1)?.type).toBe(ActivityCheckpointType.Completed);
+  expect(result.elapsed).toBeWithin(1, 120_001);
+});
+
+test('it is deterministic for a fixed seed', async () => {
+  const activity = createMockActivityInput({
+    enemies: [createMockEnemyData()],
+    id: 'world_map_encounter_1',
+    seed: buildStateFromSeed(3_047_525_658),
+    type: ActivityType.WorldMapEncounter,
+  });
+
+  const first = await runAttempt(activity, createMockAvatarData(), { maxDurationMs: 120_000 });
+  const second = await runAttempt(activity, createMockAvatarData(), { maxDurationMs: 120_000 });
+
+  expect(second).toStrictEqual(first);
+});
+
+test('it stops at the first failure and never restarts within the attempt', async () => {
+  // life 1 dies immediately, and Retry must not matter: retrying is the caller's loop
+  const avatar = createMockAvatarData({ life: 1 });
+
+  const activity = createMockActivityInput({
+    enemies: [createMockEnemyData()],
+    failureAction: ActivityFailureAction.Retry,
+    id: 'world_map_encounter_1',
+    seed: buildStateFromSeed(3_047_525_658),
+    type: ActivityType.WorldMapEncounter,
+  });
+
+  const result = await runAttempt(activity, avatar, { maxDurationMs: 120_000 });
+
+  const startedCheckpoints = result.checkpoints.filter(
+    (checkpoint) => checkpoint.type === ActivityCheckpointType.Started,
+  );
+
+  expect(result.outcome).toBe('failed');
+  expect(startedCheckpoints).toHaveLength(1);
+  expect(result.checkpoints.at(-1)?.type).toBe(ActivityCheckpointType.Failed);
+});
+
+test('it discards the whole attempt when no terminal lands inside the budget', async () => {
+  const avatar = createMockAvatarData();
+
+  const activity = createMockActivityInput({
+    enemies: [createMockEnemyData()],
+    id: 'world_map_encounter_1',
+    seed: buildStateFromSeed(3_047_525_658),
+    type: ActivityType.WorldMapEncounter,
+  });
+
+  const result = await runAttempt(activity, avatar, { maxDurationMs: 1000 });
+
+  expect(result.outcome).toBe('exceeded-budget');
+  expect(result.checkpoints).toBeEmpty();
+});

--- a/libs/game/idle-core/src/core/run-attempt.ts
+++ b/libs/game/idle-core/src/core/run-attempt.ts
@@ -1,0 +1,74 @@
+import type { ActivityCheckpoint, ActivityInput, AvatarData } from '../types';
+import { isCompletedCheckpoint } from '../utils/is-completed-checkpoint';
+import { isFailedCheckpoint } from '../utils/is-failed-checkpoint';
+import { createSimulation } from './create-simulation';
+import { SIMULATION_TIMESTEP_MS } from './simulation-timestep-ms';
+
+interface RunAttemptConfig {
+  /**
+   * Simulated-time ceiling for the attempt, in milliseconds. An attempt whose terminal checkpoint
+   * has not landed inside this budget is discarded whole.
+   */
+  readonly maxDurationMs: number;
+
+  /**
+   * Engine tick size in milliseconds. Every driver of the same stream must use the same value or
+   * replay diverges; override only to drive tests.
+   */
+  readonly timestepMs?: number;
+}
+
+interface RunAttemptResult {
+  /**
+   * The attempt's full stream, started through terminal, in order — or empty when the outcome is
+   * `exceeded-budget`, so a caller can never submit a stream that ends mid-encounter.
+   */
+  readonly checkpoints: Array<ActivityCheckpoint>;
+  readonly elapsed: number;
+  readonly outcome: 'completed' | 'exceeded-budget' | 'failed';
+}
+
+/**
+ * Runs exactly one attempt at an activity: a fresh simulation ticked until the first terminal
+ * checkpoint, never restarting through failure or completion — retry policy across attempts is
+ * the caller's. The result is committed only when its terminal landed at or under
+ * `maxDurationMs`; the tick that crosses the budget contributes nothing.
+ */
+export async function runAttempt(
+  activity: ActivityInput,
+  avatar: AvatarData,
+  config: RunAttemptConfig,
+): Promise<RunAttemptResult> {
+  const timestepMs = config.timestepMs ?? SIMULATION_TIMESTEP_MS;
+  const simulation = createSimulation();
+
+  simulation.startActivity(avatar, activity);
+
+  const checkpoints: Array<ActivityCheckpoint> = [];
+
+  while (simulation.elapsed < config.maxDurationMs) {
+    const checkpoint = await simulation.run(timestepMs);
+
+    if (simulation.elapsed > config.maxDurationMs) {
+      break;
+    }
+
+    if (!checkpoint) {
+      continue;
+    }
+
+    checkpoints.push(checkpoint);
+
+    if (isFailedCheckpoint(checkpoint)) {
+      return { checkpoints, elapsed: simulation.elapsed, outcome: 'failed' };
+    }
+
+    if (isCompletedCheckpoint(checkpoint)) {
+      return { checkpoints, elapsed: simulation.elapsed, outcome: 'completed' };
+    }
+  }
+
+  await simulation.stopActivity();
+
+  return { checkpoints: [], elapsed: simulation.elapsed, outcome: 'exceeded-budget' };
+}

--- a/libs/game/idle-core/src/core/run-simulation.test.ts
+++ b/libs/game/idle-core/src/core/run-simulation.test.ts
@@ -40,7 +40,7 @@ test('runs a simulation with default configuration', async () => {
           "rewards": {
             "xp": 60,
           },
-          "time": 16300,
+          "time": 16250,
           "type": "progress",
         },
         {
@@ -52,7 +52,7 @@ test('runs a simulation with default configuration', async () => {
           "rewards": {
             "xp": 60,
           },
-          "time": 33800,
+          "time": 33750,
           "type": "progress",
         },
         {
@@ -60,7 +60,7 @@ test('runs a simulation with default configuration', async () => {
           "rewards": {
             "xp": 30,
           },
-          "time": 43800,
+          "time": 43750,
           "type": "progress",
         },
         {
@@ -68,7 +68,7 @@ test('runs a simulation with default configuration', async () => {
           "rewards": {
             "xp": 40,
           },
-          "time": 56300,
+          "time": 56250,
           "type": "progress",
         },
         {
@@ -76,7 +76,7 @@ test('runs a simulation with default configuration', async () => {
           "rewards": {
             "xp": 215,
           },
-          "time": 56300,
+          "time": 56250,
           "type": "completed",
         },
         {
@@ -93,7 +93,7 @@ test('runs a simulation with default configuration', async () => {
           "rewards": {
             "xp": 40,
           },
-          "time": 13800,
+          "time": 13750,
           "type": "progress",
         },
       ],

--- a/libs/game/idle-core/src/core/run-simulation.ts
+++ b/libs/game/idle-core/src/core/run-simulation.ts
@@ -7,6 +7,7 @@ import { isProgressCheckpoint } from '../utils/is-progress-checkpoint';
 import { isStartedCheckpoint } from '../utils/is-started-checkpoint';
 import { logger } from '../utils/logger';
 import { createSimulation } from './create-simulation';
+import { SIMULATION_TIMESTEP_MS } from './simulation-timestep-ms';
 
 /**
  * @property duration - how long to run the simulation for. derive from the checkpoint data submitted by the
@@ -23,8 +24,6 @@ interface SimulationOutput {
   checkpoints: Array<ActivityCheckpoint>;
   elapsed: number;
 }
-
-const SERVER_SIMULATION_INTERVAL = 100;
 
 export async function runSimulation(
   activity: ActivityInput,
@@ -49,7 +48,7 @@ export async function runSimulation(
     }
 
     // run out simulation for our interval
-    const checkpoint = await simulation.run(SERVER_SIMULATION_INTERVAL);
+    const checkpoint = await simulation.run(SIMULATION_TIMESTEP_MS);
 
     if (!checkpoint) {
       continue;

--- a/libs/game/idle-core/src/core/simulation-timestep-ms.ts
+++ b/libs/game/idle-core/src/core/simulation-timestep-ms.ts
@@ -1,0 +1,7 @@
+/**
+ * Fixed timestep every simulation driver ticks with, in milliseconds. Checkpoint content is
+ * timestep-sensitive: the live worker loop, the offline fast-forward, and the verifier's replay
+ * must advance the engine in identical steps for replay to reproduce a submitted stream
+ * byte-for-byte.
+ */
+export const SIMULATION_TIMESTEP_MS = 50;

--- a/libs/game/idle-core/src/index.ts
+++ b/libs/game/idle-core/src/index.ts
@@ -1,5 +1,7 @@
 export { createSimulation } from './core/create-simulation';
+export { runAttempt } from './core/run-attempt';
 export { runSimulation } from './core/run-simulation';
+export { SIMULATION_TIMESTEP_MS } from './core/simulation-timestep-ms';
 export * from './progression';
 export { createMockActivityInput } from './test-utils/create-mock-activity-input';
 export { createMockAvatarData } from './test-utils/create-mock-avatar-data';


### PR DESCRIPTION
## Description

Part of #170, stacked on #534. Adds the pure single-attempt runner the offline fast-forward drives, and teaches the checkpoint submitter the cap-era response contract.

- `runAttempt` ticks a fresh simulation to its first terminal and never restarts; a budget miss returns empty checkpoints, so a submitted stream can never end mid-encounter.
- The engine tick is hoisted to a shared `SIMULATION_TIMESTEP_MS` consumed by the live worker loop too — checkpoint content is timestep-sensitive, so every driver must tick identically.
- Submitter branches: `ACTIVITY_CAPPED`/`SESSION_EVICTED` stop the stream and discard rows; `ACTIVITY_TERMINAL` does the same and relays a capped status; optional `onAcked`/`onCapped` callbacks anchor the worker's budget view and trigger resync.
- A `rebase()` cursor reset was considered and dropped: a capped activity is terminal, and the next attempt arrives with a fresh `attach` context.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
