### PR TITLE
fix(deploy): assert machine health and wake parked apps in verify

### DIFF
--- a/scripts/src/bin/deploy.ts
+++ b/scripts/src/bin/deploy.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { execa } from 'execa';
 import { applyDeploy } from '../deploy/apply-deploy';
 import { applyScheduledMachineActions } from '../deploy/apply-scheduled-machine-actions';
+import { checkParkedApp } from '../deploy/check-parked-app';
 import { checkTarget } from '../deploy/check-target';
 import { findStaleReason } from '../deploy/find-stale-reason';
 import { loadDeployManifest } from '../deploy/load-deploy-manifest';
@@ -138,6 +139,7 @@ async function runVerify(): Promise<void> {
     const findings = [
       ...checkTarget(target, state, changes),
       ...(await runProbes(target.probes ?? [])),
+      ...(await checkParkedApp(target.app, state)),
     ];
 
     if (findings.length === 0) {

--- a/scripts/src/deploy/check-parked-app.ts
+++ b/scripts/src/deploy/check-parked-app.ts
@@ -1,0 +1,62 @@
+import { runFlyctl } from '../utils/run-flyctl';
+import { withRetry } from '../utils/with-retry';
+import { readAppState } from './read-app-state';
+import type { AppState } from './types';
+
+const WAKE_ATTEMPTS = 20;
+const WAKE_DELAY_MS = 3000;
+
+/**
+ * Proves a fully parked app can still serve: starts one machine and waits
+ * for it to run with every health check passing, leaving re-parking to the
+ * app's auto-stop policy. A healthy parked fleet and a crash-parked one are
+ * indistinguishable in machine state and check output alone — only a
+ * successful wake separates them. Apps with a running machine are skipped;
+ * their health is asserted from fleet state directly.
+ */
+export async function checkParkedApp(app: string, state: AppState): Promise<ReadonlyArray<string>> {
+  if (state.machines.some((machine) => machine.state === 'started')) {
+    return [];
+  }
+
+  const [machine] = state.machines;
+
+  if (machine === undefined) {
+    return [];
+  }
+
+  try {
+    await runFlyctl(['machine', 'start', machine.id, '--app', app]);
+
+    await withRetry(
+      async () => {
+        const current = await readAppState(app);
+
+        const woken = current.machines.find((candidate) => candidate.id === machine.id);
+
+        if (woken === undefined) {
+          throw new Error(`machine ${machine.id} disappeared while waking`);
+        }
+
+        if (woken.state !== 'started') {
+          throw new Error(`machine ${machine.id} is ${woken.state}`);
+        }
+
+        const failing = (woken.checks ?? []).find((check) => check.status !== 'passing');
+
+        if (failing !== undefined) {
+          throw new Error(
+            `machine ${machine.id} health check ${failing.name} is ${failing.status}`,
+          );
+        }
+      },
+      { attempts: WAKE_ATTEMPTS, delayMS: WAKE_DELAY_MS },
+    );
+
+    return [];
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+
+    return [`wake failed: ${reason}`];
+  }
+}

--- a/scripts/src/deploy/check-target.test.ts
+++ b/scripts/src/deploy/check-target.test.ts
@@ -44,6 +44,68 @@ test('it flags an app below its warm-machine floor', () => {
   ]);
 });
 
+test('it flags a started machine with a non-passing health check', () => {
+  const state = {
+    deployedSHA: 'abc123',
+    machines: [
+      {
+        checks: [{ name: 'servicecheck-00-http-3000', status: 'critical' }],
+        gitSHA: 'abc123',
+        id: 'm1',
+        state: 'started',
+      },
+    ],
+    scheduledMachines: [],
+    serviceImage: 'registry.fly.io/x:tag1',
+  };
+
+  const changes = { affectedPkgs: [], changedPaths: [] };
+
+  expect(checkTarget(target, state, changes)).toStrictEqual([
+    'machine m1 health check servicecheck-00-http-3000 is critical',
+  ]);
+});
+
+test('it passes a started machine whose health checks pass', () => {
+  const state = {
+    deployedSHA: 'abc123',
+    machines: [
+      {
+        checks: [{ name: 'servicecheck-00-http-3000', status: 'passing' }],
+        gitSHA: 'abc123',
+        id: 'm1',
+        state: 'started',
+      },
+    ],
+    scheduledMachines: [],
+    serviceImage: 'registry.fly.io/x:tag1',
+  };
+
+  const changes = { affectedPkgs: [], changedPaths: [] };
+
+  expect(checkTarget(target, state, changes)).toBeEmpty();
+});
+
+test('it ignores the checks of a machine parked in its idle state', () => {
+  const state = {
+    deployedSHA: 'abc123',
+    machines: [
+      {
+        checks: [{ name: 'servicecheck-00-http-3000', status: 'warning' }],
+        gitSHA: 'abc123',
+        id: 'm1',
+        state: 'suspended',
+      },
+    ],
+    scheduledMachines: [],
+    serviceImage: 'registry.fly.io/x:tag1',
+  };
+
+  const changes = { affectedPkgs: [], changedPaths: [] };
+
+  expect(checkTarget(target, state, changes)).toBeEmpty();
+});
+
 test('it flags a stale app whose package changed since the deployed SHA', () => {
   const state = {
     deployedSHA: 'abc123',

--- a/scripts/src/deploy/check-target.ts
+++ b/scripts/src/deploy/check-target.ts
@@ -4,8 +4,11 @@ import type { AppState, ChangeSet, DeployTarget } from './types';
 /**
  * Evaluates a target's fleet state against HEAD and returns findings; an
  * empty array means the app is online and current. Machine-count rules
- * account for Fly auto-suspend: existence is always required, but a started
- * machine only where the manifest demands warm capacity.
+ * account for Fly auto-stop: existence is always required, but a started
+ * machine only where the manifest demands warm capacity. A running machine
+ * with a non-passing health check is a finding; a fully parked fleet is
+ * indistinguishable from a crash-parked one here and is asserted by the
+ * verify pass waking a machine instead.
  */
 export function checkTarget(
   target: DeployTarget,
@@ -25,6 +28,8 @@ export function checkTarget(
     findings.push(`${started} machines started, expected at least ${minStarted}`);
   }
 
+  findings.push(...checkMachineHealth(state));
+
   const staleReason = state.machines.length === 0 ? null : findStaleReason(target, changes);
 
   if (staleReason !== null) {
@@ -32,6 +37,24 @@ export function checkTarget(
   }
 
   findings.push(...checkScheduledMachines(target, state));
+
+  return findings;
+}
+
+function checkMachineHealth(state: AppState): ReadonlyArray<string> {
+  const findings: Array<string> = [];
+
+  for (const machine of state.machines) {
+    if (machine.state !== 'started') {
+      continue;
+    }
+
+    for (const check of machine.checks ?? []) {
+      if (check.status !== 'passing') {
+        findings.push(`machine ${machine.id} health check ${check.name} is ${check.status}`);
+      }
+    }
+  }
 
   return findings;
 }

--- a/scripts/src/deploy/parse-app-state.test.ts
+++ b/scripts/src/deploy/parse-app-state.test.ts
@@ -20,12 +20,39 @@ test('it reads the deployed SHA and image the whole fleet agrees on', () => {
   expect(parseAppState(json)).toStrictEqual({
     deployedSHA: 'abc123',
     machines: [
-      { gitSHA: 'abc123', id: 'm1', state: 'started' },
-      { gitSHA: 'abc123', id: 'm2', state: 'suspended' },
+      { checks: [], gitSHA: 'abc123', id: 'm1', state: 'started' },
+      { checks: [], gitSHA: 'abc123', id: 'm2', state: 'suspended' },
     ],
     scheduledMachines: [],
     serviceImage: 'registry.fly.io/x:tag1',
   });
+});
+
+test('it carries each machine health check through as name and status', () => {
+  const json = [
+    {
+      checks: [
+        { name: 'servicecheck-00-http-3000', output: 'ok', status: 'passing' },
+        { name: 'servicecheck-01-tcp-3000', output: '', status: 'warning' },
+      ],
+      config: { env: { GIT_SHA: 'abc123' } },
+      id: 'm1',
+      name: 'm1',
+      state: 'started',
+    },
+  ];
+
+  expect(parseAppState(json).machines).toStrictEqual([
+    {
+      checks: [
+        { name: 'servicecheck-00-http-3000', status: 'passing' },
+        { name: 'servicecheck-01-tcp-3000', status: 'warning' },
+      ],
+      gitSHA: 'abc123',
+      id: 'm1',
+      state: 'started',
+    },
+  ]);
 });
 
 test('it treats a fleet with mixed SHAs as having no deployed SHA', () => {
@@ -65,7 +92,7 @@ test('it ignores machines outside the app process group', () => {
 
   expect(parseAppState(json)).toStrictEqual({
     deployedSHA: 'abc123',
-    machines: [{ gitSHA: 'abc123', id: 'm1', state: 'started' }],
+    machines: [{ checks: [], gitSHA: 'abc123', id: 'm1', state: 'started' }],
     scheduledMachines: [],
     serviceImage: null,
   });
@@ -89,7 +116,7 @@ test('it separates a scheduled machine from the app process group by its schedul
 
   expect(parseAppState(json)).toStrictEqual({
     deployedSHA: 'abc123',
-    machines: [{ gitSHA: 'abc123', id: 'm1', state: 'started' }],
+    machines: [{ checks: [], gitSHA: 'abc123', id: 'm1', state: 'started' }],
     scheduledMachines: [{ id: 'm2', image: 'registry.fly.io/x:old', name: 'sweeper' }],
     serviceImage: 'registry.fly.io/x:tag1',
   });
@@ -116,7 +143,7 @@ test('it reads images with the resolved digest stripped', () => {
 
   expect(parseAppState(json)).toStrictEqual({
     deployedSHA: 'abc123',
-    machines: [{ gitSHA: 'abc123', id: 'm1', state: 'started' }],
+    machines: [{ checks: [], gitSHA: 'abc123', id: 'm1', state: 'started' }],
     scheduledMachines: [{ id: 'm2', image: 'registry.fly.io/x:tag1', name: 'sweeper' }],
     serviceImage: 'registry.fly.io/x:tag1',
   });

--- a/scripts/src/deploy/parse-app-state.ts
+++ b/scripts/src/deploy/parse-app-state.ts
@@ -12,11 +12,19 @@ const machineConfigSchema = z
   })
   .readonly();
 
+const machineCheckSchema = z
+  .object({
+    name: z.string(),
+    status: z.string(),
+  })
+  .readonly();
+
 const machineSchema = z
   .object({
     id: z.string(),
     name: z.string(),
     state: z.string(),
+    checks: z.array(machineCheckSchema).readonly().optional(),
     config: machineConfigSchema.optional(),
   })
   .readonly();
@@ -42,6 +50,7 @@ export function parseAppState(json: unknown): AppState {
     id: machine.id,
     state: machine.state,
     gitSHA: machine.config?.env?.['GIT_SHA'] ?? null,
+    checks: machine.checks ?? [],
   }));
 
   const scheduledMachines: ReadonlyArray<ScheduledMachineState> = records

--- a/scripts/src/deploy/types.ts
+++ b/scripts/src/deploy/types.ts
@@ -56,6 +56,12 @@ export interface AppMachine {
   readonly id: string;
   readonly state: string;
   readonly gitSHA: string | null;
+  readonly checks?: ReadonlyArray<MachineCheck>;
+}
+
+interface MachineCheck {
+  readonly name: string;
+  readonly status: string;
 }
 
 /**


### PR DESCRIPTION
## What

\`deploy verify\` reported the keys service "online and current" while its only machine was crash-parked at max restart count — image currency was the only thing checked. A crash-parked machine and a healthy idle one are indistinguishable in fleet state (both read \`stopped\` with a warning check), so passive inspection cannot close this gap.

- \`checkTarget\` now flags any running machine with a non-passing health check
- new \`checkParkedApp\` wake pass: an app with no running machine gets one machine started and must come up with checks passing before verify calls it online; auto-stop re-parks it
- \`parseAppState\` carries each machine's health checks through as name/status

## Why

The first keys-service deploy failed CI on exactly this, and verify contradicted the red job. Validated against the live fleet: the wake pass started one parked session machine, its check passed with real output, and the falsified state-policy approach (idle machines park as \`stopped\` even under the suspend policy) was dropped in favour of waking.
