### PR TITLE
docs(agents): update key test-data rules on what the test holds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -389,8 +389,8 @@ Everywhere:
   fixtures shared between tests.
 - A factory is called in the test that uses its value, never through a helper that pre-configures
   overrides — a second layer of defaults is a shadow factory the test site can't see.
-- `setupTest` wires runtime — servers, handlers, clients, recorders — and returns no domain data
-  and no data-builders.
+- `setupTest` wires runtime — servers, handlers, clients, recorders — and returns no domain data and
+  no data-builders.
 - `toStrictEqual`, not `toEqual`, for object assertions; asymmetric matchers inside it are fine.
 - Global mock reset lives in the preload's `afterEach` (`mock.restore()`), never per-test.
 - A test that mutates global or environment state restores it in an `onTestFinished(...)` callback

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -376,9 +376,17 @@ Everywhere:
 - Test files are co-located with the module they test (`parse-source.ts` beside
   `parse-source.test.ts`) — no `test/`, `tests/` or `__tests__` directories. Declaration emit
   excludes `*.test.ts`, so they never ship.
-- A domain object or DTO comes from its faker-defaulted `create-mock-*` factory in the package's
-  `test-utils/factories/` (each factory has its own test); tests only override the fields required
-  to express the logic under test. No module-level fixtures shared between tests.
+- A test whose unit consumes a domain object or DTO takes it from the package's faker-defaulted
+  `create-mock-*` factory in `test-utils/factories/` (each factory has its own test), overriding
+  only the fields the unit reads.
+- A unit that parses or validates raw input — a zod schema, a decoder — is tested with inline
+  literal payloads, valid and invalid, never factory output: a factory built to satisfy a schema
+  cannot falsify it. A rejection test asserts the reported issue path, never bare
+  `success: false` — a payload invalid for any reason passes the bare boolean.
+- An input that is neither a domain object nor a DTO — a plain argument, an options bag, a config —
+  is written inline at the call site, even when tests repeat the literal; repeated data reads, an
+  opaque baseline doesn't. Test files declare no baseline-builder helpers and no module-level
+  fixtures shared between tests.
 - `toStrictEqual`, not `toEqual`, for object assertions; asymmetric matchers inside it are fine.
 - Global mock reset lives in the preload's `afterEach` (`mock.restore()`), never per-test.
 - A test that mutates global or environment state restores it in an `onTestFinished(...)` callback
@@ -488,7 +496,7 @@ Everywhere:
 - **Test setup.** A local `setupTest()` per suite — typed config in, named props out, no `if` —
   builds the db and boots the service, with no data. Never centralise it: a shared `setupTest`
   accretes conditionals as services multiply.
-- **Test data — factories + composites, always.** Every domain entity/DTO gets a faker-defaulted
+- **Test data — factories + composites.** Every domain entity/DTO gets a faker-defaulted
   `create-mock-*.ts` factory in `test-utils/factories/` (a plain object, never persisted, never
   requiring a parent), each with its own test. Persisted or wired data goes through a
   composite/entity-util (`create-*.ts`, no `-mock-`) that sources its defaults from the factory.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -381,12 +381,16 @@ Everywhere:
   only the fields the unit reads.
 - A unit that parses or validates raw input — a zod schema, a decoder — is tested with inline
   literal payloads, valid and invalid, never factory output: a factory built to satisfy a schema
-  cannot falsify it. A rejection test asserts the reported issue path, never bare
-  `success: false` — a payload invalid for any reason passes the bare boolean.
+  cannot falsify it. A rejection test asserts the reported issue path, never bare `success: false` —
+  a payload invalid for any reason passes the bare boolean.
 - An input that is neither a domain object nor a DTO — a plain argument, an options bag, a config —
   is written inline at the call site, even when tests repeat the literal; repeated data reads, an
   opaque baseline doesn't. Test files declare no baseline-builder helpers and no module-level
   fixtures shared between tests.
+- A factory is called in the test that uses its value, never through a helper that pre-configures
+  overrides — a second layer of defaults is a shadow factory the test site can't see.
+- `setupTest` wires runtime — servers, handlers, clients, recorders — and returns no domain data
+  and no data-builders.
 - `toStrictEqual`, not `toEqual`, for object assertions; asymmetric matchers inside it are fine.
 - Global mock reset lives in the preload's `afterEach` (`mock.restore()`), never per-test.
 - A test that mutates global or environment state restores it in an `onTestFinished(...)` callback

--- a/agents/project.md
+++ b/agents/project.md
@@ -223,9 +223,17 @@ Everywhere:
 - Test files are co-located with the module they test (`parse-source.ts` beside
   `parse-source.test.ts`) — no `test/`, `tests/` or `__tests__` directories. Declaration emit
   excludes `*.test.ts`, so they never ship.
-- A domain object or DTO comes from its faker-defaulted `create-mock-*` factory in the package's
-  `test-utils/factories/` (each factory has its own test); tests only override the fields required
-  to express the logic under test. No module-level fixtures shared between tests.
+- A test whose unit consumes a domain object or DTO takes it from the package's faker-defaulted
+  `create-mock-*` factory in `test-utils/factories/` (each factory has its own test), overriding
+  only the fields the unit reads.
+- A unit that parses or validates raw input — a zod schema, a decoder — is tested with inline
+  literal payloads, valid and invalid, never factory output: a factory built to satisfy a schema
+  cannot falsify it. A rejection test asserts the reported issue path, never bare `success: false` —
+  a payload invalid for any reason passes the bare boolean.
+- An input that is neither a domain object nor a DTO — a plain argument, an options bag, a config —
+  is written inline at the call site, even when tests repeat the literal; repeated data reads, an
+  opaque baseline doesn't. Test files declare no baseline-builder helpers and no module-level
+  fixtures shared between tests.
 - `toStrictEqual`, not `toEqual`, for object assertions; asymmetric matchers inside it are fine.
 - Global mock reset lives in the preload's `afterEach` (`mock.restore()`), never per-test.
 - A test that mutates global or environment state restores it in an `onTestFinished(...)` callback
@@ -335,7 +343,7 @@ Everywhere:
 - **Test setup.** A local `setupTest()` per suite — typed config in, named props out, no `if` —
   builds the db and boots the service, with no data. Never centralise it: a shared `setupTest`
   accretes conditionals as services multiply.
-- **Test data — factories + composites, always.** Every domain entity/DTO gets a faker-defaulted
+- **Test data — factories + composites.** Every domain entity/DTO gets a faker-defaulted
   `create-mock-*.ts` factory in `test-utils/factories/` (a plain object, never persisted, never
   requiring a parent), each with its own test. Persisted or wired data goes through a
   composite/entity-util (`create-*.ts`, no `-mock-`) that sources its defaults from the factory.

--- a/agents/project.md
+++ b/agents/project.md
@@ -234,6 +234,10 @@ Everywhere:
   is written inline at the call site, even when tests repeat the literal; repeated data reads, an
   opaque baseline doesn't. Test files declare no baseline-builder helpers and no module-level
   fixtures shared between tests.
+- A factory is called in the test that uses its value, never through a helper that pre-configures
+  overrides — a second layer of defaults is a shadow factory the test site can't see.
+- `setupTest` wires runtime — servers, handlers, clients, recorders — and returns no domain data and
+  no data-builders.
 - `toStrictEqual`, not `toEqual`, for object assertions; asymmetric matchers inside it are fine.
 - Global mock reset lives in the preload's `afterEach` (`mock.restore()`), never per-test.
 - A test that mutates global or environment state restores it in an `onTestFinished(...)` callback


### PR DESCRIPTION
## Description

Test-data guidance keyed on what a test holds rather than what a schema defines, splitting the single factory bullet into three rules. The old wording ("tests only override the fields required") read as a universal maxim and pushed baseline builders into tests of schemas and plain functions.

- Consumer tests take domain objects/DTOs from the central `create-mock-*` factory, overriding only fields the unit reads
- Parse/validate units test inline literal payloads — a factory built to satisfy a schema cannot falsify it — and rejection tests assert the issue path, not bare `success: false`
- Non-DTO inputs are written inline at the call site; no baseline-builder helpers in test files
- Dropped ", always" from the real-database test-data heading to remove the conflict

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality