### PR TITLE
chore: upgrade @zgeoff/oxlint-config to 0.0.5

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -13,6 +13,11 @@
     }
   },
   "rules": {
+    // warn until the naming burn-down lands; `fake` and `seed` are this
+    // repo's verbs (test doubles, database seeding), `up`/`down` are
+    // Kysely-mandated migration exports
+    "zgeoff/function-verb": ["warn", { "verbs": ["fake", "seed"], "exemptNames": ["up", "down"] }],
+
     // the shared config's version minus ignorePattern — baseline(#236)
     // disable directives sit on their own line above the flagged site, and
     // demanding a blank line above them separates them from it

--- a/bun.lock
+++ b/bun.lock
@@ -1083,7 +1083,7 @@
     "@zgeoff/bun-test-extended": "0.0.3",
     "@zgeoff/dbhub": "0.23.4",
     "@zgeoff/format-codemod": "0.0.6",
-    "@zgeoff/oxlint-config": "0.0.4",
+    "@zgeoff/oxlint-config": "0.0.5",
     "autoprefixer": "10.5.2",
     "babel-plugin-react-compiler": "1.0.0",
     "camera-controls": "3.1.2",
@@ -2642,7 +2642,7 @@
 
     "@zgeoff/format-codemod": ["@zgeoff/format-codemod@0.0.6", "", { "dependencies": { "oxc-parser": "0.137.0" }, "bin": { "format-codemod": "dist/cli.js" } }, "sha512-7m2Iiydwn2ekBB+t3LUI4sUPSkb5j3zr/JnqGmBg7u21nJlY2spCz+d56jcdAhqs7bLOixZtkY6Jr9UTP9XhgA=="],
 
-    "@zgeoff/oxlint-config": ["@zgeoff/oxlint-config@0.0.4", "", { "dependencies": { "@stylistic/eslint-plugin": "5.10.0" }, "peerDependencies": { "oxlint": ">=1.71.0" } }, "sha512-nWetV+a2ir+aXgFyRwVTzNs5XY4jFWc4CCWkF242VMACLpp7D8f6U3To7TRkWnLnP4D/tmpriaW6OmtzZq3ncQ=="],
+    "@zgeoff/oxlint-config": ["@zgeoff/oxlint-config@0.0.5", "", { "dependencies": { "@stylistic/eslint-plugin": "5.10.0" }, "peerDependencies": { "oxlint": ">=1.71.0" } }, "sha512-SF7u+kGHEItEhR6twHJ4HaB1v2SpW2txepLoTzJ5GWo2T2X3NCkd5gqgjFowDykvHFeDVPwFo1gf7y672N0f+w=="],
 
     "abbrev": ["abbrev@4.0.0", "", {}, "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA=="],
 

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
       "@zgeoff/bun-test-extended": "0.0.3",
       "@zgeoff/dbhub": "0.23.4",
       "@zgeoff/format-codemod": "0.0.6",
-      "@zgeoff/oxlint-config": "0.0.4",
+      "@zgeoff/oxlint-config": "0.0.5",
       "autoprefixer": "10.5.2",
       "babel-plugin-react-compiler": "1.0.0",
       "camera-controls": "3.1.2",


### PR DESCRIPTION
## Description

Upgrades `@zgeoff/oxlint-config` to 0.0.5, which ships `zgeoff/function-verb` — the shared function-naming taxonomy as a lint rule. The rule runs at `warn` here (113 findings) until a burn-down PR renames or absorbs the backlog, then it graduates to the shared `error` severity.

- `fake` and `seed` join the repo-local verb set (test doubles, database seeding).
- `up`/`down` are exempted by name — Kysely-mandated migration exports.
- The 0.0.5 taxonomy already absorbs this repo's `setup*`, `verify*`, `toggle*`, `subscribe`/`unsubscribe`, and `reset` names.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/zgeoff/vers/pull/569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

