### PR TITLE
fix(#593): keep the welcome-back modal silent for a zero-gap resync

### DIFF
--- a/apps/web-e2e/src/avatar-satellite.spec.ts
+++ b/apps/web-e2e/src/avatar-satellite.spec.ts
@@ -16,14 +16,6 @@ test('it mounts a second canvas for the avatar satellite and drops it on navigat
     }
   });
 
-  // a zero-gap resync can open the welcome-back dialog at any point after login;
-  // dismiss it whenever it would intercept an action
-  // the dialog carries no accessible name, so match on its heading text
-  await page.addLocatorHandler(
-    page.getByRole('dialog').filter({ hasText: 'Welcome back' }),
-    (dialog) => dialog.getByRole('button', { name: 'Close' }).click(),
-  );
-
   await page.setExtraHTTPHeaders({ 'x-forwarded-for': '127.0.0.1' });
   await page.goto('/avatar');
 

--- a/apps/web/src/routes/-game/welcome-back-modal.test.tsx
+++ b/apps/web/src/routes/-game/welcome-back-modal.test.tsx
@@ -9,8 +9,8 @@ test('it renders nothing while no resync is underway', () => {
   expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 });
 
-test('it masks the check before any attempts land', () => {
-  setResyncStatus({ kind: 'checking' });
+test('it masks the catch-up from its zero-tally start', () => {
+  setResyncStatus({ attempts: 0, kind: 'fast-forwarding', levelUps: 0 });
 
   onTestFinished(() => {
     setResyncStatus(null);
@@ -18,7 +18,7 @@ test('it masks the check before any attempts land', () => {
 
   render(<WelcomeBackModal />);
   expect(screen.getByText('Welcome back')).toBeInTheDocument();
-  expect(screen.getByText('Checking your progress…')).toBeInTheDocument();
+  expect(screen.getByText('Catching up… 0 attempts, 0 level-ups so far.')).toBeInTheDocument();
 });
 
 test('it reports the running tally while fast-forwarding', () => {

--- a/apps/web/src/routes/-game/welcome-back-modal.tsx
+++ b/apps/web/src/routes/-game/welcome-back-modal.tsx
@@ -3,10 +3,10 @@ import { setResyncStatus, useResyncStatus } from '@vers/idle-client';
 import type { ResyncStatus } from '@vers/idle-client';
 
 /**
- * Masks the offline catch-up after an away-and-return: it opens the moment a resync starts,
- * reports attempts and level-ups as the fast-forward lands them, and stays up with the final
- * tally (or the cap notice) until dismissed. It never renders over a live simulation — only a
- * resync drives its store.
+ * Masks the offline catch-up after an away-and-return: it opens the moment a resync starts
+ * fast-forwarding a real away period, reports attempts and level-ups as they land, and stays up
+ * with the final tally (or the cap notice) until dismissed. A resync with no away period to
+ * report — a fresh login, a zero-gap reconnect — broadcasts no status, so it never opens this.
  */
 export function WelcomeBackModal() {
   const resyncStatus = useResyncStatus();
@@ -31,10 +31,6 @@ export function WelcomeBackModal() {
 }
 
 function formatResyncStatus(resyncStatus: Readonly<ResyncStatus>): string {
-  if (resyncStatus.kind === 'checking') {
-    return 'Checking your progress…';
-  }
-
   if (resyncStatus.kind === 'capped') {
     return 'Offline progress reached its cap. Your avatar held position — jump back in to continue.';
   }

--- a/libs/game/idle-client/src/resync/run-resync.ts
+++ b/libs/game/idle-client/src/resync/run-resync.ts
@@ -30,7 +30,14 @@ interface RunResyncOptions {
    */
   readonly isActivityLive?: (activityID: string) => boolean;
 
+  /**
+   * Reports fast-forward tallies as they land, starting with a zero-tally report the moment a
+   * fast-forward plan is committed — before any checkpoint work — so a caller masking the
+   * catch-up can open its cover for the whole run, not just from the first landed batch. Plans
+   * with no real away period (live re-attach, rebase, none) never report.
+   */
   readonly onProgress?: (progress: FastForwardProgress) => void;
+
   readonly submitter: CheckpointSubmitter;
 }
 
@@ -81,6 +88,8 @@ export async function runResync(
   if (isLive) {
     return { plan: { context: plan.context, kind: 'attach-live' }, progress };
   }
+
+  options.onProgress?.({ attempts: 0, levelUps: 0 });
 
   const report = await runFastForward({
     budgetMs: plan.budgetMs,

--- a/libs/game/idle-client/src/resync/run-resync.ts
+++ b/libs/game/idle-client/src/resync/run-resync.ts
@@ -34,7 +34,7 @@ interface RunResyncOptions {
    * Reports fast-forward tallies as they land, starting with a zero-tally report the moment a
    * fast-forward plan is committed — before any checkpoint work — so a caller masking the
    * catch-up can open its cover for the whole run, not just from the first landed batch. Plans
-   * with no real away period (live re-attach, rebase, none) never report.
+   * that run no fast-forward (live re-attach, rebase, none) never report through this callback.
    */
   readonly onProgress?: (progress: FastForwardProgress) => void;
 

--- a/libs/game/idle-client/src/types.ts
+++ b/libs/game/idle-client/src/types.ts
@@ -202,12 +202,11 @@ export interface RewardSlotLedgerSnapshot {
 }
 
 /**
- * The catch-up flow's lifecycle as tabs observe it: checking the confirmed state, fast-forwarding
- * with running attempt and level-up counts, done with the final tallies, or capped when the
- * server stopped the stream at the offline-progress bound.
+ * The catch-up flow's lifecycle as tabs observe it: fast-forwarding with running attempt and
+ * level-up counts, done with the final tallies, or capped when the server stopped the stream at
+ * the offline-progress bound. A resync with no real away period broadcasts nothing.
  */
 export type ResyncStatus =
   | { readonly attempts: number; readonly kind: 'done'; readonly levelUps: number }
   | { readonly attempts: number; readonly kind: 'fast-forwarding'; readonly levelUps: number }
-  | { readonly kind: 'capped' }
-  | { readonly kind: 'checking' };
+  | { readonly kind: 'capped' };

--- a/libs/game/idle-client/src/worker/create-resync-status-message.test.ts
+++ b/libs/game/idle-client/src/worker/create-resync-status-message.test.ts
@@ -3,10 +3,10 @@ import { WorkerMessageType } from '../types';
 import { createResyncStatusMessage } from './create-resync-status-message';
 
 test('it creates a resync status message', () => {
-  const message = createResyncStatusMessage({ kind: 'checking' });
+  const message = createResyncStatusMessage({ kind: 'capped' });
 
   expect(message).toStrictEqual({
-    status: { kind: 'checking' },
+    status: { kind: 'capped' },
     type: WorkerMessageType.ResyncStatus,
   });
 });

--- a/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
@@ -30,7 +30,7 @@ function setupTest(
   return { connection, context };
 }
 
-test('it resolves to done with zero tallies for an avatar with no activity history', async () => {
+test('it broadcasts nothing for an avatar with no activity history', async () => {
   server.use(
     mockActivityService.getLatestActivityProgress.handler((opts) => {
       throw opts.errors.NOT_FOUND({ data: {} });
@@ -46,13 +46,11 @@ test('it resolves to done with zero tallies for an avatar with no activity histo
 
   await handleRequestResyncMessage(ctx.context, message);
 
-  await ctx.connection.waitForMessages(2);
+  await new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
 
-  expect(ctx.connection.received).toStrictEqual([
-    { status: { kind: 'checking' }, type: WorkerMessageType.ResyncStatus },
-    { status: { attempts: 0, kind: 'done', levelUps: 0 }, type: WorkerMessageType.ResyncStatus },
-  ]);
-
+  expect(ctx.connection.received).toStrictEqual([]);
   expect(ctx.context.getSimulation()).toBeNull();
 });
 
@@ -78,10 +76,9 @@ test('it broadcasts capped and installs no simulation for a capped activity', as
 
   await handleRequestResyncMessage(ctx.context, message);
 
-  await ctx.connection.waitForMessages(2);
+  await ctx.connection.waitForMessages(1);
 
   expect(ctx.connection.received).toStrictEqual([
-    { status: { kind: 'checking' }, type: WorkerMessageType.ResyncStatus },
     { status: { kind: 'capped' }, type: WorkerMessageType.ResyncStatus },
   ]);
 
@@ -144,12 +141,11 @@ test('it reconstructs and installs a live simulation mid-stream, registering fro
 
   await handleRequestResyncMessage(ctx.context, message);
 
-  await ctx.connection.waitForMessages(2);
+  await new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
 
-  expect(ctx.connection.received).toStrictEqual([
-    { status: { kind: 'checking' }, type: WorkerMessageType.ResyncStatus },
-    { status: { attempts: 0, kind: 'done', levelUps: 0 }, type: WorkerMessageType.ResyncStatus },
-  ]);
+  expect(ctx.connection.received).toStrictEqual([]);
 
   const simulation = ctx.context.getSimulation();
 
@@ -196,16 +192,14 @@ test('it reports a divergence via the checkpoint-stream-error channel and skips 
 
   await handleRequestResyncMessage(ctx.context, message);
 
-  await ctx.connection.waitForMessages(3);
+  await ctx.connection.waitForMessages(1);
 
   expect(ctx.connection.received).toStrictEqual([
-    { status: { kind: 'checking' }, type: WorkerMessageType.ResyncStatus },
     {
       activityID: activity.id,
       reason: 'reconstruction-divergence',
       type: WorkerMessageType.CheckpointStreamInvalid,
     },
-    { status: { attempts: 0, kind: 'done', levelUps: 0 }, type: WorkerMessageType.ResyncStatus },
   ]);
 
   expect(ctx.context.getSimulation()).toBeNull();
@@ -276,7 +270,10 @@ test('it fast-forwards a short gap, broadcasts progress and final tallies, and i
   await ctx.connection.waitForMessages(3);
 
   expect(ctx.connection.received).toStrictEqual([
-    { status: { kind: 'checking' }, type: WorkerMessageType.ResyncStatus },
+    {
+      status: { attempts: 0, kind: 'fast-forwarding', levelUps: 0 },
+      type: WorkerMessageType.ResyncStatus,
+    },
     {
       status: { attempts: 1, kind: 'fast-forwarding', levelUps: 1 },
       type: WorkerMessageType.ResyncStatus,
@@ -367,7 +364,10 @@ test('it reconstructs a fast-forward report left mid-stream and registers from i
   await ctx.connection.waitForMessages(2);
 
   expect(ctx.connection.received).toStrictEqual([
-    { status: { kind: 'checking' }, type: WorkerMessageType.ResyncStatus },
+    {
+      status: { attempts: 0, kind: 'fast-forwarding', levelUps: 0 },
+      type: WorkerMessageType.ResyncStatus,
+    },
     { status: { attempts: 0, kind: 'done', levelUps: 0 }, type: WorkerMessageType.ResyncStatus },
   ]);
 
@@ -391,4 +391,38 @@ test('it reconstructs a fast-forward report left mid-stream and registers from i
   // the started checkpoint's own nextSeed, not the activity row's start seed — proves the
   // registered cursor chains onto the reconstruction, not a fresh checkpoint-0 sim
   expect(submittedSeeds).toStrictEqual(['525ac5e6a97591b0a1877a6606b22d9c']);
+});
+
+test('it attaches a fresh login live without broadcasting any catch-up status', async () => {
+  const activity = createMockActivityData({ appendedHead: 0, startedAt: new Date() });
+
+  server.use(
+    mockActivityService.getLatestActivityProgress.handler(() => ({
+      activity,
+      anchor: null,
+      appendedHead: 0,
+      serverTime: new Date(),
+      verifiedHead: 0,
+    })),
+  );
+
+  const ctx = setupTest();
+
+  const message: RequestResyncMessage = {
+    avatarID: activity.avatarID,
+    type: ClientMessageType.RequestResync,
+  };
+
+  await handleRequestResyncMessage(ctx.context, message);
+
+  await new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+
+  expect(ctx.connection.received).toStrictEqual([]);
+
+  const simulation = ctx.context.getSimulation();
+
+  invariant(simulation !== null, 'expected the resync to install a live simulation');
+  expect(simulation.activity?.id).toBe(activity.id);
 });

--- a/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
@@ -46,11 +46,16 @@ test('it broadcasts nothing for an avatar with no activity history', async () =>
 
   await handleRequestResyncMessage(ctx.context, message);
 
-  await new Promise((resolve) => {
-    setTimeout(resolve, 0);
-  });
+  // posted on the worker's own port after the handler settles, this arrives after anything the
+  // handler broadcast on the same channel — an empty prefix proves the resync stayed silent
+  ctx.connection.port.postMessage({ online: true, type: WorkerMessageType.ConnectionStatus });
 
-  expect(ctx.connection.received).toStrictEqual([]);
+  await ctx.connection.waitForMessages(1);
+
+  expect(ctx.connection.received).toStrictEqual([
+    { online: true, type: WorkerMessageType.ConnectionStatus },
+  ]);
+
   expect(ctx.context.getSimulation()).toBeNull();
 });
 
@@ -141,11 +146,15 @@ test('it reconstructs and installs a live simulation mid-stream, registering fro
 
   await handleRequestResyncMessage(ctx.context, message);
 
-  await new Promise((resolve) => {
-    setTimeout(resolve, 0);
-  });
+  // posted on the worker's own port after the handler settles, this arrives after anything the
+  // handler broadcast on the same channel — an empty prefix proves the resync stayed silent
+  ctx.connection.port.postMessage({ online: true, type: WorkerMessageType.ConnectionStatus });
 
-  expect(ctx.connection.received).toStrictEqual([]);
+  await ctx.connection.waitForMessages(1);
+
+  expect(ctx.connection.received).toStrictEqual([
+    { online: true, type: WorkerMessageType.ConnectionStatus },
+  ]);
 
   const simulation = ctx.context.getSimulation();
 
@@ -415,11 +424,15 @@ test('it attaches a fresh login live without broadcasting any catch-up status', 
 
   await handleRequestResyncMessage(ctx.context, message);
 
-  await new Promise((resolve) => {
-    setTimeout(resolve, 0);
-  });
+  // posted on the worker's own port after the handler settles, this arrives after anything the
+  // handler broadcast on the same channel — an empty prefix proves the resync stayed silent
+  ctx.connection.port.postMessage({ online: true, type: WorkerMessageType.ConnectionStatus });
 
-  expect(ctx.connection.received).toStrictEqual([]);
+  await ctx.connection.waitForMessages(1);
+
+  expect(ctx.connection.received).toStrictEqual([
+    { online: true, type: WorkerMessageType.ConnectionStatus },
+  ]);
 
   const simulation = ctx.context.getSimulation();
 

--- a/libs/game/idle-client/src/worker/handle-request-resync-message.ts
+++ b/libs/game/idle-client/src/worker/handle-request-resync-message.ts
@@ -14,12 +14,14 @@ import type { WorkerContext } from './types';
 
 /**
  * Orchestrates one resync request end to end: single-flight per worker, since two concurrent
- * resyncs would each reconstruct their own simulation and race to install it. Every plan kind
- * broadcasts its own `ResyncStatus` progression, ending on `done` (or `capped`) so a connected
- * tab's welcome-back UI always resolves. A live simulation this resync would install is skipped
- * when a different activity went live while it was running — a fresher `SetActivity` always wins.
- * A resync that fails outright reports the worker offline — the signal tabs use to explain a
- * stalled catch-up — and never rejects; the next reconnect retries it.
+ * resyncs would each reconstruct their own simulation and race to install it. Only a plan that
+ * covers a real away period — a fast-forward or a capped rebase — broadcasts a `ResyncStatus`
+ * progression, ending on `done` (or `capped`) so a connected tab's welcome-back UI always
+ * resolves; a zero-gap outcome (live re-attach, no activity) stays silent, so a fresh login never
+ * opens that UI. A live simulation this resync would install is skipped when a different activity
+ * went live while it was running — a fresher `SetActivity` always wins. A resync that fails
+ * outright reports the worker offline — the signal tabs use to explain a stalled catch-up — and
+ * never rejects; the next reconnect retries it.
  */
 export async function handleRequestResyncMessage(
   context: WorkerContext,
@@ -31,8 +33,6 @@ export async function handleRequestResyncMessage(
 
   context.setResyncInFlight(true);
   context.setResyncAvatarID(message.avatarID);
-
-  emitResyncStatus(context, { kind: 'checking' });
 
   try {
     // Held batches must land before the progress fetch, or the resync plans against an appended
@@ -76,11 +76,7 @@ async function applyResyncResult(
 
   if (result.plan.kind === 'attach-live') {
     await applyAttachLive(context, result.plan, result.progress);
-
-    return;
   }
-
-  emitResyncStatus(context, { attempts: 0, kind: 'done', levelUps: 0 });
 }
 
 async function applyAttachLive(
@@ -89,8 +85,6 @@ async function applyAttachLive(
   progress: ResyncResult['progress'],
 ): Promise<void> {
   if (context.getSimulation()?.activity?.id === plan.context.activityID) {
-    emitResyncStatus(context, { attempts: 0, kind: 'done', levelUps: 0 });
-
     return;
   }
 
@@ -109,7 +103,6 @@ async function applyAttachLive(
     simulation.startActivity(input.avatar, input.activity);
 
     setLiveSimulation(context, progress.activity, simulation);
-    emitResyncStatus(context, { attempts: 0, kind: 'done', levelUps: 0 });
 
     return;
   }
@@ -122,7 +115,6 @@ async function applyAttachLive(
 
   if ('divergence' in reconstruction) {
     emitDivergence(context, plan.context.activityID);
-    emitResyncStatus(context, { attempts: 0, kind: 'done', levelUps: 0 });
 
     return;
   }
@@ -133,7 +125,6 @@ async function applyAttachLive(
   });
 
   setLiveSimulation(context, progress.activity, reconstruction.simulation);
-  emitResyncStatus(context, { attempts: 0, kind: 'done', levelUps: 0 });
 }
 
 async function applyFastForward(context: WorkerContext, report: FastForwardReport): Promise<void> {


### PR DESCRIPTION
Closes #593

## Description

Every fresh login fired a resync that broadcast `checking` then `done` with zero tallies, opening the welcome-back modal with nothing to report and intercepting input. Now only a plan covering a real away period — a fast-forward or a capped rebase — broadcasts a resync status; zero-gap outcomes (live re-attach, no activity) stay silent.

- The fast-forward reports a zero tally the moment its plan commits, so the modal masks the whole catch-up; the now-unreachable `checking` status is removed.
- Zero-gap resyncs also skip the done-triggered query invalidation — a gap under the flush interval means the server holds nothing newer than the tab.
- The satellite spec's dialog-dismissal hardening comes out; full e2e suite green three consecutive local runs without it.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/zgeoff/vers/pull/609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

