### PR TITLE
fix(#601): declare post on form islands so fallback submits never leak

### DIFF
--- a/apps/web/src/routes/-forgot-password/forgot-password-form.tsx
+++ b/apps/web/src/routes/-forgot-password/forgot-password-form.tsx
@@ -47,7 +47,7 @@ export function ForgotPasswordForm(props: ForgotPasswordFormProps) {
         <Heading level={2}>Forgot your password?</Heading>
         <Text>No worries, we&apos;ll send you reset instructions to your email address.</Text>
       </section>
-      <form {...getFormProps(form)} className={formStyles}>
+      <form {...getFormProps(form)} className={formStyles} method="post">
         <HoneypotInputs />
         <Field
           errors={fields.email.errors ?? []}

--- a/apps/web/src/routes/-login-force-logout/force-logout-form.tsx
+++ b/apps/web/src/routes/-login-force-logout/force-logout-form.tsx
@@ -49,7 +49,7 @@ export function ForceLogoutForm(props: ForceLogoutFormProps) {
         <Text>Would you like to logout your other sessions?</Text>
       </section>
 
-      <form {...getFormProps(form)} className={buttonContainer}>
+      <form {...getFormProps(form)} className={buttonContainer} method="post">
         <StatusButton
           disabled={submission.isPending}
           name="intent"

--- a/apps/web/src/routes/-login/login-form.test.tsx
+++ b/apps/web/src/routes/-login/login-form.test.tsx
@@ -114,3 +114,21 @@ test('it renders the redirect target as a hidden field', async () => {
     expect(hiddenInput.value).toBe('/nexus');
   });
 });
+
+test('it declares a POST submit so a pre-hydration fallback never puts credentials in the URL', async () => {
+  await withRequestContext({}, async () => {
+    renderWithRouter(<LoginForm />);
+
+    const form = await waitFor(() => {
+      const element = document.querySelector('form');
+
+      if (element === null) {
+        throw new Error('expected the login form to be present');
+      }
+
+      return element;
+    });
+
+    expect(form).toHaveAttribute('method', 'post');
+  });
+});

--- a/apps/web/src/routes/-login/login-form.tsx
+++ b/apps/web/src/routes/-login/login-form.tsx
@@ -64,7 +64,7 @@ export function LoginForm(props: LoginFormProps) {
         <Heading level={2}>Welcome back</Heading>
         <Text>Please enter your details to login</Text>
       </section>
-      <form {...getFormProps(form)} className={formStyles}>
+      <form {...getFormProps(form)} className={formStyles} method="post">
         <HoneypotInputs />
         <Field
           errors={fields.email.errors ?? []}

--- a/apps/web/src/routes/-onboarding/onboarding-form.tsx
+++ b/apps/web/src/routes/-onboarding/onboarding-form.tsx
@@ -76,7 +76,7 @@ export function OnboardingForm(props: OnboardingFormProps) {
         <Heading level={2}>Welcome to vers</Heading>
         <Text>Please enter your details to create an account</Text>
       </section>
-      <form {...getFormProps(form)} className={formStyles}>
+      <form {...getFormProps(form)} className={formStyles} method="post">
         <HoneypotInputs />
         <Field
           errors={fields.username.errors ?? []}

--- a/apps/web/src/routes/-reset-password/reset-password-form.tsx
+++ b/apps/web/src/routes/-reset-password/reset-password-form.tsx
@@ -62,7 +62,7 @@ export function ResetPasswordForm(props: ResetPasswordFormProps) {
         <Heading level={2}>Reset your password</Heading>
         <Text>Please enter your new password</Text>
       </section>
-      <form {...getFormProps(form)} className={formStyles}>
+      <form {...getFormProps(form)} className={formStyles} method="post">
         <HoneypotInputs />
         <input name="email" type="hidden" value={props.email} />
         <input name="resetToken" type="hidden" value={props.resetToken} />

--- a/apps/web/src/routes/-signup/signup-form.tsx
+++ b/apps/web/src/routes/-signup/signup-form.tsx
@@ -59,7 +59,7 @@ export function SignupForm(props: SignupFormProps) {
         <Heading level={2}>Create an account</Heading>
         <Text>Please enter your details to create an account</Text>
       </section>
-      <form {...getFormProps(form)} className={formStyles}>
+      <form {...getFormProps(form)} className={formStyles} method="post">
         <HoneypotInputs />
         <Field
           errors={fields.email.errors ?? []}

--- a/apps/web/src/routes/-verify-otp/verify-otp-form.tsx
+++ b/apps/web/src/routes/-verify-otp/verify-otp-form.tsx
@@ -101,7 +101,7 @@ export function VerifyOTPForm(props: VerifyOTPFormProps) {
         <Heading level={2}>{HEADING_BY_TYPE[props.type]}</Heading>
         <Text>{INSTRUCTION_BY_TYPE[props.type]}</Text>
       </section>
-      <form {...getFormProps(form)} className={formStyles}>
+      <form {...getFormProps(form)} className={formStyles} method="post">
         <HoneypotInputs />
         <OTPField
           className={otpField}


### PR DESCRIPTION
Closes #601

## Description

A form element without `method` falls back to a native GET submit when clicked before React hydrates, serializing every field — including passwords and OTP codes — into the URL. Declare `method="post"` on all seven Conform form islands so the pre-hydration fallback can never put fields in the query string.

- A pre-hydration POST still fails to complete (no native POST handler); failing without leaking is the fix's contract.
- Test asserts the login form declares POST, guarding the credential-bearing flow.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/zgeoff/vers/pull/603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

