### PR TITLE
test: seed the stateful activity mock instead of scripting handlers

### DIFF
--- a/libs/game/idle-client/src/mocks/node.ts
+++ b/libs/game/idle-client/src/mocks/node.ts
@@ -1,3 +1,10 @@
+import { resolveServiceURL } from '@vers/mock-services';
+import { buildActivityMockHandlers } from '@vers/mock-services/activity';
 import { setupServer } from 'msw/node';
 
-export const server = setupServer();
+/**
+ * The shared MSW server backing this package's tests. The stateful activity backend is baked in,
+ * so happy-path responses come from seeded mock-db rows; per-test handlers layer deviations on
+ * top. Lifecycle is registered once from the bunfig preload.
+ */
+export const server = setupServer(...buildActivityMockHandlers(resolveServiceURL('activity')));

--- a/libs/game/idle-client/src/resync/run-resync.test.ts
+++ b/libs/game/idle-client/src/resync/run-resync.test.ts
@@ -8,7 +8,7 @@ import {
   createMockEnemyData,
 } from '@vers/idle-core/test-utils';
 import { createTestAccessToken, resolveServiceURL } from '@vers/mock-services';
-import { buildActivityMockHandlers, mockActivityService } from '@vers/mock-services/activity';
+import { mockActivityService } from '@vers/mock-services/activity';
 import * as db from '@vers/mock-services/db';
 import { server } from '../mocks/node';
 import { createCheckpointSubmitter } from '../submission/create-checkpoint-submitter';
@@ -25,13 +25,11 @@ interface SetupTestConfig {
 }
 
 /**
- * Wires the stateful activity mock backend and an authed client acting as the given user, so the
+ * Builds an authed client acting as the given user, so the
  * resync's fetch, drain, and append calls hit the same state transitions the real service applies
  * to the rows the test seeds in the mock db.
  */
 async function setupTest(config: Readonly<SetupTestConfig>) {
-  server.use(...buildActivityMockHandlers(resolveServiceURL('activity')));
-
   const token = await createTestAccessToken(config.userID);
 
   const client: ActivityServiceClient = createORPCClient(

--- a/libs/game/idle-client/src/worker/handle-client-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-client-message.test.ts
@@ -1,8 +1,13 @@
 import { expect, test } from 'bun:test';
+import { createORPCClient } from '@orpc/client';
+import { RPCLink } from '@orpc/client/fetch';
 import { createMockActivityData } from '@vers/contract-activity/test-utils';
 import { ActivityFailureAction, createSimulation } from '@vers/idle-core';
-import { mockActivityService } from '@vers/mock-services/activity';
+import { createTestAccessToken, resolveServiceURL } from '@vers/mock-services';
+import { buildActivityMockHandlers } from '@vers/mock-services/activity';
+import * as db from '@vers/mock-services/db';
 import { server } from '../mocks/node';
+import type { ActivityServiceClient } from '../submission/types';
 import { createStubWorkerContext } from '../test-utils/create-stub-worker-context';
 import type {
   DisconnectMessage,
@@ -76,18 +81,24 @@ test('it applies the sent failure action to the live simulation', async () => {
 });
 
 test('it records the resync request for the requested avatar', async () => {
-  server.use(
-    mockActivityService.getLatestActivityProgress.handler((opts) => {
-      throw opts.errors.NOT_FOUND({ data: {} });
+  server.use(...buildActivityMockHandlers(resolveServiceURL('activity')));
+
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+
+  const client: ActivityServiceClient = createORPCClient(
+    new RPCLink({
+      headers: { authorization: `Bearer ${await createTestAccessToken(user.id)}` },
+      url: `${resolveServiceURL('activity')}/rpc`,
     }),
   );
 
-  const context = createStubWorkerContext();
+  const context = createStubWorkerContext({ client });
 
   const channel = new MessageChannel();
 
   const message: RequestResyncMessage = {
-    avatarID: 'avatar_1',
+    avatarID: avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
@@ -95,7 +106,7 @@ test('it records the resync request for the requested avatar', async () => {
 
   await handleClientMessage(context, channel.port2, event);
 
-  expect(context.getResyncAvatarID()).toBe('avatar_1');
+  expect(context.getResyncAvatarID()).toBe(avatar.id);
 });
 
 test('it drops the connection on a disconnect message', async () => {

--- a/libs/game/idle-client/src/worker/handle-client-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-client-message.test.ts
@@ -4,9 +4,7 @@ import { RPCLink } from '@orpc/client/fetch';
 import { createMockActivityData } from '@vers/contract-activity/test-utils';
 import { ActivityFailureAction, createSimulation } from '@vers/idle-core';
 import { createTestAccessToken, resolveServiceURL } from '@vers/mock-services';
-import { buildActivityMockHandlers } from '@vers/mock-services/activity';
 import * as db from '@vers/mock-services/db';
-import { server } from '../mocks/node';
 import type { ActivityServiceClient } from '../submission/types';
 import { createStubWorkerContext } from '../test-utils/create-stub-worker-context';
 import type {
@@ -81,8 +79,6 @@ test('it applies the sent failure action to the live simulation', async () => {
 });
 
 test('it records the resync request for the requested avatar', async () => {
-  server.use(...buildActivityMockHandlers(resolveServiceURL('activity')));
-
   const user = await db.userCollection.create({});
   const avatar = await db.avatarCollection.create({ userID: user.id });
 

--- a/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
@@ -1,15 +1,13 @@
 import { expect, mock, test } from 'bun:test';
 import { createORPCClient } from '@orpc/client';
 import { RPCLink } from '@orpc/client/fetch';
-import type { ActivityData } from '@vers/contract-activity';
-import { createMockActivityData } from '@vers/contract-activity/test-utils';
 import type { ActivityCheckpoint } from '@vers/idle-core';
 import { SIMULATION_TIMESTEP_MS, buildSimulationInput, runAttempt } from '@vers/idle-core';
-import { resolveServiceURL } from '@vers/mock-services';
-import { mockActivityService } from '@vers/mock-services/activity';
+import { createTestAccessToken, resolveServiceURL } from '@vers/mock-services';
+import { buildActivityMockHandlers } from '@vers/mock-services/activity';
+import * as db from '@vers/mock-services/db';
 import invariant from 'tiny-invariant';
 import { server } from '../mocks/node';
-import type { CheckpointSubmitter } from '../submission/create-checkpoint-submitter';
 import { createCheckpointSubmitter } from '../submission/create-checkpoint-submitter';
 import type { ActivityServiceClient } from '../submission/types';
 import { createStubWorkerContext } from '../test-utils/create-stub-worker-context';
@@ -18,29 +16,51 @@ import type { RequestResyncMessage } from '../types';
 import { ClientMessageType, WorkerMessageType } from '../types';
 import { handleRequestResyncMessage } from './handle-request-resync-message';
 
-function setupTest(
-  config: Readonly<{
-    client?: ActivityServiceClient;
-    submitter?: Readonly<CheckpointSubmitter>;
-  }> = {},
-) {
-  const connection = createTestConnection();
-  const context = createStubWorkerContext({ connections: [connection.port], ...config });
-
-  return { connection, context };
+interface SetupTestConfig {
+  readonly userID: string;
 }
 
-test('it broadcasts nothing for an avatar with no activity history', async () => {
-  server.use(
-    mockActivityService.getLatestActivityProgress.handler((opts) => {
-      throw opts.errors.NOT_FOUND({ data: {} });
+/**
+ * Wires the stateful activity mock backend, an authed client acting as the given user, and a
+ * worker context wearing that client — so a resync's fetch, append, and start calls hit the same
+ * state transitions the real service applies to the rows the test seeds in the mock db. The
+ * returned flush delivers whatever the submitter has scheduled since the last call.
+ */
+async function setupTest(config: Readonly<SetupTestConfig>) {
+  server.use(...buildActivityMockHandlers(resolveServiceURL('activity')));
+
+  const token = await createTestAccessToken(config.userID);
+
+  const client: ActivityServiceClient = createORPCClient(
+    new RPCLink({
+      headers: { authorization: `Bearer ${token}` },
+      url: `${resolveServiceURL('activity')}/rpc`,
     }),
   );
 
-  const ctx = setupTest();
+  let capturedFlush: (() => Promise<void>) | undefined;
+
+  const submitter = createCheckpointSubmitter({
+    client,
+    onInvalid: mock<(activityID: string, reason: string) => void>(),
+    scheduleFlush: (flush) => {
+      capturedFlush = flush;
+    },
+  });
+
+  const connection = createTestConnection();
+  const context = createStubWorkerContext({ client, connections: [connection.port], submitter });
+
+  return { client, connection, context, flush: () => capturedFlush?.() ?? Promise.resolve() };
+}
+
+test('it broadcasts nothing for an avatar with no activity history', async () => {
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const ctx = await setupTest({ userID: user.id });
 
   const message: RequestResyncMessage = {
-    avatarID: 'avatar_1',
+    avatarID: avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
@@ -60,22 +80,19 @@ test('it broadcasts nothing for an avatar with no activity history', async () =>
 });
 
 test('it broadcasts capped and installs no simulation for a capped activity', async () => {
-  const activity = createMockActivityData({ appendedHead: 5, status: 'capped' });
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const ctx = await setupTest({ userID: user.id });
 
-  server.use(
-    mockActivityService.getLatestActivityProgress.handler(() => ({
-      activity,
-      anchor: null,
-      appendedHead: 5,
-      serverTime: new Date(),
-      verifiedHead: 3,
-    })),
-  );
-
-  const ctx = setupTest();
+  await db.activityCollection.create({
+    appendedHead: 5,
+    avatarID: avatar.id,
+    status: 'capped',
+    verifiedHead: 3,
+  });
 
   const message: RequestResyncMessage = {
-    avatarID: 'avatar_1',
+    avatarID: avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
@@ -91,7 +108,15 @@ test('it broadcasts capped and installs no simulation for a capped activity', as
 });
 
 test('it reconstructs and installs a live simulation mid-stream, registering from the recovered cursor', async () => {
-  const activity = createMockActivityData({ startedAt: new Date(Date.now() - 2000) });
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const ctx = await setupTest({ userID: user.id });
+
+  const activity = await db.activityCollection.create({
+    avatarID: avatar.id,
+    startedAt: new Date(Date.now() - 2000),
+  });
+
   const input = buildSimulationInput(activity);
 
   const attempt = await runAttempt(input.activity, input.avatar, { maxDurationMs: 120_000 });
@@ -106,41 +131,15 @@ test('it reconstructs and installs a live simulation mid-stream, registering fro
     'expected a confirmed checkpoint short of the full stream',
   );
 
-  const submittedSeeds: Array<string | undefined> = [];
-
-  server.use(
-    mockActivityService.getLatestActivityProgress.handler(() => ({
-      activity,
-      anchor: null,
-      appendedHead,
-      serverTime: new Date(),
-      verifiedHead: 0,
-    })),
-    mockActivityService.trackActivityProgress.handler((opts) => {
-      submittedSeeds.push(opts.input.checkpoints[0]?.payload.seed);
-
-      return { appendedHead: opts.input.expectedHead + opts.input.checkpoints.length };
-    }),
-  );
-
-  const client: ActivityServiceClient = createORPCClient(
-    new RPCLink({ url: `${resolveServiceURL('activity')}/rpc` }),
-  );
-
-  let capturedFlush: (() => Promise<void>) | undefined;
-
-  const submitter = createCheckpointSubmitter({
-    client,
-    onInvalid: mock<(activityID: string, reason: string) => void>(),
-    scheduleFlush: (flush) => {
-      capturedFlush = flush;
+  await db.activityCollection.update(activity, {
+    data(record) {
+      record.appendedHead = appendedHead;
     },
+    strict: true,
   });
 
-  const ctx = setupTest({ client, submitter });
-
   const message: RequestResyncMessage = {
-    avatarID: activity.avatarID,
+    avatarID: avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
@@ -170,32 +169,38 @@ test('it reconstructs and installs a live simulation mid-stream, registering fro
   }
 
   await ctx.context.getSubmitter().submit(activity.id, checkpoint);
+  await ctx.flush();
 
-  await capturedFlush?.();
+  const landed = db.checkpointCollection.findMany((q) => q.where({ activityID: activity.id }));
 
-  expect(submittedSeeds).toStrictEqual([lastConfirmed.nextSeed]);
+  expect(landed.map((row) => row.payload.seed)).toStrictEqual([lastConfirmed.nextSeed]);
 });
 
 test('it reports a divergence via the checkpoint-stream-error channel and skips registration', async () => {
-  const activity = createMockActivityData({ startedAt: new Date(Date.now() - 2000) });
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const ctx = await setupTest({ userID: user.id });
+
+  const activity = await db.activityCollection.create({
+    avatarID: avatar.id,
+    startedAt: new Date(Date.now() - 2000),
+  });
+
   const input = buildSimulationInput(activity);
 
   const attempt = await runAttempt(input.activity, input.avatar, { maxDurationMs: 120_000 });
 
-  server.use(
-    mockActivityService.getLatestActivityProgress.handler(() => ({
-      activity,
-      anchor: null,
-      appendedHead: attempt.checkpoints.length + 5,
-      serverTime: new Date(),
-      verifiedHead: 0,
-    })),
-  );
-
-  const ctx = setupTest();
+  // a confirmed head beyond anything the activity's own stream produced is unreachable by
+  // reconstruction, forcing the divergence path
+  await db.activityCollection.update(activity, {
+    data(record) {
+      record.appendedHead = attempt.checkpoints.length + 5;
+    },
+    strict: true,
+  });
 
   const message: RequestResyncMessage = {
-    avatarID: 'avatar_1',
+    avatarID: avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
@@ -215,62 +220,23 @@ test('it reports a divergence via the checkpoint-stream-error channel and skips 
 });
 
 test('it fast-forwards a short gap, broadcasts progress and final tallies, and installs a registered live sim on the final active row', async () => {
-  const client: ActivityServiceClient = createORPCClient(
-    new RPCLink({ url: `${resolveServiceURL('activity')}/rpc` }),
-  );
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const ctx = await setupTest({ userID: user.id });
 
   // this seed's placeholder encounter completes in exactly 45s of simulated time; a 50s gap
   // leaves just under 5s of budget for the next continuation, too little for any encounter to
   // reach a terminal checkpoint, so that continuation is guaranteed to be the fast-forward's
   // unregistered final row regardless of its own random seed
-  const activity = createMockActivityData({
+  const activity = await db.activityCollection.create({
     appendedHead: 0,
+    avatarID: avatar.id,
     seed: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaa6072',
     startedAt: new Date(Date.now() - 50_000),
   });
 
-  const startedActivities: Array<ActivityData> = [];
-  const batches: Array<{ readonly activityID: string }> = [];
-
-  server.use(
-    mockActivityService.getLatestActivityProgress.handler(() => ({
-      activity,
-      anchor: null,
-      appendedHead: 0,
-      serverTime: new Date(),
-      verifiedHead: 0,
-    })),
-    mockActivityService.trackActivityProgress.handler((opts) => {
-      batches.push({ activityID: opts.input.activityID });
-
-      const last = opts.input.checkpoints.at(-1);
-
-      return { appendedHead: last?.version ?? opts.input.expectedHead };
-    }),
-    mockActivityService.startActivity.handler((opts) => {
-      const started = createMockActivityData({ avatarID: opts.input.avatarID });
-
-      startedActivities.push(started);
-
-      return started;
-    }),
-  );
-
-  let capturedFlush: (() => Promise<void>) | undefined;
-  const onInvalid = mock<(activityID: string, reason: string) => void>();
-
-  const submitter = createCheckpointSubmitter({
-    client,
-    onInvalid,
-    scheduleFlush: (flush) => {
-      capturedFlush = flush;
-    },
-  });
-
-  const ctx = setupTest({ client, submitter });
-
   const message: RequestResyncMessage = {
-    avatarID: activity.avatarID,
+    avatarID: avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
@@ -290,19 +256,22 @@ test('it fast-forwards a short gap, broadcasts progress and final tallies, and i
     { status: { attempts: 1, kind: 'done', levelUps: 1 }, type: WorkerMessageType.ResyncStatus },
   ]);
 
-  expect(startedActivities).toHaveLength(1);
+  // the completed attempt's terminal batch closed the seeded row, so the backend holds exactly
+  // one fresh active continuation for the avatar
+  const minted = db.activityCollection.findFirst((q) =>
+    q.where({ avatarID: avatar.id, status: 'active' }),
+  );
+
+  invariant(minted !== undefined, 'expected the fast-forward to mint an active continuation');
+  expect(minted.id).not.toBe(activity.id);
 
   const simulation = ctx.context.getSimulation();
 
   invariant(simulation !== null, 'expected the fast-forward to install a live simulation');
 
-  const liveActivityID = simulation.activity?.id;
-
   // the live sim attaches to the fast-forward's final, never-attempted continuation — not the
   // first activity its one completed attempt already registered
-  expect(liveActivityID).toBe(startedActivities[0]?.id);
-  expect(liveActivityID).not.toBe(activity.id);
-  invariant(liveActivityID !== undefined, 'expected the live simulation to carry its activity id');
+  expect(simulation.activity?.id).toBe(minted.id);
 
   let checkpoint: ActivityCheckpoint | null = null;
 
@@ -312,59 +281,32 @@ test('it fast-forwards a short gap, broadcasts progress and final tallies, and i
 
   // proves the fresh continuation's registration actually happened: an unregistered activity's
   // checkpoint is silently dropped by the submitter rather than reaching the server
-  await ctx.context.getSubmitter().submit(liveActivityID, checkpoint);
+  await ctx.context.getSubmitter().submit(minted.id, checkpoint);
+  await ctx.flush();
 
-  await capturedFlush?.();
+  const landed = db.checkpointCollection.findMany((q) => q.where({ activityID: minted.id }));
 
-  expect(batches).toContainEqual({ activityID: liveActivityID });
+  expect(landed).toHaveLength(1);
 });
 
 test('it reconstructs a fast-forward report left mid-stream and registers from its recovered cursor', async () => {
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const ctx = await setupTest({ userID: user.id });
+
   // this seed's placeholder encounter completes in exactly 45s of simulated time with one
   // confirmed ("started") checkpoint at its head; a 20s gap is enough to pick the fast-forward
   // plan but far short of the 45s tail, so the budget check bails before any continuation is
   // attempted, reporting back the very row the resync started from
-  const activity = createMockActivityData({
+  const activity = await db.activityCollection.create({
     appendedHead: 1,
+    avatarID: avatar.id,
     seed: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaa6072',
     startedAt: new Date(Date.now() - 20_000),
   });
 
-  const submittedSeeds: Array<string | undefined> = [];
-
-  server.use(
-    mockActivityService.getLatestActivityProgress.handler(() => ({
-      activity,
-      anchor: null,
-      appendedHead: 1,
-      serverTime: new Date(),
-      verifiedHead: 0,
-    })),
-    mockActivityService.trackActivityProgress.handler((opts) => {
-      submittedSeeds.push(opts.input.checkpoints[0]?.payload.seed);
-
-      return { appendedHead: opts.input.expectedHead + opts.input.checkpoints.length };
-    }),
-  );
-
-  const client: ActivityServiceClient = createORPCClient(
-    new RPCLink({ url: `${resolveServiceURL('activity')}/rpc` }),
-  );
-
-  let capturedFlush: (() => Promise<void>) | undefined;
-
-  const submitter = createCheckpointSubmitter({
-    client,
-    onInvalid: mock<(activityID: string, reason: string) => void>(),
-    scheduleFlush: (flush) => {
-      capturedFlush = flush;
-    },
-  });
-
-  const ctx = setupTest({ client, submitter });
-
   const message: RequestResyncMessage = {
-    avatarID: activity.avatarID,
+    avatarID: avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
@@ -394,31 +336,28 @@ test('it reconstructs a fast-forward report left mid-stream and registers from i
   }
 
   await ctx.context.getSubmitter().submit(activity.id, checkpoint);
-
-  await capturedFlush?.();
+  await ctx.flush();
 
   // the started checkpoint's own nextSeed, not the activity row's start seed — proves the
   // registered cursor chains onto the reconstruction, not a fresh checkpoint-0 sim
-  expect(submittedSeeds).toStrictEqual(['525ac5e6a97591b0a1877a6606b22d9c']);
+  const landed = db.checkpointCollection.findMany((q) => q.where({ activityID: activity.id }));
+
+  expect(landed.map((row) => row.payload.seed)).toStrictEqual(['525ac5e6a97591b0a1877a6606b22d9c']);
 });
 
 test('it attaches a fresh login live without broadcasting any catch-up status', async () => {
-  const activity = createMockActivityData({ appendedHead: 0, startedAt: new Date() });
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const ctx = await setupTest({ userID: user.id });
 
-  server.use(
-    mockActivityService.getLatestActivityProgress.handler(() => ({
-      activity,
-      anchor: null,
-      appendedHead: 0,
-      serverTime: new Date(),
-      verifiedHead: 0,
-    })),
-  );
-
-  const ctx = setupTest();
+  const activity = await db.activityCollection.create({
+    appendedHead: 0,
+    avatarID: avatar.id,
+    startedAt: new Date(),
+  });
 
   const message: RequestResyncMessage = {
-    avatarID: activity.avatarID,
+    avatarID: avatar.id,
     type: ClientMessageType.RequestResync,
   };
 

--- a/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
@@ -4,10 +4,8 @@ import { RPCLink } from '@orpc/client/fetch';
 import type { ActivityCheckpoint } from '@vers/idle-core';
 import { SIMULATION_TIMESTEP_MS, buildSimulationInput, runAttempt } from '@vers/idle-core';
 import { createTestAccessToken, resolveServiceURL } from '@vers/mock-services';
-import { buildActivityMockHandlers } from '@vers/mock-services/activity';
 import * as db from '@vers/mock-services/db';
 import invariant from 'tiny-invariant';
-import { server } from '../mocks/node';
 import { createCheckpointSubmitter } from '../submission/create-checkpoint-submitter';
 import type { ActivityServiceClient } from '../submission/types';
 import { createStubWorkerContext } from '../test-utils/create-stub-worker-context';
@@ -21,14 +19,12 @@ interface SetupTestConfig {
 }
 
 /**
- * Wires the stateful activity mock backend, an authed client acting as the given user, and a
+ * Builds an authed client acting as the given user and a
  * worker context wearing that client — so a resync's fetch, append, and start calls hit the same
  * state transitions the real service applies to the rows the test seeds in the mock db. The
  * returned flush delivers whatever the submitter has scheduled since the last call.
  */
 async function setupTest(config: Readonly<SetupTestConfig>) {
-  server.use(...buildActivityMockHandlers(resolveServiceURL('activity')));
-
   const token = await createTestAccessToken(config.userID);
 
   const client: ActivityServiceClient = createORPCClient(

--- a/libs/game/idle-client/src/worker/run-continuation.test.ts
+++ b/libs/game/idle-client/src/worker/run-continuation.test.ts
@@ -1,15 +1,45 @@
 import { expect, mock, test } from 'bun:test';
+import { createORPCClient } from '@orpc/client';
+import { RPCLink } from '@orpc/client/fetch';
 import { createMockActivityData } from '@vers/contract-activity/test-utils';
 import { createSimulation } from '@vers/idle-core';
 import { createMockActivityInput, createMockAvatarData } from '@vers/idle-core/test-utils';
-import { mockActivityService } from '@vers/mock-services/activity';
+import { createTestAccessToken, resolveServiceURL } from '@vers/mock-services';
+import { buildActivityMockHandlers, mockActivityService } from '@vers/mock-services/activity';
+import * as db from '@vers/mock-services/db';
 import { HttpResponse } from 'msw';
+import invariant from 'tiny-invariant';
 import { server } from '../mocks/node';
 import type { CheckpointSubmitter } from '../submission/create-checkpoint-submitter';
+import type { ActivityServiceClient } from '../submission/types';
 import { createStubWorkerContext } from '../test-utils/create-stub-worker-context';
 import { createTestConnection } from '../test-utils/create-test-connection';
 import { WorkerMessageType } from '../types';
 import { runContinuation } from './run-continuation';
+
+interface SetupTestConfig {
+  readonly userID: string;
+}
+
+/**
+ * Wires the stateful activity mock backend and an authed client acting as the given user, so
+ * continuation starts hit the same conflict/mint logic the real service applies to the rows the
+ * test seeds in the mock db.
+ */
+async function setupTest(config: Readonly<SetupTestConfig>) {
+  server.use(...buildActivityMockHandlers(resolveServiceURL('activity')));
+
+  const token = await createTestAccessToken(config.userID);
+
+  const client: ActivityServiceClient = createORPCClient(
+    new RPCLink({
+      headers: { authorization: `Bearer ${token}` },
+      url: `${resolveServiceURL('activity')}/rpc`,
+    }),
+  );
+
+  return { client };
+}
 
 function buildSpySubmitter(): CheckpointSubmitter {
   return {
@@ -20,43 +50,50 @@ function buildSpySubmitter(): CheckpointSubmitter {
 }
 
 test('it adopts a fresh server-started row for the same scope and registers from a zero cursor', async () => {
-  const startedActivity = createMockActivityData();
-
-  server.use(mockActivityService.startActivity.handler(() => startedActivity));
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const ctx = await setupTest({ userID: user.id });
 
   const submitter = buildSpySubmitter();
-  const context = createStubWorkerContext({ submitter });
+  const context = createStubWorkerContext({ client: ctx.client, submitter });
   const simulation = createSimulation();
-  const previousActivity = createMockActivityData();
+  const previousActivity = createMockActivityData({ avatarID: avatar.id });
 
   simulation.startActivity(createMockAvatarData(), createMockActivityInput());
 
   await runContinuation(context, simulation, previousActivity);
 
-  expect(simulation.activity?.id).toBe(startedActivity.id);
-  expect(context.getActivity()).toStrictEqual(startedActivity);
+  const minted = db.activityCollection.findFirst((q) =>
+    q.where({ avatarID: avatar.id, status: 'active' }),
+  );
+
+  invariant(minted !== undefined, 'expected the continuation to mint an active row');
+  expect(minted.scopeID).toBe(previousActivity.scopeID);
+  expect(simulation.activity?.id).toBe(minted.id);
+  expect(context.getActivity()).toStrictEqual(minted);
 
   expect(submitter.registerActivity).toHaveBeenCalledExactlyOnceWith({
-    activityID: startedActivity.id,
+    activityID: minted.id,
     appendedHead: 0,
-    lastHash: startedActivity.startHash,
-    startChainIndex: startedActivity.startChainIndex,
+    lastHash: minted.startHash,
+    startChainIndex: minted.startChainIndex,
   });
 });
 
 test('it adopts the CONFLICT payload row when one is already active for the scope', async () => {
-  const conflictingActivity = createMockActivityData();
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const ctx = await setupTest({ userID: user.id });
 
-  server.use(
-    mockActivityService.startActivity.handler((opts) => {
-      throw opts.errors.CONFLICT({ data: { activity: conflictingActivity } });
-    }),
-  );
+  const conflictingActivity = await db.activityCollection.create({
+    avatarID: avatar.id,
+    status: 'active',
+  });
 
   const submitter = buildSpySubmitter();
-  const context = createStubWorkerContext({ submitter });
+  const context = createStubWorkerContext({ client: ctx.client, submitter });
   const simulation = createSimulation();
-  const previousActivity = createMockActivityData();
+  const previousActivity = createMockActivityData({ avatarID: avatar.id });
 
   simulation.startActivity(createMockAvatarData(), createMockActivityInput());
 

--- a/libs/game/idle-client/src/worker/run-continuation.test.ts
+++ b/libs/game/idle-client/src/worker/run-continuation.test.ts
@@ -5,7 +5,7 @@ import { createMockActivityData } from '@vers/contract-activity/test-utils';
 import { createSimulation } from '@vers/idle-core';
 import { createMockActivityInput, createMockAvatarData } from '@vers/idle-core/test-utils';
 import { createTestAccessToken, resolveServiceURL } from '@vers/mock-services';
-import { buildActivityMockHandlers, mockActivityService } from '@vers/mock-services/activity';
+import { mockActivityService } from '@vers/mock-services/activity';
 import * as db from '@vers/mock-services/db';
 import { HttpResponse } from 'msw';
 import invariant from 'tiny-invariant';
@@ -22,13 +22,11 @@ interface SetupTestConfig {
 }
 
 /**
- * Wires the stateful activity mock backend and an authed client acting as the given user, so
+ * Builds an authed client acting as the given user, so
  * continuation starts hit the same conflict/mint logic the real service applies to the rows the
  * test seeds in the mock db.
  */
 async function setupTest(config: Readonly<SetupTestConfig>) {
-  server.use(...buildActivityMockHandlers(resolveServiceURL('activity')));
-
   const token = await createTestAccessToken(config.userID);
 
   const client: ActivityServiceClient = createORPCClient(

--- a/libs/game/idle-client/src/worker/run-simulation.test.ts
+++ b/libs/game/idle-client/src/worker/run-simulation.test.ts
@@ -9,10 +9,8 @@ import {
   createMockEnemyData,
 } from '@vers/idle-core/test-utils';
 import { createTestAccessToken, resolveServiceURL } from '@vers/mock-services';
-import { buildActivityMockHandlers } from '@vers/mock-services/activity';
 import * as db from '@vers/mock-services/db';
 import invariant from 'tiny-invariant';
-import { server } from '../mocks/node';
 import type { CheckpointSubmitter } from '../submission/create-checkpoint-submitter';
 import type { ActivityServiceClient } from '../submission/types';
 import { createStubWorkerContext } from '../test-utils/create-stub-worker-context';
@@ -25,13 +23,11 @@ interface SetupTestConfig {
 }
 
 /**
- * Wires the stateful activity mock backend and an authed client acting as the given user, so
+ * Builds an authed client acting as the given user, so
  * continuation starts hit the same conflict/mint logic the real service applies to the rows the
  * test seeds in the mock db.
  */
 async function setupTest(config: Readonly<SetupTestConfig>) {
-  server.use(...buildActivityMockHandlers(resolveServiceURL('activity')));
-
   const token = await createTestAccessToken(config.userID);
 
   const client: ActivityServiceClient = createORPCClient(

--- a/libs/testing/mock-services/src/activity/track-activity-progress.ts
+++ b/libs/testing/mock-services/src/activity/track-activity-progress.ts
@@ -2,8 +2,16 @@ import * as db from '../db';
 import { os } from './os';
 
 /**
- * Appends a checkpoint batch, mirroring the real service's state-derived rejections: a terminal
- * status refuses further appends, and a stale `expectedHead` is a retryable CONFLICT. Hash-chain
+ * Checkpoint types whose arrival closes the activity's stream, matching the set the real service
+ * settles terminal transitions against.
+ */
+const TERMINAL_CHECKPOINT_TYPES = new Set(['completed', 'failed']);
+
+/**
+ * Appends a checkpoint batch, mirroring the real service's state-derived transitions: a terminal
+ * status refuses further appends, a stale `expectedHead` is a retryable CONFLICT, and a batch
+ * ending on a terminal checkpoint closes the stream by flipping the row to `stopped` — so a
+ * follow-up start mints a fresh row instead of conflicting with a finished one. Hash-chain
  * validation, the offline-progress cap, and writer eviction need state the mock doesn't track —
  * those rejections are per-test overrides.
  */
@@ -54,12 +62,20 @@ export const trackActivityProgress = os.trackActivityProgress.handler(async (opt
   const appendedHead = activity.appendedHead + opts.input.checkpoints.length;
   const lastCheckpoint = opts.input.checkpoints.at(-1);
 
+  const closesStream =
+    lastCheckpoint !== undefined && TERMINAL_CHECKPOINT_TYPES.has(lastCheckpoint.payload.type);
+
   await db.activityCollection.update(activity, {
     data(record) {
       record.appendedAt = now;
       record.appendedHead = appendedHead;
       record.lastHash = lastCheckpoint === undefined ? record.lastHash : lastCheckpoint.hash;
       record.updatedAt = now;
+
+      if (closesStream) {
+        record.status = 'stopped';
+        record.stoppedAt = now;
+      }
     },
     strict: true,
   });

--- a/libs/testing/mock-services/src/activity/track-activity-progress.ts
+++ b/libs/testing/mock-services/src/activity/track-activity-progress.ts
@@ -1,11 +1,7 @@
+import type { CheckpointPayload } from '@vers/contract-activity';
+import * as z from 'zod';
 import * as db from '../db';
 import { os } from './os';
-
-/**
- * Checkpoint types whose arrival closes the activity's stream, matching the set the real service
- * settles terminal transitions against.
- */
-const TERMINAL_CHECKPOINT_TYPES = new Set(['completed', 'failed']);
 
 /**
  * Appends a checkpoint batch, mirroring the real service's state-derived transitions: a terminal
@@ -61,9 +57,7 @@ export const trackActivityProgress = os.trackActivityProgress.handler(async (opt
 
   const appendedHead = activity.appendedHead + opts.input.checkpoints.length;
   const lastCheckpoint = opts.input.checkpoints.at(-1);
-
-  const closesStream =
-    lastCheckpoint !== undefined && TERMINAL_CHECKPOINT_TYPES.has(lastCheckpoint.payload.type);
+  const closesStream = lastCheckpoint !== undefined && hasTerminalRewards(lastCheckpoint.payload);
 
   await db.activityCollection.update(activity, {
     data(record) {
@@ -82,3 +76,19 @@ export const trackActivityProgress = os.trackActivityProgress.handler(async (opt
 
   return { appendedHead };
 });
+
+const TERMINAL_CHECKPOINT_TYPES = new Set(['completed', 'failed']);
+
+const TerminalRewardsSchema = z.object({ xp: z.number() });
+
+/**
+ * Whether a payload closes its stream: a terminal checkpoint type carrying a parseable final
+ * rewards total, the same gate the real service settles terminal transitions against — a terminal
+ * type with a malformed `rewards` shape settles nothing and leaves the row active.
+ */
+function hasTerminalRewards(payload: Readonly<CheckpointPayload>): boolean {
+  return (
+    TERMINAL_CHECKPOINT_TYPES.has(payload.type) &&
+    TerminalRewardsSchema.safeParse(payload['rewards']).success
+  );
+}


### PR DESCRIPTION
## Description

Moves idle-client's happy-path worker tests off per-test scripted oRPC handlers and onto the stateful `@vers/mock-services` backend: tests seed `db` collections and authenticate with a bearer whose subject owns the seeded avatar, so resyncs, continuations, and appends hit the same state transitions the real service applies.

- Migrated: all 7 resync-handler tests, 2 of 3 continuation tests, the client-message resync test; input captures became mock-db reads.
- The mock's `trackActivityProgress` now closes the stream (row → `stopped`) when a batch ends on a terminal checkpoint, matching the real service — without it a fast-forward's continuation start conflicts with its own just-finished row.
- Stays scripted per the testing conventions: transport failures, unmodeled error codes, scripted call sequences, and request-field captures (`run-fast-forward`, `create-checkpoint-submitter`, worker-runtime's incidental stub).

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/zgeoff/vers/pull/613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

