### PR TITLE
fix(deploy): run the cli only after every module binding initializes

### DIFF
--- a/scripts/src/bin/deploy.ts
+++ b/scripts/src/bin/deploy.ts
@@ -61,8 +61,6 @@ program
     console.log(hash);
   });
 
-await program.parseAsync();
-
 async function runDeploy(app: string): Promise<void> {
   const manifest = await loadDeployManifest();
 
@@ -253,3 +251,5 @@ async function readHeadSHA(): Promise<string> {
 
   return result.stdout.trim();
 }
+
+await program.parseAsync();


### PR DESCRIPTION
Every deploy job in the #543 rollout failed with `ReferenceError: Cannot access 'SIM_ENGINE_HASH_BUILD_ARG_NAMES' before initialization` — the `await program.parseAsync()` sat mid-module, so command actions executed before the module-level bindings below it initialized. Moves the dispatch to the end of the module.

- verified: `deploy list` and `deploy engine-hash` run clean (hash: `ed86c7fa4217…`)
- CI can't catch this class (the bin is effect-covered only) — the failing path needed a real deploy

Unblocks the stuck #539/#542/#543 rollouts.