### PR TITLE
feat(#469): display revealed and pending activity rewards

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -16,8 +16,7 @@
     // `up`/`down` and `seed` are Kysely-mandated migration and seed-file
     // exports; the oRPC handler exemptions mirror their contract procedure
     // names (the contract key is the public API vocabulary) and would
-    // misname the public API if renamed; worldMapNodeCodexQueryOptions
-    // follows the TanStack Query queryOptions convention
+    // misname the public API if renamed
     "zgeoff/function-verb": [
       "error",
       {
@@ -42,14 +41,12 @@
           "up",
           "down",
           "seed",
-          "activityRewardsQueryOptions",
           "changePassword",
           "consumePendingTransaction",
           "consumeTransactionToken",
           "replaySegment",
           "resumeActivity",
-          "trackActivityProgress",
-          "worldMapNodeCodexQueryOptions"
+          "trackActivityProgress"
         ]
       }
     ],

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -42,6 +42,7 @@
           "up",
           "down",
           "seed",
+          "activityRewardsQueryOptions",
           "changePassword",
           "consumePendingTransaction",
           "consumeTransactionToken",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,6 +28,7 @@
     "@tanstack/react-router": "catalog:",
     "@tanstack/react-router-ssr-query": "catalog:",
     "@tanstack/react-start": "catalog:",
+    "@vers/contract-activity": "workspace:*",
     "@vers/contract-avatar": "workspace:*",
     "@vers/contract-base": "workspace:*",
     "@vers/contract-email": "workspace:*",

--- a/apps/web/src/components/world-map-node-codex-slot.tsx
+++ b/apps/web/src/components/world-map-node-codex-slot.tsx
@@ -1,13 +1,13 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { CompositeComponent } from '@tanstack/react-start/rsc';
-import { worldMapNodeCodexQueryOptions } from '../lib/worldmap/world-map-node-codex-query-options';
+import { buildWorldMapNodeCodexQueryOptions } from '../lib/worldmap/build-world-map-node-codex-query-options';
 
 interface WorldMapNodeCodexSlotProps {
   readonly difficulty: number;
 }
 
 export function WorldMapNodeCodexSlot(props: WorldMapNodeCodexSlotProps) {
-  const result = useSuspenseQuery(worldMapNodeCodexQueryOptions(props.difficulty));
+  const result = useSuspenseQuery(buildWorldMapNodeCodexQueryOptions(props.difficulty));
 
   return <CompositeComponent src={result.data.src} />;
 }

--- a/apps/web/src/lib/activity/activity-rewards-query-options.ts
+++ b/apps/web/src/lib/activity/activity-rewards-query-options.ts
@@ -1,0 +1,12 @@
+import type { OrpcQueryUtils } from '../rpc/orpc';
+
+/**
+ * Query options for an activity's revealed reward-slot contents: refetched on a modest interval
+ * while the panel keeps it mounted, so newly verified rewards surface without a manual refresh.
+ */
+export function activityRewardsQueryOptions(orpc: OrpcQueryUtils, activityID: string) {
+  return orpc.activity.getActivityRewards.queryOptions({
+    input: { activityID },
+    refetchInterval: 10_000,
+  });
+}

--- a/apps/web/src/lib/activity/build-activity-rewards-query-options.ts
+++ b/apps/web/src/lib/activity/build-activity-rewards-query-options.ts
@@ -4,7 +4,7 @@ import type { OrpcQueryUtils } from '../rpc/orpc';
  * Query options for an activity's revealed reward-slot contents: refetched on a modest interval
  * while the panel keeps it mounted, so newly verified rewards surface without a manual refresh.
  */
-export function activityRewardsQueryOptions(orpc: OrpcQueryUtils, activityID: string) {
+export function buildActivityRewardsQueryOptions(orpc: OrpcQueryUtils, activityID: string) {
   return orpc.activity.getActivityRewards.queryOptions({
     input: { activityID },
     refetchInterval: 10_000,

--- a/apps/web/src/lib/rpc/clients/activity-client.ts
+++ b/apps/web/src/lib/rpc/clients/activity-client.ts
@@ -1,0 +1,8 @@
+import { createORPCClient } from '@orpc/client';
+import type { ContractRouterClient } from '@orpc/contract';
+import type { activityContract } from '@vers/contract-activity';
+import type { ServiceLinkContext } from '../build-service-link';
+import { buildServiceLink } from '../build-service-link';
+
+export const activityClient: ContractRouterClient<typeof activityContract, ServiceLinkContext> =
+  createORPCClient(buildServiceLink('activity'));

--- a/apps/web/src/lib/rpc/orpc.ts
+++ b/apps/web/src/lib/rpc/orpc.ts
@@ -1,10 +1,12 @@
 import { createTanstackQueryUtils } from '@orpc/tanstack-query';
+import { activityClient } from './clients/activity-client';
 import { avatarClient } from './clients/avatar-client';
 import { sessionClient } from './clients/session-client';
 import { userClient } from './clients/user-client';
 import { verificationClient } from './clients/verification-client';
 
 export const orpc = {
+  activity: createTanstackQueryUtils(activityClient),
   avatar: createTanstackQueryUtils(avatarClient),
   session: createTanstackQueryUtils(sessionClient),
   user: createTanstackQueryUtils(userClient),

--- a/apps/web/src/lib/worldmap/build-world-map-node-codex-query-options.ts
+++ b/apps/web/src/lib/worldmap/build-world-map-node-codex-query-options.ts
@@ -4,7 +4,7 @@ import { getWorldMapNodeCodexFragment } from './get-world-map-node-codex-fragmen
  * RSC values need `structuralSharing: false`: Query's default deep-equality check can't run over
  * a Composite Component source.
  */
-export function worldMapNodeCodexQueryOptions(difficulty: number) {
+export function buildWorldMapNodeCodexQueryOptions(difficulty: number) {
   return {
     queryFn: () => getWorldMapNodeCodexFragment({ data: { difficulty } }),
     queryKey: ['rsc', 'world-map-node-codex', difficulty],

--- a/apps/web/src/routes/-explore-current/activity-rewards-panel.test.tsx
+++ b/apps/web/src/routes/-explore-current/activity-rewards-panel.test.tsx
@@ -1,0 +1,83 @@
+import { expect, test } from 'bun:test';
+import { screen } from '@testing-library/react';
+import { updateRewardSlotLedger } from '@vers/idle-client';
+import { mockActivityService } from '@vers/mock-services/activity';
+import { orpc } from '../../lib/rpc/orpc';
+import { server } from '../../mocks/node';
+import { createSignedInUser } from '../../test-utils/create-signed-in-user';
+import { renderWithRouter } from '../../test-utils/render-with-router';
+import { withRequestContext } from '../../test-utils/with-request-context';
+import { ActivityRewardsPanel } from './activity-rewards-panel';
+
+test('it renders nothing without an active activity', () => {
+  // no activity id means the query never runs, so this needs no session or MSW override
+  renderWithRouter(<ActivityRewardsPanel activityID={undefined} orpc={orpc} />);
+  expect(screen.queryByTestId('activity-rewards-panel')).not.toBeInTheDocument();
+});
+
+test('it renders settled reward items once the query resolves', async () => {
+  const signedIn = await createSignedInUser();
+
+  server.use(
+    mockActivityService.getActivityRewards.handler({
+      items: [
+        {
+          chainIndex: 3,
+          item: {
+            affixes: [{ affixID: 'affix_flat_damage', groupID: 'damage', value: 12 }],
+            baseID: 'base_longsword',
+            contentVersion: 'v1',
+            rarityID: 'rare',
+          },
+          ordinal: 0,
+        },
+      ],
+      verifiedHead: 3,
+    }),
+  );
+
+  await withRequestContext({ cookies: signedIn.cookies }, async () => {
+    renderWithRouter(<ActivityRewardsPanel activityID="activity_rewards_settled" orpc={orpc} />);
+
+    const item = await screen.findByText(/base_longsword/i);
+
+    expect(item).toBeVisible();
+    expect(screen.getByText(/affix_flat_damage \+12/i)).toBeVisible();
+    expect(screen.queryByTestId('activity-rewards-pending')).not.toBeInTheDocument();
+  });
+});
+
+test('it shows the ambient catching-up line while ledger versions exceed the verified head', async () => {
+  const signedIn = await createSignedInUser();
+
+  server.use(mockActivityService.getActivityRewards.handler({ items: [], verifiedHead: 3 }));
+
+  updateRewardSlotLedger({ activityID: 'activity_rewards_pending', count: 2, version: 3 });
+  updateRewardSlotLedger({ activityID: 'activity_rewards_pending', count: 4, version: 5 });
+
+  await withRequestContext({ cookies: signedIn.cookies }, async () => {
+    renderWithRouter(<ActivityRewardsPanel activityID="activity_rewards_pending" orpc={orpc} />);
+
+    const pending = await screen.findByTestId('activity-rewards-pending');
+
+    // only the version-5 entry sits above the verified head of 3
+    expect(pending).toHaveTextContent('Catching up… 4 rewards pending.');
+  });
+});
+
+test('it hides the catching-up line once the verified head has caught up to every ledger version', async () => {
+  const signedIn = await createSignedInUser();
+
+  server.use(mockActivityService.getActivityRewards.handler({ items: [], verifiedHead: 5 }));
+
+  updateRewardSlotLedger({ activityID: 'activity_rewards_caught_up', count: 2, version: 3 });
+  updateRewardSlotLedger({ activityID: 'activity_rewards_caught_up', count: 4, version: 5 });
+
+  await withRequestContext({ cookies: signedIn.cookies }, async () => {
+    renderWithRouter(<ActivityRewardsPanel activityID="activity_rewards_caught_up" orpc={orpc} />);
+
+    await screen.findByTestId('activity-rewards-panel');
+
+    expect(screen.queryByTestId('activity-rewards-pending')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/routes/-explore-current/activity-rewards-panel.test.tsx
+++ b/apps/web/src/routes/-explore-current/activity-rewards-panel.test.tsx
@@ -1,9 +1,8 @@
 import { expect, test } from 'bun:test';
 import { screen } from '@testing-library/react';
 import { setRewardSlotLedger } from '@vers/idle-client';
-import { mockActivityService } from '@vers/mock-services/activity';
+import * as db from '@vers/mock-services/db';
 import { orpc } from '../../lib/rpc/orpc';
-import { server } from '../../mocks/node';
 import { createSignedInUser } from '../../test-utils/create-signed-in-user';
 import { renderWithRouter } from '../../test-utils/render-with-router';
 import { withRequestContext } from '../../test-utils/with-request-context';
@@ -17,24 +16,25 @@ test('it renders nothing without an active activity', () => {
 
 test('it renders settled reward items once the query resolves', async () => {
   const signedIn = await createSignedInUser();
+  const avatar = await db.avatarCollection.create({ userID: signedIn.userID });
 
-  server.use(
-    mockActivityService.getActivityRewards.handler({
-      items: [
-        {
-          chainIndex: 3,
-          item: {
-            affixes: [{ affixID: 'affix_flat_damage', groupID: 'damage', value: 12 }],
-            baseID: 'base_longsword',
-            contentVersion: 'v1',
-            rarityID: 'rare',
-          },
-          ordinal: 0,
-        },
-      ],
-      verifiedHead: 3,
-    }),
-  );
+  const activity = await db.activityCollection.create({
+    avatarID: avatar.id,
+    id: 'activity_rewards_settled',
+    verifiedHead: 3,
+  });
+
+  await db.avatarItemCollection.create({
+    affixes: [{ affixID: 'affix_flat_damage', groupID: 'damage', value: 12 }],
+    avatarID: activity.avatarID,
+    baseID: 'base_longsword',
+    chainIndex: 3,
+    contentVersion: 'v1',
+    ordinal: 0,
+    rarityID: 'rare',
+    scopeID: activity.scopeID,
+    scopeType: activity.scopeType,
+  });
 
   await withRequestContext({ cookies: signedIn.cookies }, async () => {
     renderWithRouter(<ActivityRewardsPanel activityID="activity_rewards_settled" orpc={orpc} />);
@@ -49,8 +49,13 @@ test('it renders settled reward items once the query resolves', async () => {
 
 test('it shows the ambient catching-up line while ledger versions exceed the verified head', async () => {
   const signedIn = await createSignedInUser();
+  const avatar = await db.avatarCollection.create({ userID: signedIn.userID });
 
-  server.use(mockActivityService.getActivityRewards.handler({ items: [], verifiedHead: 3 }));
+  await db.activityCollection.create({
+    avatarID: avatar.id,
+    id: 'activity_rewards_pending',
+    verifiedHead: 3,
+  });
 
   setRewardSlotLedger({
     activityID: 'activity_rewards_pending',
@@ -72,8 +77,13 @@ test('it shows the ambient catching-up line while ledger versions exceed the ver
 
 test('it hides the catching-up line once the verified head has caught up to every ledger version', async () => {
   const signedIn = await createSignedInUser();
+  const avatar = await db.avatarCollection.create({ userID: signedIn.userID });
 
-  server.use(mockActivityService.getActivityRewards.handler({ items: [], verifiedHead: 5 }));
+  await db.activityCollection.create({
+    avatarID: avatar.id,
+    id: 'activity_rewards_caught_up',
+    verifiedHead: 5,
+  });
 
   setRewardSlotLedger({
     activityID: 'activity_rewards_caught_up',
@@ -94,8 +104,13 @@ test('it hides the catching-up line once the verified head has caught up to ever
 
 test('it shows no catching-up line when the ledger belongs to a different activity', async () => {
   const signedIn = await createSignedInUser();
+  const avatar = await db.avatarCollection.create({ userID: signedIn.userID });
 
-  server.use(mockActivityService.getActivityRewards.handler({ items: [], verifiedHead: 3 }));
+  await db.activityCollection.create({
+    avatarID: avatar.id,
+    id: 'activity_rendered',
+    verifiedHead: 3,
+  });
 
   setRewardSlotLedger({
     activityID: 'activity_other',

--- a/apps/web/src/routes/-explore-current/activity-rewards-panel.test.tsx
+++ b/apps/web/src/routes/-explore-current/activity-rewards-panel.test.tsx
@@ -1,6 +1,6 @@
 import { expect, test } from 'bun:test';
 import { screen } from '@testing-library/react';
-import { updateRewardSlotLedger } from '@vers/idle-client';
+import { setRewardSlotLedger } from '@vers/idle-client';
 import { mockActivityService } from '@vers/mock-services/activity';
 import { orpc } from '../../lib/rpc/orpc';
 import { server } from '../../mocks/node';
@@ -52,8 +52,13 @@ test('it shows the ambient catching-up line while ledger versions exceed the ver
 
   server.use(mockActivityService.getActivityRewards.handler({ items: [], verifiedHead: 3 }));
 
-  updateRewardSlotLedger({ activityID: 'activity_rewards_pending', count: 2, version: 3 });
-  updateRewardSlotLedger({ activityID: 'activity_rewards_pending', count: 4, version: 5 });
+  setRewardSlotLedger({
+    activityID: 'activity_rewards_pending',
+    entries: [
+      { count: 2, version: 3 },
+      { count: 4, version: 5 },
+    ],
+  });
 
   await withRequestContext({ cookies: signedIn.cookies }, async () => {
     renderWithRouter(<ActivityRewardsPanel activityID="activity_rewards_pending" orpc={orpc} />);
@@ -70,11 +75,35 @@ test('it hides the catching-up line once the verified head has caught up to ever
 
   server.use(mockActivityService.getActivityRewards.handler({ items: [], verifiedHead: 5 }));
 
-  updateRewardSlotLedger({ activityID: 'activity_rewards_caught_up', count: 2, version: 3 });
-  updateRewardSlotLedger({ activityID: 'activity_rewards_caught_up', count: 4, version: 5 });
+  setRewardSlotLedger({
+    activityID: 'activity_rewards_caught_up',
+    entries: [
+      { count: 2, version: 3 },
+      { count: 4, version: 5 },
+    ],
+  });
 
   await withRequestContext({ cookies: signedIn.cookies }, async () => {
     renderWithRouter(<ActivityRewardsPanel activityID="activity_rewards_caught_up" orpc={orpc} />);
+
+    await screen.findByTestId('activity-rewards-panel');
+
+    expect(screen.queryByTestId('activity-rewards-pending')).not.toBeInTheDocument();
+  });
+});
+
+test('it shows no catching-up line when the ledger belongs to a different activity', async () => {
+  const signedIn = await createSignedInUser();
+
+  server.use(mockActivityService.getActivityRewards.handler({ items: [], verifiedHead: 3 }));
+
+  setRewardSlotLedger({
+    activityID: 'activity_other',
+    entries: [{ count: 4, version: 5 }],
+  });
+
+  await withRequestContext({ cookies: signedIn.cookies }, async () => {
+    renderWithRouter(<ActivityRewardsPanel activityID="activity_rendered" orpc={orpc} />);
 
     await screen.findByTestId('activity-rewards-panel');
 

--- a/apps/web/src/routes/-explore-current/activity-rewards-panel.tsx
+++ b/apps/web/src/routes/-explore-current/activity-rewards-panel.tsx
@@ -51,7 +51,12 @@ export function ActivityRewardsPanel(props: ActivityRewardsPanelProps) {
     return null;
   }
 
-  const pendingCount = countPendingRewardSlots(rewardSlotLedger, query.data.verifiedHead);
+  // A ledger built for a different activity describes a run this panel isn't showing, so its
+  // counts can't report pending rewards here.
+  const pendingCount =
+    rewardSlotLedger.activityID === props.activityID
+      ? countPendingRewardSlots(rewardSlotLedger.entries, query.data.verifiedHead)
+      : 0;
 
   return (
     <section className={panelStyles} data-testid="activity-rewards-panel">
@@ -68,7 +73,7 @@ export function ActivityRewardsPanel(props: ActivityRewardsPanelProps) {
               {item.item.rarityID} {item.item.baseID}
             </Text>
             {item.item.affixes.map((affix) => (
-              <Text key={affix.affixID}>
+              <Text key={`${affix.affixID}-${affix.groupID}`}>
                 {affix.affixID} +{affix.value}
               </Text>
             ))}

--- a/apps/web/src/routes/-explore-current/activity-rewards-panel.tsx
+++ b/apps/web/src/routes/-explore-current/activity-rewards-panel.tsx
@@ -3,7 +3,7 @@ import { Heading, Text } from '@vers/design-system';
 import { useRewardSlotLedger } from '@vers/idle-client';
 import type { RewardSlotLedgerEntry } from '@vers/idle-client';
 import { css } from '@vers/styled-system/css';
-import { activityRewardsQueryOptions } from '../../lib/activity/activity-rewards-query-options';
+import { buildActivityRewardsQueryOptions } from '../../lib/activity/build-activity-rewards-query-options';
 import type { OrpcQueryUtils } from '../../lib/rpc/orpc';
 
 interface ActivityRewardsPanelProps {
@@ -43,7 +43,7 @@ export function ActivityRewardsPanel(props: ActivityRewardsPanelProps) {
   const rewardSlotLedger = useRewardSlotLedger();
 
   const query = useQuery({
-    ...activityRewardsQueryOptions(props.orpc, props.activityID ?? ''),
+    ...buildActivityRewardsQueryOptions(props.orpc, props.activityID ?? ''),
     enabled: props.activityID !== undefined,
   });
 

--- a/apps/web/src/routes/-explore-current/activity-rewards-panel.tsx
+++ b/apps/web/src/routes/-explore-current/activity-rewards-panel.tsx
@@ -1,0 +1,95 @@
+import { useQuery } from '@tanstack/react-query';
+import { Heading, Text } from '@vers/design-system';
+import { useRewardSlotLedger } from '@vers/idle-client';
+import type { RewardSlotLedgerEntry } from '@vers/idle-client';
+import { css } from '@vers/styled-system/css';
+import { activityRewardsQueryOptions } from '../../lib/activity/activity-rewards-query-options';
+import type { OrpcQueryUtils } from '../../lib/rpc/orpc';
+
+interface ActivityRewardsPanelProps {
+  readonly activityID: string | undefined;
+  readonly orpc: OrpcQueryUtils;
+}
+
+const panelStyles = css({
+  backgroundColor: 'bg.panel',
+  borderColor: 'border',
+  borderWidth: '[1px]',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '2',
+  padding: '4',
+});
+
+const listStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '2',
+});
+
+const itemStyles = css({
+  backgroundColor: 'bg.panelElevated',
+  padding: '2',
+});
+
+/**
+ * Shows an activity's settled reward items and, while checkpoints the server hasn't yet verified
+ * are still in flight, one ambient line reporting how many rewards are pending — never a per-item
+ * placeholder. Renders nothing without an active activity. The reveal itself is already gated
+ * server-side on the verified anchor, so every item this panel receives is settled — it applies no
+ * chain-index filtering of its own.
+ */
+export function ActivityRewardsPanel(props: ActivityRewardsPanelProps) {
+  const rewardSlotLedger = useRewardSlotLedger();
+
+  const query = useQuery({
+    ...activityRewardsQueryOptions(props.orpc, props.activityID ?? ''),
+    enabled: props.activityID !== undefined,
+  });
+
+  if (props.activityID === undefined || query.data === undefined) {
+    return null;
+  }
+
+  const pendingCount = countPendingRewardSlots(rewardSlotLedger, query.data.verifiedHead);
+
+  return (
+    <section className={panelStyles} data-testid="activity-rewards-panel">
+      <Heading level={3}>Rewards</Heading>
+      {pendingCount > 0 && (
+        <Text data-testid="activity-rewards-pending">
+          {formatPendingRewardsStatus(pendingCount)}
+        </Text>
+      )}
+      <ul className={listStyles}>
+        {query.data.items.map((item) => (
+          <li className={itemStyles} key={`${item.chainIndex}-${item.ordinal}`}>
+            <Text>
+              {item.item.rarityID} {item.item.baseID}
+            </Text>
+            {item.item.affixes.map((affix) => (
+              <Text key={affix.affixID}>
+                {affix.affixID} +{affix.value}
+              </Text>
+            ))}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function countPendingRewardSlots(
+  ledger: ReadonlyArray<RewardSlotLedgerEntry>,
+  verifiedHead: number,
+): number {
+  return ledger
+    .filter((entry) => entry.version > verifiedHead)
+    .reduce((total, entry) => total + entry.count, 0);
+}
+
+function formatPendingRewardsStatus(pendingCount: number): string {
+  const noun = pendingCount === 1 ? 'reward' : 'rewards';
+
+  return `Catching up… ${pendingCount} ${noun} pending.`;
+}

--- a/apps/web/src/routes/-explore-current/explore-current-panel.test.tsx
+++ b/apps/web/src/routes/-explore-current/explore-current-panel.test.tsx
@@ -1,28 +1,14 @@
 import { expect, test } from 'bun:test';
-import { QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ActivityFailureAction } from '@vers/idle-core';
 import { createMockActivitySnapshot } from '@vers/idle-core/test-utils';
 import { setSelectedNode } from '@vers/worldmap-client';
-import { buildQueryClient } from '../../lib/query/build-query-client';
 import { orpc } from '../../lib/rpc/orpc';
 import { removeSharedWorker } from '../../test-utils/remove-shared-worker';
+import { renderWithRouter } from '../../test-utils/render-with-router';
 import { withIdleWorkerHandle } from '../../test-utils/with-idle-worker-handle';
 import { ExploreCurrentPanel } from './explore-current-panel';
-
-/**
- * `ActivityRewardsPanel`'s `useQuery` needs a `QueryClient` in context; this file's tests assert
- * synchronously on the effect's dispatched messages right after mounting, so they render bare
- * (never through the async `renderWithRouter` transition) with just that one provider layered on.
- */
-function renderExploreCurrentPanel() {
-  return render(
-    <QueryClientProvider client={buildQueryClient()}>
-      <ExploreCurrentPanel orpc={orpc} />
-    </QueryClientProvider>,
-  );
-}
 
 interface SetActivityMessage {
   readonly activity: { readonly id: string };
@@ -48,8 +34,12 @@ test('it shows a spinner and sends initialize before the worker reports its stat
       initialized: false,
       worker,
     },
-    () => {
-      renderExploreCurrentPanel();
+    async () => {
+      renderWithRouter(<ExploreCurrentPanel orpc={orpc} />);
+
+      await waitFor(() => {
+        expect(calls).toContainEqual({ type: 'initialize' });
+      });
     },
   );
 
@@ -68,12 +58,14 @@ test('it reports the simulation as unavailable when SharedWorker is unsupported'
       initialized: false,
       worker: undefined,
     },
-    () => {
-      renderExploreCurrentPanel();
+    async () => {
+      renderWithRouter(<ExploreCurrentPanel orpc={orpc} />);
+
+      const status = await screen.findByRole('status');
+
+      expect(status).toHaveTextContent(/activity simulation is unavailable/i);
     },
   );
-
-  expect(screen.getByRole('status')).toHaveTextContent(/activity simulation is unavailable/i);
 });
 
 test('it sends set-activity once initialized but the worker has not caught up yet', async () => {
@@ -84,12 +76,14 @@ test('it sends set-activity once initialized but the worker has not caught up ye
 
   await withIdleWorkerHandle(
     { activity: undefined, failureAction: ActivityFailureAction.Abort, initialized: true, worker },
-    () => {
-      renderExploreCurrentPanel();
+    async () => {
+      renderWithRouter(<ExploreCurrentPanel orpc={orpc} />);
+
+      await waitFor(() => {
+        expect(calls).toHaveLength(1);
+      });
     },
   );
-
-  expect(calls).toHaveLength(1);
 
   const [sentMessage] = calls;
 
@@ -111,8 +105,12 @@ test('it renders the node and its codex fragment once the worker reports the sen
   // the worker as having caught up to that exact activity
   await withIdleWorkerHandle(
     { activity: undefined, failureAction: ActivityFailureAction.Abort, initialized: true, worker },
-    () => {
-      renderExploreCurrentPanel();
+    async () => {
+      renderWithRouter(<ExploreCurrentPanel orpc={orpc} />);
+
+      await waitFor(() => {
+        expect(calls).toHaveLength(1);
+      });
     },
   );
 
@@ -130,7 +128,7 @@ test('it renders the node and its codex fragment once the worker reports the sen
       worker,
     },
     async () => {
-      renderExploreCurrentPanel();
+      renderWithRouter(<ExploreCurrentPanel orpc={orpc} />);
 
       const codex = await screen.findByTestId('world-map-node-codex-stub');
 
@@ -150,8 +148,12 @@ test('it renders the auto-retry checkbox unchecked by default and dispatches the
   // the worker as having caught up to that exact activity
   await withIdleWorkerHandle(
     { activity: undefined, failureAction: ActivityFailureAction.Abort, initialized: true, worker },
-    () => {
-      renderExploreCurrentPanel();
+    async () => {
+      renderWithRouter(<ExploreCurrentPanel orpc={orpc} />);
+
+      await waitFor(() => {
+        expect(calls).toHaveLength(1);
+      });
     },
   );
 
@@ -169,9 +171,9 @@ test('it renders the auto-retry checkbox unchecked by default and dispatches the
       worker,
     },
     async () => {
-      renderExploreCurrentPanel();
+      renderWithRouter(<ExploreCurrentPanel orpc={orpc} />);
 
-      const checkbox = screen.getByLabelText('Auto-retry on failure');
+      const checkbox = await screen.findByLabelText('Auto-retry on failure');
 
       expect(checkbox).not.toBeChecked();
 

--- a/apps/web/src/routes/-explore-current/explore-current-panel.test.tsx
+++ b/apps/web/src/routes/-explore-current/explore-current-panel.test.tsx
@@ -1,12 +1,28 @@
 import { expect, test } from 'bun:test';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ActivityFailureAction } from '@vers/idle-core';
 import { createMockActivitySnapshot } from '@vers/idle-core/test-utils';
 import { setSelectedNode } from '@vers/worldmap-client';
+import { buildQueryClient } from '../../lib/query/build-query-client';
+import { orpc } from '../../lib/rpc/orpc';
 import { removeSharedWorker } from '../../test-utils/remove-shared-worker';
 import { withIdleWorkerHandle } from '../../test-utils/with-idle-worker-handle';
 import { ExploreCurrentPanel } from './explore-current-panel';
+
+/**
+ * `ActivityRewardsPanel`'s `useQuery` needs a `QueryClient` in context; this file's tests assert
+ * synchronously on the effect's dispatched messages right after mounting, so they render bare
+ * (never through the async `renderWithRouter` transition) with just that one provider layered on.
+ */
+function renderExploreCurrentPanel() {
+  return render(
+    <QueryClientProvider client={buildQueryClient()}>
+      <ExploreCurrentPanel orpc={orpc} />
+    </QueryClientProvider>,
+  );
+}
 
 interface SetActivityMessage {
   readonly activity: { readonly id: string };
@@ -33,7 +49,7 @@ test('it shows a spinner and sends initialize before the worker reports its stat
       worker,
     },
     () => {
-      render(<ExploreCurrentPanel />);
+      renderExploreCurrentPanel();
     },
   );
 
@@ -53,7 +69,7 @@ test('it reports the simulation as unavailable when SharedWorker is unsupported'
       worker: undefined,
     },
     () => {
-      render(<ExploreCurrentPanel />);
+      renderExploreCurrentPanel();
     },
   );
 
@@ -69,7 +85,7 @@ test('it sends set-activity once initialized but the worker has not caught up ye
   await withIdleWorkerHandle(
     { activity: undefined, failureAction: ActivityFailureAction.Abort, initialized: true, worker },
     () => {
-      render(<ExploreCurrentPanel />);
+      renderExploreCurrentPanel();
     },
   );
 
@@ -96,7 +112,7 @@ test('it renders the node and its codex fragment once the worker reports the sen
   await withIdleWorkerHandle(
     { activity: undefined, failureAction: ActivityFailureAction.Abort, initialized: true, worker },
     () => {
-      render(<ExploreCurrentPanel />);
+      renderExploreCurrentPanel();
     },
   );
 
@@ -114,7 +130,7 @@ test('it renders the node and its codex fragment once the worker reports the sen
       worker,
     },
     async () => {
-      render(<ExploreCurrentPanel />);
+      renderExploreCurrentPanel();
 
       const codex = await screen.findByTestId('world-map-node-codex-stub');
 
@@ -135,7 +151,7 @@ test('it renders the auto-retry checkbox unchecked by default and dispatches the
   await withIdleWorkerHandle(
     { activity: undefined, failureAction: ActivityFailureAction.Abort, initialized: true, worker },
     () => {
-      render(<ExploreCurrentPanel />);
+      renderExploreCurrentPanel();
     },
   );
 
@@ -153,7 +169,7 @@ test('it renders the auto-retry checkbox unchecked by default and dispatches the
       worker,
     },
     async () => {
-      render(<ExploreCurrentPanel />);
+      renderExploreCurrentPanel();
 
       const checkbox = screen.getByLabelText('Auto-retry on failure');
 

--- a/apps/web/src/routes/-explore-current/explore-current-panel.tsx
+++ b/apps/web/src/routes/-explore-current/explore-current-panel.tsx
@@ -11,6 +11,8 @@ import { sendIdleSetActivity } from '../../lib/idle/send-idle-set-activity';
 import { sendIdleSetFailureAction } from '../../lib/idle/send-idle-set-failure-action';
 import { useIdleWorkerHandle } from '../../lib/idle/use-idle-worker-handle';
 import { useIsSharedWorkerSupported } from '../../lib/platform/use-is-shared-worker-supported';
+import type { OrpcQueryUtils } from '../../lib/rpc/orpc';
+import { ActivityRewardsPanel } from './activity-rewards-panel';
 import { ApproachingCapWarning } from './approaching-cap-warning';
 
 /**
@@ -22,11 +24,15 @@ const PLACEHOLDER_ACTIVITY = createMockActivityInput({
 
 const PLACEHOLDER_AVATAR = createMockAvatarData();
 
+interface ExploreCurrentPanelProps {
+  readonly orpc: OrpcQueryUtils;
+}
+
 /**
  * The world map node detail view: shows a spinner until the idle worker reports the activity it
  * was sent, then renders the encounter, its auto-retry toggle, and its codex slot.
  */
-export function ExploreCurrentPanel() {
+export function ExploreCurrentPanel(props: ExploreCurrentPanelProps) {
   const isSharedWorkerSupported = useIsSharedWorkerSupported();
   const idleWorkerHandle = useIdleWorkerHandle();
   const selectedNode = useSelectedNode().node;
@@ -80,6 +86,7 @@ export function ExploreCurrentPanel() {
       />
       <ApproachingCapWarning />
       <IdleWorldMapEncounterActivity />
+      <ActivityRewardsPanel activityID={idleWorkerHandle.activity?.id} orpc={props.orpc} />
       <Suspense fallback={<p data-testid="world-map-node-codex-loading">Loading codex…</p>}>
         <WorldMapNodeCodexSlot difficulty={selectedNode?.difficulty ?? 1} />
       </Suspense>

--- a/apps/web/src/routes/_game/explore_.current.tsx
+++ b/apps/web/src/routes/_game/explore_.current.tsx
@@ -3,7 +3,7 @@ import { ExploreCurrentPanel } from '../-explore-current/explore-current-panel';
 import { avatarClient } from '../../lib/rpc/clients/avatar-client';
 
 export const Route = createFileRoute('/_game/explore_/current')({
-  component: ExploreCurrentPanel,
+  component: ExploreCurrentPage,
   head: () => ({ meta: [{ title: 'vers | World Map Encounter' }] }),
   loader: async () => {
     const [avatar] = await avatarClient.getAvatars({});
@@ -14,3 +14,9 @@ export const Route = createFileRoute('/_game/explore_/current')({
   },
   staticData: { presentation: 'focus', scene: 'worldmap' },
 });
+
+function ExploreCurrentPage() {
+  const ctx = Route.useRouteContext();
+
+  return <ExploreCurrentPanel orpc={ctx.orpc} />;
+}

--- a/bun.lock
+++ b/bun.lock
@@ -49,6 +49,7 @@
         "@tanstack/react-router": "catalog:",
         "@tanstack/react-router-ssr-query": "catalog:",
         "@tanstack/react-start": "catalog:",
+        "@vers/contract-activity": "workspace:*",
         "@vers/contract-avatar": "workspace:*",
         "@vers/contract-base": "workspace:*",
         "@vers/contract-email": "workspace:*",

--- a/libs/game/idle-client/src/index.ts
+++ b/libs/game/idle-client/src/index.ts
@@ -13,6 +13,7 @@ export type {
 
 export { setOfflineCapStatus } from './state/set-offline-cap-status';
 export { setResyncStatus } from './state/set-resync-status';
+export { setRewardSlotLedger } from './state/set-reward-slot-ledger';
 export { setSimulationWorker } from './state/set-simulation-worker';
 export { updateRewardSlotLedger } from './state/update-reward-slot-ledger';
 export { useOfflineCapStatus } from './state/use-offline-cap-status';

--- a/libs/game/idle-client/src/index.ts
+++ b/libs/game/idle-client/src/index.ts
@@ -14,12 +14,14 @@ export type {
 export { setOfflineCapStatus } from './state/set-offline-cap-status';
 export { setResyncStatus } from './state/set-resync-status';
 export { setSimulationWorker } from './state/set-simulation-worker';
+export { updateRewardSlotLedger } from './state/update-reward-slot-ledger';
 export { useOfflineCapStatus } from './state/use-offline-cap-status';
 export { useResyncStatus } from './state/use-resync-status';
 export { useActivity } from './state/use-activity';
 export { useAvatar } from './state/use-avatar';
 export { useCheckpointStreamError } from './state/use-checkpoint-stream-error';
 export { useFailureAction } from './state/use-failure-action';
+export { useRewardSlotLedger } from './state/use-reward-slot-ledger';
 export { useSimulationInitialized } from './state/use-simulation-initialized';
 export type { ActivitySubmissionContext } from './submission/types';
 export * from './types';

--- a/libs/game/idle-client/src/state/create-sync-slice.test.ts
+++ b/libs/game/idle-client/src/state/create-sync-slice.test.ts
@@ -6,5 +6,7 @@ test('it builds the empty sync state', () => {
     checkpointStreamError: null,
     offlineCapStatus: null,
     resyncStatus: null,
+    rewardSlotLedger: [],
+    rewardSlotLedgerActivityID: null,
   });
 });

--- a/libs/game/idle-client/src/state/create-sync-slice.ts
+++ b/libs/game/idle-client/src/state/create-sync-slice.ts
@@ -12,9 +12,8 @@ export interface SyncSlice {
   rewardSlotLedger: ReadonlyArray<RewardSlotLedgerEntry>;
 
   /**
-   * The activity `rewardSlotLedger`'s entries belong to, tracked independently of the simulation
-   * snapshot's own activity field so a ledger reset never races that field's update — internal
-   * bookkeeping for `updateRewardSlotLedger`, with no selector of its own.
+   * The activity `rewardSlotLedger`'s entries belong to, kept in sync whenever the ledger resets
+   * or gains an entry — internal bookkeeping with no selector of its own.
    */
   rewardSlotLedgerActivityID: null | string;
 }

--- a/libs/game/idle-client/src/state/create-sync-slice.ts
+++ b/libs/game/idle-client/src/state/create-sync-slice.ts
@@ -1,9 +1,22 @@
-import type { CheckpointStreamError, OfflineCapStatus, ResyncStatus } from '../types';
+import type {
+  CheckpointStreamError,
+  OfflineCapStatus,
+  ResyncStatus,
+  RewardSlotLedgerEntry,
+} from '../types';
 
 export interface SyncSlice {
   checkpointStreamError: CheckpointStreamError | null;
   offlineCapStatus: null | OfflineCapStatus;
   resyncStatus: null | ResyncStatus;
+  rewardSlotLedger: ReadonlyArray<RewardSlotLedgerEntry>;
+
+  /**
+   * The activity `rewardSlotLedger`'s entries belong to, tracked independently of the simulation
+   * snapshot's own activity field so a ledger reset never races that field's update — internal
+   * bookkeeping for `updateRewardSlotLedger`, with no selector of its own.
+   */
+  rewardSlotLedgerActivityID: null | string;
 }
 
 export function createSyncSlice(): SyncSlice {
@@ -11,5 +24,7 @@ export function createSyncSlice(): SyncSlice {
     checkpointStreamError: null,
     offlineCapStatus: null,
     resyncStatus: null,
+    rewardSlotLedger: [],
+    rewardSlotLedgerActivityID: null,
   };
 }

--- a/libs/game/idle-client/src/state/set-checkpoint-stream-error.test.ts
+++ b/libs/game/idle-client/src/state/set-checkpoint-stream-error.test.ts
@@ -13,3 +13,18 @@ test('it updates the checkpoint stream error state', () => {
     reason: 'broken-chain-link',
   });
 });
+
+test('it clears the reward-slot ledger when the stream is rejected', () => {
+  useIdleStore.setState({
+    checkpointStreamError: null,
+    rewardSlotLedger: [{ count: 2, version: 1 }],
+  });
+
+  setCheckpointStreamError({ activityID: 'activity_1', reason: 'broken-chain-link' });
+  expect(useIdleStore.getState().rewardSlotLedger).toStrictEqual([]);
+
+  expect(useIdleStore.getState().checkpointStreamError).toStrictEqual({
+    activityID: 'activity_1',
+    reason: 'broken-chain-link',
+  });
+});

--- a/libs/game/idle-client/src/state/set-checkpoint-stream-error.ts
+++ b/libs/game/idle-client/src/state/set-checkpoint-stream-error.ts
@@ -1,6 +1,11 @@
 import type { CheckpointStreamError } from '../types';
 import { useIdleStore } from './use-idle-store';
 
+/**
+ * Records a fatal checkpoint-stream rejection and empties the reward-slot ledger in the same
+ * update: once the stream is invalid its pending rewards will never verify, so the same event that
+ * reports the failure also drops the counts that were catching up.
+ */
 export function setCheckpointStreamError(checkpointStreamError: CheckpointStreamError) {
-  useIdleStore.setState(() => ({ checkpointStreamError }));
+  useIdleStore.setState(() => ({ checkpointStreamError, rewardSlotLedger: [] }));
 }

--- a/libs/game/idle-client/src/state/set-reward-slot-ledger.ts
+++ b/libs/game/idle-client/src/state/set-reward-slot-ledger.ts
@@ -1,0 +1,13 @@
+import type { RewardSlotLedgerSnapshot } from '../types';
+import { useIdleStore } from './use-idle-store';
+
+/**
+ * Replaces the reward-slot ledger wholesale with the activity and entries carried by an initial
+ * state, so a tab connecting mid-run adopts the worker's current view in one update.
+ */
+export function setRewardSlotLedger(ledger: RewardSlotLedgerSnapshot) {
+  useIdleStore.setState({
+    rewardSlotLedger: ledger.entries,
+    rewardSlotLedgerActivityID: ledger.activityID,
+  });
+}

--- a/libs/game/idle-client/src/state/set-simulation-snapshot.test.ts
+++ b/libs/game/idle-client/src/state/set-simulation-snapshot.test.ts
@@ -67,3 +67,25 @@ test('it leaves the reward-slot ledger untouched while the active activity stays
   expect(useIdleStore.getState().rewardSlotLedger).toStrictEqual([{ count: 2, version: 1 }]);
   expect(useIdleStore.getState().rewardSlotLedgerActivityID).toBe('activity_1');
 });
+
+test('it resets the reward-slot ledger once, not on every snapshot of the new activity', () => {
+  useIdleStore.setState({
+    activity: createMockActivitySnapshot({ id: 'activity_1' }),
+    rewardSlotLedger: [{ count: 2, version: 1 }],
+    rewardSlotLedgerActivityID: 'activity_1',
+  });
+
+  setSimulationSnapshot({
+    activity: createMockActivitySnapshot({ id: 'activity_2' }),
+    failureAction: ActivityFailureAction.Retry,
+  });
+
+  useIdleStore.setState({ rewardSlotLedger: [{ count: 9, version: 1 }] });
+
+  setSimulationSnapshot({
+    activity: createMockActivitySnapshot({ id: 'activity_2' }),
+    failureAction: ActivityFailureAction.Retry,
+  });
+
+  expect(useIdleStore.getState().rewardSlotLedger).toStrictEqual([{ count: 9, version: 1 }]);
+});

--- a/libs/game/idle-client/src/state/set-simulation-snapshot.test.ts
+++ b/libs/game/idle-client/src/state/set-simulation-snapshot.test.ts
@@ -35,3 +35,35 @@ test('it clears fields the snapshot omits', () => {
   expect(useIdleStore.getState().avatar).toBeNull();
   expect(useIdleStore.getState().combat).toBeNull();
 });
+
+test('it resets the reward-slot ledger the moment the active activity changes', () => {
+  useIdleStore.setState({
+    activity: createMockActivitySnapshot({ id: 'activity_1' }),
+    rewardSlotLedger: [{ count: 2, version: 1 }],
+    rewardSlotLedgerActivityID: 'activity_1',
+  });
+
+  setSimulationSnapshot({
+    activity: createMockActivitySnapshot({ id: 'activity_2' }),
+    failureAction: ActivityFailureAction.Retry,
+  });
+
+  expect(useIdleStore.getState().rewardSlotLedger).toStrictEqual([]);
+  expect(useIdleStore.getState().rewardSlotLedgerActivityID).toBe('activity_2');
+});
+
+test('it leaves the reward-slot ledger untouched while the active activity stays the same', () => {
+  useIdleStore.setState({
+    activity: createMockActivitySnapshot({ id: 'activity_1' }),
+    rewardSlotLedger: [{ count: 2, version: 1 }],
+    rewardSlotLedgerActivityID: 'activity_1',
+  });
+
+  setSimulationSnapshot({
+    activity: createMockActivitySnapshot({ id: 'activity_1' }),
+    failureAction: ActivityFailureAction.Retry,
+  });
+
+  expect(useIdleStore.getState().rewardSlotLedger).toStrictEqual([{ count: 2, version: 1 }]);
+  expect(useIdleStore.getState().rewardSlotLedgerActivityID).toBe('activity_1');
+});

--- a/libs/game/idle-client/src/state/set-simulation-snapshot.ts
+++ b/libs/game/idle-client/src/state/set-simulation-snapshot.ts
@@ -3,13 +3,30 @@ import { useIdleStore } from './use-idle-store';
 
 /**
  * Applies a whole worker simulation snapshot in one `setState`, so a per-frame update triggers a
- * single notification pass instead of one per field.
+ * single notification pass instead of one per field. Resets the reward-slot ledger the instant the
+ * active activity's id changes, rather than waiting for that activity's first non-zero reward-slot
+ * message — a fresh activity can otherwise go checkpoints deep before it emits one.
  */
 export function setSimulationSnapshot(snapshot: SimulationSnapshot) {
-  useIdleStore.setState(() => ({
-    activity: snapshot.activity ?? null,
-    avatar: snapshot.avatar ?? null,
-    combat: snapshot.combat ?? null,
-    failureAction: snapshot.failureAction,
-  }));
+  useIdleStore.setState((state) => {
+    const activity = snapshot.activity ?? null;
+    const activityID = activity?.id ?? null;
+
+    return {
+      activity,
+      avatar: snapshot.avatar ?? null,
+      combat: snapshot.combat ?? null,
+      failureAction: snapshot.failureAction,
+      ...(needsRewardSlotLedgerReset(state.activity?.id ?? null, activityID)
+        ? { rewardSlotLedger: [], rewardSlotLedgerActivityID: activityID }
+        : {}),
+    };
+  });
+}
+
+function needsRewardSlotLedgerReset(
+  previousActivityID: string | null,
+  nextActivityID: string | null,
+): boolean {
+  return previousActivityID !== nextActivityID;
 }

--- a/libs/game/idle-client/src/state/set-simulation-snapshot.ts
+++ b/libs/game/idle-client/src/state/set-simulation-snapshot.ts
@@ -17,7 +17,7 @@ export function setSimulationSnapshot(snapshot: SimulationSnapshot) {
       avatar: snapshot.avatar ?? null,
       combat: snapshot.combat ?? null,
       failureAction: snapshot.failureAction,
-      ...(needsRewardSlotLedgerReset(state.activity?.id ?? null, activityID)
+      ...(needsRewardSlotLedgerReset(state.rewardSlotLedgerActivityID, activityID)
         ? { rewardSlotLedger: [], rewardSlotLedgerActivityID: activityID }
         : {}),
     };
@@ -25,8 +25,8 @@ export function setSimulationSnapshot(snapshot: SimulationSnapshot) {
 }
 
 function needsRewardSlotLedgerReset(
-  previousActivityID: string | null,
+  ledgerActivityID: string | null,
   nextActivityID: string | null,
 ): boolean {
-  return previousActivityID !== nextActivityID;
+  return ledgerActivityID !== nextActivityID;
 }

--- a/libs/game/idle-client/src/state/update-reward-slot-ledger.test.ts
+++ b/libs/game/idle-client/src/state/update-reward-slot-ledger.test.ts
@@ -1,9 +1,14 @@
 import { expect, test } from 'bun:test';
+import { createMockActivitySnapshot } from '@vers/idle-core/test-utils';
 import { updateRewardSlotLedger } from './update-reward-slot-ledger';
 import { useIdleStore } from './use-idle-store';
 
 test('it accumulates ledger entries for the current activity', () => {
-  useIdleStore.setState({ rewardSlotLedger: [], rewardSlotLedgerActivityID: null });
+  useIdleStore.setState({
+    checkpointStreamError: null,
+    rewardSlotLedger: [],
+    rewardSlotLedgerActivityID: 'activity_1',
+  });
 
   updateRewardSlotLedger({ activityID: 'activity_1', count: 2, version: 1 });
   updateRewardSlotLedger({ activityID: 'activity_1', count: 3, version: 2 });
@@ -14,12 +19,39 @@ test('it accumulates ledger entries for the current activity', () => {
   ]);
 });
 
-test('it resets the ledger when a message names an activity the ledger was not built for', () => {
+test('it drops a message naming an activity the ledger was not built for', () => {
   useIdleStore.setState({
+    activity: createMockActivitySnapshot({ id: 'activity_1' }),
+    checkpointStreamError: null,
     rewardSlotLedger: [{ count: 2, version: 1 }],
     rewardSlotLedgerActivityID: 'activity_1',
   });
 
   updateRewardSlotLedger({ activityID: 'activity_2', count: 4, version: 1 });
-  expect(useIdleStore.getState().rewardSlotLedger).toStrictEqual([{ count: 4, version: 1 }]);
+  expect(useIdleStore.getState().rewardSlotLedger).toStrictEqual([{ count: 2, version: 1 }]);
+  expect(useIdleStore.getState().rewardSlotLedgerActivityID).toBe('activity_1');
+});
+
+test('it installs the first entry when the ledger has no activity and the message matches the simulation', () => {
+  useIdleStore.setState({
+    activity: createMockActivitySnapshot({ id: 'activity_1' }),
+    checkpointStreamError: null,
+    rewardSlotLedger: [],
+    rewardSlotLedgerActivityID: null,
+  });
+
+  updateRewardSlotLedger({ activityID: 'activity_1', count: 2, version: 1 });
+  expect(useIdleStore.getState().rewardSlotLedger).toStrictEqual([{ count: 2, version: 1 }]);
+  expect(useIdleStore.getState().rewardSlotLedgerActivityID).toBe('activity_1');
+});
+
+test('it ignores a message while the stream for that activity is rejected', () => {
+  useIdleStore.setState({
+    checkpointStreamError: { activityID: 'activity_1', reason: 'broken-chain-link' },
+    rewardSlotLedger: [],
+    rewardSlotLedgerActivityID: 'activity_1',
+  });
+
+  updateRewardSlotLedger({ activityID: 'activity_1', count: 2, version: 1 });
+  expect(useIdleStore.getState().rewardSlotLedger).toStrictEqual([]);
 });

--- a/libs/game/idle-client/src/state/update-reward-slot-ledger.test.ts
+++ b/libs/game/idle-client/src/state/update-reward-slot-ledger.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from 'bun:test';
+import { updateRewardSlotLedger } from './update-reward-slot-ledger';
+import { useIdleStore } from './use-idle-store';
+
+test('it accumulates ledger entries for the current activity', () => {
+  useIdleStore.setState({ rewardSlotLedger: [], rewardSlotLedgerActivityID: null });
+
+  updateRewardSlotLedger({ activityID: 'activity_1', count: 2, version: 1 });
+  updateRewardSlotLedger({ activityID: 'activity_1', count: 3, version: 2 });
+
+  expect(useIdleStore.getState().rewardSlotLedger).toStrictEqual([
+    { count: 2, version: 1 },
+    { count: 3, version: 2 },
+  ]);
+});
+
+test('it resets the ledger when a message names an activity the ledger was not built for', () => {
+  useIdleStore.setState({
+    rewardSlotLedger: [{ count: 2, version: 1 }],
+    rewardSlotLedgerActivityID: 'activity_1',
+  });
+
+  updateRewardSlotLedger({ activityID: 'activity_2', count: 4, version: 1 });
+  expect(useIdleStore.getState().rewardSlotLedger).toStrictEqual([{ count: 4, version: 1 }]);
+});

--- a/libs/game/idle-client/src/state/update-reward-slot-ledger.ts
+++ b/libs/game/idle-client/src/state/update-reward-slot-ledger.ts
@@ -1,0 +1,24 @@
+import { useIdleStore } from './use-idle-store';
+
+interface RewardSlotsRecordedInput {
+  readonly activityID: string;
+  readonly count: number;
+  readonly version: number;
+}
+
+/**
+ * Appends one checkpoint's recorded reward-slot count to the ledger, resetting it first when
+ * `activityID` doesn't match the activity the ledger's current entries were built for — so a
+ * stale entry from an activity the ledger has moved past never survives into the next one.
+ */
+export function updateRewardSlotLedger(input: Readonly<RewardSlotsRecordedInput>) {
+  useIdleStore.setState((state) => {
+    const entries =
+      state.rewardSlotLedgerActivityID === input.activityID ? state.rewardSlotLedger : [];
+
+    return {
+      rewardSlotLedger: [...entries, { count: input.count, version: input.version }],
+      rewardSlotLedgerActivityID: input.activityID,
+    };
+  });
+}

--- a/libs/game/idle-client/src/state/update-reward-slot-ledger.ts
+++ b/libs/game/idle-client/src/state/update-reward-slot-ledger.ts
@@ -7,18 +7,30 @@ interface RewardSlotsRecordedInput {
 }
 
 /**
- * Appends one checkpoint's recorded reward-slot count to the ledger, resetting it first when
- * `activityID` doesn't match the activity the ledger's current entries were built for — so a
- * stale entry from an activity the ledger has moved past never survives into the next one.
+ * Appends one checkpoint's recorded reward-slot count to the ledger. A message naming any activity
+ * other than the one the ledger's entries belong to is dropped rather than treated as a switch, so
+ * a late checkpoint from a previous activity can't wipe and repopulate the current activity's
+ * ledger. The activity change itself is owned by the snapshot handler, which resets the ledger and
+ * stamps its new activity; this appends into an empty ledger only when the message matches the
+ * running simulation. A message for an activity whose stream has been rejected is ignored, so a
+ * ledger cleared by that rejection never repopulates from checkpoints still in flight.
  */
 export function updateRewardSlotLedger(input: Readonly<RewardSlotsRecordedInput>) {
   useIdleStore.setState((state) => {
-    const entries =
-      state.rewardSlotLedgerActivityID === input.activityID ? state.rewardSlotLedger : [];
+    if (state.checkpointStreamError?.activityID === input.activityID) {
+      return {};
+    }
 
-    return {
-      rewardSlotLedger: [...entries, { count: input.count, version: input.version }],
-      rewardSlotLedgerActivityID: input.activityID,
-    };
+    const entry = { count: input.count, version: input.version };
+
+    if (state.rewardSlotLedgerActivityID === input.activityID) {
+      return { rewardSlotLedger: [...state.rewardSlotLedger, entry] };
+    }
+
+    if (state.rewardSlotLedgerActivityID === null && state.activity?.id === input.activityID) {
+      return { rewardSlotLedger: [entry], rewardSlotLedgerActivityID: input.activityID };
+    }
+
+    return {};
   });
 }

--- a/libs/game/idle-client/src/state/use-reward-slot-ledger.test.ts
+++ b/libs/game/idle-client/src/state/use-reward-slot-ledger.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from 'bun:test';
+import { renderHook } from '@testing-library/react';
+import { useIdleStore } from './use-idle-store';
+import { useRewardSlotLedger } from './use-reward-slot-ledger';
+
+test('it provides the reward-slot ledger', () => {
+  useIdleStore.setState({ rewardSlotLedger: [{ count: 2, version: 1 }] });
+
+  const hook = renderHook(() => useRewardSlotLedger());
+
+  expect(hook.result.current).toStrictEqual([{ count: 2, version: 1 }]);
+});

--- a/libs/game/idle-client/src/state/use-reward-slot-ledger.test.ts
+++ b/libs/game/idle-client/src/state/use-reward-slot-ledger.test.ts
@@ -3,10 +3,16 @@ import { renderHook } from '@testing-library/react';
 import { useIdleStore } from './use-idle-store';
 import { useRewardSlotLedger } from './use-reward-slot-ledger';
 
-test('it provides the reward-slot ledger', () => {
-  useIdleStore.setState({ rewardSlotLedger: [{ count: 2, version: 1 }] });
+test('it provides the reward-slot ledger with the activity its entries belong to', () => {
+  useIdleStore.setState({
+    rewardSlotLedger: [{ count: 2, version: 1 }],
+    rewardSlotLedgerActivityID: 'activity_1',
+  });
 
   const hook = renderHook(() => useRewardSlotLedger());
 
-  expect(hook.result.current).toStrictEqual([{ count: 2, version: 1 }]);
+  expect(hook.result.current).toStrictEqual({
+    activityID: 'activity_1',
+    entries: [{ count: 2, version: 1 }],
+  });
 });

--- a/libs/game/idle-client/src/state/use-reward-slot-ledger.ts
+++ b/libs/game/idle-client/src/state/use-reward-slot-ledger.ts
@@ -1,5 +1,12 @@
+import { useShallow } from 'zustand/react/shallow';
+import type { RewardSlotLedgerSnapshot } from '../types';
 import { useIdleStore } from './use-idle-store';
 
-export function useRewardSlotLedger() {
-  return useIdleStore((state) => state.rewardSlotLedger);
+export function useRewardSlotLedger(): RewardSlotLedgerSnapshot {
+  return useIdleStore(
+    useShallow((state) => ({
+      activityID: state.rewardSlotLedgerActivityID,
+      entries: state.rewardSlotLedger,
+    })),
+  );
 }

--- a/libs/game/idle-client/src/state/use-reward-slot-ledger.ts
+++ b/libs/game/idle-client/src/state/use-reward-slot-ledger.ts
@@ -1,0 +1,5 @@
+import { useIdleStore } from './use-idle-store';
+
+export function useRewardSlotLedger() {
+  return useIdleStore((state) => state.rewardSlotLedger);
+}

--- a/libs/game/idle-client/src/submission/create-checkpoint-submitter.test.ts
+++ b/libs/game/idle-client/src/submission/create-checkpoint-submitter.test.ts
@@ -489,3 +489,35 @@ test('it drops a checkpoint for an activity that was never registered', async ()
 
   expect(remaining).toStrictEqual([]);
 });
+
+test('it resolves each submit with the activity-relative version it assigned', async () => {
+  const ctx = setupTest();
+
+  await ctx.submitter.registerActivity({
+    activityID: 'versioned-activity',
+    appendedHead: 0,
+    lastHash: 'start_hash',
+    startChainIndex: 0,
+  });
+
+  const firstVersion = await ctx.submitter.submit(
+    'versioned-activity',
+    createMockStartedCheckpoint(),
+  );
+
+  const secondVersion = await ctx.submitter.submit(
+    'versioned-activity',
+    createMockProgressCheckpoint(),
+  );
+
+  expect(firstVersion).toBe(1);
+  expect(secondVersion).toBe(2);
+});
+
+test('it resolves with undefined for a checkpoint dropped by an unattached activity', async () => {
+  const ctx = setupTest();
+
+  const version = await ctx.submitter.submit('never-registered', createMockStartedCheckpoint());
+
+  expect(version).toBeUndefined();
+});

--- a/libs/game/idle-client/src/submission/create-checkpoint-submitter.ts
+++ b/libs/game/idle-client/src/submission/create-checkpoint-submitter.ts
@@ -39,9 +39,13 @@ export interface CheckpointSubmitter {
    * while the seed read is still in flight never chains onto a stale hash. Silently drops the
    * checkpoint if the activity was never attached or its stream is stopped. Resolves once the
    * checkpoint is durably queued, so a caller that awaits each submission in order never races a
-   * later checkpoint's write against an earlier one's.
+   * later checkpoint's write against an earlier one's. Resolves with the activity-relative version
+   * assigned to the queued entry, or `undefined` when the checkpoint was dropped.
    */
-  submit: (activityID: string, checkpoint: Readonly<ActivityCheckpoint>) => Promise<void>;
+  submit: (
+    activityID: string,
+    checkpoint: Readonly<ActivityCheckpoint>,
+  ) => Promise<number | undefined>;
 }
 
 interface CreateCheckpointSubmitterOptions {
@@ -247,11 +251,11 @@ export function createCheckpointSubmitter(
   const submit = async (
     activityID: string,
     checkpoint: Readonly<ActivityCheckpoint>,
-  ): Promise<void> => {
+  ): Promise<number | undefined> => {
     const registration = registrations.get(activityID);
 
     if (registration === undefined) {
-      return;
+      return undefined;
     }
 
     await registration;
@@ -261,7 +265,7 @@ export function createCheckpointSubmitter(
     invariant(state !== undefined, 'a registered activity has no submission state');
 
     if (state.invalid) {
-      return;
+      return undefined;
     }
 
     const entry = buildCheckpointBatchEntry({
@@ -288,7 +292,7 @@ export function createCheckpointSubmitter(
 
       await flush(activityID);
 
-      return;
+      return entry.version;
     }
 
     if (!state.flushScheduled) {
@@ -304,6 +308,8 @@ export function createCheckpointSubmitter(
         await flush(activityID);
       });
     }
+
+    return entry.version;
   };
 
   return { registerActivity, submit };

--- a/libs/game/idle-client/src/test-utils/factories/create-mock-worker-context.test.ts
+++ b/libs/game/idle-client/src/test-utils/factories/create-mock-worker-context.test.ts
@@ -40,7 +40,7 @@ test('it drops a port from the connections set', () => {
 test('it returns the injected submitter', () => {
   const submitter: CheckpointSubmitter = {
     registerActivity: mock(() => Promise.resolve()),
-    submit: mock(() => Promise.resolve()),
+    submit: mock(() => Promise.resolve(undefined)),
   };
 
   const context = createMockWorkerContext({ submitter });

--- a/libs/game/idle-client/src/test-utils/factories/create-mock-worker-context.ts
+++ b/libs/game/idle-client/src/test-utils/factories/create-mock-worker-context.ts
@@ -1,5 +1,6 @@
 import type { Simulation } from '@vers/idle-core';
 import type { CheckpointSubmitter } from '../../submission/create-checkpoint-submitter';
+import type { RewardSlotLedgerEntry } from '../../types';
 import type { WorkerContext } from '../../worker/types';
 
 interface CreateMockWorkerContextOptions {
@@ -19,12 +20,28 @@ export function createMockWorkerContext(
   };
 
   let simulation: null | Simulation = null;
+  let rewardSlotLedgerActivityID: null | string = null;
+  let rewardSlotLedger: ReadonlyArray<RewardSlotLedgerEntry> = [];
 
   return {
     connections,
     getRemainingBudgetMs: () => options.remainingBudgetMs ?? Number.MAX_SAFE_INTEGER,
+    getRewardSlotLedger: () => ({
+      activityID: rewardSlotLedgerActivityID,
+      entries: rewardSlotLedger,
+    }),
     getSimulation: () => simulation,
     getSubmitter: () => submitter,
+    recordRewardSlots: (activityID, entry) => {
+      if (rewardSlotLedgerActivityID === activityID) {
+        rewardSlotLedger = [...rewardSlotLedger, entry];
+
+        return;
+      }
+
+      rewardSlotLedgerActivityID = activityID;
+      rewardSlotLedger = [entry];
+    },
     removeConnection: (port) => {
       connections.delete(port);
     },

--- a/libs/game/idle-client/src/test-utils/factories/create-mock-worker-context.ts
+++ b/libs/game/idle-client/src/test-utils/factories/create-mock-worker-context.ts
@@ -15,7 +15,7 @@ export function createMockWorkerContext(
 
   const submitter: CheckpointSubmitter = options.submitter ?? {
     registerActivity: () => Promise.resolve(),
-    submit: () => Promise.resolve(),
+    submit: () => Promise.resolve(undefined),
   };
 
   let simulation: null | Simulation = null;

--- a/libs/game/idle-client/src/types.ts
+++ b/libs/game/idle-client/src/types.ts
@@ -53,6 +53,7 @@ export enum WorkerMessageType {
   CheckpointStreamInvalid = 'checkpoint_stream_invalid',
   InitialState = 'initial_state',
   OfflineCapStatus = 'offline_cap_status',
+  RewardSlotsRecorded = 'reward_slots_recorded',
   SimulationUpdate = 'simulation_update',
 }
 
@@ -91,10 +92,25 @@ export interface OfflineCapStatusMessage extends IWorkerMessage {
   readonly type: WorkerMessageType.OfflineCapStatus;
 }
 
+/**
+ * Reports a checkpoint's reward-slot count as it leaves the generator and enters the submission
+ * path, keyed by the activity-relative `version` the checkpoint chain assigns it — the same
+ * numbering the server's `verifiedHead` advances against. Only carries checkpoints the submitter
+ * actually queued and that earned at least one slot; a dropped or zero-slot checkpoint never
+ * broadcasts one of these.
+ */
+export interface RewardSlotsRecordedMessage extends IWorkerMessage {
+  readonly activityID: string;
+  readonly rewardSlotCount: number;
+  readonly type: WorkerMessageType.RewardSlotsRecorded;
+  readonly version: number;
+}
+
 export type WorkerMessage =
   | CheckpointStreamInvalidMessage
   | InitialStateMessage
   | OfflineCapStatusMessage
+  | RewardSlotsRecordedMessage
   | SimulationUpdateMessage;
 
 export interface CheckpointStreamError {
@@ -105,6 +121,15 @@ export interface CheckpointStreamError {
 export interface OfflineCapStatus {
   readonly halted: boolean;
   readonly remainingMs: number;
+}
+
+/**
+ * One checkpoint's recorded reward-slot count, keyed by the activity-relative version the
+ * checkpoint chain assigns it — the same numbering the server's `verifiedHead` advances against.
+ */
+export interface RewardSlotLedgerEntry {
+  readonly count: number;
+  readonly version: number;
 }
 
 /**

--- a/libs/game/idle-client/src/types.ts
+++ b/libs/game/idle-client/src/types.ts
@@ -62,6 +62,11 @@ interface IWorkerMessage {
 }
 
 export interface InitialStateMessage extends IWorkerMessage {
+  /**
+   * The current activity's reward-slot ledger as the worker holds it, so a tab connecting mid-run
+   * catches up on pending rewards instead of starting empty.
+   */
+  readonly rewardSlotLedger: RewardSlotLedgerSnapshot;
   readonly state: SimulationSnapshot;
   readonly type: WorkerMessageType.InitialState;
 }
@@ -130,6 +135,15 @@ export interface OfflineCapStatus {
 export interface RewardSlotLedgerEntry {
   readonly count: number;
   readonly version: number;
+}
+
+/**
+ * A reward-slot ledger paired with the activity its entries belong to, so a consumer can tell
+ * whether the entries describe the activity it's rendering before trusting their counts.
+ */
+export interface RewardSlotLedgerSnapshot {
+  readonly activityID: null | string;
+  readonly entries: ReadonlyArray<RewardSlotLedgerEntry>;
 }
 
 /**

--- a/libs/game/idle-client/src/worker/create-initial-state-message.test.ts
+++ b/libs/game/idle-client/src/worker/create-initial-state-message.test.ts
@@ -15,9 +15,13 @@ test('it creates an initial state message', () => {
     failureAction: ActivityFailureAction.Abort,
   };
 
-  const message = createInitialStateMessage(state);
+  const message = createInitialStateMessage(state, {
+    activityID: 'activity_1',
+    entries: [{ count: 2, version: 1 }],
+  });
 
   expect(message).toStrictEqual({
+    rewardSlotLedger: { activityID: 'activity_1', entries: [{ count: 2, version: 1 }] },
     state,
     type: WorkerMessageType.InitialState,
   });

--- a/libs/game/idle-client/src/worker/create-initial-state-message.ts
+++ b/libs/game/idle-client/src/worker/create-initial-state-message.ts
@@ -1,9 +1,13 @@
 import type { SimulationSnapshot } from '@vers/idle-core';
-import type { InitialStateMessage } from '../types';
+import type { InitialStateMessage, RewardSlotLedgerSnapshot } from '../types';
 import { WorkerMessageType } from '../types';
 
-export function createInitialStateMessage(state: SimulationSnapshot): InitialStateMessage {
+export function createInitialStateMessage(
+  state: SimulationSnapshot,
+  rewardSlotLedger: RewardSlotLedgerSnapshot,
+): InitialStateMessage {
   return {
+    rewardSlotLedger,
     state,
     type: WorkerMessageType.InitialState,
   };

--- a/libs/game/idle-client/src/worker/create-reward-slots-recorded-message.test.ts
+++ b/libs/game/idle-client/src/worker/create-reward-slots-recorded-message.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from 'bun:test';
+import { WorkerMessageType } from '../types';
+import { createRewardSlotsRecordedMessage } from './create-reward-slots-recorded-message';
+
+test('it carries the activity, version, and reward-slot count', () => {
+  const message = createRewardSlotsRecordedMessage('activity_1', 3, 5);
+
+  expect(message).toStrictEqual({
+    activityID: 'activity_1',
+    rewardSlotCount: 5,
+    type: WorkerMessageType.RewardSlotsRecorded,
+    version: 3,
+  });
+});

--- a/libs/game/idle-client/src/worker/create-reward-slots-recorded-message.ts
+++ b/libs/game/idle-client/src/worker/create-reward-slots-recorded-message.ts
@@ -1,0 +1,15 @@
+import type { RewardSlotsRecordedMessage } from '../types';
+import { WorkerMessageType } from '../types';
+
+export function createRewardSlotsRecordedMessage(
+  activityID: string,
+  version: number,
+  rewardSlotCount: number,
+): RewardSlotsRecordedMessage {
+  return {
+    activityID,
+    rewardSlotCount,
+    type: WorkerMessageType.RewardSlotsRecorded,
+    version,
+  };
+}

--- a/libs/game/idle-client/src/worker/create-worker-runtime.ts
+++ b/libs/game/idle-client/src/worker/create-worker-runtime.ts
@@ -4,7 +4,7 @@ import { SIMULATION_TIMESTEP_MS } from '@vers/idle-core';
 import invariant from 'tiny-invariant';
 import { createActivityServiceClient } from '../submission/create-activity-service-client';
 import { createCheckpointSubmitter } from '../submission/create-checkpoint-submitter';
-import type { ClientMessage } from '../types';
+import type { ClientMessage, RewardSlotLedgerEntry } from '../types';
 import { createCheckpointStreamInvalidMessage } from './create-checkpoint-stream-invalid-message';
 import { createOfflineCapStatusMessage } from './create-offline-cap-status-message';
 import { handleClientMessage } from './handle-client-message';
@@ -40,6 +40,8 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
   // A fresh worker starts fully funded and drains toward the cap until its first acknowledged
   // submission; every ack re-anchors the budget at the cap.
   let lastAckAt = Date.now();
+  let rewardSlotLedgerActivityID: null | string = null;
+  let rewardSlotLedger: ReadonlyArray<RewardSlotLedgerEntry> = [];
 
   const submitter = createCheckpointSubmitter({
     client: createActivityServiceClient(),
@@ -65,8 +67,22 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
   const context: WorkerContext = {
     connections,
     getRemainingBudgetMs: () => OFFLINE_PROGRESS_CAP_MS - (Date.now() - lastAckAt),
+    getRewardSlotLedger: () => ({
+      activityID: rewardSlotLedgerActivityID,
+      entries: rewardSlotLedger,
+    }),
     getSimulation: () => simulation,
     getSubmitter: () => submitter,
+    recordRewardSlots: (activityID, entry) => {
+      if (rewardSlotLedgerActivityID === activityID) {
+        rewardSlotLedger = [...rewardSlotLedger, entry];
+
+        return;
+      }
+
+      rewardSlotLedgerActivityID = activityID;
+      rewardSlotLedger = [entry];
+    },
     removeConnection: (port) => {
       connections.delete(port);
     },

--- a/libs/game/idle-client/src/worker/handle-initialize-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-initialize-message.test.ts
@@ -38,7 +38,36 @@ test('it sends an initial state message to all connections', async () => {
   const simulation = context.getSimulation();
 
   expect(event.data).toStrictEqual({
+    rewardSlotLedger: { activityID: null, entries: [] },
     state: simulation?.getSnapshot(),
+    type: WorkerMessageType.InitialState,
+  });
+});
+
+test('it sends the retained reward-slot ledger to a connection that initializes mid-run', async () => {
+  const channel = new MessageChannel();
+
+  const context = createMockWorkerContext({ connections: [channel.port2] });
+
+  context.setSimulation(createSimulation());
+  context.recordRewardSlots('activity_1', { count: 2, version: 1 });
+  channel.port1.start();
+
+  const received = new Promise<MessageEvent>((resolve) => {
+    channel.port1.addEventListener('message', resolve, { once: true });
+  });
+
+  const message: InitializeMessage = {
+    type: ClientMessageType.Initialize,
+  };
+
+  handleInitializeMessage(context, message);
+
+  const event = await received;
+
+  expect(event.data).toStrictEqual({
+    rewardSlotLedger: { activityID: 'activity_1', entries: [{ count: 2, version: 1 }] },
+    state: context.getSimulation()?.getSnapshot(),
     type: WorkerMessageType.InitialState,
   });
 });

--- a/libs/game/idle-client/src/worker/handle-initialize-message.ts
+++ b/libs/game/idle-client/src/worker/handle-initialize-message.ts
@@ -1,3 +1,4 @@
+import type { Simulation } from '@vers/idle-core';
 import { createSimulation } from '@vers/idle-core';
 import type { InitializeMessage } from '../types';
 import { createInitialStateMessage } from './create-initial-state-message';
@@ -7,21 +8,29 @@ import { handleSimulationStopped } from './handle-simulation-stopped';
 import { handleSimulationUpdate } from './handle-simulation-update';
 import type { WorkerContext } from './types';
 
+/**
+ * Answers an initialize with the worker's current state: it creates the one simulation on the
+ * first initialize and reuses it afterward, then broadcasts the snapshot and the retained
+ * reward-slot ledger to every connection — so a tab connecting mid-run catches up rather than
+ * starting empty.
+ */
 export function handleInitializeMessage(context: WorkerContext, _message: InitializeMessage) {
-  // bail out if we already have a simulation initialized
-  if (context.getSimulation()) {
-    return;
-  }
+  const simulation = context.getSimulation() ?? createSimulationForContext(context);
 
-  const simulation = createSimulation();
-
-  context.setSimulation(simulation);
-
-  const initialStateMessage = createInitialStateMessage(simulation.getSnapshot());
+  const initialStateMessage = createInitialStateMessage(
+    simulation.getSnapshot(),
+    context.getRewardSlotLedger(),
+  );
 
   for (const connection of context.connections) {
     connection.postMessage(initialStateMessage);
   }
+}
+
+function createSimulationForContext(context: WorkerContext): Simulation {
+  const simulation = createSimulation();
+
+  context.setSimulation(simulation);
 
   simulation.addEventListener('updated', () => {
     handleSimulationUpdate(context);
@@ -38,4 +47,6 @@ export function handleInitializeMessage(context: WorkerContext, _message: Initia
   simulation.addEventListener('restarted', () => {
     handleSimulationRestarted(context);
   });
+
+  return simulation;
 }

--- a/libs/game/idle-client/src/worker/handle-set-activity-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-set-activity-message.test.ts
@@ -10,7 +10,7 @@ import { handleSetActivityMessage } from './handle-set-activity-message';
 function buildSpySubmitter(): CheckpointSubmitter {
   return {
     registerActivity: mock(() => Promise.resolve()),
-    submit: mock(() => Promise.resolve()),
+    submit: mock(() => Promise.resolve(undefined)),
   };
 }
 

--- a/libs/game/idle-client/src/worker/run-simulation.test.ts
+++ b/libs/game/idle-client/src/worker/run-simulation.test.ts
@@ -6,6 +6,7 @@ import {
   createMockAvatarData,
   createMockEnemyData,
 } from '@vers/idle-core/test-utils';
+import type { CheckpointSubmitter } from '../submission/create-checkpoint-submitter';
 import { createMockWorkerContext } from '../test-utils/factories/create-mock-worker-context';
 import { runSimulation } from './run-simulation';
 import type { WorkerContext } from './types';
@@ -137,4 +138,95 @@ test('it stops an aborted failure even when the budget is spent', async () => {
 
   expect(stoppedSpy).toHaveBeenCalled();
   expect(simulation.activity).toBeNull();
+});
+
+test('it broadcasts a reward-slot ledger message for each submitted checkpoint that earns slots', async () => {
+  const channel = new MessageChannel();
+
+  const received: Array<unknown> = [];
+
+  channel.port2.addEventListener('message', (event) => {
+    received.push(event.data);
+  });
+
+  channel.port2.start();
+
+  let nextVersion = 1;
+
+  const submitter: CheckpointSubmitter = {
+    registerActivity: () => Promise.resolve(),
+    submit: () => {
+      const version = nextVersion;
+
+      nextVersion += 1;
+
+      return Promise.resolve(version);
+    },
+  };
+
+  const context = createMockWorkerContext({ connections: [channel.port1], submitter });
+  const simulation = createSimulation();
+  const avatar = createMockAvatarData();
+  const activity = createMockActivityInput({ enemies: [createMockEnemyData()] });
+
+  simulation.startActivity(avatar, activity);
+
+  await runSimulationSteps(context, simulation, 100, 700);
+
+  // MessagePort delivery is a queued task; yield once so every broadcast lands
+  await new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+
+  const rewardMessages = received.filter(
+    (message): message is { rewardSlotCount: number; type: string; version: number } =>
+      typeof message === 'object' &&
+      message !== null &&
+      'type' in message &&
+      message.type === 'reward_slots_recorded',
+  );
+
+  expect(rewardMessages.length).toBeGreaterThan(0);
+  expect(rewardMessages.every((message) => message.rewardSlotCount > 0)).toBeTrue();
+
+  // the very first submitted checkpoint is the zero-slot Started checkpoint (version 1) — it
+  // never earns a broadcast of its own
+  expect(rewardMessages.some((message) => message.version === 1)).toBeFalse();
+});
+
+test('it never broadcasts a ledger message for a checkpoint the submitter dropped', async () => {
+  const channel = new MessageChannel();
+
+  const received: Array<unknown> = [];
+
+  channel.port2.addEventListener('message', (event) => {
+    received.push(event.data);
+  });
+
+  channel.port2.start();
+
+  // the default mock context's submitter always resolves `undefined`, standing in for a
+  // dropped checkpoint (an unattached or already-invalid activity)
+  const context = createMockWorkerContext({ connections: [channel.port1] });
+  const simulation = createSimulation();
+  const avatar = createMockAvatarData();
+  const activity = createMockActivityInput({ enemies: [createMockEnemyData()] });
+
+  simulation.startActivity(avatar, activity);
+
+  await runSimulationSteps(context, simulation, 100, 700);
+
+  await new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+
+  const rewardMessages = received.filter(
+    (message): message is { type: string } =>
+      typeof message === 'object' &&
+      message !== null &&
+      'type' in message &&
+      message.type === 'reward_slots_recorded',
+  );
+
+  expect(rewardMessages).toStrictEqual([]);
 });

--- a/libs/game/idle-client/src/worker/run-simulation.ts
+++ b/libs/game/idle-client/src/worker/run-simulation.ts
@@ -1,6 +1,7 @@
 import type { Simulation } from '@vers/idle-core';
 import { ActivityCheckpointType } from '@vers/idle-core';
 import { createOfflineCapStatusMessage } from './create-offline-cap-status-message';
+import { createRewardSlotsRecordedMessage } from './create-reward-slots-recorded-message';
 import { OFFLINE_CAP_WARNING_MS } from './offline-cap-warning-ms';
 import { pickPostTerminalAction } from './pick-post-terminal-action';
 import type { WorkerContext } from './types';
@@ -29,7 +30,11 @@ export async function runSimulation(
     return;
   }
 
-  await context.getSubmitter().submit(activityID, checkpoint);
+  const version = await context.getSubmitter().submit(activityID, checkpoint);
+
+  if (version !== undefined && checkpoint.rewardSlots.length > 0) {
+    emitRewardSlotsRecorded(context, activityID, version, checkpoint.rewardSlots.length);
+  }
 
   const isTerminal =
     checkpoint.type === ActivityCheckpointType.Completed ||
@@ -64,6 +69,19 @@ export async function runSimulation(
   }
 
   simulation.restartActivity();
+}
+
+function emitRewardSlotsRecorded(
+  context: WorkerContext,
+  activityID: string,
+  version: number,
+  rewardSlotCount: number,
+) {
+  const message = createRewardSlotsRecordedMessage(activityID, version, rewardSlotCount);
+
+  for (const connection of context.connections) {
+    connection.postMessage(message);
+  }
 }
 
 function emitCapStatus(context: WorkerContext, remainingMs: number, halted: boolean) {

--- a/libs/game/idle-client/src/worker/run-simulation.ts
+++ b/libs/game/idle-client/src/worker/run-simulation.ts
@@ -33,6 +33,8 @@ export async function runSimulation(
   const version = await context.getSubmitter().submit(activityID, checkpoint);
 
   if (version !== undefined && checkpoint.rewardSlots.length > 0) {
+    context.recordRewardSlots(activityID, { count: checkpoint.rewardSlots.length, version });
+
     emitRewardSlotsRecorded(context, activityID, version, checkpoint.rewardSlots.length);
   }
 

--- a/libs/game/idle-client/src/worker/types.ts
+++ b/libs/game/idle-client/src/worker/types.ts
@@ -1,5 +1,6 @@
 import type { Simulation } from '@vers/idle-core';
 import type { CheckpointSubmitter } from '../submission/create-checkpoint-submitter';
+import type { RewardSlotLedgerEntry, RewardSlotLedgerSnapshot } from '../types';
 
 /**
  * Accessors over the runtime's closure state, threaded to every message and simulation event
@@ -16,8 +17,20 @@ export interface WorkerContext {
    * server's meter, never over-run it.
    */
   readonly getRemainingBudgetMs: () => number;
+
+  /**
+   * The current activity's reward-slot ledger, retained so a tab connecting mid-run receives it in
+   * its initial state.
+   */
+  readonly getRewardSlotLedger: () => RewardSlotLedgerSnapshot;
   readonly getSimulation: () => null | Simulation;
   readonly getSubmitter: () => CheckpointSubmitter;
+
+  /**
+   * Appends one checkpoint's reward-slot count to the retained ledger, resetting it first when the
+   * activity differs from the one the retained entries belong to.
+   */
+  readonly recordRewardSlots: (activityID: string, entry: RewardSlotLedgerEntry) => void;
   readonly removeConnection: (port: MessagePort) => void;
   readonly setSimulation: (simulation: null | Simulation) => void;
 }

--- a/libs/game/idle-client/src/worker/use-simulation-worker.test.ts
+++ b/libs/game/idle-client/src/worker/use-simulation-worker.test.ts
@@ -1,10 +1,16 @@
 import { expect, onTestFinished, test } from 'bun:test';
 import { renderHook, waitFor } from '@testing-library/react';
 import { ActivityFailureAction } from '@vers/idle-core';
+import { createMockActivitySnapshot } from '@vers/idle-core/test-utils';
 import invariant from 'tiny-invariant';
 import { setSimulationWorker } from '../state/set-simulation-worker';
 import { useIdleStore } from '../state/use-idle-store';
-import type { CheckpointStreamInvalidMessage, ClientMessage, InitialStateMessage } from '../types';
+import type {
+  CheckpointStreamInvalidMessage,
+  ClientMessage,
+  InitialStateMessage,
+  RewardSlotsRecordedMessage,
+} from '../types';
 import { ClientMessageType, WorkerMessageType } from '../types';
 import { useSimulationWorker } from './use-simulation-worker';
 
@@ -155,4 +161,123 @@ test('it sends a disconnect message on pagehide', async () => {
   const event = await received;
 
   expect(event.data).toStrictEqual({ type: ClientMessageType.Disconnect });
+});
+
+test('it accumulates the reward-slot ledger from worker messages', async () => {
+  registerSharedWorkerStub();
+
+  const hook = renderHook(() => useSimulationWorker());
+
+  hook.rerender();
+
+  invariant(hook.result.current, 'Worker not initialized');
+
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the hook was stubbed to construct a StubSharedWorker, so its return value has that shape at runtime
+  const worker = hook.result.current as unknown as StubSharedWorker;
+
+  worker.channel.port2.start();
+
+  const initialStateMessage: InitialStateMessage = {
+    state: {
+      activity: createMockActivitySnapshot({ id: 'activity_1' }),
+      failureAction: ActivityFailureAction.Retry,
+    },
+    type: WorkerMessageType.InitialState,
+  };
+
+  worker.channel.port2.postMessage(initialStateMessage);
+
+  await waitFor(() => {
+    expect(useIdleStore.getState().activity?.id).toBe('activity_1');
+  });
+
+  const firstMessage: RewardSlotsRecordedMessage = {
+    activityID: 'activity_1',
+    rewardSlotCount: 2,
+    type: WorkerMessageType.RewardSlotsRecorded,
+    version: 1,
+  };
+
+  worker.channel.port2.postMessage(firstMessage);
+
+  await waitFor(() => {
+    expect(useIdleStore.getState().rewardSlotLedger).toStrictEqual([{ count: 2, version: 1 }]);
+  });
+
+  const secondMessage: RewardSlotsRecordedMessage = {
+    activityID: 'activity_1',
+    rewardSlotCount: 3,
+    type: WorkerMessageType.RewardSlotsRecorded,
+    version: 2,
+  };
+
+  worker.channel.port2.postMessage(secondMessage);
+
+  await waitFor(() => {
+    expect(useIdleStore.getState().rewardSlotLedger).toStrictEqual([
+      { count: 2, version: 1 },
+      { count: 3, version: 2 },
+    ]);
+  });
+});
+
+test('it resets the reward-slot ledger once a new activity reports its own message', async () => {
+  registerSharedWorkerStub();
+
+  const hook = renderHook(() => useSimulationWorker());
+
+  hook.rerender();
+
+  invariant(hook.result.current, 'Worker not initialized');
+
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the hook was stubbed to construct a StubSharedWorker, so its return value has that shape at runtime
+  const worker = hook.result.current as unknown as StubSharedWorker;
+
+  worker.channel.port2.start();
+
+  worker.channel.port2.postMessage({
+    state: {
+      activity: createMockActivitySnapshot({ id: 'activity_1' }),
+      failureAction: ActivityFailureAction.Retry,
+    },
+    type: WorkerMessageType.InitialState,
+  } satisfies InitialStateMessage);
+
+  await waitFor(() => {
+    expect(useIdleStore.getState().activity?.id).toBe('activity_1');
+  });
+
+  worker.channel.port2.postMessage({
+    activityID: 'activity_1',
+    rewardSlotCount: 2,
+    type: WorkerMessageType.RewardSlotsRecorded,
+    version: 1,
+  } satisfies RewardSlotsRecordedMessage);
+
+  await waitFor(() => {
+    expect(useIdleStore.getState().rewardSlotLedger).toStrictEqual([{ count: 2, version: 1 }]);
+  });
+
+  worker.channel.port2.postMessage({
+    state: {
+      activity: createMockActivitySnapshot({ id: 'activity_2' }),
+      failureAction: ActivityFailureAction.Retry,
+    },
+    type: WorkerMessageType.SimulationUpdate,
+  });
+
+  await waitFor(() => {
+    expect(useIdleStore.getState().activity?.id).toBe('activity_2');
+  });
+
+  worker.channel.port2.postMessage({
+    activityID: 'activity_2',
+    rewardSlotCount: 5,
+    type: WorkerMessageType.RewardSlotsRecorded,
+    version: 1,
+  } satisfies RewardSlotsRecordedMessage);
+
+  await waitFor(() => {
+    expect(useIdleStore.getState().rewardSlotLedger).toStrictEqual([{ count: 5, version: 1 }]);
+  });
 });

--- a/libs/game/idle-client/src/worker/use-simulation-worker.test.ts
+++ b/libs/game/idle-client/src/worker/use-simulation-worker.test.ts
@@ -10,6 +10,7 @@ import type {
   ClientMessage,
   InitialStateMessage,
   RewardSlotsRecordedMessage,
+  SimulationUpdateMessage,
 } from '../types';
 import { ClientMessageType, WorkerMessageType } from '../types';
 import { useSimulationWorker } from './use-simulation-worker';
@@ -94,6 +95,7 @@ test('it updates simulation state from worker messages', async () => {
   worker.channel.port2.start();
 
   const message: InitialStateMessage = {
+    rewardSlotLedger: { activityID: null, entries: [] },
     state: { combat: { elapsed: 1000 }, failureAction: ActivityFailureAction.Retry },
     type: WorkerMessageType.InitialState,
   };
@@ -166,6 +168,8 @@ test('it sends a disconnect message on pagehide', async () => {
 test('it accumulates the reward-slot ledger from worker messages', async () => {
   registerSharedWorkerStub();
 
+  useIdleStore.setState({ checkpointStreamError: null });
+
   const hook = renderHook(() => useSimulationWorker());
 
   hook.rerender();
@@ -178,6 +182,7 @@ test('it accumulates the reward-slot ledger from worker messages', async () => {
   worker.channel.port2.start();
 
   const initialStateMessage: InitialStateMessage = {
+    rewardSlotLedger: { activityID: null, entries: [] },
     state: {
       activity: createMockActivitySnapshot({ id: 'activity_1' }),
       failureAction: ActivityFailureAction.Retry,
@@ -224,6 +229,8 @@ test('it accumulates the reward-slot ledger from worker messages', async () => {
 test('it resets the reward-slot ledger once a new activity reports its own message', async () => {
   registerSharedWorkerStub();
 
+  useIdleStore.setState({ checkpointStreamError: null });
+
   const hook = renderHook(() => useSimulationWorker());
 
   hook.rerender();
@@ -236,6 +243,7 @@ test('it resets the reward-slot ledger once a new activity reports its own messa
   worker.channel.port2.start();
 
   worker.channel.port2.postMessage({
+    rewardSlotLedger: { activityID: null, entries: [] },
     state: {
       activity: createMockActivitySnapshot({ id: 'activity_1' }),
       failureAction: ActivityFailureAction.Retry,
@@ -264,7 +272,7 @@ test('it resets the reward-slot ledger once a new activity reports its own messa
       failureAction: ActivityFailureAction.Retry,
     },
     type: WorkerMessageType.SimulationUpdate,
-  });
+  } satisfies SimulationUpdateMessage);
 
   await waitFor(() => {
     expect(useIdleStore.getState().activity?.id).toBe('activity_2');
@@ -280,4 +288,36 @@ test('it resets the reward-slot ledger once a new activity reports its own messa
   await waitFor(() => {
     expect(useIdleStore.getState().rewardSlotLedger).toStrictEqual([{ count: 5, version: 1 }]);
   });
+});
+
+test('it installs the reward-slot ledger carried by the initial state', async () => {
+  registerSharedWorkerStub();
+
+  useIdleStore.setState({ rewardSlotLedger: [], rewardSlotLedgerActivityID: null });
+
+  const hook = renderHook(() => useSimulationWorker());
+
+  hook.rerender();
+
+  invariant(hook.result.current, 'Worker not initialized');
+
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the hook was stubbed to construct a StubSharedWorker, so its return value has that shape at runtime
+  const worker = hook.result.current as unknown as StubSharedWorker;
+
+  worker.channel.port2.start();
+
+  worker.channel.port2.postMessage({
+    rewardSlotLedger: { activityID: 'activity_1', entries: [{ count: 2, version: 1 }] },
+    state: {
+      activity: createMockActivitySnapshot({ id: 'activity_1' }),
+      failureAction: ActivityFailureAction.Retry,
+    },
+    type: WorkerMessageType.InitialState,
+  } satisfies InitialStateMessage);
+
+  await waitFor(() => {
+    expect(useIdleStore.getState().rewardSlotLedger).toStrictEqual([{ count: 2, version: 1 }]);
+  });
+
+  expect(useIdleStore.getState().rewardSlotLedgerActivityID).toBe('activity_1');
 });

--- a/libs/game/idle-client/src/worker/use-simulation-worker.test.ts
+++ b/libs/game/idle-client/src/worker/use-simulation-worker.test.ts
@@ -21,10 +21,12 @@ import { useSimulationWorker } from './use-simulation-worker';
  * simulation ticking) is covered by `create-worker-runtime.test.ts` — this file only exercises the
  * hook's own wiring.
  */
-class StubSharedWorker {
+class StubSharedWorker extends EventTarget {
   channel = new MessageChannel();
 
   port = this.channel.port1;
+
+  onerror = null;
 }
 
 function registerSharedWorkerStub() {
@@ -35,6 +37,12 @@ function registerSharedWorkerStub() {
   onTestFinished(() => {
     Reflect.set(globalThis, 'SharedWorker', originalSharedWorker);
   });
+}
+
+function getStubSharedWorker(current: SharedWorker | null): StubSharedWorker {
+  invariant(current instanceof StubSharedWorker, 'expected the hook to hold a StubSharedWorker');
+
+  return current;
 }
 
 test('it initializes the worker connection', () => {
@@ -50,8 +58,7 @@ test('it initializes the worker connection', () => {
 });
 
 test('it returns an existing worker instead of creating a new one', () => {
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- StubSharedWorker stands in for a real SharedWorker; the hook only ever touches its `.port`
-  const worker = new StubSharedWorker() as unknown as SharedWorker;
+  const worker = new StubSharedWorker();
 
   setSimulationWorker(worker);
 
@@ -87,10 +94,7 @@ test('it updates simulation state from worker messages', async () => {
 
   hook.rerender();
 
-  invariant(hook.result.current, 'Worker not initialized');
-
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the hook was stubbed to construct a StubSharedWorker, so its return value has that shape at runtime
-  const worker = hook.result.current as unknown as StubSharedWorker;
+  const worker = getStubSharedWorker(hook.result.current);
 
   worker.channel.port2.start();
 
@@ -117,10 +121,7 @@ test('it reports a checkpoint stream error from worker messages', async () => {
 
   hook.rerender();
 
-  invariant(hook.result.current, 'Worker not initialized');
-
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the hook was stubbed to construct a StubSharedWorker, so its return value has that shape at runtime
-  const worker = hook.result.current as unknown as StubSharedWorker;
+  const worker = getStubSharedWorker(hook.result.current);
 
   worker.channel.port2.start();
 
@@ -147,10 +148,7 @@ test('it sends a disconnect message on pagehide', async () => {
 
   hook.rerender();
 
-  invariant(hook.result.current, 'Worker not initialized');
-
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the hook was stubbed to construct a StubSharedWorker, so its return value has that shape at runtime
-  const worker = hook.result.current as unknown as StubSharedWorker;
+  const worker = getStubSharedWorker(hook.result.current);
 
   worker.channel.port2.start();
 
@@ -174,10 +172,7 @@ test('it accumulates the reward-slot ledger from worker messages', async () => {
 
   hook.rerender();
 
-  invariant(hook.result.current, 'Worker not initialized');
-
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the hook was stubbed to construct a StubSharedWorker, so its return value has that shape at runtime
-  const worker = hook.result.current as unknown as StubSharedWorker;
+  const worker = getStubSharedWorker(hook.result.current);
 
   worker.channel.port2.start();
 
@@ -235,10 +230,7 @@ test('it resets the reward-slot ledger once a new activity reports its own messa
 
   hook.rerender();
 
-  invariant(hook.result.current, 'Worker not initialized');
-
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the hook was stubbed to construct a StubSharedWorker, so its return value has that shape at runtime
-  const worker = hook.result.current as unknown as StubSharedWorker;
+  const worker = getStubSharedWorker(hook.result.current);
 
   worker.channel.port2.start();
 
@@ -299,10 +291,7 @@ test('it installs the reward-slot ledger carried by the initial state', async ()
 
   hook.rerender();
 
-  invariant(hook.result.current, 'Worker not initialized');
-
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the hook was stubbed to construct a StubSharedWorker, so its return value has that shape at runtime
-  const worker = hook.result.current as unknown as StubSharedWorker;
+  const worker = getStubSharedWorker(hook.result.current);
 
   worker.channel.port2.start();
 

--- a/libs/game/idle-client/src/worker/use-simulation-worker.ts
+++ b/libs/game/idle-client/src/worker/use-simulation-worker.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { setCheckpointStreamError } from '../state/set-checkpoint-stream-error';
 import { setOfflineCapStatus } from '../state/set-offline-cap-status';
+import { setRewardSlotLedger } from '../state/set-reward-slot-ledger';
 import { setSimulationInitialized } from '../state/set-simulation-initialized';
 import { setSimulationSnapshot } from '../state/set-simulation-snapshot';
 import { setSimulationWorker } from '../state/set-simulation-worker';
@@ -66,6 +67,10 @@ function handleWorkerMessage(event: MessageEvent<WorkerMessage>) {
 
   if (isInitialStateMessage(event.data) || isUpdateMessage(event.data)) {
     setSimulationSnapshot(event.data.state);
+  }
+
+  if (isInitialStateMessage(event.data)) {
+    setRewardSlotLedger(event.data.rewardSlotLedger);
   }
 
   if (isCheckpointStreamInvalidMessage(event.data)) {

--- a/libs/game/idle-client/src/worker/use-simulation-worker.ts
+++ b/libs/game/idle-client/src/worker/use-simulation-worker.ts
@@ -4,11 +4,13 @@ import { setOfflineCapStatus } from '../state/set-offline-cap-status';
 import { setSimulationInitialized } from '../state/set-simulation-initialized';
 import { setSimulationSnapshot } from '../state/set-simulation-snapshot';
 import { setSimulationWorker } from '../state/set-simulation-worker';
+import { updateRewardSlotLedger } from '../state/update-reward-slot-ledger';
 import { useIdleStore } from '../state/use-idle-store';
 import type {
   CheckpointStreamInvalidMessage,
   InitialStateMessage,
   OfflineCapStatusMessage,
+  RewardSlotsRecordedMessage,
   SimulationUpdateMessage,
   WorkerMessage,
 } from '../types';
@@ -79,6 +81,14 @@ function handleWorkerMessage(event: MessageEvent<WorkerMessage>) {
       remainingMs: event.data.remainingMs,
     });
   }
+
+  if (isRewardSlotsRecordedMessage(event.data)) {
+    updateRewardSlotLedger({
+      activityID: event.data.activityID,
+      count: event.data.rewardSlotCount,
+      version: event.data.version,
+    });
+  }
 }
 
 function isInitialStateMessage(message: WorkerMessage): message is InitialStateMessage {
@@ -97,4 +107,10 @@ function isCheckpointStreamInvalidMessage(
 
 function isOfflineCapStatusMessage(message: WorkerMessage): message is OfflineCapStatusMessage {
   return message.type === WorkerMessageType.OfflineCapStatus;
+}
+
+function isRewardSlotsRecordedMessage(
+  message: WorkerMessage,
+): message is RewardSlotsRecordedMessage {
+  return message.type === WorkerMessageType.RewardSlotsRecorded;
 }

--- a/libs/testing/mock-services/src/activity/get-activity-rewards.ts
+++ b/libs/testing/mock-services/src/activity/get-activity-rewards.ts
@@ -2,9 +2,9 @@ import * as db from '../db';
 import { os } from './os';
 
 /**
- * Returns an owned activity's revealed reward-slot contents. The mock backend carries no minted
- * `avatar_items` rows, so `items` is always empty — a test asserting on revealed content seeds its
- * own override.
+ * Returns an owned activity's revealed reward-slot contents: the minted `avatarItemCollection` rows
+ * matching the activity's scope, gated to coordinates at or below its verified anchor and ordered by
+ * chain position then slot ordinal. Seed the collection to assert on revealed content.
  */
 export const getActivityRewards = os.getActivityRewards.handler((opts) => {
   const actingUserId = opts.context.actingUserId;
@@ -27,5 +27,31 @@ export const getActivityRewards = os.getActivityRewards.handler((opts) => {
     throw opts.errors.NOT_FOUND({ data: {} });
   }
 
-  return { items: [], verifiedHead: activity.verifiedHead };
+  const minChainIndex = Math.max(activity.startChainIndex, opts.input.afterChainIndex ?? -1);
+  const maxChainIndex = activity.startChainIndex + activity.verifiedHead;
+
+  const rows = db.avatarItemCollection.findMany(
+    (q) =>
+      q.where({
+        avatarID: activity.avatarID,
+        chainIndex: (value) => value > minChainIndex && value <= maxChainIndex,
+        scopeID: activity.scopeID,
+        scopeType: activity.scopeType,
+      }),
+    { orderBy: [{ chainIndex: 'asc' }, { ordinal: 'asc' }] },
+  );
+
+  return {
+    items: rows.map((row) => ({
+      chainIndex: row.chainIndex,
+      item: {
+        affixes: row.affixes,
+        baseID: row.baseID,
+        contentVersion: row.contentVersion,
+        rarityID: row.rarityID,
+      },
+      ordinal: row.ordinal,
+    })),
+    verifiedHead: activity.verifiedHead,
+  };
 });

--- a/libs/testing/mock-services/src/db/avatar-item-collection.ts
+++ b/libs/testing/mock-services/src/db/avatar-item-collection.ts
@@ -1,0 +1,26 @@
+import { faker } from '@faker-js/faker';
+import { Collection } from '@msw/data';
+import { createId } from '@paralleldrive/cuid2';
+import * as z from 'zod';
+
+const AffixSchema = z.object({ affixID: z.string(), groupID: z.string(), value: z.number() });
+
+/**
+ * A stored mock minted-item row: one revealed reward-slot coordinate an activity settled at, with
+ * every field defaulted so a seeding test states only what it asserts on. `avatarID`, `scopeType`,
+ * and `scopeID` default to random values — a test reading rows back by scope sets them to match
+ * the activity it seeded alongside.
+ */
+const AvatarItemRowSchema = z.object({
+  affixes: z.array(AffixSchema).default(() => []),
+  avatarID: z.string().default(() => createId()),
+  baseID: z.string().default(() => `base_${faker.string.alpha({ casing: 'lower', length: 8 })}`),
+  chainIndex: z.int().min(0).default(0),
+  contentVersion: z.string().default('0.0.0-mock'),
+  ordinal: z.int().min(0).default(0),
+  rarityID: z.string().default('common'),
+  scopeID: z.string().default(() => createId()),
+  scopeType: z.string().default('node'),
+});
+
+export const avatarItemCollection = new Collection({ schema: AvatarItemRowSchema });

--- a/libs/testing/mock-services/src/db/index.ts
+++ b/libs/testing/mock-services/src/db/index.ts
@@ -1,5 +1,6 @@
 export { activityCollection } from './activity-collection';
 export { avatarCollection } from './avatar-collection';
+export { avatarItemCollection } from './avatar-item-collection';
 export { checkpointCollection } from './checkpoint-collection';
 export { pendingTransactionCollection } from './pending-transaction-collection';
 export { sentEmailCollection } from './sent-email-collection';


### PR DESCRIPTION
## Description

Closes #469

Adds the client half of activity reward display: idle-client tracks a reward-slot ledger from submitted checkpoints, and app-web renders it as a settled-rewards panel with a pending-count line.

- idle-client broadcasts a `RewardSlotsRecorded` worker message for each submitted checkpoint whose `rewardSlots` is non-empty, skipping zero-slot checkpoints
- `checkpointSubmitter.submit` now resolves with the activity-relative version it assigned (or `undefined` when dropped), so the ledger can key entries by version
- the sync slice adds `rewardSlotLedger`, reset whenever the tracked activity changes
- `ActivityRewardsPanel` reads the ledger directly and polls `activityRewardsQueryOptions` (10s) for settled items, rendering nothing until an activity and data are present
- pending count is derived client-side as ledger entries past `verifiedHead`; settled items arrive pre-filtered from the server

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/zgeoff/vers/pull/579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

