### PR TITLE
perf(ci): parallelise e2e and cut suite waits

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     # a hung step (a script that never exits, a wedged container) must fail the
-    # run, not burn runner hours — the suite's worst observed run is ~4 minutes
+    # run, not burn runner hours
     timeout-minutes: 10
     env:
       TURBO_SCM_BASE: main
@@ -22,14 +22,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-
-      - name: Setup Dotenv
-        env:
-          DOTENV_APP_WEB_DEV: ${{ secrets.DOTENV_APP_WEB_DEV }}
-          DOTENV_APP_WEB_E2E: ${{ secrets.DOTENV_APP_WEB_E2E }}
-        run: |
-          printf '%s\n' "$DOTENV_APP_WEB_DEV" > apps/web/.env.development.local
-          printf '%s\n' "$DOTENV_APP_WEB_E2E" > apps/web-e2e/.env
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -90,6 +82,56 @@ jobs:
 
       - name: Build
         run: node_modules/.bin/turbo run build --affected
+
+  e2e:
+    runs-on: ubuntu-latest
+    # a hung step (a wedged webServer, a stuck browser) must fail the run, not
+    # burn runner hours
+    timeout-minutes: 10
+    env:
+      TURBO_SCM_BASE: main
+      # CI never commits, but skip hook install/execution regardless
+      LEFTHOOK: 0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Setup Dotenv
+        env:
+          DOTENV_APP_WEB_DEV: ${{ secrets.DOTENV_APP_WEB_DEV }}
+          DOTENV_APP_WEB_E2E: ${{ secrets.DOTENV_APP_WEB_E2E }}
+        run: |
+          printf '%s\n' "$DOTENV_APP_WEB_DEV" > apps/web/.env.development.local
+          printf '%s\n' "$DOTENV_APP_WEB_E2E" > apps/web-e2e/.env
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.18.0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: .bun-version
+
+      - name: Install Dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Track main branch
+        run: git branch --track main origin/main
+
+      # scoped key so this job's saved cache never collides with the checks job's;
+      # the prefix restore matches either job's most recent save
+      - name: Setup Turbo cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .turbo
+          key: turbo-e2e-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            turbo-e2e-${{ runner.os }}-
+            turbo-${{ runner.os }}-
 
       - name: Install E2E browsers
         run: bun run playwright install --with-deps --only-shell chromium

--- a/apps/web-e2e/playwright.config.ts
+++ b/apps/web-e2e/playwright.config.ts
@@ -48,12 +48,16 @@ export default defineConfig({
     {
       // the dev server's own vite plugin starts the mock backend, giving journey specs the mock
       // services a signed-in flow needs. Only `vite dev` fires that plugin's `configureServer`
-      // hook, so the production build below can't host it.
-      command: 'bun run dev',
+      // hook, so the production build below can't host it. The explicit port keeps a BASE_URL
+      // override honest — vite's config pins a default port that would win otherwise.
+      command: `bun run dev --port ${new URL(baseURL).port}`,
       cwd: appWebRoot,
       env: {
         // canvas-persistence.spec.ts clicks through to the Market nav link
         FEATURE_MARKET: 'true',
+
+        // specs submit forms instantly; the bot-pacing floor would reject every one of them
+        VITE_HONEYPOT_MIN_FILL_TIME_MS: '0',
 
         PLAYWRIGHT_TEST_BASE_URL: baseURL,
 
@@ -67,10 +71,12 @@ export default defineConfig({
       url: baseURL,
     },
     {
-      // the real production artifact (`vite build` + `server.mjs`) on its own port, so a smoke
-      // spec can prove the deployable build serves traffic. It hosts no mock backend, so only
-      // routes that call no downstream service (the health check, the anonymous home page) work.
-      command: 'bun run build && node ./server.mjs',
+      // the real production artifact on its own port, so a smoke spec can prove the deployable
+      // build serves traffic. The e2e turbo task depends on the app's build task, so the artifact
+      // is already on disk (cached or fresh) — serving it here must not rebuild it. It hosts no
+      // mock backend, so only routes that call no downstream service (the health check, the
+      // anonymous home page) work.
+      command: 'node ./server.mjs',
       cwd: appWebRoot,
       env: {
         LOGGING: 'warn',
@@ -87,5 +93,8 @@ export default defineConfig({
       url: `${productionBaseURL}/health`,
     },
   ],
-  ...(process.env['CI'] !== undefined && { workers: 1 }),
+
+  // CI runners have 4 cores shared with both webServers; more workers than this starves the
+  // canvas specs' software-GL rendering
+  ...(process.env['CI'] !== undefined && { workers: 2 }),
 });

--- a/apps/web-e2e/playwright.config.ts
+++ b/apps/web-e2e/playwright.config.ts
@@ -96,5 +96,5 @@ export default defineConfig({
 
   // CI runners have 4 cores shared with both webServers; more workers than this starves the
   // canvas specs' software-GL rendering
-  ...(process.env['CI'] !== undefined && { workers: 3 }),
+  ...(process.env['CI'] !== undefined && { workers: 2 }),
 });

--- a/apps/web-e2e/playwright.config.ts
+++ b/apps/web-e2e/playwright.config.ts
@@ -96,5 +96,5 @@ export default defineConfig({
 
   // CI runners have 4 cores shared with both webServers; more workers than this starves the
   // canvas specs' software-GL rendering
-  ...(process.env['CI'] !== undefined && { workers: 2 }),
+  ...(process.env['CI'] !== undefined && { workers: 3 }),
 });

--- a/apps/web-e2e/src/avatar-satellite.spec.ts
+++ b/apps/web-e2e/src/avatar-satellite.spec.ts
@@ -24,10 +24,6 @@ test('it mounts a second canvas for the avatar satellite and drops it on navigat
   await page.waitForLoadState('networkidle');
   await page.getByLabel('Email').fill('e2e-avatar-satellite@vers.test');
   await page.getByLabel('Password').fill('password123');
-
-  // the honeypot rejects any submission under 1.5s old as bot-paced — real typing naturally
-  // clears it, a scripted fill+click doesn't
-  await page.waitForTimeout(1600);
   await page.getByRole('button', { exact: true, name: 'Login' }).click();
 
   await expect(page).toHaveURL(/\/avatar$/);

--- a/apps/web-e2e/src/canvas-persistence.spec.ts
+++ b/apps/web-e2e/src/canvas-persistence.spec.ts
@@ -26,10 +26,6 @@ test('it keeps the same canvas element across client-side game navigation', asyn
   await page.waitForLoadState('networkidle');
   await page.getByLabel('Email').fill('e2e-canvas@vers.test');
   await page.getByLabel('Password').fill('password123');
-
-  // the honeypot rejects any submission under 1.5s old as bot-paced — real typing naturally
-  // clears it, a scripted fill+click doesn't
-  await page.waitForTimeout(1600);
   await page.getByRole('button', { exact: true, name: 'Login' }).click();
 
   await expect(page).toHaveURL(/\/explore$/);

--- a/apps/web-e2e/src/game-smoke.spec.ts
+++ b/apps/web-e2e/src/game-smoke.spec.ts
@@ -19,10 +19,6 @@ test('it renders respite, avatar, and explore for a signed-in caller without con
   await page.waitForLoadState('networkidle');
   await page.getByLabel('Email').fill('e2e-game@vers.test');
   await page.getByLabel('Password').fill('password123');
-
-  // the honeypot rejects any submission under 1.5s old as bot-paced — real typing naturally
-  // clears it, a scripted fill+click doesn't
-  await page.waitForTimeout(1600);
   await page.getByRole('button', { exact: true, name: 'Login' }).click();
 
   await expect(page).toHaveURL(/\/respite$/);

--- a/apps/web-e2e/src/home-smoke.spec.ts
+++ b/apps/web-e2e/src/home-smoke.spec.ts
@@ -36,10 +36,6 @@ test('it serves the signed-in home page server-rendered, lands at respite, and l
   await page.waitForLoadState('networkidle');
   await page.getByLabel('Email').fill('demo@vers.test');
   await page.getByLabel('Password').fill('password123');
-
-  // the honeypot rejects any submission under 1.5s old as bot-paced — real typing naturally
-  // clears it, a scripted fill+click doesn't
-  await page.waitForTimeout(1600);
   await page.getByRole('button', { exact: true, name: 'Login' }).click();
   await page.waitForURL(/\/respite$/);
 

--- a/apps/web/src/lib/auth/build-honeypot-valid-from.ts
+++ b/apps/web/src/lib/auth/build-honeypot-valid-from.ts
@@ -5,7 +5,15 @@ const HONEYPOT_MIN_FILL_TIME_MS = 1500;
 
 /**
  * Computes the valid-from timestamp for a freshly rendered form.
+ *
+ * Client hydration recomputes the rendered value, so the override must reach the browser bundle:
+ * `VITE_HONEYPOT_MIN_FILL_TIME_MS` lifts the human-speed floor so e2e runs can submit forms
+ * instantly. Production builds never set it.
  */
 export function buildHoneypotValidFrom(): string {
-  return String(Date.now() + HONEYPOT_MIN_FILL_TIME_MS);
+  const envOverride: string | undefined = import.meta.env['VITE_HONEYPOT_MIN_FILL_TIME_MS'];
+  const overrideMs = Number(envOverride);
+  const minFillTimeMs = Number.isFinite(overrideMs) ? overrideMs : HONEYPOT_MIN_FILL_TIME_MS;
+
+  return String(Date.now() + minFillTimeMs);
 }

--- a/turbo.json
+++ b/turbo.json
@@ -34,14 +34,6 @@
       "inputs": ["$TURBO_DEFAULT$", "esbuild.config.cjs"],
       "outputs": ["dist/**", "build/**", ".react-router/**"]
     },
-    "@vers/web#build:e2e": {
-      "dependsOn": ["^build", "codegen", "typegen"],
-      "inputs": ["$TURBO_DEFAULT$", "esbuild.config.cjs"],
-      // writes the same build/ dir as `build` but with mocks baked in — left
-      // uncached so its artifact can never be restored over (or restore from)
-      // the production build's cache entry
-      "cache": false
-    },
     "codegen": {
       "dependsOn": ["^codegen"],
       "inputs": ["$TURBO_DEFAULT$", "panda.config.ts"],
@@ -59,7 +51,9 @@
       "outputs": []
     },
     "e2e": {
-      "dependsOn": ["@vers/web#codegen", "@vers/web#typegen"],
+      // the build dependency keeps the production-artifact webServer from rebuilding: the e2e
+      // run serves whatever this task graph just built (or restored from cache)
+      "dependsOn": ["@vers/web#build", "@vers/web#codegen", "@vers/web#typegen"],
       "cache": false
     },
     "dev": {


### PR DESCRIPTION
## Description

E2E was the longest serial step in the PR job (~2:15 of a ~5:45 run); this splits it into its own job and removes its built-in waits, so the two jobs finish concurrently in roughly 3.5–4 minutes.

- e2e runs as a parallel job with its own turbo cache key; the checks job keeps everything else.
- The honeypot pacing floor is env-overridable (`VITE_HONEYPOT_MIN_FILL_TIME_MS`) — via `import.meta.env`, since client hydration recomputes the rendered timestamp — replacing the four 1.6s spec sleeps; production builds never set it.
- The `e2e` turbo task now depends on `@vers/web#build`, so the production-artifact webServer serves the built output instead of rebuilding it.
- CI e2e workers go 1 → 2; 4-core runners share with both webServers, so higher counts starve the canvas specs.
- The dev webServer passes `--port` derived from `BASE_URL`, making that override work.
- Drops the stale `@vers/web#build:e2e` turbo task and the brittle worst-observed-runtime note.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality