### PR TITLE
feat(#467): add avatar economy mode

### DIFF
--- a/apps/web/src/routes/-avatar-create/avatar-create-form-schema.ts
+++ b/apps/web/src/routes/-avatar-create/avatar-create-form-schema.ts
@@ -1,7 +1,8 @@
-import { AvatarNameSchema } from '@vers/contract-avatar';
+import { AvatarModeSchema, AvatarNameSchema } from '@vers/contract-avatar';
 import * as z from 'zod';
 
 export const AvatarCreateFormSchema = z.object({
+  mode: AvatarModeSchema.default('trade'),
   name: AvatarNameSchema,
 });
 

--- a/apps/web/src/routes/-avatar-create/avatar-create-form.test.tsx
+++ b/apps/web/src/routes/-avatar-create/avatar-create-form.test.tsx
@@ -1,5 +1,6 @@
 import { expect, test } from 'bun:test';
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { renderWithRouter } from '../../test-utils/render-with-router';
 import { withRequestContext } from '../../test-utils/with-request-context';
 import { AvatarCreateForm } from './avatar-create-form';
@@ -12,5 +13,31 @@ test('it renders the name field and submit button', async () => {
 
     expect(nameField).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Create Avatar' })).toBeInTheDocument();
+  });
+});
+
+test('it defaults to Trade mode with no permanence warning shown', async () => {
+  await withRequestContext({}, async () => {
+    renderWithRouter(<AvatarCreateForm />);
+
+    const tradeOption = await screen.findByRole('radio', { name: 'Trade' });
+
+    expect(tradeOption).toBeChecked();
+    expect(screen.queryByText(/Self-Found is permanent/)).not.toBeInTheDocument();
+  });
+});
+
+test('it shows a permanence warning when Self-Found is selected', async () => {
+  const user = userEvent.setup();
+
+  await withRequestContext({}, async () => {
+    renderWithRouter(<AvatarCreateForm />);
+
+    const selfFoundOption = await screen.findByRole('radio', { name: 'Self-Found' });
+
+    await user.click(selfFoundOption);
+
+    expect(selfFoundOption).toBeChecked();
+    expect(screen.getByText(/Self-Found is permanent/)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/routes/-avatar-create/avatar-create-form.test.tsx
+++ b/apps/web/src/routes/-avatar-create/avatar-create-form.test.tsx
@@ -54,13 +54,13 @@ test('it submits mode self_found when Self-Found is selected', async () => {
 
     const nameField = await screen.findByLabelText('Name');
 
-    await user.type(nameField, 'Vagrant');
+    await user.type(nameField, 'Outlander');
     await user.click(screen.getByRole('radio', { name: 'Self-Found' }));
     await user.click(screen.getByRole('button', { name: 'Create Avatar' }));
 
     await waitFor(() => {
       const created = db.avatarCollection.findFirst((q) =>
-        q.where({ name: 'Vagrant', userID: signedIn.userID }),
+        q.where({ name: 'Outlander', userID: signedIn.userID }),
       );
 
       expect(created).toMatchObject({ mode: 'self_found' });

--- a/apps/web/src/routes/-avatar-create/avatar-create-form.test.tsx
+++ b/apps/web/src/routes/-avatar-create/avatar-create-form.test.tsx
@@ -44,7 +44,7 @@ test('it shows a permanence warning when Self-Found is selected', async () => {
   });
 });
 
-test('it submits mode self_found when Self-Found is selected', async () => {
+test('it creates a Self-Found avatar when that option is selected', async () => {
   const user = userEvent.setup();
 
   const signedIn = await createSignedInUser();

--- a/apps/web/src/routes/-avatar-create/avatar-create-form.test.tsx
+++ b/apps/web/src/routes/-avatar-create/avatar-create-form.test.tsx
@@ -1,6 +1,8 @@
 import { expect, test } from 'bun:test';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import * as db from '@vers/mock-services/db';
+import { createSignedInUser } from '../../test-utils/create-signed-in-user';
 import { renderWithRouter } from '../../test-utils/render-with-router';
 import { withRequestContext } from '../../test-utils/with-request-context';
 import { AvatarCreateForm } from './avatar-create-form';
@@ -39,5 +41,29 @@ test('it shows a permanence warning when Self-Found is selected', async () => {
 
     expect(selfFoundOption).toBeChecked();
     expect(screen.getByText(/Self-Found is permanent/)).toBeInTheDocument();
+  });
+});
+
+test('it submits mode self_found when Self-Found is selected', async () => {
+  const user = userEvent.setup();
+
+  const signedIn = await createSignedInUser();
+
+  await withRequestContext({ cookies: signedIn.cookies }, async () => {
+    renderWithRouter(<AvatarCreateForm />);
+
+    const nameField = await screen.findByLabelText('Name');
+
+    await user.type(nameField, 'Vagrant');
+    await user.click(screen.getByRole('radio', { name: 'Self-Found' }));
+    await user.click(screen.getByRole('button', { name: 'Create Avatar' }));
+
+    await waitFor(() => {
+      const created = db.avatarCollection.findFirst((q) =>
+        q.where({ name: 'Vagrant', userID: signedIn.userID }),
+      );
+
+      expect(created).toMatchObject({ mode: 'self_found' });
+    });
   });
 });

--- a/apps/web/src/routes/-avatar-create/avatar-create-form.tsx
+++ b/apps/web/src/routes/-avatar-create/avatar-create-form.tsx
@@ -94,7 +94,9 @@ export function AvatarCreateForm() {
             <input
               checked={mode === 'trade'}
               name="mode"
-              onChange={() => setMode('trade')}
+              onChange={() => {
+                setMode('trade');
+              }}
               type="radio"
               value="trade"
             />
@@ -104,7 +106,9 @@ export function AvatarCreateForm() {
             <input
               checked={mode === 'self_found'}
               name="mode"
-              onChange={() => setMode('self_found')}
+              onChange={() => {
+                setMode('self_found');
+              }}
               type="radio"
               value="self_found"
             />

--- a/apps/web/src/routes/-avatar-create/avatar-create-form.tsx
+++ b/apps/web/src/routes/-avatar-create/avatar-create-form.tsx
@@ -115,7 +115,7 @@ export function AvatarCreateForm() {
             <span className={modeLabelStyles}>Self-Found</span>
           </label>
           {mode === 'self_found' && (
-            <Text className={modeWarningStyles}>
+            <Text className={modeWarningStyles} role="alert">
               Self-Found is permanent. Nothing this avatar earns can ever be traded, gifted, or
               moved to another avatar. A player who never trades loses nothing by staying Trade.
             </Text>

--- a/apps/web/src/routes/-avatar-create/avatar-create-form.tsx
+++ b/apps/web/src/routes/-avatar-create/avatar-create-form.tsx
@@ -1,5 +1,6 @@
 import { useServerFn } from '@tanstack/react-start';
-import { Field, Heading, StatusButton } from '@vers/design-system';
+import type { AvatarMode } from '@vers/contract-avatar';
+import { Field, Heading, StatusButton, Text } from '@vers/design-system';
 import { css } from '@vers/styled-system/css';
 import { useState } from 'react';
 import { avatarCreate } from './avatar-create';
@@ -13,10 +14,38 @@ const formStyles = css({
   width: '96',
 });
 
+const modeGroupStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '2',
+  marginBottom: '3',
+});
+
+const modeOptionStyles = css({
+  alignItems: 'center',
+  display: 'flex',
+  flexFlow: 'row nowrap',
+  gap: '3',
+});
+
+const modeLabelStyles = css({
+  color: 'text.primary',
+  fontSize: 'md',
+});
+
+const modeWarningStyles = css({
+  borderColor: 'border.danger',
+  borderWidth: '[1px]',
+  color: 'text.danger',
+  fontSize: 'sm',
+  padding: '3',
+});
+
 export function AvatarCreateForm() {
   const avatarCreateFn = useServerFn(avatarCreate);
   const [fieldErrors, setFieldErrors] = useState<AvatarCreateResult['fieldErrors']>({});
   const [isPending, setIsPending] = useState(false);
+  const [mode, setMode] = useState<AvatarMode>('trade');
 
   const handleSubmit = async (form: HTMLFormElement) => {
     const formData = new FormData(form);
@@ -60,6 +89,34 @@ export function AvatarCreateForm() {
           }}
           labelProps={{ children: 'Name', htmlFor: 'name' }}
         />
+        <div className={modeGroupStyles} role="radiogroup" aria-label="Economy mode">
+          <label className={modeOptionStyles}>
+            <input
+              checked={mode === 'trade'}
+              name="mode"
+              onChange={() => setMode('trade')}
+              type="radio"
+              value="trade"
+            />
+            <span className={modeLabelStyles}>Trade</span>
+          </label>
+          <label className={modeOptionStyles}>
+            <input
+              checked={mode === 'self_found'}
+              name="mode"
+              onChange={() => setMode('self_found')}
+              type="radio"
+              value="self_found"
+            />
+            <span className={modeLabelStyles}>Self-Found</span>
+          </label>
+          {mode === 'self_found' && (
+            <Text className={modeWarningStyles}>
+              Self-Found is permanent. Nothing this avatar earns can ever be traded, gifted, or
+              moved to another avatar. A player who never trades loses nothing by staying Trade.
+            </Text>
+          )}
+        </div>
         <StatusButton
           disabled={isPending}
           status={isPending ? StatusButton.Status.Pending : StatusButton.Status.Idle}

--- a/apps/web/src/routes/-avatar-create/avatar-create-handler.test.ts
+++ b/apps/web/src/routes/-avatar-create/avatar-create-handler.test.ts
@@ -54,14 +54,16 @@ test('it creates the avatar and redirects to the avatar page', async () => {
   expect(created).toMatchObject({ level: 1, mode: 'trade', name: 'Karnak', xp: 0 });
 });
 
-test('it forwards a self_found mode selection to the created avatar', async () => {
+test('it creates a Self-Found avatar when that mode is requested', async () => {
   const signedIn = await createSignedInUser();
 
-  await withRequestContext({ cookies: signedIn.cookies }, () =>
+  const outcome = await withRequestContext({ cookies: signedIn.cookies }, () =>
     avatarCreateHandler(buildFormData({ mode: 'self_found', name: 'Vagrant' }))
       .then(() => null)
       .catch((error: unknown) => (isRedirect(error) ? error.options.href : null)),
   );
+
+  expect(outcome.value).toBe('/avatar');
 
   const created = db.avatarCollection.findFirst((q) =>
     q.where({ name: 'Vagrant', userID: signedIn.userID }),

--- a/apps/web/src/routes/-avatar-create/avatar-create-handler.test.ts
+++ b/apps/web/src/routes/-avatar-create/avatar-create-handler.test.ts
@@ -51,5 +51,21 @@ test('it creates the avatar and redirects to the avatar page', async () => {
     q.where({ name: 'Karnak', userID: signedIn.userID }),
   );
 
-  expect(created).toMatchObject({ level: 1, name: 'Karnak', xp: 0 });
+  expect(created).toMatchObject({ level: 1, mode: 'trade', name: 'Karnak', xp: 0 });
+});
+
+test('it forwards a self_found mode selection to the created avatar', async () => {
+  const signedIn = await createSignedInUser();
+
+  await withRequestContext({ cookies: signedIn.cookies }, () =>
+    avatarCreateHandler(buildFormData({ mode: 'self_found', name: 'Vagrant' }))
+      .then(() => null)
+      .catch((error: unknown) => (isRedirect(error) ? error.options.href : null)),
+  );
+
+  const created = db.avatarCollection.findFirst((q) =>
+    q.where({ name: 'Vagrant', userID: signedIn.userID }),
+  );
+
+  expect(created).toMatchObject({ mode: 'self_found' });
 });

--- a/apps/web/src/routes/-avatar-create/avatar-create-handler.ts
+++ b/apps/web/src/routes/-avatar-create/avatar-create-handler.ts
@@ -13,6 +13,7 @@ export async function avatarCreateHandler(formData: FormData): Promise<AvatarCre
   await requireAuth();
 
   const submission = AvatarCreateFormSchema.safeParse({
+    mode: formData.get('mode') ?? undefined,
     name: formData.get('name'),
   });
 
@@ -20,7 +21,9 @@ export async function avatarCreateHandler(formData: FormData): Promise<AvatarCre
     return { fieldErrors: toFieldErrors(submission.error), status: 'invalid-fields' };
   }
 
-  const [error] = await safe(avatarClient.createAvatar({ name: submission.data.name }));
+  const [error] = await safe(
+    avatarClient.createAvatar({ mode: submission.data.mode, name: submission.data.name }),
+  );
 
   if (error) {
     return {

--- a/contracts/avatar/src/avatar-contract.ts
+++ b/contracts/avatar/src/avatar-contract.ts
@@ -1,6 +1,7 @@
 import { authedRoute, defineErrors } from '@vers/contract-base';
 import * as z from 'zod';
 import { AvatarDataSchema } from './avatar-data-schema';
+import { AvatarModeSchema } from './avatar-mode-schema';
 import { AvatarNameSchema } from './avatar-name-schema';
 
 /**
@@ -9,7 +10,7 @@ import { AvatarNameSchema } from './avatar-name-schema';
 export const avatarContract = {
   createAvatar: authedRoute
     .route({ method: 'POST', path: '/avatars', summary: 'Create an avatar for the caller' })
-    .input(z.object({ name: AvatarNameSchema }))
+    .input(z.object({ mode: AvatarModeSchema.default('trade'), name: AvatarNameSchema }))
     .output(AvatarDataSchema)
     .errors(
       defineErrors({

--- a/contracts/avatar/src/avatar-data-schema.test.ts
+++ b/contracts/avatar/src/avatar-data-schema.test.ts
@@ -1,11 +1,12 @@
 import { expect, test } from 'bun:test';
 import { AvatarDataSchema } from './avatar-data-schema';
 
-test('it accepts a well-formed avatar', () => {
+test('it accepts a well-formed trade-mode avatar', () => {
   const result = AvatarDataSchema.safeParse({
     createdAt: new Date(),
     id: 'avatar_1',
     level: 1,
+    mode: 'trade',
     name: 'Aria',
     updatedAt: new Date(),
     userID: 'user_1',
@@ -13,4 +14,35 @@ test('it accepts a well-formed avatar', () => {
   });
 
   expect(result.success).toBeTrue();
+});
+
+test('it accepts a well-formed self_found-mode avatar', () => {
+  const result = AvatarDataSchema.safeParse({
+    createdAt: new Date(),
+    id: 'avatar_1',
+    level: 1,
+    mode: 'self_found',
+    name: 'Aria',
+    updatedAt: new Date(),
+    userID: 'user_1',
+    xp: 0,
+  });
+
+  expect(result.success).toBeTrue();
+});
+
+test('it rejects an unrecognized mode', () => {
+  const result = AvatarDataSchema.safeParse({
+    createdAt: new Date(),
+    id: 'avatar_1',
+    level: 1,
+    mode: 'hardcore',
+    name: 'Aria',
+    updatedAt: new Date(),
+    userID: 'user_1',
+    xp: 0,
+  });
+
+  expect(result.success).toBeFalse();
+  expect(result.error?.issues).toPartiallyContain(expect.objectContaining({ path: ['mode'] }));
 });

--- a/contracts/avatar/src/avatar-data-schema.ts
+++ b/contracts/avatar/src/avatar-data-schema.ts
@@ -1,4 +1,5 @@
 import * as z from 'zod';
+import { AvatarModeSchema } from './avatar-mode-schema';
 
 /**
  * An avatar as returned to callers.
@@ -7,6 +8,7 @@ export const AvatarDataSchema = z.object({
   createdAt: z.date(),
   id: z.string(),
   level: z.int(),
+  mode: AvatarModeSchema,
   name: z.string(),
   updatedAt: z.date(),
   userID: z.string(),

--- a/contracts/avatar/src/avatar-mode-schema.test.ts
+++ b/contracts/avatar/src/avatar-mode-schema.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from 'bun:test';
+import { AvatarModeSchema } from './avatar-mode-schema';
+
+test('it accepts trade', () => {
+  expect(AvatarModeSchema.safeParse('trade').success).toBeTrue();
+});
+
+test('it accepts self_found', () => {
+  expect(AvatarModeSchema.safeParse('self_found').success).toBeTrue();
+});
+
+test('it rejects an unrecognized mode', () => {
+  const result = AvatarModeSchema.safeParse('hardcore');
+
+  expect(result.success).toBeFalse();
+  expect(result.error?.issues).toPartiallyContain(expect.objectContaining({ path: [] }));
+});

--- a/contracts/avatar/src/avatar-mode-schema.test.ts
+++ b/contracts/avatar/src/avatar-mode-schema.test.ts
@@ -13,5 +13,5 @@ test('it rejects an unrecognized mode', () => {
   const result = AvatarModeSchema.safeParse('hardcore');
 
   expect(result.success).toBeFalse();
-  expect(result.error?.issues).toPartiallyContain(expect.objectContaining({ path: [] }));
+  expect(result.error?.issues).toIncludeAllPartialMembers([{ path: [] }]);
 });

--- a/contracts/avatar/src/avatar-mode-schema.ts
+++ b/contracts/avatar/src/avatar-mode-schema.ts
@@ -1,8 +1,7 @@
 import * as z from 'zod';
 
 /**
- * An avatar's economy mode, chosen once at creation and never mutated: it fixes key custody and
- * partitions every economic container the avatar touches.
+ * An avatar's economy mode, chosen once at creation: no procedure accepts a mode mutation.
  */
 export const AvatarModeSchema = z.enum(['trade', 'self_found']);
 

--- a/contracts/avatar/src/avatar-mode-schema.ts
+++ b/contracts/avatar/src/avatar-mode-schema.ts
@@ -1,0 +1,9 @@
+import * as z from 'zod';
+
+/**
+ * An avatar's economy mode, chosen once at creation and never mutated: it fixes key custody and
+ * partitions every economic container the avatar touches.
+ */
+export const AvatarModeSchema = z.enum(['trade', 'self_found']);
+
+export type AvatarMode = z.infer<typeof AvatarModeSchema>;

--- a/contracts/avatar/src/index.ts
+++ b/contracts/avatar/src/index.ts
@@ -2,4 +2,6 @@ export type { AvatarContract } from './avatar-contract';
 export { avatarContract } from './avatar-contract';
 export type { AvatarData } from './avatar-data-schema';
 export { AvatarDataSchema } from './avatar-data-schema';
+export type { AvatarMode } from './avatar-mode-schema';
+export { AvatarModeSchema } from './avatar-mode-schema';
 export { AvatarNameSchema } from './avatar-name-schema';

--- a/contracts/avatar/src/test-utils/factories/create-mock-avatar-data.test.ts
+++ b/contracts/avatar/src/test-utils/factories/create-mock-avatar-data.test.ts
@@ -9,9 +9,10 @@ test('it builds a contract-valid avatar', () => {
 });
 
 test('it applies overrides over the defaults', () => {
-  const avatar = createMockAvatarData({ level: 12, name: 'Karnak', xp: 4500 });
+  const avatar = createMockAvatarData({ level: 12, mode: 'self_found', name: 'Karnak', xp: 4500 });
 
   expect(avatar.level).toBe(12);
+  expect(avatar.mode).toBe('self_found');
   expect(avatar.name).toBe('Karnak');
   expect(avatar.xp).toBe(4500);
 });

--- a/contracts/avatar/src/test-utils/factories/create-mock-avatar-data.ts
+++ b/contracts/avatar/src/test-utils/factories/create-mock-avatar-data.ts
@@ -9,6 +9,7 @@ export function createMockAvatarData(overrides: Partial<AvatarData> = {}): Avata
     createdAt,
     id: createId(),
     level: faker.number.int({ max: 99, min: 1 }),
+    mode: 'trade',
     name: faker.person.firstName(),
     updatedAt: createdAt,
     userID: createId(),

--- a/libs/data/db/migrations/1784108335096_add_avatar_mode.ts
+++ b/libs/data/db/migrations/1784108335096_add_avatar_mode.ts
@@ -1,0 +1,20 @@
+import type { Kysely } from 'kysely';
+import { sql } from 'kysely';
+
+/**
+ * Creates the `avatar_mode` enum and adds the `mode` column to `avatars`, defaulted to `trade`
+ * for every existing row.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema.createType('avatar_mode').asEnum(['trade', 'self_found']).execute();
+
+  await db.schema
+    .alterTable('avatars')
+    .addColumn('mode', sql`avatar_mode`, (col) => col.notNull().defaultTo('trade'))
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.alterTable('avatars').dropColumn('mode').execute();
+  await db.schema.dropType('avatar_mode').execute();
+}

--- a/libs/data/db/src/schema.generated.ts
+++ b/libs/data/db/src/schema.generated.ts
@@ -13,6 +13,8 @@ export type ActivityStatus =
   | 'rejected'
   | 'stopped';
 
+export type AvatarMode = 'self_found' | 'trade';
+
 export type Generated<T> =
   T extends ColumnType<infer S, infer I, infer U>
     ? ColumnType<S, I | undefined, U>
@@ -84,6 +86,7 @@ export interface Avatars {
   createdAt: Generated<Timestamp>;
   id: string;
   level: Generated<number>;
+  mode: Generated<AvatarMode>;
   name: string;
   simBudgetMs: Generated<Int8>;
   simMeteredAt: Generated<Timestamp>;

--- a/libs/testing/mock-services/src/avatar/create-avatar.ts
+++ b/libs/testing/mock-services/src/avatar/create-avatar.ts
@@ -22,6 +22,7 @@ export const createAvatar = os.createAvatar.handler((opts) => {
     createdAt: now,
     id: createId(),
     level: 1,
+    mode: opts.input.mode,
     name: opts.input.name,
     updatedAt: now,
     userID: actingUserId,

--- a/libs/testing/mock-services/src/db/avatar-collection.ts
+++ b/libs/testing/mock-services/src/db/avatar-collection.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { Collection } from '@msw/data';
 import { createId } from '@paralleldrive/cuid2';
-import { AvatarDataSchema } from '@vers/contract-avatar';
+import { AvatarDataSchema, AvatarModeSchema } from '@vers/contract-avatar';
 import * as z from 'zod';
 
 /**
@@ -12,6 +12,7 @@ const AvatarRowSchema = AvatarDataSchema.extend({
   createdAt: z.date().default(() => new Date()),
   id: z.string().default(() => createId()),
   level: z.int().default(1),
+  mode: AvatarModeSchema.default('trade'),
   name: z
     .string()
     .default(() => faker.string.alpha({ casing: 'lower', length: { max: 12, min: 6 } })),

--- a/services/avatar/src/handlers/create-avatar.test.ts
+++ b/services/avatar/src/handlers/create-avatar.test.ts
@@ -11,7 +11,7 @@ async function setupTest() {
   return { app: service.app, db: db.db, [Symbol.asyncDispose]: db[Symbol.asyncDispose] };
 }
 
-test('it creates an avatar owned by the acting user', async () => {
+test('it creates an avatar owned by the acting user, defaulted to trade mode', async () => {
   await using ctx = await setupTest();
 
   const viewer = await createViewer({ audience: 'service-avatar', db: ctx.db });
@@ -24,11 +24,24 @@ test('it creates an avatar owned by the acting user', async () => {
     createdAt: expect.toBeValidDate(),
     id: expect.toBeString(),
     level: 1,
+    mode: 'trade',
     name: 'Brutus',
     updatedAt: expect.toBeValidDate(),
     userID: viewer.user.id,
     xp: 0,
   });
+});
+
+test('it creates an avatar with an explicitly chosen self_found mode', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-avatar', db: ctx.db });
+
+  const client = buildRPCTestClient<AvatarContract>(ctx.app, { token: viewer.token });
+
+  const avatar = await client.createAvatar({ mode: 'self_found', name: 'Vagrant' });
+
+  expect(avatar.mode).toBe('self_found');
 });
 
 test('it rejects a second avatar with a duplicate name with CONFLICT', async () => {

--- a/services/avatar/src/handlers/create-avatar.ts
+++ b/services/avatar/src/handlers/create-avatar.ts
@@ -1,5 +1,5 @@
 import { createId } from '@paralleldrive/cuid2';
-import type { AvatarData } from '@vers/contract-avatar';
+import type { AvatarData, AvatarMode } from '@vers/contract-avatar';
 import type { DB } from '@vers/db';
 import type { Kysely } from 'kysely';
 import type { EmptyErrorPayload, MissingSessionPayload } from '../types';
@@ -14,7 +14,7 @@ interface CreateAvatarOpts {
     readonly CONFLICT: (payload: EmptyErrorPayload) => Error;
     readonly UNAUTHORIZED: (payload: MissingSessionPayload) => Error;
   };
-  readonly input: { readonly name: string };
+  readonly input: { readonly mode: AvatarMode; readonly name: string };
 }
 
 /**
@@ -30,6 +30,7 @@ export async function createAvatar(db: Kysely<DB>, opts: CreateAvatarOpts): Prom
       .insertInto('avatars')
       .values({
         id: createId(),
+        mode: opts.input.mode,
         name: opts.input.name,
         userId: opts.context.actingUserId,
       })

--- a/services/avatar/src/handlers/to-avatar-data.ts
+++ b/services/avatar/src/handlers/to-avatar-data.ts
@@ -10,6 +10,7 @@ export function toAvatarData(row: Readonly<Selectable<Avatars>>): AvatarData {
     createdAt: row.createdAt,
     id: row.id,
     level: row.level,
+    mode: row.mode,
     name: row.name,
     updatedAt: row.updatedAt,
     userID: row.userId,

--- a/services/avatar/src/handlers/update-avatar.test.ts
+++ b/services/avatar/src/handlers/update-avatar.test.ts
@@ -33,6 +33,52 @@ test('it updates the name of an owned avatar and reports the updated id', async 
   expect(row.name).toBe('Renamed');
 });
 
+test('it leaves an avatar mode unchanged after a rename', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-avatar', db: ctx.db });
+
+  const client = buildRPCTestClient<AvatarContract>(ctx.app, { token: viewer.token });
+
+  const created = await client.createAvatar({ mode: 'self_found', name: 'Steadfast' });
+
+  await client.updateAvatar({ id: created.id, name: 'Renamed' });
+
+  const row = await ctx.db
+    .selectFrom('avatars')
+    .selectAll()
+    .where('id', '=', created.id)
+    .executeTakeFirstOrThrow();
+
+  expect(row.mode).toBe('self_found');
+});
+
+test('it does not apply a mode carried on an updateAvatar payload', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-avatar', db: ctx.db });
+
+  const client = buildRPCTestClient<AvatarContract>(ctx.app, { token: viewer.token });
+
+  const created = await client.createAvatar({ mode: 'trade', name: 'Unswayed' });
+
+  // updateAvatar's input schema has no mode field — cast past the typed client to prove an extra
+  // key on the wire payload has no effect on the persisted row.
+  const updateAvatarWithMode = client.updateAvatar as (
+    input: Record<string, unknown>,
+  ) => Promise<unknown>;
+
+  await updateAvatarWithMode({ id: created.id, mode: 'self_found', name: 'UnswayedRenamed' });
+
+  const row = await ctx.db
+    .selectFrom('avatars')
+    .selectAll()
+    .where('id', '=', created.id)
+    .executeTakeFirstOrThrow();
+
+  expect(row.mode).toBe('trade');
+});
+
 test('it returns NOT_FOUND updating an avatar the caller does not own', async () => {
   await using ctx = await setupTest();
 

--- a/services/avatar/src/handlers/update-avatar.test.ts
+++ b/services/avatar/src/handlers/update-avatar.test.ts
@@ -62,13 +62,12 @@ test('it does not apply a mode carried on an updateAvatar payload', async () => 
 
   const created = await client.createAvatar({ mode: 'trade', name: 'Unswayed' });
 
-  // updateAvatar's input schema has no mode field — cast past the typed client to prove an extra
-  // key on the wire payload has no effect on the persisted row.
-  const updateAvatarWithMode = client.updateAvatar as (
-    input: Record<string, unknown>,
-  ) => Promise<unknown>;
+  // updateAvatar's input schema declares no mode field; the extra key on this wire payload
+  // survives JS structural typing but is stripped by the server's zod parse before the handler
+  // ever sees it.
+  const payload = { id: created.id, mode: 'self_found', name: 'UnswayedRenamed' };
 
-  await updateAvatarWithMode({ id: created.id, mode: 'self_found', name: 'UnswayedRenamed' });
+  await client.updateAvatar(payload);
 
   const row = await ctx.db
     .selectFrom('avatars')

--- a/services/avatar/src/test-utils/factories/create-mock-avatar.test.ts
+++ b/services/avatar/src/test-utils/factories/create-mock-avatar.test.ts
@@ -6,16 +6,18 @@ test('it builds a default avatar row', () => {
 
   expect(row).toStrictEqual({
     id: expect.toBeString(),
+    mode: 'trade',
     name: expect.toBeString(),
     userId: expect.toBeString(),
   });
 });
 
 test('it applies overrides on top of the defaults', () => {
-  const row = createMockAvatar({ name: 'Fixedname', userId: 'user_1' });
+  const row = createMockAvatar({ mode: 'self_found', name: 'Fixedname', userId: 'user_1' });
 
   expect(row).toStrictEqual({
     id: expect.toBeString(),
+    mode: 'self_found',
     name: 'Fixedname',
     userId: 'user_1',
   });

--- a/services/avatar/src/test-utils/factories/create-mock-avatar.ts
+++ b/services/avatar/src/test-utils/factories/create-mock-avatar.ts
@@ -12,6 +12,7 @@ export function createMockAvatar(
 ): Insertable<Avatars> {
   return {
     id: createId(),
+    mode: 'trade',
     name: faker.string.alpha({ casing: 'lower', length: { max: 12, min: 6 } }),
     userId: createId(),
     ...overrides,


### PR DESCRIPTION
## Description

Closes #467

Adds an avatar economy mode (`trade` | `self_found`), chosen once at creation and fixed thereafter, spanning the schema, contract, service, mock, and web layers.

- Adds the `avatar_mode` postgres enum and a not-null `mode` column on `avatars`, defaulted to `trade`.
- Adds `AvatarModeSchema` to `@vers/contract-avatar` and wires it into `AvatarDataSchema` and `createAvatar`'s input, defaulting to `trade`; `updateAvatar`'s frozen input schema is untouched, so an extra `mode` key on its payload is dropped server-side.
- `service-avatar` persists and returns `mode` through `createAvatar`/`toAvatarData`; mock services mirror it in the msw/data row schema and handler.
- The avatar-creation form adds a Trade/Self-Found radio group defaulting to Trade, with an inline non-blocking permanence warning shown only for Self-Found.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/zgeoff/vers/pull/573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

