### PR TITLE
chore: add issue templates and the issue-hygiene check

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,21 @@
+---
+name: Bug
+about: Something behaves wrong
+labels: bug
+---
+
+## Observed
+
+<!-- what actually happens — quote error text exact -->
+
+## Expected
+
+<!-- what should happen instead -->
+
+## Repro
+
+<!-- numbered steps, or the failing command/test; note environment when it matters -->
+
+## Notes
+
+<!-- suspected area, related issues -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,25 @@
+---
+name: Feature
+about: New capability — player-facing or system
+labels: feature
+---
+
+<!-- Lead paragraph: what ships and why, ≤2 sentences. -->
+
+## Player story
+
+<!--
+Required when the outcome is player-perceivable (every area/game issue). Second person, present
+tense: what you concretely see or feel once this ships — and what you don't experience (no dupes,
+no lost progress, no spinner spam); absences are part of the story. No implementation nouns: no
+table, field, component, or service names. Close with a one-sentence distillation of the whole
+story. Delete this section only when nothing a player can perceive changes.
+-->
+
+## Scope
+
+- <!-- the behaviors this delivers, one line each -->
+
+## Notes
+
+<!-- dependencies (#issue links), design-doc links, interactions with other work, non-goals -->

--- a/.github/ISSUE_TEMPLATE/upkeep.md
+++ b/.github/ISSUE_TEMPLATE/upkeep.md
@@ -1,0 +1,21 @@
+---
+name: Upkeep
+about: Event- or date-triggered maintenance
+labels: upkeep
+---
+
+```
+trigger: date <YYYY-MM-DD>
+```
+
+<!--
+Or: `trigger: release <pkg> ><version>`. The weekly dep-health sweep evaluates the trigger line and
+marks the issue upkeep-ready when it fires. Add an area label; no milestone, off the delivery
+board.
+-->
+
+<!-- what gap this closes and why it can't be done yet -->
+
+When the trigger fires:
+
+- [ ] <!-- the cleanup steps, verifiable one by one -->

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -13,12 +13,17 @@ permissions:
   contents: read
   issues: write
 
+concurrency:
+  group: issue-hygiene-${{ github.event.issue.number || inputs.issue }}
+
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -28,7 +33,10 @@ jobs:
       - name: Install Dependencies
         run: bun install --frozen-lockfile
 
+      # the issue number reaches the shell through env, never expression expansion — a crafted
+      # workflow_dispatch input must not become shell source
       - name: Check
         env:
           GH_TOKEN: ${{ github.token }}
-        run: bun scripts/src/bin/issue-hygiene.ts "${{ github.event.issue.number || inputs.issue }}"
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue }}
+        run: bun scripts/src/bin/issue-hygiene.ts "$ISSUE_NUMBER"

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -1,0 +1,34 @@
+name: Issue Hygiene
+
+on:
+  issues:
+    types: [opened]
+  workflow_dispatch:
+    inputs:
+      issue:
+        description: Issue number to check
+        required: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: .bun-version
+
+      - name: Install Dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bun scripts/src/bin/issue-hygiene.ts "${{ github.event.issue.number || inputs.issue }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,13 +191,13 @@ Triage a GitHub issue the moment it's opened, not in a later pass:
 
 An open issue that isn't on the board with a milestone and status is a defect.
 
-A new issue's body follows its type's template in `.github/ISSUE_TEMPLATE` (feature, bug, upkeep).
-A feature issue whose outcome a player can perceive — every `area/game` feature — opens with a
+A new issue's body follows its type's template in `.github/ISSUE_TEMPLATE` (feature, bug, upkeep). A
+feature issue whose outcome a player can perceive — every `area/game` feature — opens with a
 `## Player story` section: second person, present tense, what the player concretely sees or feels
 once it ships, including what they don't experience (no dupes, no lost progress), closing with a
 one-sentence distillation. The story names no implementation nouns — no table, field, component, or
-service names; machinery belongs in Scope. The issue-hygiene workflow checks every new issue's
-shape against these rules and comments the defects it finds.
+service names; machinery belongs in Scope. The issue-hygiene workflow checks every new issue's shape
+against these rules and comments the defects it finds.
 
 Upkeep issues are the exception: event- or date-triggered maintenance (dropping a dependency
 override, deleting an audit ignore) carries the `upkeep` label plus an area label, no milestone, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,14 @@ Triage a GitHub issue the moment it's opened, not in a later pass:
 
 An open issue that isn't on the board with a milestone and status is a defect.
 
+A new issue's body follows its type's template in `.github/ISSUE_TEMPLATE` (feature, bug, upkeep).
+A feature issue whose outcome a player can perceive — every `area/game` feature — opens with a
+`## Player story` section: second person, present tense, what the player concretely sees or feels
+once it ships, including what they don't experience (no dupes, no lost progress), closing with a
+one-sentence distillation. The story names no implementation nouns — no table, field, component, or
+service names; machinery belongs in Scope. The issue-hygiene workflow checks every new issue's
+shape against these rules and comments the defects it finds.
+
 Upkeep issues are the exception: event- or date-triggered maintenance (dropping a dependency
 override, deleting an audit ignore) carries the `upkeep` label plus an area label, no milestone, and
 stays off the delivery board. The issue body opens with a fenced trigger line —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,12 +192,13 @@ Triage a GitHub issue the moment it's opened, not in a later pass:
 An open issue that isn't on the board with a milestone and status is a defect.
 
 A new issue's body follows its type's template in `.github/ISSUE_TEMPLATE` (feature, bug, upkeep). A
-feature issue whose outcome a player can perceive — every `area/game` feature — opens with a
+feature issue whose outcome a player can perceive — every `area/game` feature — carries a
 `## Player story` section: second person, present tense, what the player concretely sees or feels
 once it ships, including what they don't experience (no dupes, no lost progress), closing with a
 one-sentence distillation. The story names no implementation nouns — no table, field, component, or
-service names; machinery belongs in Scope. The issue-hygiene workflow checks every new issue's shape
-against these rules and comments the defects it finds.
+service names; machinery belongs in Scope. The issue-hygiene workflow checks each new issue's
+labels, milestone, and required sections (dep-health's generated report issues excepted) and
+comments the defects it finds.
 
 Upkeep issues are the exception: event- or date-triggered maintenance (dropping a dependency
 override, deleting an audit ignore) carries the `upkeep` label plus an area label, no milestone, and

--- a/agents/project.md
+++ b/agents/project.md
@@ -37,12 +37,13 @@ Triage a GitHub issue the moment it's opened, not in a later pass:
 An open issue that isn't on the board with a milestone and status is a defect.
 
 A new issue's body follows its type's template in `.github/ISSUE_TEMPLATE` (feature, bug, upkeep). A
-feature issue whose outcome a player can perceive — every `area/game` feature — opens with a
+feature issue whose outcome a player can perceive — every `area/game` feature — carries a
 `## Player story` section: second person, present tense, what the player concretely sees or feels
 once it ships, including what they don't experience (no dupes, no lost progress), closing with a
 one-sentence distillation. The story names no implementation nouns — no table, field, component, or
-service names; machinery belongs in Scope. The issue-hygiene workflow checks every new issue's shape
-against these rules and comments the defects it finds.
+service names; machinery belongs in Scope. The issue-hygiene workflow checks each new issue's
+labels, milestone, and required sections (dep-health's generated report issues excepted) and
+comments the defects it finds.
 
 Upkeep issues are the exception: event- or date-triggered maintenance (dropping a dependency
 override, deleting an audit ignore) carries the `upkeep` label plus an area label, no milestone, and

--- a/agents/project.md
+++ b/agents/project.md
@@ -36,6 +36,14 @@ Triage a GitHub issue the moment it's opened, not in a later pass:
 
 An open issue that isn't on the board with a milestone and status is a defect.
 
+A new issue's body follows its type's template in `.github/ISSUE_TEMPLATE` (feature, bug, upkeep). A
+feature issue whose outcome a player can perceive — every `area/game` feature — opens with a
+`## Player story` section: second person, present tense, what the player concretely sees or feels
+once it ships, including what they don't experience (no dupes, no lost progress), closing with a
+one-sentence distillation. The story names no implementation nouns — no table, field, component, or
+service names; machinery belongs in Scope. The issue-hygiene workflow checks every new issue's shape
+against these rules and comments the defects it finds.
+
 Upkeep issues are the exception: event- or date-triggered maintenance (dropping a dependency
 override, deleting an audit ignore) carries the `upkeep` label plus an area label, no milestone, and
 stays off the delivery board. The issue body opens with a fenced trigger line —

--- a/scripts/src/bin/issue-hygiene.ts
+++ b/scripts/src/bin/issue-hygiene.ts
@@ -1,11 +1,13 @@
 import { $ } from 'bun';
-import invariant from 'tiny-invariant';
 import { z } from 'zod';
 import { checkIssue } from '../issue-hygiene/check-issue';
 
 const issueNumber = Number(process.argv[2]);
 
-invariant(Number.isInteger(issueNumber) && issueNumber > 0, 'usage: issue-hygiene.ts <issue>');
+if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+  console.error('usage: issue-hygiene.ts <issue>');
+  process.exit(1);
+}
 
 const labelSchema = z.object({ name: z.string() });
 

--- a/scripts/src/bin/issue-hygiene.ts
+++ b/scripts/src/bin/issue-hygiene.ts
@@ -1,0 +1,47 @@
+import { $ } from 'bun';
+import invariant from 'tiny-invariant';
+import { z } from 'zod';
+import { checkIssue } from '../issue-hygiene/check-issue';
+
+const issueNumber = Number(process.argv[2]);
+
+invariant(Number.isInteger(issueNumber) && issueNumber > 0, 'usage: issue-hygiene.ts <issue>');
+
+const labelSchema = z.object({ name: z.string() });
+
+const issueSchema = z.object({
+  body: z.string(),
+  labels: z.array(labelSchema),
+  milestone: z.object({ title: z.string() }).nullable(),
+});
+
+const rawIssue: unknown = await $`gh issue view ${issueNumber} --json body,labels,milestone`.json();
+
+const issue = issueSchema.parse(rawIssue);
+
+const findings = checkIssue({
+  body: issue.body,
+  labels: issue.labels.map((label) => label.name),
+  milestone: issue.milestone?.title ?? null,
+});
+
+if (findings.length === 0) {
+  console.log(`#${issueNumber} is clean`);
+  process.exit(0);
+}
+
+const comment = [
+  'Issue hygiene check found defects:',
+  '',
+  ...findings.map((finding) => `- ${finding}`),
+  '',
+  'Templates live in `.github/ISSUE_TEMPLATE`; the rules are the Issue hygiene section of AGENTS.md.',
+].join('\n');
+
+await $`gh issue comment ${issueNumber} --body ${comment}`;
+
+for (const finding of findings) {
+  console.log(`#${issueNumber}: ${finding}`);
+}
+
+process.exit(1);

--- a/scripts/src/issue-hygiene/check-issue.test.ts
+++ b/scripts/src/issue-hygiene/check-issue.test.ts
@@ -1,0 +1,130 @@
+import { expect, test } from 'bun:test';
+import { checkIssue } from './check-issue';
+
+test('it passes a fully triaged feature issue', () => {
+  const findings = checkIssue({
+    body: '## Player story\n\nYou log in.\n\n## Scope\n\n- a behavior',
+    labels: ['feature', 'area/game', 'p2-medium'],
+    milestone: 'P3 · World map',
+  });
+
+  expect(findings).toStrictEqual([]);
+});
+
+test('it flags a feature issue without a Scope section', () => {
+  const findings = checkIssue({
+    body: 'Just a lead paragraph.',
+    labels: ['feature', 'area/services', 'p1-high'],
+    milestone: 'P2 · Game backend spine',
+  });
+
+  expect(findings).toStrictEqual(['missing a `## Scope` section']);
+});
+
+test('it requires a player story on an area/game feature', () => {
+  const findings = checkIssue({
+    body: '## Scope\n\n- a behavior',
+    labels: ['feature', 'area/game', 'p2-medium'],
+    milestone: 'P3 · World map',
+  });
+
+  expect(findings).toStrictEqual([
+    'missing a `## Player story` section (required for area/game features)',
+  ]);
+});
+
+test('it accepts a player story regardless of heading case', () => {
+  const findings = checkIssue({
+    body: '## Player Story\n\nYou log in.\n\n## Scope\n\n- a behavior',
+    labels: ['feature', 'area/game', 'p2-medium'],
+    milestone: 'P3 · World map',
+  });
+
+  expect(findings).toStrictEqual([]);
+});
+
+test('it does not require a player story on a non-game feature', () => {
+  const findings = checkIssue({
+    body: '## Scope\n\n- a behavior',
+    labels: ['feature', 'area/platform', 'p2-medium'],
+    milestone: 'P0 · Tooling',
+  });
+
+  expect(findings).toStrictEqual([]);
+});
+
+test('it flags an untriaged issue once per missing triage field', () => {
+  const findings = checkIssue({ body: 'prose', labels: [], milestone: null });
+
+  expect(findings).toIncludeSameMembers([
+    'missing an `area/*` label',
+    'missing a type label (feature, bug, chore, …)',
+    'missing a priority label (`p0-critical`, `p1-high`, `p2-medium`)',
+    'missing the delivery-phase milestone',
+  ]);
+});
+
+test('it requires observed, expected, and repro sections on a bug', () => {
+  const findings = checkIssue({
+    body: '## Observed\n\nIt crashes.',
+    labels: ['bug', 'area/web', 'p1-high'],
+    milestone: 'P3 · World map',
+  });
+
+  expect(findings).toStrictEqual([
+    'missing a `## Expected` section',
+    'missing a `## Repro` section',
+  ]);
+});
+
+test('it passes a complete bug issue', () => {
+  const findings = checkIssue({
+    body: '## Observed\n\nIt crashes.\n\n## Expected\n\nNo crash.\n\n## Repro\n\n1. run it',
+    labels: ['bug', 'area/web', 'p1-high'],
+    milestone: 'P3 · World map',
+  });
+
+  expect(findings).toStrictEqual([]);
+});
+
+test('it passes a well-formed upkeep issue without milestone or priority', () => {
+  const findings = checkIssue({
+    body: '```\ntrigger: date 2026-08-01\n```\n\nDrop the override.',
+    labels: ['upkeep', 'area/platform'],
+    milestone: null,
+  });
+
+  expect(findings).toStrictEqual([]);
+});
+
+test('it flags an upkeep issue with a milestone', () => {
+  const findings = checkIssue({
+    body: '```\ntrigger: date 2026-08-01\n```',
+    labels: ['upkeep', 'area/platform'],
+    milestone: 'P0 · Tooling',
+  });
+
+  expect(findings).toStrictEqual(['upkeep issues carry no milestone — remove it']);
+});
+
+test('it flags an upkeep issue without a parseable trigger line', () => {
+  const findings = checkIssue({
+    body: 'no trigger here',
+    labels: ['upkeep', 'area/platform'],
+    milestone: null,
+  });
+
+  expect(findings).toStrictEqual([
+    'body carries no parseable trigger line (`trigger: date <YYYY-MM-DD>` or `trigger: release <pkg> ><version>`)',
+  ]);
+});
+
+test('it exempts the dep-health report issues', () => {
+  const findings = checkIssue({
+    body: 'generated report',
+    labels: ['dep-outdated'],
+    milestone: null,
+  });
+
+  expect(findings).toStrictEqual([]);
+});

--- a/scripts/src/issue-hygiene/check-issue.test.ts
+++ b/scripts/src/issue-hygiene/check-issue.test.ts
@@ -64,6 +64,18 @@ test('it flags an untriaged issue once per missing triage field', () => {
   ]);
 });
 
+test('it rejects a priority label outside the supported set', () => {
+  const findings = checkIssue({
+    body: '## Scope\n\n- a behavior',
+    labels: ['feature', 'area/platform', 'p9-placeholder'],
+    milestone: 'P0 · Tooling',
+  });
+
+  expect(findings).toStrictEqual([
+    'missing a priority label (`p0-critical`, `p1-high`, `p2-medium`)',
+  ]);
+});
+
 test('it requires observed, expected, and repro sections on a bug', () => {
   const findings = checkIssue({
     body: '## Observed\n\nIt crashes.',

--- a/scripts/src/issue-hygiene/check-issue.ts
+++ b/scripts/src/issue-hygiene/check-issue.ts
@@ -1,0 +1,87 @@
+import { parseTrigger } from '../upkeep/parse-trigger';
+import type { IssueShape } from './types';
+
+/**
+ * Labels for issues the dep-health sweep creates and manages itself; their bodies are generated
+ * reports, so the shape rules don't apply.
+ */
+const EXEMPT_LABELS = new Set(['dep-audit', 'dep-outdated']);
+
+const TYPE_LABELS = new Set([
+  'bug',
+  'chore',
+  'documentation',
+  'epic',
+  'feature',
+  'game-design',
+  'refactor',
+  'research',
+  'spike',
+]);
+
+/**
+ * Evaluates an issue against the shape rules in the Issue hygiene section of AGENTS.md and the
+ * `.github/ISSUE_TEMPLATE` bodies. Returns one human-readable finding per violated rule, empty
+ * when the issue is clean.
+ */
+export function checkIssue(issue: IssueShape): Array<string> {
+  if (issue.labels.some((label) => EXEMPT_LABELS.has(label))) {
+    return [];
+  }
+
+  const findings: Array<string> = [];
+
+  if (!issue.labels.some((label) => label.startsWith('area/'))) {
+    findings.push('missing an `area/*` label');
+  }
+
+  if (issue.labels.includes('upkeep')) {
+    if (issue.milestone !== null) {
+      findings.push('upkeep issues carry no milestone — remove it');
+    }
+
+    if (parseTrigger(issue.body) === null) {
+      findings.push(
+        'body carries no parseable trigger line (`trigger: date <YYYY-MM-DD>` or `trigger: release <pkg> ><version>`)',
+      );
+    }
+
+    return findings;
+  }
+
+  if (!issue.labels.some((label) => TYPE_LABELS.has(label))) {
+    findings.push('missing a type label (feature, bug, chore, …)');
+  }
+
+  if (!issue.labels.some((label) => /^p\d-/.test(label))) {
+    findings.push('missing a priority label (`p0-critical`, `p1-high`, `p2-medium`)');
+  }
+
+  if (issue.milestone === null) {
+    findings.push('missing the delivery-phase milestone');
+  }
+
+  if (issue.labels.includes('feature')) {
+    if (!hasSection(issue.body, 'Scope')) {
+      findings.push('missing a `## Scope` section');
+    }
+
+    if (issue.labels.includes('area/game') && !hasSection(issue.body, 'Player story')) {
+      findings.push('missing a `## Player story` section (required for area/game features)');
+    }
+  }
+
+  if (issue.labels.includes('bug')) {
+    for (const section of ['Observed', 'Expected', 'Repro']) {
+      if (!hasSection(issue.body, section)) {
+        findings.push(`missing a \`## ${section}\` section`);
+      }
+    }
+  }
+
+  return findings;
+}
+
+function hasSection(body: string, title: string): boolean {
+  return new RegExp(`^##\\s+${title}\\s*$`, 'im').test(body);
+}

--- a/scripts/src/issue-hygiene/check-issue.ts
+++ b/scripts/src/issue-hygiene/check-issue.ts
@@ -6,6 +6,7 @@ import type { IssueShape } from './types';
  * reports, so the shape rules don't apply.
  */
 const EXEMPT_LABELS = new Set(['dep-audit', 'dep-outdated']);
+const PRIORITY_LABELS = new Set(['p0-critical', 'p1-high', 'p2-medium']);
 
 const TYPE_LABELS = new Set([
   'bug',
@@ -53,7 +54,7 @@ export function checkIssue(issue: IssueShape): Array<string> {
     findings.push('missing a type label (feature, bug, chore, …)');
   }
 
-  if (!issue.labels.some((label) => /^p\d-/.test(label))) {
+  if (!issue.labels.some((label) => PRIORITY_LABELS.has(label))) {
     findings.push('missing a priority label (`p0-critical`, `p1-high`, `p2-medium`)');
   }
 

--- a/scripts/src/issue-hygiene/types.ts
+++ b/scripts/src/issue-hygiene/types.ts
@@ -1,0 +1,5 @@
+export interface IssueShape {
+  readonly body: string;
+  readonly labels: ReadonlyArray<string>;
+  readonly milestone: string | null;
+}


### PR DESCRIPTION
## Description

Codifies the implicit issue structure so tickets stay legible to non-implementers: templates, an agent-side rule, and a mechanical check.

- Markdown templates (feature, bug, upkeep) in `.github/ISSUE_TEMPLATE`, with `blank_issues_enabled: false`; markdown over yml forms so the same files guide agents opening issues via `gh`
- Feature template adds a Player story section — second person, present tense, no implementation nouns, one-sentence distillation, absences included
- Issue hygiene rule in `agents/project.md`: bodies follow the templates; every `area/game` feature opens with a player story
- `issue-hygiene` workflow on `issues.opened` runs `checkIssue` (pure, tested, reuses the upkeep trigger parser) and comments a defect list; dep-health report issues are exempt
- `workflow_dispatch` input allows re-checking any issue by number

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/zgeoff/vers/pull/572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

