### PR TITLE
docs: record the standing axiom admin token and metrics dataset api

### DIFF
--- a/docs/architecture/deployment.md
+++ b/docs/architecture/deployment.md
@@ -337,18 +337,23 @@ Actions variable, then assemble the acquisition funnel report over the tracked e
 
 Stand up the telemetry backend. The Axiom account is created in its UI; its standing tokens live on
 the `axiom` item in the `vers` 1Password vault: `ingest-token` (ingest on all datasets — the fleet's
-export credential) and `mcp-token` (query, for read-only investigation). Administration — creating
-datasets, dashboards, monitors, notifiers — uses a short-lived token minted in the UI with
-management scopes and revoked when the work is done. Create one dataset per signal and point the
-fleet at them:
+export credential), `mcp-token` (query, for read-only investigation), and `admin-token` (an advanced
+API token with create/read/update — never delete — on datasets, monitors, notifiers, and dashboards,
+for agent-driven administration). Destructive administration (deleting any of those) uses a
+short-lived token minted in the UI with the needed scopes and revoked when the work is done. Create
+one dataset per signal and point the fleet at them — the metrics dataset needs the `otel:metrics:v1`
+kind, since an events dataset rejects OTLP metrics ingest:
 
 ```sh
-ADMIN="<short-lived management token from the Axiom UI>"
+ADMIN="$(op read 'op://vers/axiom/admin-token')"
 for ds in vers-traces vers-logs; do
   curl -s -X POST https://api.axiom.co/v1/datasets \
     -H "Authorization: Bearer $ADMIN" -H "Content-Type: application/json" \
     -d "{\"name\":\"$ds\"}"
 done
+curl -s -X POST https://api.axiom.co/v2/datasets \
+  -H "Authorization: Bearer $ADMIN" -H "Content-Type: application/json" \
+  -d '{"name":"vers-metrics","kind":"otel:metrics:v1"}'
 
 INGEST="$(op read 'op://vers/axiom/ingest-token')"
 for app in vers-app-web vers-service-activity vers-service-avatar vers-service-email vers-service-keys vers-service-replay vers-service-session vers-service-user vers-service-verification; do
@@ -360,13 +365,10 @@ for app in vers-app-web vers-service-activity vers-service-avatar vers-service-e
 done
 ```
 
-The `vers-metrics` dataset is created in the Axiom UI with the Metrics dataset type — the dataset
-API creates Events datasets, which reject OTLP metrics ingest.
-
 The `vers services — baseline` dashboard (request rate, 5xx responses, and p95 latency per service,
 plus an error-log stream) and the `vers 5xx responses` and `vers verification lag`
 (`vers.verification.lag` over its threshold — `docs/architecture/observability.md`) threshold
-monitors are created through the same API; the monitors notify the `vers alerts` notifier. Agent
+monitors are created through the same API; the monitors notify the `vers alarms` notifier. Agent
 access goes through the hosted MCP server (`https://mcp.axiom.co/mcp`, OAuth) declared in
 `.mcp.json`.
 

--- a/docs/architecture/deployment.md
+++ b/docs/architecture/deployment.md
@@ -347,11 +347,11 @@ kind, since an events dataset rejects OTLP metrics ingest:
 ```sh
 ADMIN="$(op read 'op://vers/axiom/admin-token')"
 for ds in vers-traces vers-logs; do
-  curl -s -X POST https://api.axiom.co/v1/datasets \
+  curl -sS --fail -X POST https://api.axiom.co/v1/datasets \
     -H "Authorization: Bearer $ADMIN" -H "Content-Type: application/json" \
     -d "{\"name\":\"$ds\"}"
 done
-curl -s -X POST https://api.axiom.co/v2/datasets \
+curl -sS --fail -X POST https://api.axiom.co/v2/datasets \
   -H "Authorization: Bearer $ADMIN" -H "Content-Type: application/json" \
   -d '{"name":"vers-metrics","kind":"otel:metrics:v1"}'
 

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -41,7 +41,7 @@ lands with the metrics that make it observable. The conventions:
   observes.
 - Every instrument lands with its row in the registry below, in the same PR.
 
-Alerting is Axiom threshold monitors over these datasets, notifying the `vers alerts` notifier.
+Alerting is Axiom threshold monitors over these datasets, notifying the `vers alarms` notifier.
 
 ## Instrument registry
 
@@ -65,4 +65,4 @@ problems needing fleet action), `elapsed-time` (replay duration cap tripped — 
 Each recording's log line carries the raw numbers behind it (heads, checkpoint counts, sim version).
 
 The `vers verification lag` threshold monitor watches `vers.verification.lag` and notifies
-`vers alerts`.
+`vers alarms`.


### PR DESCRIPTION
## Description

Aligns the deployment and observability docs with the provisioned Axiom reality.

- The vault's `admin-token` (create/read/update on datasets, monitors, notifiers, dashboards — no deletes) is the standing credential for agent-driven administration; short-lived UI tokens remain only for destructive operations
- The v2 dataset API creates the metrics dataset directly (`kind: otel:metrics:v1`) — drops the claim that the UI is required
- The notifier's real name is `vers alarms`, not `vers alerts`

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality (docs only)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/zgeoff/vers/pull/606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

