### PR TITLE
test(#593): dismiss the welcome-back dialog in the satellite spec

### DIFF
--- a/apps/web-e2e/src/avatar-satellite.spec.ts
+++ b/apps/web-e2e/src/avatar-satellite.spec.ts
@@ -18,8 +18,10 @@ test('it mounts a second canvas for the avatar satellite and drops it on navigat
 
   // a zero-gap resync can open the welcome-back dialog at any point after login;
   // dismiss it whenever it would intercept an action
-  await page.addLocatorHandler(page.getByRole('dialog', { name: 'Welcome back' }), (dialog) =>
-    dialog.getByRole('button', { name: 'Close' }).click(),
+  // the dialog carries no accessible name, so match on its heading text
+  await page.addLocatorHandler(
+    page.getByRole('dialog').filter({ hasText: 'Welcome back' }),
+    (dialog) => dialog.getByRole('button', { name: 'Close' }).click(),
   );
 
   await page.setExtraHTTPHeaders({ 'x-forwarded-for': '127.0.0.1' });

--- a/apps/web-e2e/src/avatar-satellite.spec.ts
+++ b/apps/web-e2e/src/avatar-satellite.spec.ts
@@ -16,6 +16,12 @@ test('it mounts a second canvas for the avatar satellite and drops it on navigat
     }
   });
 
+  // a zero-gap resync can open the welcome-back dialog at any point after login;
+  // dismiss it whenever it would intercept an action
+  await page.addLocatorHandler(page.getByRole('dialog', { name: 'Welcome back' }), (dialog) =>
+    dialog.getByRole('button', { name: 'Close' }).click(),
+  );
+
   await page.setExtraHTTPHeaders({ 'x-forwarded-for': '127.0.0.1' });
   await page.goto('/avatar');
 


### PR DESCRIPTION
## Description

The avatar-satellite spec times out whenever a zero-gap resync opens the welcome-back dialog over the Menu button — four consecutive `e2e` failures on #590 today, and other open PRs' gates are exposed. Register a `page.addLocatorHandler` that closes the dialog whenever it would intercept an action.

- Test-side hardening only; the spurious zero-progress resync is tracked in #593 and the handler can come out when it's fixed.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality (hardens an existing spec)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/zgeoff/vers/pull/594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

