### PR TITLE
ci: add gitleaks secret-scanning job and pre-commit hook

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,24 @@ permissions:
   contents: read
 
 jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # the action comments findings on the PR, which needs write on pull-requests
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Gitleaks
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   checks:
     runs-on: ubuntu-latest
     # a hung step (a script that never exits, a wedged container) must fail the

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -11,10 +11,14 @@ targetRules = ["private-key", "jwt"]
 description = "test files and test preloads hold intentionally fake keys and tokens"
 paths = ['''\.test\.tsx?$''', '''(^|/)test-setup\.ts$''']
 
+# Matched by secret value AND path, so an example documenting a new key value
+# flags until that value is triaged here.
 [[allowlists]]
 targetRules = ["private-key"]
-description = "committed .env examples document key shape with throwaway values"
+description = "committed .env examples document key shape with a throwaway value"
+condition = "AND"
 paths = ['''\.env(\.[\w.-]+)?\.example$''']
+regexes = ['''MC4CAQAwBQYDK2VwBCIEII0t42Zs6tdR0AkoR3hBCw4ACRMg/RPZRdyZ2Pjz\+3wc''']
 
 # Matched by secret value AND path, so replacing or adding a key in these
 # fixture files flags until the new value is triaged here.

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,16 @@
+# Secret-scanning config for gitleaks (PR job + pre-commit hook). Extends the
+# default ruleset; allowlists cover only files whose purpose is to hold
+# throwaway key material. Committed dev/test .env fixtures are deliberately NOT
+# path-allowlisted — their known findings are pinned by fingerprint in
+# .gitleaksignore so any new secret in them still flags.
+
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "test files and test preloads hold intentionally fake keys and tokens"
+paths = ['''\.test\.tsx?$''', '''(^|/)test-setup\.ts$''']
+
+[[allowlists]]
+description = "committed .env examples document key shape with throwaway values"
+paths = ['''\.env(\.[\w.-]+)?\.example$''']

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -22,10 +22,7 @@ paths = ['''\.env(\.[\w.-]+)?\.example$''']
 targetRules = ["private-key"]
 description = "known throwaway signing keys in committed dev/test env fixtures"
 condition = "AND"
-paths = [
-  '''(^|/)services/replay/\.env\.test$''',
-  '''(^|/)services/session/\.env\.development$''',
-]
+paths = ['''(^|/)services/replay/\.env\.test$''', '''(^|/)services/session/\.env\.development$''']
 regexes = [
   '''MC4CAQAwBQYDK2VwBCIEIBMom57erggdVdDCIdRWS\+NKMykK\+I5BUKpuHziAq\+0W''',
   '''MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC\+ItgiAjP9V8TH''',

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,16 +1,32 @@
 # Secret-scanning config for gitleaks (PR job + pre-commit hook). Extends the
-# default ruleset; allowlists cover only files whose purpose is to hold
-# throwaway key material. Committed dev/test .env fixtures are deliberately NOT
-# path-allowlisted — their known findings are pinned by fingerprint in
-# .gitleaksignore so any new secret in them still flags.
+# default ruleset; every allowlist is scoped to the rules its files actually
+# trip, so any other kind of secret in those files still flags. Findings in
+# immutable historic commits are pinned by fingerprint in .gitleaksignore.
 
 [extend]
 useDefault = true
 
 [[allowlists]]
+targetRules = ["private-key", "jwt"]
 description = "test files and test preloads hold intentionally fake keys and tokens"
 paths = ['''\.test\.tsx?$''', '''(^|/)test-setup\.ts$''']
 
 [[allowlists]]
+targetRules = ["private-key"]
 description = "committed .env examples document key shape with throwaway values"
 paths = ['''\.env(\.[\w.-]+)?\.example$''']
+
+# Matched by secret value AND path, so replacing or adding a key in these
+# fixture files flags until the new value is triaged here.
+[[allowlists]]
+targetRules = ["private-key"]
+description = "known throwaway signing keys in committed dev/test env fixtures"
+condition = "AND"
+paths = [
+  '''(^|/)services/replay/\.env\.test$''',
+  '''(^|/)services/session/\.env\.development$''',
+]
+regexes = [
+  '''MC4CAQAwBQYDK2VwBCIEIBMom57erggdVdDCIdRWS\+NKMykK\+I5BUKpuHziAq\+0W''',
+  '''MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC\+ItgiAjP9V8TH''',
+]

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -3,11 +3,6 @@
 # access to anything. A new secret in these files still flags: fingerprints
 # match one finding (commit, file, rule, line), not the file.
 
-# Commitless fingerprints: committed dev/test .env fixtures in the working
-# tree, matched by the pre-commit --staged scan when these files are edited.
-services/replay/.env.test:private-key:6
-services/session/.env.development:private-key:6
-
 # Historic: local-only signing keys in dev/test env files under the pre-2025
 # projects/ layout and their later moves; all mock-auth material.
 832044ec6803ce8dafdf6bbe3797f9edc2e9e637:services/replay/.env.test:private-key:5

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,33 @@
+# Triaged findings pinned by fingerprint. Every entry is a throwaway dev/test
+# key or a dead token in an immutable historic commit — nothing here grants
+# access to anything. A new secret in these files still flags: fingerprints
+# match one finding (commit, file, rule, line), not the file.
+
+# Commitless fingerprints: committed dev/test .env fixtures in the working
+# tree, matched by the pre-commit --staged scan when these files are edited.
+services/replay/.env.test:private-key:6
+services/session/.env.development:private-key:6
+
+# Historic: local-only signing keys in dev/test env files under the pre-2025
+# projects/ layout and their later moves; all mock-auth material.
+832044ec6803ce8dafdf6bbe3797f9edc2e9e637:services/replay/.env.test:private-key:5
+cfa3d357be8574fe0c030c3a31c2c7e7fc430fb4:projects/service-session/.env.development:private-key:6
+f6e68fd8f44ca9f1d3d91e7957b442383133be4a:projects/service-session/.env.development:private-key:6
+448b14f7c3029b65b3094a2465752919d8e2193f:projects/service-api/.env.development:private-key:12
+448b14f7c3029b65b3094a2465752919d8e2193f:projects/service-api/.env.test:private-key:12
+448b14f7c3029b65b3094a2465752919d8e2193f:projects/service-session/.env.development:private-key:7
+448b14f7c3029b65b3094a2465752919d8e2193f:projects/service-session/.env.test:private-key:7
+7f04881c3ee5b8991d228ffa4e4b8ee24ed4a921:projects/service-api/.env.development:private-key:12
+7f04881c3ee5b8991d228ffa4e4b8ee24ed4a921:projects/service-api/.env.test:private-key:12
+7f04881c3ee5b8991d228ffa4e4b8ee24ed4a921:projects/service-session/.env.development:private-key:6
+7f04881c3ee5b8991d228ffa4e4b8ee24ed4a921:projects/service-session/.env.test:private-key:6
+
+# Historic: Auth0 dev-tenant client config in the old app-web env files.
+d27d31e287ca8dee7432e4be56f1e0f14466ccab:projects/app-web/.env.development:generic-api-key:6
+d27d31e287ca8dee7432e4be56f1e0f14466ccab:projects/app-web/.env.production:generic-api-key:6
+
+# Historic: Nx Cloud access token from the abandoned Nx setup; the workspace
+# it addressed is gone from this repo.
+8bf95e0dd84ecf654bf68c705648da4d5ba37ebc:nx.json:generic-api-key:54
+01b0f423a0cbee4d0294a0b21106d40438e7fd57:nx.json:generic-api-key:54
+46d58d3373f97746c52daa4974ccff2dc1e3d809:nx.json:generic-api-key:55

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -25,6 +25,10 @@ pre-commit:
       glob: '**/*.graphql'
       run: bun run format
       stage_fixed: true
+    # last so it scans what the fixers above re-staged; needs the gitleaks
+    # binary on PATH (mise: `mise use -g gitleaks`)
+    - name: gitleaks
+      run: gitleaks git --pre-commit --staged --redact --no-banner
 
 commit-msg:
   jobs:


### PR DESCRIPTION
## Description

Adds gitleaks secret scanning as a PR check (gitleaks-action v3, SHA-pinned) and a lefthook pre-commit job (`gitleaks git --pre-commit --staged`), so a leaked credential is blocked at commit time and again at review time.

- `.gitleaks.toml` extends the default ruleset and path-allowlists only files whose purpose is throwaway key material: `*.test.ts(x)`, `test-setup.ts`, and committed `.env*.example` files.
- Committed dev/test env fixtures are pinned by fingerprint in `.gitleaksignore` instead of path-allowlisted, so a new secret in them still flags.
- Full-history scan (745 commits) triaged: every finding is a throwaway dev/test key, public Auth0 client config, or the dead Nx Cloud token from the pre-Turborepo setup.
- The pre-commit job needs the gitleaks binary on PATH (`mise use -g gitleaks`).

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality

Verified locally: full-history scan and staged scan exit clean; a staged planted AWS key + GitHub PAT fail the hook.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/zgeoff/vers/pull/612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

