### PR TITLE
test(#593): gate e2e logins on a hydration marker instead of networkidle

### DIFF
--- a/apps/web-e2e/src/avatar-satellite.spec.ts
+++ b/apps/web-e2e/src/avatar-satellite.spec.ts
@@ -29,7 +29,9 @@ test('it mounts a second canvas for the avatar satellite and drops it on navigat
 
   await expect(page).toHaveURL(/\/login/);
 
-  await page.waitForLoadState('networkidle');
+  // hydration gate: the login form's submit handler attaches only once React commits; an
+  // earlier click falls back to the browser's native GET submit and never leaves /login
+  await page.locator('html[data-hydrated]').waitFor();
   await page.getByLabel('Email').fill('e2e-avatar-satellite@vers.test');
   await page.getByLabel('Password').fill('password123');
   await page.getByRole('button', { exact: true, name: 'Login' }).click();

--- a/apps/web-e2e/src/canvas-persistence.spec.ts
+++ b/apps/web-e2e/src/canvas-persistence.spec.ts
@@ -23,7 +23,9 @@ test('it keeps the same canvas element across client-side game navigation', asyn
 
   await expect(page).toHaveURL(/\/login/);
 
-  await page.waitForLoadState('networkidle');
+  // hydration gate: the login form's submit handler attaches only once React commits; an
+  // earlier click falls back to the browser's native GET submit and never leaves /login
+  await page.locator('html[data-hydrated]').waitFor();
   await page.getByLabel('Email').fill('e2e-canvas@vers.test');
   await page.getByLabel('Password').fill('password123');
   await page.getByRole('button', { exact: true, name: 'Login' }).click();

--- a/apps/web-e2e/src/game-smoke.spec.ts
+++ b/apps/web-e2e/src/game-smoke.spec.ts
@@ -16,7 +16,9 @@ test('it renders respite, avatar, and explore for a signed-in caller without con
 
   await expect(page).toHaveURL(/\/login/);
 
-  await page.waitForLoadState('networkidle');
+  // hydration gate: the login form's submit handler attaches only once React commits; an
+  // earlier click falls back to the browser's native GET submit and never leaves /login
+  await page.locator('html[data-hydrated]').waitFor();
   await page.getByLabel('Email').fill('e2e-game@vers.test');
   await page.getByLabel('Password').fill('password123');
   await page.getByRole('button', { exact: true, name: 'Login' }).click();

--- a/apps/web-e2e/src/home-smoke.spec.ts
+++ b/apps/web-e2e/src/home-smoke.spec.ts
@@ -33,7 +33,10 @@ test('it serves the signed-in home page server-rendered, lands at respite, and l
 }) => {
   await page.setExtraHTTPHeaders({ 'x-forwarded-for': '127.0.0.1' });
   await page.goto('/login');
-  await page.waitForLoadState('networkidle');
+
+  // hydration gate: the login form's submit handler attaches only once React commits; an
+  // earlier click falls back to the browser's native GET submit and never leaves /login
+  await page.locator('html[data-hydrated]').waitFor();
   await page.getByLabel('Email').fill('demo@vers.test');
   await page.getByLabel('Password').fill('password123');
   await page.getByRole('button', { exact: true, name: 'Login' }).click();

--- a/apps/web/src/components/hydration-marker.tsx
+++ b/apps/web/src/components/hydration-marker.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+
+/**
+ * Stamps `data-hydrated` on the root element once React has committed the hydrated tree, i.e. once
+ * event handlers are live. E2E specs wait for the attribute before driving forms — interacting
+ * earlier hits server-rendered markup whose submit falls back to a native GET.
+ */
+export function HydrationMarker(): null {
+  useEffect(() => {
+    document.documentElement.dataset['hydrated'] = 'true';
+  }, []);
+
+  return null;
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,6 +1,7 @@
 import type { QueryClient } from '@tanstack/react-query';
 import { HeadContent, Outlet, Scripts, createRootRouteWithContext } from '@tanstack/react-router';
 import type { ReactNode } from 'react';
+import { HydrationMarker } from '../components/hydration-marker';
 import { RootErrorScreen } from '../components/root-error-screen';
 import { buildUmamiScripts } from '../lib/build-umami-scripts';
 import type { OrpcQueryUtils } from '../lib/rpc/orpc';
@@ -44,6 +45,7 @@ function RootDocument(props: RootDocumentProps) {
         <HeadContent />
       </head>
       <body>
+        <HydrationMarker />
         {props.children}
         <Scripts />
       </body>


### PR DESCRIPTION
## Description

The journey specs' pre-login `waitForLoadState('networkidle')` costs 9–10s per spec in CI (dev-server compile plus resync/analytics traffic never settling) and is a large share of the avatar-satellite spec's 30s-budget flake (#593). Replace it with an explicit hydration gate: the root document stamps `data-hydrated` once React commits, and specs wait for that attribute before driving the login form.

- Removing the wait outright fails: a pre-hydration Login click falls back to the browser's native GET submit, putting credentials in the URL and never leaving /login.
- The marker resolves as soon as handlers are live, instead of requiring 500ms of network silence after all traffic — umami and resync polling would keep deferring networkidle.
- Verified locally: avatar-satellite green 3/3 fresh runs, full suite 7/7.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality

## Context

The spec's remaining budget pressure (software-GL canvas init, zero-gap resync dialog) is tracked in #593.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/zgeoff/vers/pull/600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

