### PR TITLE
fix: cover analytics cold start within the proxy deadline

### DIFF
--- a/apps/web/src/server/make-umami-proxy.ts
+++ b/apps/web/src/server/make-umami-proxy.ts
@@ -85,7 +85,10 @@ async function sendUpstream(target: URL, init?: RelayInit): Promise<Response> {
   });
 }
 
-const UPSTREAM_DEADLINE_MS = 5000;
+// generous enough to cover the upstream's full cold-start chain — Fly machine wake, app boot, and
+// the database compute resuming — which a first beacon after an idle period pays all at once;
+// dropping that beacon undercounts landings, the funnel's first step
+const UPSTREAM_DEADLINE_MS = 15_000;
 
 /**
  * Rejects once the upstream deadline passes; the timer never keeps the process alive.

--- a/apps/web/src/server/make-umami-proxy.ts
+++ b/apps/web/src/server/make-umami-proxy.ts
@@ -54,6 +54,11 @@ interface RelayInit {
   readonly method: 'POST';
 }
 
+// generous enough to cover the upstream's full cold-start chain — Fly machine wake, app boot, and
+// the database compute resuming — which a first beacon after an idle period pays all at once;
+// dropping that beacon undercounts landings, the funnel's first step
+const UPSTREAM_DEADLINE_MS = 15_000;
+
 /**
  * Fetches the upstream target and rewraps the result. fetch responses carry immutable headers,
  * which the server framework must still be able to finalize — and the body arrives already
@@ -62,15 +67,27 @@ interface RelayInit {
  */
 async function sendUpstream(target: URL, init?: RelayInit): Promise<Response> {
   let response: Response;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const deadline = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error('analytics upstream deadline exceeded'));
+    }, UPSTREAM_DEADLINE_MS);
+
+    // the timer never keeps the process alive
+    timer.unref?.();
+  });
 
   // a stalled upstream must not pin request handlers — analytics traffic gives up quickly and the
   // tracker tolerates the loss. The race bounds the wait rather than aborting the socket: signal
   // instances don't survive environments that patch the fetch globals, and the runtime's pool
   // reclaims the connection
   try {
-    response = await Promise.race([fetch(target, init), waitUpstreamDeadline()]);
+    response = await Promise.race([fetch(target, init), deadline]);
   } catch {
     return new Response(null, { status: 502 });
+  } finally {
+    clearTimeout(timer);
   }
 
   const headers = new Headers([...response.headers]);
@@ -82,23 +99,5 @@ async function sendUpstream(target: URL, init?: RelayInit): Promise<Response> {
     headers,
     status: response.status,
     statusText: response.statusText,
-  });
-}
-
-// generous enough to cover the upstream's full cold-start chain — Fly machine wake, app boot, and
-// the database compute resuming — which a first beacon after an idle period pays all at once;
-// dropping that beacon undercounts landings, the funnel's first step
-const UPSTREAM_DEADLINE_MS = 15_000;
-
-/**
- * Rejects once the upstream deadline passes; the timer never keeps the process alive.
- */
-function waitUpstreamDeadline(): Promise<never> {
-  return new Promise((_resolve, reject) => {
-    const timer = setTimeout(() => {
-      reject(new Error('analytics upstream deadline exceeded'));
-    }, UPSTREAM_DEADLINE_MS);
-
-    timer.unref?.();
   });
 }


### PR DESCRIPTION
## Description

Raises the analytics proxy's upstream deadline from 5s to 15s so a beacon arriving during the upstream's cold start survives.

- Observed live after #592 merged: the landing beacon answered 502 (Fly wake + Umami boot + Neon compute resume overran 5s) while the route-change beacon 2.5s later answered 200
- A dropped landing pageview undercounts the funnel's first step — on a scale-to-zero fleet most first visits pay a cold start

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality (constant change; existing proxy suite covers the paths)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/zgeoff/vers/pull/598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

