### PR TITLE
docs: add the item-generation architecture note

### DIFF
--- a/docs/architecture/game-entropy.md
+++ b/docs/architecture/game-entropy.md
@@ -74,7 +74,9 @@ the same appended, verifiable record.
 Rolled content is `f(key, coordinate)`, where `f` is a keyed PRF — a pseudorandom function whose
 revealed outputs carry no predictive power over unrevealed coordinates. The property matters because
 every reveal hands the client a known input/output pair. The reward's identity is its coordinate, so
-minting is idempotent and re-verification can neither duplicate nor re-roll a reward.
+minting is idempotent and re-verification can neither duplicate nor re-roll a reward. The machinery
+that turns a digest into item content — the shared interpreter, draw-order versioning, craft
+positions — is [item generation](./item-generation.md).
 
 Key custody is the economy boundary:
 

--- a/docs/architecture/item-generation.md
+++ b/docs/architecture/item-generation.md
@@ -1,0 +1,78 @@
+# Item generation
+
+How committed entropy becomes item content. The [entropy model](./game-entropy.md) fixes where
+randomness comes from and who may compute it; this document is the machinery that turns an entropy
+source into a concrete item — one interpreter shared by every consumer, under every key custody.
+
+## The roll stream
+
+A roll stream is a deterministic tape of typed draws — a bounded range, a weighted pick — expanded
+(HKDF) from a single digest. Equal inputs produce an equal tape, and the stream is the only
+randomness an interpreter ever sees. Each entropy source has its own stream builder:
+
+- A **keyed position stream** expands the keyed PRF digest (`buildRollDigest` in
+  `@vers/roll-crypto`) over a position's canonical byte encoding under the avatar's roll key. Reward
+  coordinates and self-found craft positions both ride this builder, domain-separated by position
+  type so a craft position and a reward coordinate can never share a digest.
+- A **salt stream** expands a sealed pre-commit salt, for trade-avatar craft resolutions.
+
+An interpreter cannot tell which builder fed it. A new entropy source (a verifiable-randomness
+beacon, a rotated key generation) is a new builder, never an interpreter change.
+
+## The interpreter
+
+`@vers/item-gen` (`libs/game/item-gen`) holds the interpreter as pure functions over versioned table
+data. It is a `lib` consumed by the server (mint at settlement, the reveal read path, craft
+resolution) and by the client (device-custody local rolls), so it imports no service code and
+performs no I/O.
+
+- `rollItemFromStream(tables, context, stream)` rolls a complete item in canonical draw order:
+  rarity, base, affix count, then each affix. `context` is the producing slot's trajectory facts —
+  deterministic, replay-verified selectors (node tier, encounter class, chosen juice tier) that pick
+  which tables the tape is read against. Context selects tables; the stream decides outcomes.
+- `rollAffixesFromStream(tables, base, constraints, stream)` rolls affixes onto an existing base
+  under a constraint set — the crafting entry point.
+
+Context is client-computable, so it obeys the
+[tail rule](../game-design/economy-modes.md#perfect-foresight): a context field that scales a
+market-grade quantity is a published scalar chosen by the player, never a rolled value.
+
+## Draw order is contract
+
+A content version pins table data and interpreter behaviour together. Inserting, removing, or
+reordering one draw changes every outcome after it on the same tape, so any change to the draw
+sequence is a new content version. Every shipped version stays loadable: mint, reveal, replay, and
+device rolls all resolve under the version pinned in the activity's `Started` snapshot and must
+agree byte-for-byte across deploys and key rotations.
+
+## Craft constraints
+
+A constraint set narrows an affix roll through a closed vocabulary: protect a group, force an affix,
+reweight a pool, reroll values only, exclude occupied groups. Constraint application and pool
+ordering are canonical — a pool sorts deterministically before any weighted draw — because both sit
+on the tape's draw path. The vocabulary is machinery; which craft actions exist, what they cost, and
+what the affix tables contain is itemisation design.
+
+## Craft positions and item lineage
+
+Every craft action occupies a position in its avatar's craft sequence — an append-only per-avatar
+counter. The position is the action's identity: application is exactly-once per position, so a
+network retry never applies a spend twice. A roll-bearing action's entropy keys on its position; a
+roll-free action — a deterministic state transition at a published cost — occupies a position all
+the same. The sequence is a transaction log first and an entropy source second.
+
+Each position pins the item state it acts on and rejects a retry against stale state rather than
+re-rolling. An item's identity is its lineage — the reward coordinate that dropped it plus the craft
+positions applied since — a complete, replayable provenance chain. A self-found craft sequence
+verifies by replay under the re-derived device key like any self-found stream; a trade craft action
+is server-computed, so there is nothing to replay.
+
+## Call sites
+
+| Call site                            | Entry point             | Stream         | Key custody     |
+| ------------------------------------ | ----------------------- | -------------- | --------------- |
+| Mint at settlement (replay apply)    | `rollItemFromStream`    | keyed position | server          |
+| Reveal read path (activity contract) | `rollItemFromStream`    | keyed position | server          |
+| Self-found local roll (client)       | `rollItemFromStream`    | keyed position | device          |
+| Trade craft resolution               | `rollAffixesFromStream` | salt           | server (sealed) |
+| Self-found craft (client)            | `rollAffixesFromStream` | keyed position | device          |

--- a/docs/architecture/item-generation.md
+++ b/docs/architecture/item-generation.md
@@ -63,6 +63,13 @@ network retry never applies a spend twice. A roll-bearing action's entropy keys 
 roll-free action — a deterministic state transition at a published cost — occupies a position all
 the same. The sequence is a transaction log first and an entropy source second.
 
+Who assigns a position follows key custody. A self-found sequence is client-authored — the device
+numbers its own actions and the server verifies the sequence by replay, so no allocation race
+exists. A trade action carries a client-minted action identifier, and the server's durable mapping
+from identifier to position and result makes reservation and application one atomic step: a
+retransmitted action lands on its recorded position and returns its recorded result, never a fresh
+position or a second spend.
+
 Each position pins the item state it acts on and rejects a retry against stale state rather than
 re-rolling. An item's identity is its lineage — the reward coordinate that dropped it plus the craft
 positions applied since — a complete, replayable provenance chain. A self-found craft sequence

--- a/docs/architecture/item-generation.md
+++ b/docs/architecture/item-generation.md
@@ -6,14 +6,16 @@ source into a concrete item — one interpreter shared by every consumer, under 
 
 ## The roll stream
 
-A roll stream is a deterministic tape of typed draws — a bounded range, a weighted pick — expanded
-(HKDF) from a single digest. Equal inputs produce an equal tape, and the stream is the only
+A roll stream is a deterministic sequence of typed draws — a bounded range, a weighted pick —
+stretched from a single digest by standard key expansion (HKDF), so one digest yields as many draws
+as an interpreter asks for. Equal inputs produce identical draws, and the stream is the only
 randomness an interpreter ever sees. Each entropy source has its own stream builder:
 
-- A **keyed position stream** expands the keyed PRF digest (`buildRollDigest` in
-  `@vers/roll-crypto`) over a position's canonical byte encoding under the avatar's roll key. Reward
-  coordinates and self-found craft positions both ride this builder, domain-separated by position
-  type so a craft position and a reward coordinate can never share a digest.
+- A **keyed position stream** starts from `buildRollDigest` (`@vers/roll-crypto`) — a keyed hash
+  over a position's canonical byte encoding under the avatar's roll key, so only a key holder can
+  compute it. Reward coordinates and self-found craft positions both ride this builder, with the
+  position type folded into the hashed bytes so a craft position and a reward coordinate can never
+  share a digest.
 - A **salt stream** expands a sealed pre-commit salt, for trade-avatar craft resolutions.
 
 An interpreter cannot tell which builder fed it. A new entropy source (a verifiable-randomness
@@ -29,7 +31,7 @@ performs no I/O.
 - `rollItemFromStream(tables, context, stream)` rolls a complete item in canonical draw order:
   rarity, base, affix count, then each affix. `context` is the producing slot's trajectory facts —
   deterministic, replay-verified selectors (node tier, encounter class, chosen juice tier) that pick
-  which tables the tape is read against. Context selects tables; the stream decides outcomes.
+  which tables the stream is read against. Context selects tables; the stream decides outcomes.
 - `rollAffixesFromStream(tables, base, constraints, stream)` rolls affixes onto an existing base
   under a constraint set — the crafting entry point.
 
@@ -40,18 +42,18 @@ market-grade quantity is a published scalar chosen by the player, never a rolled
 ## Draw order is contract
 
 A content version pins table data and interpreter behaviour together. Inserting, removing, or
-reordering one draw changes every outcome after it on the same tape, so any change to the draw
-sequence is a new content version. Every shipped version stays loadable: mint, reveal, replay, and
-device rolls all resolve under the version pinned in the activity's `Started` snapshot and must
-agree byte-for-byte across deploys and key rotations.
+reordering one draw shifts every draw after it in the sequence, so any change to the draw sequence
+is a new content version. Every shipped version stays loadable: mint, reveal, replay, and device
+rolls all resolve under the version pinned in the activity's `Started` snapshot and must agree
+byte-for-byte across deploys and key rotations.
 
 ## Craft constraints
 
 A constraint set narrows an affix roll through a closed vocabulary: protect a group, force an affix,
 reweight a pool, reroll values only, exclude occupied groups. Constraint application and pool
-ordering are canonical — a pool sorts deterministically before any weighted draw — because both sit
-on the tape's draw path. The vocabulary is machinery; which craft actions exist, what they cost, and
-what the affix tables contain is itemisation design.
+ordering are canonical — a pool sorts deterministically before any weighted draw — because both
+consume draws from the stream. The vocabulary is machinery; which craft actions exist, what they
+cost, and what the affix tables contain is itemisation design.
 
 ## Craft positions and item lineage
 

--- a/docs/architecture/item-generation.md
+++ b/docs/architecture/item-generation.md
@@ -71,10 +71,11 @@ is server-computed, so there is nothing to replay.
 
 ## Call sites
 
-| Call site                            | Entry point             | Stream         | Key custody     |
-| ------------------------------------ | ----------------------- | -------------- | --------------- |
-| Mint at settlement (replay apply)    | `rollItemFromStream`    | keyed position | server          |
-| Reveal read path (activity contract) | `rollItemFromStream`    | keyed position | server          |
-| Self-found local roll (client)       | `rollItemFromStream`    | keyed position | device          |
-| Trade craft resolution               | `rollAffixesFromStream` | salt           | server (sealed) |
-| Self-found craft (client)            | `rollAffixesFromStream` | keyed position | device          |
+| Call site                               | Entry point             | Stream         | Key custody                   |
+| --------------------------------------- | ----------------------- | -------------- | ----------------------------- |
+| Mint at settlement (replay apply)       | `rollItemFromStream`    | keyed position | server                        |
+| Reveal read path (activity contract)    | `rollItemFromStream`    | keyed position | server                        |
+| Self-found local roll (client)          | `rollItemFromStream`    | keyed position | device                        |
+| Self-found replay verification (replay) | both entry points       | keyed position | server, re-derived device key |
+| Trade craft resolution                  | `rollAffixesFromStream` | salt           | server (sealed)               |
+| Self-found craft (client)               | `rollAffixesFromStream` | keyed position | device                        |


### PR DESCRIPTION
## Description

Adds `docs/architecture/item-generation.md`: the machinery that turns committed entropy into item content — one pure interpreter shared by every consumer under every key custody.

- Roll streams: keyed-position and salt builders over one interpreter, domain-separated so a craft position never shares a digest with a reward coordinate
- Interpreter entry points (`rollItemFromStream`, `rollAffixesFromStream`) in a client-safe `@vers/item-gen` lib
- Draw order as versioned contract, pinned by content version alongside table data
- Craft positions as an append-only per-avatar transaction log; item identity as lineage (drop coordinate + craft positions)
- Cross-link from the entropy model's rolled-rewards section

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an architectural specification describing deterministic item generation from committed entropy.
  * Documented versioned roll streams, draw-order compatibility, crafting constraints, and item lineage.
  * Clarified how per-avatar craft positions preserve item state and help prevent stale replays.
  * Updated the game-entropy documentation to reference the item-generation process for reward minting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->