### PR TITLE
fix(#602): answer aborted rpc proxy calls with 499 instead of a 500

### DIFF
--- a/apps/web/src/lib/proxy/send-rpc-request.test.ts
+++ b/apps/web/src/lib/proxy/send-rpc-request.test.ts
@@ -125,3 +125,34 @@ test('it returns a response whose headers the server can still modify', async ()
     outcome.value.headers.delete('x-upstream');
   }).not.toThrow();
 });
+
+test('it answers an aborted request whose body is unreadable with a client-closed status', async () => {
+  const controller = new AbortController();
+
+  const request = new Request('http://app.test/api/rpc/user/updateEmail', {
+    body: JSON.stringify({ email: 'new@vers.test' }),
+    method: 'POST',
+    signal: controller.signal,
+  });
+
+  await request.blob();
+
+  controller.abort();
+
+  const outcome = await withRequestContext({}, () => sendRPCRequest(request, 'user'));
+
+  expect(outcome.value.status).toBe(499);
+});
+
+test('it rethrows a body read failure for a caller that is still connected', async () => {
+  const request = new Request('http://app.test/api/rpc/user/updateEmail', {
+    body: JSON.stringify({ email: 'new@vers.test' }),
+    method: 'POST',
+  });
+
+  await request.blob();
+
+  const promise = withRequestContext({}, () => sendRPCRequest(request, 'user'));
+
+  expect(promise).rejects.toBeInstanceOf(TypeError);
+});

--- a/apps/web/src/lib/proxy/send-rpc-request.ts
+++ b/apps/web/src/lib/proxy/send-rpc-request.ts
@@ -22,6 +22,22 @@ export async function sendRPCRequest(request: Request, service: ServiceName): Pr
   );
 
   const hasBody = request.method !== 'GET' && request.method !== 'HEAD';
+  let body: Blob | undefined;
+
+  if (hasBody) {
+    try {
+      body = await request.blob();
+    } catch (error) {
+      // a caller that aborted mid-flight leaves its body stream unreadable — nothing is waiting
+      // for this response, so answer with 499 (client closed request) instead of letting the
+      // read failure escape as a server fault
+      if (request.signal.aborted) {
+        return new Response(null, { status: 499 });
+      }
+
+      throw error;
+    }
+  }
 
   const headers = new Headers(request.headers);
 
@@ -38,7 +54,7 @@ export async function sendRPCRequest(request: Request, service: ServiceName): Pr
   const response = await fetch(target, {
     headers,
     method: request.method,
-    ...(hasBody && { body: await request.blob() }),
+    ...(body !== undefined && { body }),
   });
 
   // fetch responses carry immutable headers, which the server framework must still be able to


### PR DESCRIPTION
Closes #602

## Description

When the browser aborts an RPC mid-flight, the proxy's body read builds the standard `Request` over an already-destroyed socket stream and throws, escaping as a 500 plus an unhandled-error log line for a caller that is gone. Read the body up front and answer an aborted caller with 499 (client closed request); a body read that fails for a still-connected caller keeps throwing.

- Reading the body before the session/token awaits also shrinks the window in which an abort can land mid-handler.
- Verified against a live dev server: the raw-socket abort repro produced 500s + TypeErrors before, 499s and a clean log after.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/zgeoff/vers/pull/605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

