### PR TITLE
feat(#516): forward-advance the seed chain on user-stop and cap exits

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -28,6 +28,10 @@ reviews:
         labels, canonical encodings, expected draw values). Never suggest replacing
         such a literal with an import of the constant it verifies — if the constant
         changes, the test must fail.
+        expect(...).rejects/.resolves assertion chains are deliberately not
+        awaited: Bun's matcher types declare them synchronous, per the AGENTS.md
+        testing rules. Only toResolve()/toReject() return promises and are
+        awaited. Never flag an unawaited .rejects/.resolves chain.
     - path: 'AGENTS.md'
       instructions: |
         AGENTS.md is generated from agents/shared.md and agents/project.md and

--- a/libs/testing/test-utils/src/index.ts
+++ b/libs/testing/test-utils/src/index.ts
@@ -3,3 +3,4 @@ export { collectConformanceCases } from './collect-conformance-cases';
 export type { ConformanceCase, ConformanceCaseApp } from './collect-conformance-cases';
 export { createTestJWT } from './create-test-jwt';
 export { getTestJWTKeyPair } from './get-test-jwt-key-pair';
+export { waitFor } from './wait-for';

--- a/libs/testing/test-utils/src/wait-for.test.ts
+++ b/libs/testing/test-utils/src/wait-for.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from 'bun:test';
+import { waitFor } from './wait-for';
+
+test('it resolves with the value once the attempt stops throwing', async () => {
+  let calls = 0;
+
+  const value = await waitFor(
+    () => {
+      calls += 1;
+
+      if (calls < 3) {
+        throw new Error('not yet');
+      }
+
+      return 'ready';
+    },
+    { intervalMs: 1, timeoutMs: 500 },
+  );
+
+  expect(value).toBe('ready');
+  expect(calls).toBe(3);
+});
+
+test('it retries expect-style assertions in the attempt', async () => {
+  let observed = 0;
+
+  await waitFor(
+    () => {
+      observed += 1;
+
+      expect(observed).toBeGreaterThan(2);
+    },
+    { intervalMs: 1, timeoutMs: 500 },
+  );
+
+  expect(observed).toBe(3);
+});
+
+test('it never sleeps for an attempt that already passes', async () => {
+  const before = Date.now();
+
+  await waitFor(() => true, { intervalMs: 50, timeoutMs: 500 });
+
+  expect(Date.now() - before).toBeLessThan(50);
+});
+
+test('it supports an async attempt', async () => {
+  let calls = 0;
+
+  const value = await waitFor(
+    async () => {
+      await Bun.sleep(1);
+
+      calls += 1;
+
+      if (calls < 2) {
+        throw new Error('not yet');
+      }
+
+      return calls;
+    },
+    { intervalMs: 1, timeoutMs: 500 },
+  );
+
+  expect(value).toBe(2);
+});
+
+test('it rethrows the last failure when the deadline passes', () => {
+  expect(
+    waitFor(
+      () => {
+        throw new Error('still failing');
+      },
+      { intervalMs: 1, timeoutMs: 10 },
+    ),
+  ).rejects.toThrow('still failing');
+});

--- a/libs/testing/test-utils/src/wait-for.ts
+++ b/libs/testing/test-utils/src/wait-for.ts
@@ -1,0 +1,37 @@
+interface WaitForOptions {
+  /**
+   * Milliseconds between retries.
+   */
+  readonly intervalMs?: number;
+
+  /**
+   * Milliseconds before the wait gives up.
+   */
+  readonly timeoutMs?: number;
+}
+
+/**
+ * Retries the attempt until it stops throwing or rejecting, resolving with its value — so
+ * assertion-style checks read exactly as they would in a straight-line test body. Once the
+ * deadline passes, the attempt's final failure is rethrown as the wait's rejection.
+ */
+export async function waitFor<T>(
+  attempt: () => Promise<T> | T,
+  options: Readonly<WaitForOptions> = {},
+): Promise<T> {
+  const intervalMs = options.intervalMs ?? 50;
+  const timeoutMs = options.timeoutMs ?? 1000;
+  const deadline = Date.now() + timeoutMs;
+
+  for (;;) {
+    try {
+      return await attempt();
+    } catch (error) {
+      if (Date.now() >= deadline) {
+        throw error;
+      }
+    }
+
+    await Bun.sleep(intervalMs);
+  }
+}

--- a/services/activity/src/create-activity-service.test.ts
+++ b/services/activity/src/create-activity-service.test.ts
@@ -7,7 +7,7 @@ import { createActivityService } from './create-activity-service';
 import { createAvatarRow } from './test-utils/create-avatar-row';
 
 test('it wires an injected db into the router instead of building one from env', async () => {
-  await using db = await createTestDB();
+  await using db = await createTestDB({ isolation: 'schema' });
 
   await createSimVersionRow(db.db);
 
@@ -35,7 +35,7 @@ test('it boots from env.DATABASE_URL when no db is injected', async () => {
 });
 
 test('it defaults the content and key versions when none are injected', async () => {
-  await using db = await createTestDB();
+  await using db = await createTestDB({ isolation: 'schema' });
 
   await createSimVersionRow(db.db);
 
@@ -55,7 +55,7 @@ test('it defaults the content and key versions when none are injected', async ()
 });
 
 test('it uses an injected content version when given', async () => {
-  await using db = await createTestDB();
+  await using db = await createTestDB({ isolation: 'schema' });
 
   await createSimVersionRow(db.db);
 
@@ -75,7 +75,7 @@ test('it uses an injected content version when given', async () => {
 });
 
 test('it uses an injected key version when given', async () => {
-  await using db = await createTestDB();
+  await using db = await createTestDB({ isolation: 'schema' });
 
   await createSimVersionRow(db.db);
 

--- a/services/activity/src/handlers/get-current-activity.test.ts
+++ b/services/activity/src/handlers/get-current-activity.test.ts
@@ -11,8 +11,12 @@ import { buildRPCTestClient } from '@vers/test-utils';
 import { createActivityService } from '../create-activity-service';
 import { createAvatarRow } from '../test-utils/create-avatar-row';
 
+/**
+ * These tests drive startActivity, whose own `db.transaction()` can't nest under the default
+ * rollback-on-dispose isolation — this suite runs against a real, committed schema clone instead.
+ */
 async function setupTest() {
-  const db = await createTestDB();
+  const db = await createTestDB({ isolation: 'schema' });
 
   await createSimVersionRow(db.db);
 

--- a/services/activity/src/handlers/get-latest-activity-progress.test.ts
+++ b/services/activity/src/handlers/get-latest-activity-progress.test.ts
@@ -106,8 +106,10 @@ test('it returns the activity anchored to its verified checkpoint once verifiedH
   expect(progress.verifiedHead).toBe(1);
 });
 
+// schema isolation: this exercises stopActivity, whose own db.transaction() can't nest under the
+// default rollback-on-dispose isolation.
 test('it returns the newest activity regardless of status', async () => {
-  await using ctx = await setupTest();
+  await using ctx = await setupTest({ isolation: 'schema' });
 
   const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
   const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });

--- a/services/activity/src/handlers/get-latest-activity-progress.test.ts
+++ b/services/activity/src/handlers/get-latest-activity-progress.test.ts
@@ -1,6 +1,5 @@
 import { expect, test } from 'bun:test';
 import type { ActivityContract } from '@vers/contract-activity';
-import type { Isolation } from '@vers/service-test-utils/bun';
 import { createAnonymousViewer, createTestDB, createViewer } from '@vers/service-test-utils/bun';
 import { createSimVersionRow } from '@vers/sim-registry/test-utils';
 import { buildRPCTestClient } from '@vers/test-utils';
@@ -8,8 +7,13 @@ import { createActivityService } from '../create-activity-service';
 import { createAvatarRow } from '../test-utils/create-avatar-row';
 import { createMockCheckpointBatch } from '../test-utils/factories/create-mock-checkpoint-batch';
 
-async function setupTest(options: { readonly isolation?: Isolation } = {}) {
-  const db = await createTestDB(options);
+/**
+ * Several tests here drive startActivity, stopActivity, or trackActivityProgress, whose own
+ * `db.transaction()` can't nest under the default rollback-on-dispose isolation — this suite runs
+ * against a real, committed schema clone instead.
+ */
+async function setupTest() {
+  const db = await createTestDB({ isolation: 'schema' });
 
   await createSimVersionRow(db.db);
 
@@ -65,10 +69,8 @@ test('it returns the server clock beside the resume cursors', async () => {
   expect(progress.serverTime.getTime()).toBeGreaterThanOrEqual(started.startedAt.getTime());
 });
 
-// schema isolation: this exercises trackActivityProgress, whose own db.transaction() can't
-// nest under the default rollback-on-dispose isolation.
 test('it returns the activity anchored to its verified checkpoint once verifiedHead advances', async () => {
-  await using ctx = await setupTest({ isolation: 'schema' });
+  await using ctx = await setupTest();
 
   const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
   const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
@@ -106,10 +108,8 @@ test('it returns the activity anchored to its verified checkpoint once verifiedH
   expect(progress.verifiedHead).toBe(1);
 });
 
-// schema isolation: this exercises stopActivity, whose own db.transaction() can't nest under the
-// default rollback-on-dispose isolation.
 test('it returns the newest activity regardless of status', async () => {
-  await using ctx = await setupTest({ isolation: 'schema' });
+  await using ctx = await setupTest();
 
   const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
   const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });

--- a/services/activity/src/handlers/resume-activity.test.ts
+++ b/services/activity/src/handlers/resume-activity.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'bun:test';
 import type { ActivityContract } from '@vers/contract-activity';
+import type { Isolation } from '@vers/service-test-utils/bun';
 import {
   createServiceToken,
   createTestDB,
@@ -11,8 +12,8 @@ import { buildRPCTestClient } from '@vers/test-utils';
 import { createActivityService } from '../create-activity-service';
 import { createAvatarRow } from '../test-utils/create-avatar-row';
 
-async function setupTest() {
-  const db = await createTestDB();
+async function setupTest(options: { readonly isolation?: Isolation } = {}) {
+  const db = await createTestDB(options);
 
   await createSimVersionRow(db.db);
 
@@ -64,8 +65,10 @@ test('it stamps the acting session as the writer', async () => {
   expect(row.writerSessionId).toBe('session-b');
 });
 
+// schema isolation: this exercises stopActivity, whose own db.transaction() can't nest under the
+// default rollback-on-dispose isolation.
 test('it reports NOT_FOUND for a stopped activity', async () => {
-  await using ctx = await setupTest();
+  await using ctx = await setupTest({ isolation: 'schema' });
 
   const viewer = await createViewer({
     audience: 'service-activity',

--- a/services/activity/src/handlers/resume-activity.test.ts
+++ b/services/activity/src/handlers/resume-activity.test.ts
@@ -1,6 +1,5 @@
 import { expect, test } from 'bun:test';
 import type { ActivityContract } from '@vers/contract-activity';
-import type { Isolation } from '@vers/service-test-utils/bun';
 import {
   createServiceToken,
   createTestDB,
@@ -12,8 +11,13 @@ import { buildRPCTestClient } from '@vers/test-utils';
 import { createActivityService } from '../create-activity-service';
 import { createAvatarRow } from '../test-utils/create-avatar-row';
 
-async function setupTest(options: { readonly isolation?: Isolation } = {}) {
-  const db = await createTestDB(options);
+/**
+ * Several tests here drive startActivity, stopActivity, or trackActivityProgress, whose own
+ * `db.transaction()` can't nest under the default rollback-on-dispose isolation — this suite runs
+ * against a real, committed schema clone instead.
+ */
+async function setupTest() {
+  const db = await createTestDB({ isolation: 'schema' });
 
   await createSimVersionRow(db.db);
 
@@ -65,10 +69,8 @@ test('it stamps the acting session as the writer', async () => {
   expect(row.writerSessionId).toBe('session-b');
 });
 
-// schema isolation: this exercises stopActivity, whose own db.transaction() can't nest under the
-// default rollback-on-dispose isolation.
 test('it reports NOT_FOUND for a stopped activity', async () => {
-  await using ctx = await setupTest({ isolation: 'schema' });
+  await using ctx = await setupTest();
 
   const viewer = await createViewer({
     audience: 'service-activity',

--- a/services/activity/src/handlers/start-activity.test.ts
+++ b/services/activity/src/handlers/start-activity.test.ts
@@ -7,7 +7,8 @@ import {
   createViewer,
 } from '@vers/service-test-utils/bun';
 import { createSimVersionRow } from '@vers/sim-registry/test-utils';
-import { buildRPCTestClient } from '@vers/test-utils';
+import { buildRPCTestClient, waitFor } from '@vers/test-utils';
+import { sql } from 'kysely';
 import { createActivityService } from '../create-activity-service';
 import { createAvatarRow } from '../test-utils/create-avatar-row';
 
@@ -439,8 +440,9 @@ test('it roots a new activity at the anchor a concurrent forward exit commits', 
   const anchorSeed = '0f'.repeat(16);
 
   // A transaction holding the chain-row lock with an uncommitted anchor advance stands in for a
-  // forward exit still in flight: the concurrent start below must wait it out and root at the
-  // anchor it commits, never at the stale pre-advance position.
+  // forward exit still in flight. The advance commits only once the concurrent start is observed
+  // queued behind the lock, so the blocking interleaving is what actually runs — and a start that
+  // roots without ever taking the lock times the wait out and fails the test.
   const held = await ctx.db.transaction().execute(async (trx) => {
     await trx
       .updateTable('activityChains')
@@ -456,7 +458,18 @@ test('it roots a new activity at the anchor a concurrent forward exit commits', 
       scopeType: 'world_map_node',
     });
 
-    await Bun.sleep(75);
+    // pg_stat_activity is snapshot-cached for the duration of the polling transaction, so the
+    // wait reads pg_locks, which reports the lock manager live.
+    await waitFor(
+      async () => {
+        const blocked = await sql<{ waiting: number }>`
+          select count(*)::int as waiting from pg_locks where not granted
+        `.execute(trx);
+
+        expect(blocked.rows[0]?.waiting).toBeGreaterThan(0);
+      },
+      { intervalMs: 10, timeoutMs: 3000 },
+    );
 
     return { pending: start };
   });

--- a/services/activity/src/handlers/start-activity.test.ts
+++ b/services/activity/src/handlers/start-activity.test.ts
@@ -1,6 +1,5 @@
 import { expect, test } from 'bun:test';
 import type { ActivityContract } from '@vers/contract-activity';
-import type { Isolation } from '@vers/service-test-utils/bun';
 import {
   createAnonymousViewer,
   createTestDB,
@@ -12,8 +11,13 @@ import { buildRPCTestClient } from '@vers/test-utils';
 import { createActivityService } from '../create-activity-service';
 import { createAvatarRow } from '../test-utils/create-avatar-row';
 
-async function setupTest(options: { readonly isolation?: Isolation } = {}) {
-  const db = await createTestDB(options);
+/**
+ * `startActivity` opens its own `db.transaction()` to root the new activity under the chain-row
+ * lock, which can't nest under the default rollback-on-dispose isolation — this suite runs
+ * against a real, committed schema clone instead.
+ */
+async function setupTest() {
+  const db = await createTestDB({ isolation: 'schema' });
   const service = await createActivityService({ db: db.db });
 
   return { app: service.app, db: db.db, [Symbol.asyncDispose]: db[Symbol.asyncDispose] };
@@ -162,11 +166,8 @@ test('it reads the existing chain anchor for a second activity on an already-cha
   expect(second.startChainIndex).toBe(0);
 });
 
-// schema isolation: the handler re-queries for the conflicting activity after catching the
-// unique violation, and a prior statement's constraint violation aborts the rest of a shared
-// test transaction under the default isolation.
 test('it rejects a second start with CONFLICT carrying the already-active activity', async () => {
-  await using ctx = await setupTest({ isolation: 'schema' });
+  await using ctx = await setupTest();
 
   await createSimVersionRow(ctx.db);
 
@@ -413,4 +414,62 @@ test('it rejects an active stamped version past its retention deadline with SIM_
     code: 'SIM_VERSION_EXPIRED',
     data: { currentSimVersion: current.engineHash },
   });
+});
+
+test('it roots a new activity at the anchor a concurrent forward exit commits', async () => {
+  await using ctx = await setupTest();
+
+  await createSimVersionRow(ctx.db);
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const first = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'node_1',
+    scopeType: 'world_map_node',
+  });
+
+  await client.stopActivity({ avatarID: avatar.id });
+
+  expect(first.status).toBeDefined();
+
+  const anchorSeed = '0f'.repeat(16);
+
+  // A transaction holding the chain-row lock with an uncommitted anchor advance stands in for a
+  // forward exit still in flight: the concurrent start below must wait it out and root at the
+  // anchor it commits, never at the stale pre-advance position.
+  const held = await ctx.db.transaction().execute(async (trx) => {
+    await trx
+      .updateTable('activityChains')
+      .set({ appendedChainIndex: 7, appendedNextSeed: anchorSeed })
+      .where('avatarId', '=', avatar.id)
+      .where('scopeType', '=', 'world_map_node')
+      .where('scopeId', '=', 'node_1')
+      .execute();
+
+    const start = client.startActivity({
+      avatarID: avatar.id,
+      scopeID: 'node_1',
+      scopeType: 'world_map_node',
+    });
+
+    await Bun.sleep(75);
+
+    return { pending: start };
+  });
+
+  const started = await held.pending;
+
+  expect(started.seed).toBe(anchorSeed);
+
+  const row = await ctx.db
+    .selectFrom('activities')
+    .select('startChainIndex')
+    .where('id', '=', started.id)
+    .executeTakeFirstOrThrow();
+
+  expect(row.startChainIndex).toBe(7);
 });

--- a/services/activity/src/handlers/start-activity.ts
+++ b/services/activity/src/handlers/start-activity.ts
@@ -91,56 +91,63 @@ export async function startActivity(
 
   const id = `act_${createId()}`;
   const genesisSeed = createGenesisSeed();
-
-  const chain = await deps.db
-    .insertInto('activityChains')
-    .values({
-      appendedNextSeed: genesisSeed,
-      avatarId: opts.input.avatarID,
-      genesisSeed,
-      scopeId: opts.input.scopeID,
-      scopeType: opts.input.scopeType,
-      verifiedNextSeed: genesisSeed,
-    })
-    .onConflict((oc) =>
-      oc
-        .columns(['avatarId', 'scopeType', 'scopeId'])
-        .doUpdateSet({ genesisSeed: (eb) => eb.ref('activityChains.genesisSeed') }),
-    )
-    .returning(['appendedNextSeed', 'appendedChainIndex'])
-    .executeTakeFirstOrThrow();
-
-  const seed = chain.appendedNextSeed;
   const buildSnapshot: BuildSnapshot = { level: avatar.level, xp: avatar.xp };
 
-  const startHash = buildStartHash({
-    activityID: id,
-    contentVersion: deps.contentVersion,
-    keyVersion: deps.keyVersion,
-    seed,
-    simVersion,
-  });
-
   try {
-    const row = await deps.db
-      .insertInto('activities')
-      .values({
-        avatarId: opts.input.avatarID,
-        buildSnapshot,
+    // One transaction, chain row first: the upsert's write lock is held until commit, so a
+    // forward exit advancing this chain's anchor either commits before the anchor is read here or
+    // waits behind it — a new activity always roots at the anchor current at insert time. Every
+    // writer that touches both rows acquires the chain row before the activity row, so no
+    // interleaving admits a lock cycle.
+    const row = await deps.db.transaction().execute(async (trx) => {
+      const chain = await trx
+        .insertInto('activityChains')
+        .values({
+          appendedNextSeed: genesisSeed,
+          avatarId: opts.input.avatarID,
+          genesisSeed,
+          scopeId: opts.input.scopeID,
+          scopeType: opts.input.scopeType,
+          verifiedNextSeed: genesisSeed,
+        })
+        .onConflict((oc) =>
+          oc
+            .columns(['avatarId', 'scopeType', 'scopeId'])
+            .doUpdateSet({ genesisSeed: (eb) => eb.ref('activityChains.genesisSeed') }),
+        )
+        .returning(['appendedNextSeed', 'appendedChainIndex'])
+        .executeTakeFirstOrThrow();
+
+      const seed = chain.appendedNextSeed;
+
+      const startHash = buildStartHash({
+        activityID: id,
         contentVersion: deps.contentVersion,
-        id,
         keyVersion: deps.keyVersion,
-        lastHash: startHash,
-        scopeId: opts.input.scopeID,
-        scopeType: opts.input.scopeType,
         seed,
         simVersion,
-        startChainIndex: chain.appendedChainIndex,
-        startHash,
-        writerSessionId: opts.context.actingSessionId,
-      })
-      .returningAll()
-      .executeTakeFirstOrThrow();
+      });
+
+      return trx
+        .insertInto('activities')
+        .values({
+          avatarId: opts.input.avatarID,
+          buildSnapshot,
+          contentVersion: deps.contentVersion,
+          id,
+          keyVersion: deps.keyVersion,
+          lastHash: startHash,
+          scopeId: opts.input.scopeID,
+          scopeType: opts.input.scopeType,
+          seed,
+          simVersion,
+          startChainIndex: chain.appendedChainIndex,
+          startHash,
+          writerSessionId: opts.context.actingSessionId,
+        })
+        .returningAll()
+        .executeTakeFirstOrThrow();
+    });
 
     return toActivityData(row);
   } catch (error: unknown) {

--- a/services/activity/src/handlers/stop-activity.test.ts
+++ b/services/activity/src/handlers/stop-activity.test.ts
@@ -5,9 +5,15 @@ import { createSimVersionRow } from '@vers/sim-registry/test-utils';
 import { buildRPCTestClient } from '@vers/test-utils';
 import { createActivityService } from '../create-activity-service';
 import { createAvatarRow } from '../test-utils/create-avatar-row';
+import { createMockCheckpointBatch } from '../test-utils/factories/create-mock-checkpoint-batch';
 
+/**
+ * `stopActivity` opens its own `db.transaction()` for the terminal-status claim and the chain's
+ * consequent anchor advance, which can't nest under the default rollback-on-dispose isolation —
+ * this suite runs against a real, committed schema clone instead.
+ */
 async function setupTest() {
-  const db = await createTestDB();
+  const db = await createTestDB({ isolation: 'schema' });
 
   await createSimVersionRow(db.db);
 
@@ -62,4 +68,175 @@ test('it rejects an anonymous acting user with UNAUTHORIZED', async () => {
     code: 'UNAUTHORIZED',
     data: { reason: 'missing-session' },
   });
+});
+
+test('it advances the chain anchor to the last appended checkpoint on stop', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'node_1',
+    scopeType: 'world_map_node',
+  });
+
+  const batch = createMockCheckpointBatch({
+    count: 2,
+    startPrevHash: started.startHash,
+    startVersion: 1,
+  });
+
+  await client.trackActivityProgress({
+    activityID: started.id,
+    checkpoints: batch,
+    expectedHead: 0,
+  });
+
+  await client.stopActivity({ avatarID: avatar.id });
+
+  const tail = batch[1]!;
+
+  const chain = await ctx.db
+    .selectFrom('activityChains')
+    .selectAll()
+    .where('avatarId', '=', avatar.id)
+    .where('scopeType', '=', 'world_map_node')
+    .where('scopeId', '=', 'node_1')
+    .executeTakeFirstOrThrow();
+
+  expect(chain.appendedNextSeed).toBe(tail.payload.nextSeed);
+  expect(chain.appendedChainIndex).toBe(tail.payload.chainIndex);
+});
+
+test('it leaves the anchor unchanged when nothing was appended', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'node_1',
+    scopeType: 'world_map_node',
+  });
+
+  const chainBefore = await ctx.db
+    .selectFrom('activityChains')
+    .selectAll()
+    .where('avatarId', '=', avatar.id)
+    .where('scopeType', '=', 'world_map_node')
+    .where('scopeId', '=', 'node_1')
+    .executeTakeFirstOrThrow();
+
+  await client.stopActivity({ avatarID: avatar.id });
+
+  const chainAfter = await ctx.db
+    .selectFrom('activityChains')
+    .selectAll()
+    .where('avatarId', '=', avatar.id)
+    .where('scopeType', '=', 'world_map_node')
+    .where('scopeId', '=', 'node_1')
+    .executeTakeFirstOrThrow();
+
+  expect(chainAfter).toStrictEqual(chainBefore);
+});
+
+test('it leaves the anchor unchanged when only the Started checkpoint was appended', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'node_1',
+    scopeType: 'world_map_node',
+  });
+
+  const chainBefore = await ctx.db
+    .selectFrom('activityChains')
+    .selectAll()
+    .where('avatarId', '=', avatar.id)
+    .where('scopeType', '=', 'world_map_node')
+    .where('scopeId', '=', 'node_1')
+    .executeTakeFirstOrThrow();
+
+  const batch = createMockCheckpointBatch({
+    finalPayloadOverrides: { nextSeed: started.seed, seed: started.seed, type: 'started' },
+    startPrevHash: started.startHash,
+    startVersion: 1,
+  });
+
+  await client.trackActivityProgress({
+    activityID: started.id,
+    checkpoints: batch,
+    expectedHead: 0,
+  });
+
+  await client.stopActivity({ avatarID: avatar.id });
+
+  const chainAfter = await ctx.db
+    .selectFrom('activityChains')
+    .selectAll()
+    .where('avatarId', '=', avatar.id)
+    .where('scopeType', '=', 'world_map_node')
+    .where('scopeId', '=', 'node_1')
+    .executeTakeFirstOrThrow();
+
+  expect(chainAfter).toStrictEqual(chainBefore);
+});
+
+test('it rejects a duplicate stop with NOT_FOUND and advances the anchor exactly once', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'node_1',
+    scopeType: 'world_map_node',
+  });
+
+  const batch = createMockCheckpointBatch({ startPrevHash: started.startHash, startVersion: 1 });
+
+  await client.trackActivityProgress({
+    activityID: started.id,
+    checkpoints: batch,
+    expectedHead: 0,
+  });
+
+  await client.stopActivity({ avatarID: avatar.id });
+
+  const chainAfterFirst = await ctx.db
+    .selectFrom('activityChains')
+    .selectAll()
+    .where('avatarId', '=', avatar.id)
+    .where('scopeType', '=', 'world_map_node')
+    .where('scopeId', '=', 'node_1')
+    .executeTakeFirstOrThrow();
+
+  expect(client.stopActivity({ avatarID: avatar.id })).rejects.toMatchObject({
+    code: 'NOT_FOUND',
+  });
+
+  const chainAfterSecond = await ctx.db
+    .selectFrom('activityChains')
+    .selectAll()
+    .where('avatarId', '=', avatar.id)
+    .where('scopeType', '=', 'world_map_node')
+    .where('scopeId', '=', 'node_1')
+    .executeTakeFirstOrThrow();
+
+  expect(chainAfterSecond).toStrictEqual(chainAfterFirst);
 });

--- a/services/activity/src/handlers/stop-activity.ts
+++ b/services/activity/src/handlers/stop-activity.ts
@@ -51,7 +51,6 @@ export async function stopActivity(db: Kysely<DB>, opts: StopActivityOpts): Prom
       activityId: stopped.id,
       appendedHead: stopped.appendedHead,
       avatarId: stopped.avatarId,
-      lastHash: stopped.lastHash,
       scopeId: stopped.scopeId,
       scopeType: stopped.scopeType,
       startChainIndex: stopped.startChainIndex,

--- a/services/activity/src/handlers/stop-activity.ts
+++ b/services/activity/src/handlers/stop-activity.ts
@@ -4,6 +4,7 @@ import { sql } from 'kysely';
 import type { Kysely } from 'kysely';
 import type { EmptyErrorPayload, MissingSessionPayload } from '../types';
 import { toActivityData } from './to-activity-data';
+import { updateAppendedAnchorFromTail } from './update-appended-anchor-from-tail';
 
 /**
  * oRPC handler opts for the authed `stopActivity` procedure.
@@ -18,9 +19,10 @@ interface StopActivityOpts {
 }
 
 /**
- * Stops the active activity for an avatar owned by the acting user. The ownership check folds
- * into the same statement — a foreign or missing avatar matches no row, the same NOT_FOUND path
- * as an avatar with nothing active.
+ * Stops the active activity for an avatar owned by the acting user, then advances the chain's
+ * appended anchor to the stopped stream's tail. The ownership check folds into the same statement
+ * — a foreign or missing avatar matches no row, the same NOT_FOUND path as an avatar with nothing
+ * active.
  */
 export async function stopActivity(db: Kysely<DB>, opts: StopActivityOpts): Promise<ActivityData> {
   const actingUserID = opts.context.actingUserId;
@@ -29,20 +31,34 @@ export async function stopActivity(db: Kysely<DB>, opts: StopActivityOpts): Prom
     throw opts.errors.UNAUTHORIZED({ data: { reason: 'missing-session' } });
   }
 
-  const row = await db
-    .updateTable('activities')
-    .set({ status: 'stopped', stoppedAt: sql`now()` })
-    .where('avatarId', '=', opts.input.avatarID)
-    .where('status', '=', 'active')
-    .where('avatarId', 'in', (subquery) =>
-      subquery.selectFrom('avatars').select('id').where('userId', '=', actingUserID),
-    )
-    .returningAll()
-    .executeTakeFirst();
+  const row = await db.transaction().execute(async (trx) => {
+    const stopped = await trx
+      .updateTable('activities')
+      .set({ status: 'stopped', stoppedAt: sql`now()` })
+      .where('avatarId', '=', opts.input.avatarID)
+      .where('status', '=', 'active')
+      .where('avatarId', 'in', (subquery) =>
+        subquery.selectFrom('avatars').select('id').where('userId', '=', actingUserID),
+      )
+      .returningAll()
+      .executeTakeFirst();
 
-  if (row === undefined) {
-    throw opts.errors.NOT_FOUND({ data: {} });
-  }
+    if (stopped === undefined) {
+      throw opts.errors.NOT_FOUND({ data: {} });
+    }
+
+    await updateAppendedAnchorFromTail(trx, {
+      activityId: stopped.id,
+      appendedHead: stopped.appendedHead,
+      avatarId: stopped.avatarId,
+      lastHash: stopped.lastHash,
+      scopeId: stopped.scopeId,
+      scopeType: stopped.scopeType,
+      startChainIndex: stopped.startChainIndex,
+    });
+
+    return stopped;
+  });
 
   return toActivityData(row);
 }

--- a/services/activity/src/handlers/stop-activity.ts
+++ b/services/activity/src/handlers/stop-activity.ts
@@ -32,6 +32,32 @@ export async function stopActivity(db: Kysely<DB>, opts: StopActivityOpts): Prom
   }
 
   const row = await db.transaction().execute(async (trx) => {
+    // A lockless read to learn which chain the active activity belongs to; the guarded update
+    // below re-verifies everything it found. Writers that touch both rows acquire the chain row
+    // before the activity row, so the chain lock comes first.
+    const active = await trx
+      .selectFrom('activities')
+      .select(['scopeId', 'scopeType'])
+      .where('avatarId', '=', opts.input.avatarID)
+      .where('status', '=', 'active')
+      .where('avatarId', 'in', (subquery) =>
+        subquery.selectFrom('avatars').select('id').where('userId', '=', actingUserID),
+      )
+      .executeTakeFirst();
+
+    if (active === undefined) {
+      throw opts.errors.NOT_FOUND({ data: {} });
+    }
+
+    await trx
+      .selectFrom('activityChains')
+      .select('appendedChainIndex')
+      .where('avatarId', '=', opts.input.avatarID)
+      .where('scopeType', '=', active.scopeType)
+      .where('scopeId', '=', active.scopeId)
+      .forUpdate()
+      .execute();
+
     const stopped = await trx
       .updateTable('activities')
       .set({ status: 'stopped', stoppedAt: sql`now()` })

--- a/services/activity/src/handlers/track-activity-progress.test.ts
+++ b/services/activity/src/handlers/track-activity-progress.test.ts
@@ -617,7 +617,78 @@ test('it rejects a chainIndex that is not startChainIndex plus version with CHEC
   });
 });
 
-test('it advances the chain anchor exactly once across a duplicate terminal submission', async () => {
+test('it returns the settled head when a terminal batch is resubmitted unchanged', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id, xp: 0 });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'node_1',
+    scopeType: 'world_map_node',
+  });
+
+  const batch = createMockCheckpointBatch({
+    finalPayloadOverrides: { rewards: { xp: 150 }, type: 'completed' },
+    startPrevHash: started.startHash,
+    startVersion: 1,
+  });
+
+  const firstResult = await client.trackActivityProgress({
+    activityID: started.id,
+    checkpoints: batch,
+    expectedHead: 0,
+  });
+
+  expect(firstResult).toStrictEqual({ appendedHead: 1 });
+
+  const chainAfterFirst = await ctx.db
+    .selectFrom('activityChains')
+    .selectAll()
+    .where('avatarId', '=', avatar.id)
+    .where('scopeType', '=', 'world_map_node')
+    .where('scopeId', '=', 'node_1')
+    .executeTakeFirstOrThrow();
+
+  const resubmitResult = await client.trackActivityProgress({
+    activityID: started.id,
+    checkpoints: batch,
+    expectedHead: 0,
+  });
+
+  expect(resubmitResult).toStrictEqual({ appendedHead: 1 });
+
+  const chainAfterSecond = await ctx.db
+    .selectFrom('activityChains')
+    .selectAll()
+    .where('avatarId', '=', avatar.id)
+    .where('scopeType', '=', 'world_map_node')
+    .where('scopeId', '=', 'node_1')
+    .executeTakeFirstOrThrow();
+
+  expect(chainAfterSecond).toStrictEqual(chainAfterFirst);
+
+  const updatedAvatar = await ctx.db
+    .selectFrom('avatars')
+    .selectAll()
+    .where('id', '=', avatar.id)
+    .executeTakeFirstOrThrow();
+
+  expect(updatedAvatar.xp).toBe(150);
+
+  const checkpoints = await ctx.db
+    .selectFrom('activityCheckpoints')
+    .selectAll()
+    .where('activityId', '=', started.id)
+    .execute();
+
+  expect(checkpoints).toHaveLength(1);
+});
+
+test('it rejects a non-matching batch against a settled activity as terminal', async () => {
   await using ctx = await setupTest();
 
   const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
@@ -643,38 +714,24 @@ test('it advances the chain anchor exactly once across a duplicate terminal subm
     expectedHead: 0,
   });
 
-  const chainAfterFirst = await ctx.db
-    .selectFrom('activityChains')
-    .selectAll()
-    .where('avatarId', '=', avatar.id)
-    .where('scopeType', '=', 'world_map_node')
-    .where('scopeId', '=', 'node_1')
-    .executeTakeFirstOrThrow();
+  const tampered = [
+    { ...batch[0]!, payload: { ...batch[0]!.payload, time: batch[0]!.payload.time + 1 } },
+  ];
 
   expect(
     client.trackActivityProgress({
       activityID: started.id,
-      checkpoints: batch,
+      checkpoints: tampered,
       expectedHead: 0,
     }),
   ).rejects.toMatchObject({ code: 'ACTIVITY_TERMINAL', data: { status: 'stopped' } });
-
-  const chainAfterSecond = await ctx.db
-    .selectFrom('activityChains')
-    .selectAll()
-    .where('avatarId', '=', avatar.id)
-    .where('scopeType', '=', 'world_map_node')
-    .where('scopeId', '=', 'node_1')
-    .executeTakeFirstOrThrow();
-
-  expect(chainAfterSecond).toStrictEqual(chainAfterFirst);
 });
 
-test('it does not double-apply xp on a duplicate terminal submission', async () => {
+test('it returns the settled head when a landed batch is resubmitted after a user stop', async () => {
   await using ctx = await setupTest();
 
   const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
-  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id, xp: 0 });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
 
   const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
 
@@ -684,11 +741,7 @@ test('it does not double-apply xp on a duplicate terminal submission', async () 
     scopeType: 'world_map_node',
   });
 
-  const batch = createMockCheckpointBatch({
-    finalPayloadOverrides: { rewards: { xp: 150 }, type: 'completed' },
-    startPrevHash: started.startHash,
-    startVersion: 1,
-  });
+  const batch = createMockCheckpointBatch({ startPrevHash: started.startHash, startVersion: 1 });
 
   await client.trackActivityProgress({
     activityID: started.id,
@@ -696,21 +749,15 @@ test('it does not double-apply xp on a duplicate terminal submission', async () 
     expectedHead: 0,
   });
 
-  expect(
-    client.trackActivityProgress({
-      activityID: started.id,
-      checkpoints: batch,
-      expectedHead: 0,
-    }),
-  ).rejects.toMatchObject({ code: 'ACTIVITY_TERMINAL', data: { status: 'stopped' } });
+  await client.stopActivity({ avatarID: avatar.id });
 
-  const updated = await ctx.db
-    .selectFrom('avatars')
-    .selectAll()
-    .where('id', '=', avatar.id)
-    .executeTakeFirstOrThrow();
+  const resubmitResult = await client.trackActivityProgress({
+    activityID: started.id,
+    checkpoints: batch,
+    expectedHead: 0,
+  });
 
-  expect(updated.xp).toBe(150);
+  expect(resubmitResult).toStrictEqual({ appendedHead: 1 });
 });
 
 test('it rejects an append from a displaced writer session with SESSION_EVICTED', async () => {

--- a/services/activity/src/handlers/track-activity-progress.test.ts
+++ b/services/activity/src/handlers/track-activity-progress.test.ts
@@ -1163,7 +1163,7 @@ test('it consumes no budget and leaves the meter anchor untouched on a cap trip'
   expect(updated.simMeteredAt).toStrictEqual(avatar.simMeteredAt);
 });
 
-test('it leaves the chain anchor untouched on a cap trip', async () => {
+test('it leaves the anchor unchanged when a cap trips before anything appended', async () => {
   await using ctx = await setupTest();
 
   const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
@@ -1209,6 +1209,65 @@ test('it leaves the chain anchor untouched on a cap trip', async () => {
     .executeTakeFirstOrThrow();
 
   expect(chainAfter).toStrictEqual(chainBefore);
+});
+
+test('it advances the chain anchor to the pre-batch tail on a cap trip', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+
+  const avatar = await createAvatarRow(ctx.db, {
+    simBudgetMs: 10_000,
+    simMeteredAt: new Date(),
+    userId: viewer.user.id,
+  });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'node_1',
+    scopeType: 'world_map_node',
+  });
+
+  const firstBatch = createMockCheckpointBatch({
+    startPrevHash: started.startHash,
+    startVersion: 1,
+    timeStepMs: 5000,
+  });
+
+  await client.trackActivityProgress({
+    activityID: started.id,
+    checkpoints: firstBatch,
+    expectedHead: 0,
+  });
+
+  const overCap = createMockCheckpointBatch({
+    startPrevHash: firstBatch[0]?.hash ?? '',
+    startVersion: 2,
+    timeStepMs: 3_600_000,
+  });
+
+  expect(
+    client.trackActivityProgress({
+      activityID: started.id,
+      checkpoints: overCap,
+      expectedHead: 1,
+    }),
+  ).rejects.toMatchObject({ code: 'ACTIVITY_CAPPED' });
+
+  const tail = firstBatch[0]!;
+
+  const chainAfter = await ctx.db
+    .selectFrom('activityChains')
+    .selectAll()
+    .where('avatarId', '=', avatar.id)
+    .where('scopeType', '=', 'world_map_node')
+    .where('scopeId', '=', 'node_1')
+    .executeTakeFirstOrThrow();
+
+  expect(chainAfter.appendedNextSeed).toBe(tail.payload.nextSeed);
+  expect(chainAfter.appendedChainIndex).toBe(tail.payload.chainIndex);
 });
 
 test('it rejects a batch whose time regresses within the batch with CHECKPOINT_INVALID', async () => {

--- a/services/activity/src/handlers/track-activity-progress.test.ts
+++ b/services/activity/src/handlers/track-activity-progress.test.ts
@@ -476,6 +476,56 @@ test('it advances the chain anchor to the terminal checkpoint on a failed batch'
   expect(chain.appendedChainIndex).toBe(terminal.payload.chainIndex);
 });
 
+test('it advances the chain anchor when the terminal segment consumed no entropy', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'node_1',
+    scopeType: 'world_map_node',
+  });
+
+  // A checkpoint's seed is its own segment's origin, so a terminal whose segment rolled nothing
+  // carries nextSeed equal to seed while earlier checkpoints in the stream consumed entropy.
+  const restingSeed = 'aaaabbbbccccdddd';
+
+  const batch = createMockCheckpointBatch({
+    count: 2,
+    finalPayloadOverrides: {
+      nextSeed: restingSeed,
+      rewards: { xp: 100 },
+      seed: restingSeed,
+      type: 'completed',
+    },
+    startPrevHash: started.startHash,
+    startVersion: 1,
+  });
+
+  await client.trackActivityProgress({
+    activityID: started.id,
+    checkpoints: batch,
+    expectedHead: 0,
+  });
+
+  const terminal = batch[1]!;
+
+  const chain = await ctx.db
+    .selectFrom('activityChains')
+    .selectAll()
+    .where('avatarId', '=', avatar.id)
+    .where('scopeType', '=', 'world_map_node')
+    .where('scopeId', '=', 'node_1')
+    .executeTakeFirstOrThrow();
+
+  expect(chain.appendedNextSeed).toBe(restingSeed);
+  expect(chain.appendedChainIndex).toBe(terminal.payload.chainIndex);
+});
+
 test('it continues the next activity on the same node from the previous terminal checkpoint', async () => {
   await using ctx = await setupTest();
 

--- a/services/activity/src/handlers/track-activity-progress.ts
+++ b/services/activity/src/handlers/track-activity-progress.ts
@@ -14,6 +14,7 @@ import type {
   StaleHeadPayload,
   TerminalStatusPayload,
 } from '../types';
+import { updateAppendedAnchorFromTail } from './update-appended-anchor-from-tail';
 
 interface TrackActivityProgressDeps {
   readonly db: Kysely<DB>;
@@ -144,32 +145,46 @@ export async function trackActivityProgress(
   const availableMs = Math.min(deps.simTimeCapMs, accruedMs);
 
   if (headMatches && timeDelta > availableMs) {
-    // A single-statement claim, deliberately outside the append transaction: the append is
-    // rejected whole (nothing was accepted, so no head, hash, or meter movement) while the capped
-    // transition itself must commit before the error below reports it.
-    const capped = await db
-      .updateTable('activities')
-      .set({ status: 'capped', stoppedAt: sql`now()` })
-      .where('id', '=', opts.input.activityID)
-      .where('appendedHead', '=', opts.input.expectedHead)
-      .where('status', '=', 'active')
-      .where((eb) =>
-        eb.or([eb('writerSessionId', 'is', null), eb('writerSessionId', '=', actingSessionID)]),
-      )
-      .returning('appendedHead')
-      .executeTakeFirst();
-
-    if (capped === undefined) {
-      const current = await db
-        .selectFrom('activities')
-        .select(['appendedHead', 'status', 'writerSessionId'])
+    // Its own transaction, not the append transaction: the append is rejected whole (nothing was
+    // accepted, so no head, hash, or meter movement) while the capped transition and the chain's
+    // consequent anchor advance commit together.
+    const capOutcome = await db.transaction().execute(async (trx) => {
+      const capped = await trx
+        .updateTable('activities')
+        .set({ status: 'capped', stoppedAt: sql`now()` })
         .where('id', '=', opts.input.activityID)
+        .where('appendedHead', '=', opts.input.expectedHead)
+        .where('status', '=', 'active')
+        .where((eb) =>
+          eb.or([eb('writerSessionId', 'is', null), eb('writerSessionId', '=', actingSessionID)]),
+        )
+        .returning(['appendedHead', 'lastHash'])
         .executeTakeFirst();
 
-      throw pickAppendRaceError(opts.errors, actingSessionID, current);
-    }
+      if (capped === undefined) {
+        const current = await trx
+          .selectFrom('activities')
+          .select(['appendedHead', 'status', 'writerSessionId'])
+          .where('id', '=', opts.input.activityID)
+          .executeTakeFirst();
 
-    throw opts.errors.ACTIVITY_CAPPED({ data: { appendedHead: capped.appendedHead } });
+        throw pickAppendRaceError(opts.errors, actingSessionID, current);
+      }
+
+      await updateAppendedAnchorFromTail(trx, {
+        activityId: opts.input.activityID,
+        appendedHead: capped.appendedHead,
+        avatarId: head.avatarId,
+        lastHash: capped.lastHash,
+        scopeId: head.scopeId,
+        scopeType: head.scopeType,
+        startChainIndex: head.startChainIndex,
+      });
+
+      return capped.appendedHead;
+    });
+
+    throw opts.errors.ACTIVITY_CAPPED({ data: { appendedHead: capOutcome } });
   }
 
   const appendedHead = await db.transaction().execute(async (trx) => {
@@ -222,17 +237,15 @@ export async function trackActivityProgress(
     }
 
     if (terminalRewardsXP !== undefined && lastCheckpoint !== undefined) {
-      await trx
-        .updateTable('activityChains')
-        .set({
-          appendedChainIndex: lastCheckpoint.payload.chainIndex,
-          appendedNextSeed: lastCheckpoint.payload.nextSeed,
-        })
-        .where('avatarId', '=', head.avatarId)
-        .where('scopeType', '=', head.scopeType)
-        .where('scopeId', '=', head.scopeId)
-        .where('appendedChainIndex', '=', head.startChainIndex)
-        .execute();
+      await updateAppendedAnchorFromTail(trx, {
+        activityId: opts.input.activityID,
+        appendedHead: newHead,
+        avatarId: head.avatarId,
+        lastHash: newLastHash,
+        scopeId: head.scopeId,
+        scopeType: head.scopeType,
+        startChainIndex: head.startChainIndex,
+      });
 
       const newXP = Math.max(0, Math.round(head.xp + terminalRewardsXP));
 

--- a/services/activity/src/handlers/track-activity-progress.ts
+++ b/services/activity/src/handlers/track-activity-progress.ts
@@ -114,18 +114,7 @@ export async function trackActivityProgress(
   }
 
   if (head.status !== 'active') {
-    const outcome = pickTerminalOutcome(opts.input.checkpoints, head, opts.errors);
-
-    if (outcome instanceof Error) {
-      throw outcome;
-    }
-
-    opts.context.logger.info(
-      { activityID: opts.input.activityID },
-      'settled batch re-acknowledged after a dropped ack',
-    );
-
-    return outcome;
+    return checkAppendRace(db, opts);
   }
 
   if (head.writerSessionId !== null && head.writerSessionId !== actingSessionID) {
@@ -169,40 +158,19 @@ export async function trackActivityProgress(
         .where((eb) =>
           eb.or([eb('writerSessionId', 'is', null), eb('writerSessionId', '=', actingSessionID)]),
         )
-        .returning(['appendedHead', 'lastHash'])
+        .returning('appendedHead')
         .executeTakeFirst();
 
       if (capped === undefined) {
-        const current = await trx
-          .selectFrom('activities')
-          .select(['appendedHead', 'lastHash', 'status', 'writerSessionId'])
-          .where('id', '=', opts.input.activityID)
-          .executeTakeFirst();
+        const resolved = await checkAppendRace(trx, opts);
 
-        const outcome = pickAppendRaceOutcome(
-          opts.errors,
-          actingSessionID,
-          current,
-          opts.input.checkpoints,
-        );
-
-        if (outcome instanceof Error) {
-          throw outcome;
-        }
-
-        opts.context.logger.info(
-          { activityID: opts.input.activityID },
-          'settled batch re-acknowledged after a dropped ack',
-        );
-
-        return { appendedHead: outcome.appendedHead, kind: 'resolved' } as const;
+        return { appendedHead: resolved.appendedHead, kind: 'resolved' } as const;
       }
 
       await updateAppendedAnchorFromTail(trx, {
         activityId: opts.input.activityID,
         appendedHead: capped.appendedHead,
         avatarId: head.avatarId,
-        lastHash: capped.lastHash,
         scopeId: head.scopeId,
         scopeType: head.scopeType,
         startChainIndex: head.startChainIndex,
@@ -242,29 +210,9 @@ export async function trackActivityProgress(
       .executeTakeFirst();
 
     if (updated === undefined) {
-      const current = await trx
-        .selectFrom('activities')
-        .select(['appendedHead', 'lastHash', 'status', 'writerSessionId'])
-        .where('id', '=', opts.input.activityID)
-        .executeTakeFirst();
+      const resolved = await checkAppendRace(trx, opts);
 
-      const outcome = pickAppendRaceOutcome(
-        opts.errors,
-        actingSessionID,
-        current,
-        opts.input.checkpoints,
-      );
-
-      if (outcome instanceof Error) {
-        throw outcome;
-      }
-
-      opts.context.logger.info(
-        { activityID: opts.input.activityID },
-        'settled batch re-acknowledged after a dropped ack',
-      );
-
-      return outcome.appendedHead;
+      return resolved.appendedHead;
     }
 
     if (opts.input.checkpoints.length > 0) {
@@ -288,7 +236,6 @@ export async function trackActivityProgress(
         activityId: opts.input.activityID,
         appendedHead: newHead,
         avatarId: head.avatarId,
-        lastHash: newLastHash,
         scopeId: head.scopeId,
         scopeType: head.scopeType,
         startChainIndex: head.startChainIndex,
@@ -331,6 +278,40 @@ export async function trackActivityProgress(
   });
 
   return { appendedHead };
+}
+
+/**
+ * Resolves a batch that lost its guarded update, from a fresh read of the activity row. A batch
+ * that recomputes onto the settled tail is a dropped-ack retry: it re-acknowledges with the
+ * recorded head — logged, no writes. Every other outcome throws its typed error.
+ */
+async function checkAppendRace(
+  db: Kysely<DB>,
+  opts: TrackActivityProgressOpts,
+): Promise<{ appendedHead: number }> {
+  const current = await db
+    .selectFrom('activities')
+    .select(['appendedHead', 'lastHash', 'status', 'writerSessionId'])
+    .where('id', '=', opts.input.activityID)
+    .executeTakeFirst();
+
+  const outcome = pickAppendRaceOutcome(
+    opts.errors,
+    opts.context.actingSessionId,
+    current,
+    opts.input.checkpoints,
+  );
+
+  if (outcome instanceof Error) {
+    throw outcome;
+  }
+
+  opts.context.logger.info(
+    { activityID: opts.input.activityID },
+    'settled batch re-acknowledged after a dropped ack',
+  );
+
+  return { appendedHead: outcome.appendedHead };
 }
 
 interface SettledTailRow {

--- a/services/activity/src/handlers/track-activity-progress.ts
+++ b/services/activity/src/handlers/track-activity-progress.ts
@@ -149,6 +149,16 @@ export async function trackActivityProgress(
     // accepted, so no head, hash, or meter movement) while the capped transition and the chain's
     // consequent anchor advance commit together.
     const capOutcome = await db.transaction().execute(async (trx) => {
+      // Chain row before activity row — the one lock order every writer that touches both shares.
+      await trx
+        .selectFrom('activityChains')
+        .select('appendedChainIndex')
+        .where('avatarId', '=', head.avatarId)
+        .where('scopeType', '=', head.scopeType)
+        .where('scopeId', '=', head.scopeId)
+        .forUpdate()
+        .execute();
+
       const capped = await trx
         .updateTable('activities')
         .set({ status: 'capped', stoppedAt: sql`now()` })
@@ -187,6 +197,19 @@ export async function trackActivityProgress(
   }
 
   const appendedHead = await db.transaction().execute(async (trx) => {
+    // Only a terminal batch advances the chain anchor; a batch that never touches the chain row
+    // takes part in no lock ordering. When both rows are taken, the chain row comes first.
+    if (terminalRewardsXP !== undefined) {
+      await trx
+        .selectFrom('activityChains')
+        .select('appendedChainIndex')
+        .where('avatarId', '=', head.avatarId)
+        .where('scopeType', '=', head.scopeType)
+        .where('scopeId', '=', head.scopeId)
+        .forUpdate()
+        .execute();
+    }
+
     const updated = await trx
       .updateTable('activities')
       .set({

--- a/services/activity/src/handlers/track-activity-progress.ts
+++ b/services/activity/src/handlers/track-activity-progress.ts
@@ -2,6 +2,7 @@ import type { CheckpointBatchEntry, CheckpointPayload } from '@vers/contract-act
 import { buildCheckpointHash } from '@vers/contract-activity';
 import type { ActivityStatus, DB, Json } from '@vers/db';
 import { levelForXP } from '@vers/idle-core';
+import type { ServiceContext } from '@vers/service-runtime';
 import { sql } from 'kysely';
 import type { Kysely } from 'kysely';
 import invariant from 'tiny-invariant';
@@ -32,6 +33,7 @@ interface TrackActivityProgressOpts {
   readonly context: {
     readonly actingSessionId: null | string;
     readonly actingUserId: null | string;
+    readonly logger: ServiceContext['logger'];
   };
   readonly errors: {
     readonly ACTIVITY_CAPPED: (payload: CappedPayload) => Error;
@@ -112,9 +114,18 @@ export async function trackActivityProgress(
   }
 
   if (head.status !== 'active') {
-    throw opts.errors.ACTIVITY_TERMINAL({
-      data: { appendedHead: head.appendedHead, status: head.status },
-    });
+    const outcome = pickTerminalOutcome(opts.input.checkpoints, head, opts.errors);
+
+    if (outcome instanceof Error) {
+      throw outcome;
+    }
+
+    opts.context.logger.info(
+      { activityID: opts.input.activityID },
+      'settled batch re-acknowledged after a dropped ack',
+    );
+
+    return outcome;
   }
 
   if (head.writerSessionId !== null && head.writerSessionId !== actingSessionID) {
@@ -164,11 +175,27 @@ export async function trackActivityProgress(
       if (capped === undefined) {
         const current = await trx
           .selectFrom('activities')
-          .select(['appendedHead', 'status', 'writerSessionId'])
+          .select(['appendedHead', 'lastHash', 'status', 'writerSessionId'])
           .where('id', '=', opts.input.activityID)
           .executeTakeFirst();
 
-        throw pickAppendRaceError(opts.errors, actingSessionID, current);
+        const outcome = pickAppendRaceOutcome(
+          opts.errors,
+          actingSessionID,
+          current,
+          opts.input.checkpoints,
+        );
+
+        if (outcome instanceof Error) {
+          throw outcome;
+        }
+
+        opts.context.logger.info(
+          { activityID: opts.input.activityID },
+          'settled batch re-acknowledged after a dropped ack',
+        );
+
+        return { appendedHead: outcome.appendedHead, kind: 'resolved' } as const;
       }
 
       await updateAppendedAnchorFromTail(trx, {
@@ -181,10 +208,14 @@ export async function trackActivityProgress(
         startChainIndex: head.startChainIndex,
       });
 
-      return capped.appendedHead;
+      return { appendedHead: capped.appendedHead, kind: 'capped' } as const;
     });
 
-    throw opts.errors.ACTIVITY_CAPPED({ data: { appendedHead: capOutcome } });
+    if (capOutcome.kind === 'resolved') {
+      return { appendedHead: capOutcome.appendedHead };
+    }
+
+    throw opts.errors.ACTIVITY_CAPPED({ data: { appendedHead: capOutcome.appendedHead } });
   }
 
   const appendedHead = await db.transaction().execute(async (trx) => {
@@ -213,11 +244,27 @@ export async function trackActivityProgress(
     if (updated === undefined) {
       const current = await trx
         .selectFrom('activities')
-        .select(['appendedHead', 'status', 'writerSessionId'])
+        .select(['appendedHead', 'lastHash', 'status', 'writerSessionId'])
         .where('id', '=', opts.input.activityID)
         .executeTakeFirst();
 
-      throw pickAppendRaceError(opts.errors, actingSessionID, current);
+      const outcome = pickAppendRaceOutcome(
+        opts.errors,
+        actingSessionID,
+        current,
+        opts.input.checkpoints,
+      );
+
+      if (outcome instanceof Error) {
+        throw outcome;
+      }
+
+      opts.context.logger.info(
+        { activityID: opts.input.activityID },
+        'settled batch re-acknowledged after a dropped ack',
+      );
+
+      return outcome.appendedHead;
     }
 
     if (opts.input.checkpoints.length > 0) {
@@ -284,6 +331,73 @@ export async function trackActivityProgress(
   });
 
   return { appendedHead };
+}
+
+interface SettledTailRow {
+  readonly appendedHead: number;
+  readonly lastHash: string;
+}
+
+/**
+ * Reports whether a checkpoint batch, replayed from scratch, recomputes onto a settled activity's
+ * recorded tail: the last entry's version lands on `settled.appendedHead`, and every entry's hash —
+ * rebuilt via `buildCheckpointHash`, never trusted from the submitted `hash` field — chains onto
+ * the previous entry's rebuilt hash and the final one reproduces `settled.lastHash`. A match proves
+ * the recorded tail is this exact batch: the original submit landed and only the ack was lost.
+ */
+function isSettledResubmit(
+  checkpoints: ReadonlyArray<CheckpointBatchEntry>,
+  settled: Readonly<SettledTailRow>,
+): boolean {
+  const lastCheckpoint = checkpoints.at(-1);
+
+  if (lastCheckpoint === undefined || lastCheckpoint.version !== settled.appendedHead) {
+    return false;
+  }
+
+  let previousHash: string | undefined;
+
+  for (const checkpoint of checkpoints) {
+    if (previousHash !== undefined && checkpoint.prevHash !== previousHash) {
+      return false;
+    }
+
+    previousHash = buildCheckpointHash({
+      chainIndex: checkpoint.payload.chainIndex,
+      entropySource: checkpoint.payload.entropySource,
+      nextSeed: checkpoint.payload.nextSeed,
+      prevHash: checkpoint.prevHash,
+      seed: checkpoint.payload.seed,
+      time: checkpoint.payload.time,
+      type: checkpoint.payload.type,
+      version: checkpoint.version,
+    });
+  }
+
+  return previousHash === settled.lastHash;
+}
+
+interface TerminalRow extends SettledTailRow {
+  readonly status: ActivityStatus;
+}
+
+/**
+ * Resolves a non-active head: a resubmit that recomputes onto the recorded tail settles as the
+ * already-settled head, a normal success; any other batch against a terminal status resolves
+ * ACTIVITY_TERMINAL.
+ */
+function pickTerminalOutcome(
+  checkpoints: ReadonlyArray<CheckpointBatchEntry>,
+  current: Readonly<TerminalRow>,
+  errors: TrackActivityProgressOpts['errors'],
+): { readonly appendedHead: number } | Error {
+  if (isSettledResubmit(checkpoints, current)) {
+    return { appendedHead: current.appendedHead };
+  }
+
+  return errors.ACTIVITY_TERMINAL({
+    data: { appendedHead: current.appendedHead, status: current.status },
+  });
 }
 
 interface CheckpointBatchInput {
@@ -365,29 +479,27 @@ function findInvalidReason(
   return undefined;
 }
 
-interface AppendRaceRow {
-  readonly appendedHead: number;
-  readonly status: ActivityStatus;
+interface AppendRaceRow extends TerminalRow {
   readonly writerSessionId: null | string;
 }
 
 /**
- * Picks the error a lost head-row race resolves to, from a fresh read of the activity row: gone,
- * terminal, writer taken over, or a retryable stale head.
+ * Resolves a lost head-row race from a fresh read of the activity row: gone (NOT_FOUND), terminal
+ * (a matching resubmit settles, otherwise ACTIVITY_TERMINAL), writer taken over (SESSION_EVICTED),
+ * or a retryable stale head (CONFLICT).
  */
-function pickAppendRaceError(
+function pickAppendRaceOutcome(
   errors: TrackActivityProgressOpts['errors'],
   actingSessionID: null | string,
   current: AppendRaceRow | undefined,
-): Error {
+  checkpoints: ReadonlyArray<CheckpointBatchEntry>,
+): { readonly appendedHead: number } | Error {
   if (current === undefined) {
     return errors.NOT_FOUND({ data: {} });
   }
 
   if (current.status !== 'active') {
-    return errors.ACTIVITY_TERMINAL({
-      data: { appendedHead: current.appendedHead, status: current.status },
-    });
+    return pickTerminalOutcome(checkpoints, current, errors);
   }
 
   if (current.writerSessionId !== null && current.writerSessionId !== actingSessionID) {

--- a/services/activity/src/handlers/update-appended-anchor-from-tail.ts
+++ b/services/activity/src/handlers/update-appended-anchor-from-tail.ts
@@ -6,7 +6,6 @@ interface UpdateAppendedAnchorFromTailActivity {
   readonly activityId: string;
   readonly appendedHead: number;
   readonly avatarId: string;
-  readonly lastHash: string;
   readonly scopeId: string;
   readonly scopeType: string;
   readonly startChainIndex: number;
@@ -16,7 +15,10 @@ interface UpdateAppendedAnchorFromTailActivity {
  * Advances a chain's appended anchor to a forward-exited activity's last appended checkpoint,
  * guarded by a compare-and-swap on the chain's own `startChainIndex` so a duplicate transition
  * moves nothing. No-ops when the activity appended nothing, or when its only checkpoint is the
- * Started one — whose `nextSeed` equals `seed`, so nothing was consumed.
+ * Started one — the sole case where nothing was consumed. Any other tail advances the anchor even
+ * when `nextSeed` equals `seed`: a checkpoint's `seed` is its own segment's origin, not the
+ * activity's, so that equality only says the final segment rolled nothing while earlier segments
+ * may have consumed plenty.
  */
 export async function updateAppendedAnchorFromTail(
   trx: Kysely<DB>,
@@ -30,7 +32,7 @@ export async function updateAppendedAnchorFromTail(
     .selectFrom('activityCheckpoints')
     .select('payload')
     .where('activityId', '=', activity.activityId)
-    .where('hash', '=', activity.lastHash)
+    .where('version', '=', activity.appendedHead)
     .executeTakeFirst();
 
   if (tail === undefined) {
@@ -39,7 +41,7 @@ export async function updateAppendedAnchorFromTail(
 
   const payload = CheckpointPayloadSchema.parse(tail.payload);
 
-  if (payload.nextSeed === payload.seed) {
+  if (payload.type === 'started') {
     return;
   }
 

--- a/services/activity/src/handlers/update-appended-anchor-from-tail.ts
+++ b/services/activity/src/handlers/update-appended-anchor-from-tail.ts
@@ -1,0 +1,54 @@
+import { CheckpointPayloadSchema } from '@vers/contract-activity';
+import type { DB } from '@vers/db';
+import type { Kysely } from 'kysely';
+
+interface UpdateAppendedAnchorFromTailActivity {
+  readonly activityId: string;
+  readonly appendedHead: number;
+  readonly avatarId: string;
+  readonly lastHash: string;
+  readonly scopeId: string;
+  readonly scopeType: string;
+  readonly startChainIndex: number;
+}
+
+/**
+ * Advances a chain's appended anchor to a forward-exited activity's last appended checkpoint,
+ * guarded by a compare-and-swap on the chain's own `startChainIndex` so a duplicate transition
+ * moves nothing. No-ops when the activity appended nothing, or when its only checkpoint is the
+ * Started one — whose `nextSeed` equals `seed`, so nothing was consumed.
+ */
+export async function updateAppendedAnchorFromTail(
+  trx: Kysely<DB>,
+  activity: Readonly<UpdateAppendedAnchorFromTailActivity>,
+): Promise<void> {
+  if (activity.appendedHead === 0) {
+    return;
+  }
+
+  const tail = await trx
+    .selectFrom('activityCheckpoints')
+    .select('payload')
+    .where('activityId', '=', activity.activityId)
+    .where('hash', '=', activity.lastHash)
+    .executeTakeFirst();
+
+  if (tail === undefined) {
+    return;
+  }
+
+  const payload = CheckpointPayloadSchema.parse(tail.payload);
+
+  if (payload.nextSeed === payload.seed) {
+    return;
+  }
+
+  await trx
+    .updateTable('activityChains')
+    .set({ appendedChainIndex: payload.chainIndex, appendedNextSeed: payload.nextSeed })
+    .where('avatarId', '=', activity.avatarId)
+    .where('scopeType', '=', activity.scopeType)
+    .where('scopeId', '=', activity.scopeId)
+    .where('appendedChainIndex', '=', activity.startChainIndex)
+    .execute();
+}

--- a/services/activity/src/isolation.test.ts
+++ b/services/activity/src/isolation.test.ts
@@ -1,48 +1,33 @@
 import { expect, test } from 'bun:test';
-import type { ActivityContract } from '@vers/contract-activity';
 import { createTestDB, createViewer } from '@vers/service-test-utils/bun';
-import { createSimVersionRow } from '@vers/sim-registry/test-utils';
-import { buildRPCTestClient } from '@vers/test-utils';
-import { createActivityService } from './create-activity-service';
 import { createAvatarRow } from './test-utils/create-avatar-row';
 
 async function setupTest() {
   const db = await createTestDB();
 
-  await createSimVersionRow(db.db);
-
-  const service = await createActivityService({ db: db.db });
-
-  return { app: service.app, db: db.db, [Symbol.asyncDispose]: db[Symbol.asyncDispose] };
+  return { db: db.db, [Symbol.asyncDispose]: db[Symbol.asyncDispose] };
 }
 
 // Each call acquires its own transaction-isolated handle from the same shared worker database
 // (`@vers/service-test-utils/bun`'s default isolation). These two tests prove the rollback
 // actually holds across test boundaries — order-dependent by design.
 
-test('it creates an activity visible within this test', async () => {
+test('it creates an avatar visible within this test', async () => {
   await using ctx = await setupTest();
 
   const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
-  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
 
-  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+  await createAvatarRow(ctx.db, { userId: viewer.user.id });
 
-  await client.startActivity({
-    avatarID: avatar.id,
-    scopeID: 'node_1',
-    scopeType: 'world_map_node',
-  });
-
-  const rows = await ctx.db.selectFrom('activities').selectAll().execute();
+  const rows = await ctx.db.selectFrom('avatars').selectAll().execute();
 
   expect(rows).toHaveLength(1);
 });
 
-test('it starts with no activities left over from the previous test', async () => {
+test('it starts with no avatars left over from the previous test', async () => {
   await using ctx = await setupTest();
 
-  const rows = await ctx.db.selectFrom('activities').selectAll().execute();
+  const rows = await ctx.db.selectFrom('avatars').selectAll().execute();
 
   expect(rows).toBeEmpty();
 });


### PR DESCRIPTION
Closes #516

## Description

A user stop and a cap exit now forward-advance the seed chain's appended anchor the same way a terminal checkpoint already does, and a resubmitted terminal batch settles idempotently instead of erroring. Review follow-ups landed the doc-prescribed chain-row-first lock ordering across every writer.

- New `updateAppendedAnchorFromTail` helper advances the chain anchor from an activity's last appended checkpoint, guarded on the chain's `startChainIndex`; no-ops when nothing was appended or the tail is the Started checkpoint.
- `stopActivity` and the cap claim run in transactions that advance the chain; the terminal advance shares the helper.
- A resubmitted batch whose recomputed hash chain reproduces the settled tail returns the original success (logged) instead of `ACTIVITY_TERMINAL`.
- `startActivity` roots the new activity under the chain-row lock in one transaction, closing a race that let a start rooted at a stale anchor replay spent chain positions; all dual-row writers acquire chain before activity, so no lock cycle exists.
- Suites driving the transactional handlers moved to `schema` isolation.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
