### PR TITLE
docs(#170): name the four simulation-result processes distinctly

### DIFF
--- a/docs/architecture/game-simulation.md
+++ b/docs/architecture/game-simulation.md
@@ -121,6 +121,15 @@ directly, because they lag verification by design.
 
 ## Offline progress
 
+Four processes move simulation results around, each with one name. **Replay** is the verifier's
+asynchronous re-execution of submitted checkpoints — the trust decision, and nothing else. A
+**resync** is the client's confirmed-state fetch (verified anchor, appended head, server time) and
+the decision it drives. A **fast-forward** is the client's catch-up simulation of an offline gap,
+run on return. **Reconstruction** is the first step inside a fast-forward: re-running the
+interrupted activity from its seed to rebuild simulation state the client no longer holds —
+determinism makes the result identical to the lost original, and the already-accepted prefix costs
+nothing against the budget.
+
 Offline progress is bounded by a per-avatar simulated-time meter, enforced on the append path — the
 server never simulates. The avatar's budget refills at wall-clock rate since it was last banked,
 never past the cap (`OFFLINE_PROGRESS_CAP_MS`, 24h), and every accepted checkpoint batch debits its

--- a/libs/game/idle-client/src/resync/run-fast-forward.ts
+++ b/libs/game/idle-client/src/resync/run-fast-forward.ts
@@ -22,13 +22,13 @@ interface RunFastForwardOptions {
 }
 
 /**
- * Re-simulates an offline gap attempt by attempt: the snapshot's active activity first, then
- * fresh continuations started server-side, submitting each committed attempt's stream as it
- * lands. Budget accounting mirrors the server's meter — each attempt consumes its last
- * checkpoint's cumulative time beyond what the head row already accounted, so a re-simulated
- * prefix costs nothing — and an attempt whose unaccounted time overruns the remaining budget is
- * discarded, never submitted, keeping every submitted stream inside the cap and
- * boundary-terminated. Failure policy is the activity's own, identical to live play: a failed
+ * Simulates an offline gap attempt by attempt: reconstruction of the snapshot's active activity
+ * from its seed first, then fresh continuations started server-side, submitting each committed
+ * attempt's stream as it lands. Budget accounting mirrors the server's meter — each attempt
+ * consumes its last checkpoint's cumulative time beyond what the head row already accounted, so a
+ * reconstructed prefix costs nothing — and an attempt whose unaccounted time overruns the
+ * remaining budget is discarded, never submitted, keeping every submitted stream inside the cap
+ * and boundary-terminated. Failure policy is the activity's own, identical to live play: a failed
  * attempt under `Retry` continues to the next continuation, under `Abort` it ends the
  * fast-forward.
  */
@@ -45,7 +45,7 @@ export async function runFastForward(
   while (remainingMs > 0) {
     const input = options.buildActivityInput(activity);
 
-    // A resumed stream must reach its terminal to reconcile, whatever the budget — its prefix is
+    // A reconstruction must reach its terminal to reconcile, whatever the budget — its prefix is
     // already accounted server-side, so only the tail is priced against the budget below.
     const ceilingMs = appendedHead > 0 ? Number.MAX_SAFE_INTEGER : remainingMs;
 


### PR DESCRIPTION
## Description

Part of #170, stacked on #538. Terminology only — the words replay, resync, fast-forward, and reconstruction were converging on one meaning in discussion.

- The offline-progress doc defines each once: replay = verifier trust decision, resync = confirmed-state fetch + decision, fast-forward = client catch-up simulation, reconstruction = from-seed rebuild of the interrupted activity inside a fast-forward.
- The fast-forward runner's JSDoc and inline commentary adopt "reconstruction" for that first step.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality (n/a — prose only)
