### PR TITLE
chore: drop unused @orpc/contract dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -193,7 +193,6 @@
       "name": "@vers/contract-keys",
       "version": "0.0.0",
       "dependencies": {
-        "@orpc/contract": "catalog:",
         "@vers/contract-base": "workspace:*",
         "zod": "catalog:",
       },
@@ -210,7 +209,6 @@
       "name": "@vers/contract-replay",
       "version": "0.0.0",
       "dependencies": {
-        "@orpc/contract": "catalog:",
         "@vers/contract-base": "workspace:*",
         "zod": "catalog:",
       },

--- a/contracts/keys/package.json
+++ b/contracts/keys/package.json
@@ -11,7 +11,6 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@orpc/contract": "catalog:",
     "@vers/contract-base": "workspace:*",
     "zod": "catalog:"
   },

--- a/contracts/replay/package.json
+++ b/contracts/replay/package.json
@@ -11,7 +11,6 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@orpc/contract": "catalog:",
     "@vers/contract-base": "workspace:*",
     "zod": "catalog:"
   },


### PR DESCRIPTION
## Description

`contracts/keys` and `contracts/replay` declare `@orpc/contract` but import nothing from it (both build on `@vers/contract-base`), so root knip fails on every branch — this unblocks the pre-push and CI deadcode gates repo-wide.

- Removes the dependency from both manifests and syncs `bun.lock`.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality (n/a — manifest-only)