### PR TITLE
feat(#409): run app-web server requests inside a trace-context scope

### DIFF
--- a/apps/web/src/lib/rpc/build-service-link.ts
+++ b/apps/web/src/lib/rpc/build-service-link.ts
@@ -1,9 +1,7 @@
 import { RPCLink } from '@orpc/client/fetch';
 import { createIsomorphicFn } from '@tanstack/react-start';
-import { getRequest } from '@tanstack/react-start/server';
 import type { ServiceName } from '@vers/service-auth';
-import type { TraceContext } from '@vers/service-utils';
-import { buildTraceparent, createTraceContext, parseTraceparent } from '@vers/service-utils';
+import { buildTraceparent, createTraceContext, findTraceContext } from '@vers/service-utils';
 import { createTraceparent } from '../trace/create-traceparent';
 import { createEdgeServiceToken } from './create-edge-service-token';
 import { loadSessionActor } from './load-session-actor';
@@ -48,7 +46,9 @@ export function buildServiceLink(service: ServiceName): RPCLink<ServiceLinkConte
               audience: service,
             });
 
-            const trace = createTraceContext(findAmbientTrace());
+            // mint this hop as a child of the request's ambient trace scope; outside a request
+            // (background work) no scope exists, which starts a fresh trace instead
+            const trace = createTraceContext(findTraceContext());
 
             return { authorization: `Bearer ${token}`, traceparent: buildTraceparent(trace) };
           },
@@ -62,17 +62,4 @@ export function buildServiceLink(service: ServiceName): RPCLink<ServiceLinkConte
           url: `${globalThis.location.origin}/api/rpc/${service}`,
         }),
     )();
-}
-
-/**
- * The trace named by the ambient request's `traceparent`, continuing the browser's trace across
- * this hop; undefined when the call runs outside a request (background work), which starts a fresh
- * trace instead. `getRequest` throws outside a request scope, so absence arrives as an exception.
- */
-function findAmbientTrace(): TraceContext | undefined {
-  try {
-    return parseTraceparent(getRequest().headers.get('traceparent')) ?? undefined;
-  } catch {
-    return undefined;
-  }
 }

--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -9,6 +9,7 @@ import { makeSecureHeaders } from './server/make-secure-headers';
 import { withMiddleware } from './server/middleware';
 import { redirectToHTTPS } from './server/redirect-to-https';
 import { removeTrailingSlash } from './server/remove-trailing-slash';
+import { withRequestTrace } from './server/with-request-trace';
 
 // resolved from this built file's own location (`dist/server/server.js`) rather than the
 // process's cwd, since the root `server.mjs` shim and the Docker runtime image invoke this bundle
@@ -47,6 +48,8 @@ function serveClientAssets(request: Request, next: () => Promise<Response>): Pro
 const serverEntry = {
   fetch: withMiddleware(
     [
+      // outermost so the request logger's lines already run inside the trace scope
+      withRequestTrace,
       makeRequestLogger(logger, { colorize: !env.isProduction }),
       removeTrailingSlash,
       redirectToHTTPS,

--- a/apps/web/src/server/with-request-trace.test.ts
+++ b/apps/web/src/server/with-request-trace.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from 'bun:test';
+import { findTraceContext } from '@vers/service-utils';
+import { withRequestTrace } from './with-request-trace';
+
+test('it continues the trace named by a valid inbound traceparent', async () => {
+  const request = new Request('https://example.test/nexus', {
+    headers: { traceparent: '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01' },
+  });
+
+  const response = await withRequestTrace(request, () => Promise.resolve(new Response('ok')));
+
+  expect(response.headers.get('x-trace-id')).toBe('0af7651916cd43dd8448eb211c80319c');
+});
+
+test('it starts a fresh trace when no traceparent came in', async () => {
+  const response = await withRequestTrace(new Request('https://example.test/nexus'), () =>
+    Promise.resolve(new Response('ok')),
+  );
+
+  expect(response.headers.get('x-trace-id')).toMatch(/^[0-9a-f]{32}$/u);
+});
+
+test('it starts a fresh trace when the inbound traceparent is malformed', async () => {
+  const request = new Request('https://example.test/nexus', {
+    headers: { traceparent: '00-not-a-real-header' },
+  });
+
+  const response = await withRequestTrace(request, () => Promise.resolve(new Response('ok')));
+
+  expect(response.headers.get('x-trace-id')).toMatch(/^[0-9a-f]{32}$/u);
+});
+
+test('it exposes the trace scope to work running inside the request', async () => {
+  const request = new Request('https://example.test/nexus', {
+    headers: { traceparent: '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01' },
+  });
+
+  let observed = findTraceContext();
+
+  await withRequestTrace(request, () => {
+    observed = findTraceContext();
+
+    return Promise.resolve(new Response('ok'));
+  });
+
+  expect(observed?.traceID).toBe('0af7651916cd43dd8448eb211c80319c');
+  expect(findTraceContext()).toBeUndefined();
+});
+
+test('it relays a redirect response even when its headers refuse the stamp', async () => {
+  // Node marks redirect headers immutable while Bun leaves them writable; a set-refusing Headers
+  // stand-in pins the immutable behaviour so the test exercises the same path in both runtimes
+  class SealedHeaders extends Headers {
+    override set(): never {
+      throw new TypeError('immutable');
+    }
+  }
+
+  const redirect = Response.redirect('https://example.test/nexus', 301);
+
+  Object.defineProperty(redirect, 'headers', {
+    value: new SealedHeaders(redirect.headers),
+  });
+
+  const response = await withRequestTrace(new Request('https://example.test/nexus/'), () =>
+    Promise.resolve(redirect),
+  );
+
+  expect(response.status).toBe(301);
+  expect(response.headers.get('location')).toBe('https://example.test/nexus');
+});

--- a/apps/web/src/server/with-request-trace.test.ts
+++ b/apps/web/src/server/with-request-trace.test.ts
@@ -68,4 +68,6 @@ test('it relays a redirect response even when its headers refuse the stamp', asy
 
   expect(response.status).toBe(301);
   expect(response.headers.get('location')).toBe('https://example.test/nexus');
+  expect(response).toBe(redirect);
+  expect(response.headers.get('x-trace-id')).toBeNull();
 });

--- a/apps/web/src/server/with-request-trace.ts
+++ b/apps/web/src/server/with-request-trace.ts
@@ -1,0 +1,29 @@
+import { createTraceContext, parseTraceparent, withTraceContext } from '@vers/service-utils';
+
+/**
+ * Runs the request inside its W3C trace-context scope: a valid inbound `traceparent` continues the
+ * caller's trace, anything else starts a fresh one for this hop. Readers of the ambient scope —
+ * server log lines, outbound service-call headers — then carry the request's trace id, and the
+ * response reports it in `x-trace-id` so a support report can name the trace.
+ */
+export function withRequestTrace(
+  request: Request,
+  next: () => Promise<Response>,
+): Promise<Response> {
+  const trace = createTraceContext(
+    parseTraceparent(request.headers.get('traceparent')) ?? undefined,
+  );
+
+  return withTraceContext(trace, async () => {
+    const response = await next();
+
+    try {
+      response.headers.set('x-trace-id', trace.traceID);
+    } catch {
+      // a response built by Response.redirect or Response.error carries immutable headers; those
+      // still correlate through the request log lines, so pass them through unstamped
+    }
+
+    return response;
+  });
+}


### PR DESCRIPTION
## Description

Closes #409

Wires a trace-scope middleware at app-web's server entry so every SSR and server-function request runs inside `withTraceContext`, making server log lines carry `traceID` via the existing pino mixin.

- Middleware sits outermost so the request logger's lines land inside the scope; it continues a valid inbound `traceparent` or mints a fresh trace, mirroring the services' inbound pattern, and stamps `x-trace-id` on the response.
- A response with immutable headers (Node's `Response.redirect`) passes through unstamped — it still correlates via request logs.
- The service-link headers callback now mints its outbound hop from the ambient scope (`findTraceContext`) instead of re-parsing the request's `traceparent` per call.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/zgeoff/vers/pull/587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

