### PR TITLE
fix: share one cursor seeding across concurrent activity registrations

### DIFF
--- a/libs/game/idle-client/src/submission/create-checkpoint-submitter.test.ts
+++ b/libs/game/idle-client/src/submission/create-checkpoint-submitter.test.ts
@@ -416,3 +416,72 @@ test('it discards the queue and stops the stream on SESSION_EVICTED', async () =
 
   expect(stillEmpty).toStrictEqual([]);
 });
+
+test('it seeds a checkpoint submitted during registration from the queued cursor', async () => {
+  await writeQueuedCheckpoint(
+    'race-activity',
+    createMockCheckpointBatchEntry({ hash: 'queued_hash', version: 5 }),
+  );
+
+  const ctx = setupTest({ scheduleFlush: () => {} });
+
+  server.use(mockActivityService.trackActivityProgress.handler(() => ({ appendedHead: 5 })));
+
+  // deliberately not awaited: the submit lands while the seed read is still in flight
+  const registration = ctx.submitter.registerActivity({
+    activityID: 'race-activity',
+    appendedHead: 0,
+    lastHash: 'start_hash',
+    startChainIndex: 0,
+  });
+
+  await ctx.submitter.submit('race-activity', createMockProgressCheckpoint());
+
+  await registration;
+
+  const remaining = await readQueuedCheckpoints('race-activity');
+
+  expect(remaining).toHaveLength(1);
+  expect(remaining).toPartiallyContain({ prevHash: 'queued_hash', version: 6 });
+});
+
+test('it seeds a registration that arrives while another is already loading', async () => {
+  await writeQueuedCheckpoint(
+    'shared-seed-activity',
+    createMockCheckpointBatchEntry({ hash: 'queued_hash', version: 5 }),
+  );
+
+  const ctx = setupTest({ scheduleFlush: () => {} });
+
+  server.use(mockActivityService.trackActivityProgress.handler(() => ({ appendedHead: 5 })));
+
+  const context = {
+    activityID: 'shared-seed-activity',
+    appendedHead: 0,
+    lastHash: 'start_hash',
+    startChainIndex: 0,
+  };
+
+  const first = ctx.submitter.registerActivity(context);
+
+  // awaiting only the overlapping registration must still leave the cursor fully seeded
+  await ctx.submitter.registerActivity(context);
+  await ctx.submitter.submit('shared-seed-activity', createMockProgressCheckpoint());
+
+  await first;
+
+  const remaining = await readQueuedCheckpoints('shared-seed-activity');
+
+  expect(remaining).toHaveLength(1);
+  expect(remaining).toPartiallyContain({ prevHash: 'queued_hash', version: 6 });
+});
+
+test('it drops a checkpoint for an activity that was never registered', async () => {
+  const ctx = setupTest({ scheduleFlush: () => {} });
+
+  await ctx.submitter.submit('unregistered-activity', createMockProgressCheckpoint());
+
+  const remaining = await readQueuedCheckpoints('unregistered-activity');
+
+  expect(remaining).toStrictEqual([]);
+});

--- a/libs/game/idle-client/src/submission/create-checkpoint-submitter.test.ts
+++ b/libs/game/idle-client/src/submission/create-checkpoint-submitter.test.ts
@@ -455,17 +455,21 @@ test('it seeds a registration that arrives while another is already loading', as
 
   server.use(mockActivityService.trackActivityProgress.handler(() => ({ appendedHead: 5 })));
 
-  const context = {
+  const first = ctx.submitter.registerActivity({
     activityID: 'shared-seed-activity',
     appendedHead: 0,
     lastHash: 'start_hash',
     startChainIndex: 0,
-  };
-
-  const first = ctx.submitter.registerActivity(context);
+  });
 
   // awaiting only the overlapping registration must still leave the cursor fully seeded
-  await ctx.submitter.registerActivity(context);
+  await ctx.submitter.registerActivity({
+    activityID: 'shared-seed-activity',
+    appendedHead: 0,
+    lastHash: 'start_hash',
+    startChainIndex: 0,
+  });
+
   await ctx.submitter.submit('shared-seed-activity', createMockProgressCheckpoint());
 
   await first;

--- a/libs/game/idle-client/src/submission/create-checkpoint-submitter.ts
+++ b/libs/game/idle-client/src/submission/create-checkpoint-submitter.ts
@@ -1,6 +1,7 @@
 import { isDefinedError, safe } from '@orpc/client';
 import type { ActivityCheckpoint } from '@vers/idle-core';
 import { ActivityCheckpointType } from '@vers/idle-core';
+import invariant from 'tiny-invariant';
 import { buildCheckpointBatchEntry } from './build-checkpoint-batch-entry';
 import { ENTROPY_SOURCE_SERVER_KEY, PROGRESS_FLUSH_INTERVAL_MS } from './constants';
 import { readQueuedCheckpoints } from './read-queued-checkpoints';
@@ -24,19 +25,21 @@ interface ActivityState {
 export interface CheckpointSubmitter {
   /**
    * Seeds an activity's chain-link cursor from its head row and resends whatever the durable
-   * queue still holds pending for it. Idempotent per activity — a second call for an activity
-   * already registered this worker lifetime is a no-op, so it never clobbers an in-progress
-   * cursor. Resolves once the cursor is seeded from any pending rows, so a caller that awaits it
-   * before producing the activity's first checkpoint never races the resume read.
+   * queue still holds pending for it. Idempotent per activity — every call for an activity this
+   * worker lifetime shares one seeding, so concurrent registrations from separate tabs resolve
+   * together and none clobbers an in-progress cursor. A failed seed read stops the activity's
+   * stream through `onInvalid`.
    */
   registerActivity: (context: Readonly<ActivitySubmissionContext>) => Promise<void>;
 
   /**
    * Maps and enqueues one engine checkpoint for a previously attached activity, then schedules a
    * flush: immediately for a terminal checkpoint, otherwise on the shared progress window.
-   * Silently drops the checkpoint if the activity was never attached or its stream is stopped.
-   * Resolves once the checkpoint is durably queued, so a caller that awaits each submission in
-   * order never races a later checkpoint's write against an earlier one's.
+   * Waits for the activity's registration to finish seeding the cursor, so a checkpoint produced
+   * while the seed read is still in flight never chains onto a stale hash. Silently drops the
+   * checkpoint if the activity was never attached or its stream is stopped. Resolves once the
+   * checkpoint is durably queued, so a caller that awaits each submission in order never races a
+   * later checkpoint's write against an earlier one's.
    */
   submit: (activityID: string, checkpoint: Readonly<ActivityCheckpoint>) => Promise<void>;
 }
@@ -84,6 +87,7 @@ export function createCheckpointSubmitter(
   options: Readonly<CreateCheckpointSubmitterOptions>,
 ): CheckpointSubmitter {
   const activityStates = new Map<string, ActivityState>();
+  const registrations = new Map<string, Promise<void>>();
 
   const scheduleFlush: (flush: () => Promise<void>) => void =
     options.scheduleFlush ??
@@ -199,11 +203,9 @@ export function createCheckpointSubmitter(
     }
   };
 
-  const registerActivity = async (context: Readonly<ActivitySubmissionContext>): Promise<void> => {
-    if (activityStates.has(context.activityID)) {
-      return;
-    }
-
+  const createActivityState = async (
+    context: Readonly<ActivitySubmissionContext>,
+  ): Promise<void> => {
     const state: ActivityState = {
       expectedHead: context.appendedHead,
       flushPending: false,
@@ -218,7 +220,25 @@ export function createCheckpointSubmitter(
 
     activityStates.set(context.activityID, state);
 
-    await loadPendingCheckpoints(context.activityID, state);
+    try {
+      await loadPendingCheckpoints(context.activityID, state);
+    } catch (error) {
+      state.invalid = true;
+
+      options.onInvalid(context.activityID, `pending-checkpoint read failed: ${String(error)}`);
+    }
+  };
+
+  const registerActivity = async (context: Readonly<ActivitySubmissionContext>): Promise<void> => {
+    let registration = registrations.get(context.activityID);
+
+    if (registration === undefined) {
+      registration = createActivityState(context);
+
+      registrations.set(context.activityID, registration);
+    }
+
+    await registration;
     await flush(context.activityID);
   };
 
@@ -226,9 +246,19 @@ export function createCheckpointSubmitter(
     activityID: string,
     checkpoint: Readonly<ActivityCheckpoint>,
   ): Promise<void> => {
+    const registration = registrations.get(activityID);
+
+    if (registration === undefined) {
+      return;
+    }
+
+    await registration;
+
     const state = activityStates.get(activityID);
 
-    if (state === undefined || state.invalid) {
+    invariant(state !== undefined, 'a registered activity has no submission state');
+
+    if (state.invalid) {
       return;
     }
 

--- a/libs/game/idle-client/src/submission/create-checkpoint-submitter.ts
+++ b/libs/game/idle-client/src/submission/create-checkpoint-submitter.ts
@@ -24,11 +24,11 @@ interface ActivityState {
 
 export interface CheckpointSubmitter {
   /**
-   * Seeds an activity's chain-link cursor from its head row and resends whatever the durable
-   * queue still holds pending for it. Idempotent per activity — every call for an activity this
-   * worker lifetime shares one seeding, so concurrent registrations from separate tabs resolve
-   * together and none clobbers an in-progress cursor. A failed seed read stops the activity's
-   * stream through `onInvalid`.
+   * Seeds an activity's chain-link cursor from its head row; the call that first registers the
+   * activity also resends whatever the durable queue still holds pending for it. Idempotent per
+   * activity — every call this worker lifetime shares one seeding, so concurrent registrations
+   * from separate tabs resolve together and none clobbers an in-progress cursor or piles on
+   * extra resends. A failed seed read stops the activity's stream through `onInvalid`.
    */
   registerActivity: (context: Readonly<ActivitySubmissionContext>) => Promise<void>;
 
@@ -230,13 +230,15 @@ export function createCheckpointSubmitter(
   };
 
   const registerActivity = async (context: Readonly<ActivitySubmissionContext>): Promise<void> => {
-    let registration = registrations.get(context.activityID);
+    const existing = registrations.get(context.activityID);
 
-    if (registration === undefined) {
-      registration = createActivityState(context);
-
-      registrations.set(context.activityID, registration);
+    if (existing !== undefined) {
+      return existing;
     }
+
+    const registration = createActivityState(context);
+
+    registrations.set(context.activityID, registration);
 
     await registration;
     await flush(context.activityID);


### PR DESCRIPTION
## Description

Two concurrent registrations for the same activity — two tabs of the shared worker racing their set-activity messages — let the second caller start submitting before the durable-queue seed read finished, chaining checkpoints onto a stale hash the server's chain check rejects.

- Registrations share one per-activity seeding promise; a concurrent call awaits the in-flight seed instead of returning early.
- `submit` awaits the activity's registration before building an entry; unregistered activities still drop silently (placeholder activities run sim-only by design).
- A failed seed read stops the stream through `onInvalid`, which already reaches Sentry via the checkpoint-stream-invalid pipe.
- Regression tests reproduce the race deterministically; both fail against the previous implementation.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/zgeoff/vers/pull/578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

