### PR TITLE
fix: set service-replay's keys service url in its fly config

### DIFF
--- a/services/replay/fly.toml
+++ b/services/replay/fly.toml
@@ -26,6 +26,9 @@ interval = '15s'
 timeout = '2s'
 grace_period = '10s'
 
+[env]
+KEYS_SERVICE_URL = 'http://vers-service-keys.flycast'
+
 [[vm]]
 memory = '256mb'
 cpu_kind = 'shared'


### PR DESCRIPTION
## Description

Production `vers-service-replay` crash-loops at boot: its env schema requires `KEYS_SERVICE_URL` (added in #575) but no production value was ever configured, so env validation fails and every machine exits before the health check passes — the last two Main runs failed at Verify fleet on its wake check.

- Set `KEYS_SERVICE_URL` in fly.toml's `[env]` to `http://vers-service-keys.flycast`, matching app-web's peer-service-URL pattern.
- The fly.toml change makes `@vers/service-replay` turbo-affected, so the merge redeploys replay with the config applied.

## Testing

- [ ] `bun run typecheck` passes
- [ ] `bun run test` passes
- [ ] `bun run lint` passes
- [ ] New tests added for new functionality

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/zgeoff/vers/pull/586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

