### PR TITLE
feat(#380): define the log-line standard and log every request

### DIFF
--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -51,7 +51,7 @@ const serverEntry = {
     [
       // outermost so the request logger's lines already run inside the trace scope
       withRequestTrace,
-      makeRequestLogger(logger, { colorize: !env.isProduction }),
+      makeRequestLogger(logger),
       removeTrailingSlash,
       redirectToHTTPS,
       makeSecureHeaders({ sentryOrigin: SENTRY_ORIGIN }),

--- a/apps/web/src/server/make-request-logger.test.ts
+++ b/apps/web/src/server/make-request-logger.test.ts
@@ -1,12 +1,22 @@
 import { expect, test } from 'bun:test';
+import invariant from 'tiny-invariant';
 import { makeRequestLogger } from './make-request-logger';
 
-test('it logs one line before and one line after the request completes', async () => {
-  const lines: Array<string> = [];
+test('it logs one structured line at info when a page request completes', async () => {
+  const lines: Array<{ fields: Record<string, unknown>; level: string; message: string }> = [];
 
   const requestLogger = makeRequestLogger({
-    info: (message) => {
-      lines.push(message);
+    debug: (fields, message) => {
+      lines.push({ fields, level: 'debug', message });
+    },
+    error: (fields, message) => {
+      lines.push({ fields, level: 'error', message });
+    },
+    info: (fields, message) => {
+      lines.push({ fields, level: 'info', message });
+    },
+    warn: (fields, message) => {
+      lines.push({ fields, level: 'warn', message });
     },
   });
 
@@ -15,18 +25,36 @@ test('it logs one line before and one line after the request completes', async (
   );
 
   expect(response.status).toBe(200);
-  expect(lines).toHaveLength(2);
-  expect(lines[0]).toInclude('GET /nexus processing...');
-  expect(lines[1]).toInclude('GET');
-  expect(lines[1]).toInclude('200');
+  expect(lines).toHaveLength(1);
+  invariant(lines[0], 'one line was logged');
+
+  expect(lines[0]).toStrictEqual({
+    fields: {
+      durationMs: expect.toBeNumber(),
+      method: 'GET',
+      path: '/nexus',
+      status: 200,
+    },
+    level: 'info',
+    message: 'request completed',
+  });
 });
 
 test('it includes the query string in the logged path', async () => {
-  const lines: Array<string> = [];
+  const lines: Array<{ fields: Record<string, unknown>; level: string; message: string }> = [];
 
   const requestLogger = makeRequestLogger({
-    info: (message) => {
-      lines.push(message);
+    debug: (fields, message) => {
+      lines.push({ fields, level: 'debug', message });
+    },
+    error: (fields, message) => {
+      lines.push({ fields, level: 'error', message });
+    },
+    info: (fields, message) => {
+      lines.push({ fields, level: 'info', message });
+    },
+    warn: (fields, message) => {
+      lines.push({ fields, level: 'warn', message });
     },
   });
 
@@ -34,36 +62,52 @@ test('it includes the query string in the logged path', async () => {
     Promise.resolve(new Response('ok')),
   );
 
-  expect(lines[0]).toInclude('/login?next=/account');
+  invariant(lines[0], 'one line was logged');
+  expect(lines[0].fields).toContainEntry(['path', '/login?next=/account']);
 });
 
-test('it emits no escape codes when colorize is off', async () => {
-  const lines: Array<string> = [];
-
-  const requestLogger = makeRequestLogger(
-    {
-      info: (message) => {
-        lines.push(message);
-      },
-    },
-    { colorize: false },
-  );
-
-  await requestLogger(new Request('https://example.test/nexus'), () =>
-    Promise.resolve(new Response('ok')),
-  );
-
-  expect(lines).toHaveLength(2);
-  expect(lines.join('')).not.toInclude('\u001B[');
-  expect(lines[1]).toInclude('[--->] GET /nexus 200');
-});
-
-test('it labels a server error response distinctly from a success', async () => {
-  const lines: Array<string> = [];
+test('it logs a client error response at warn', async () => {
+  const lines: Array<{ fields: Record<string, unknown>; level: string; message: string }> = [];
 
   const requestLogger = makeRequestLogger({
-    info: (message) => {
-      lines.push(message);
+    debug: (fields, message) => {
+      lines.push({ fields, level: 'debug', message });
+    },
+    error: (fields, message) => {
+      lines.push({ fields, level: 'error', message });
+    },
+    info: (fields, message) => {
+      lines.push({ fields, level: 'info', message });
+    },
+    warn: (fields, message) => {
+      lines.push({ fields, level: 'warn', message });
+    },
+  });
+
+  await requestLogger(new Request('https://example.test/missing'), () =>
+    Promise.resolve(new Response('nope', { status: 404 })),
+  );
+
+  invariant(lines[0], 'one line was logged');
+  expect(lines[0].level).toBe('warn');
+  expect(lines[0].fields).toContainEntry(['status', 404]);
+});
+
+test('it logs a server error response at error', async () => {
+  const lines: Array<{ fields: Record<string, unknown>; level: string; message: string }> = [];
+
+  const requestLogger = makeRequestLogger({
+    debug: (fields, message) => {
+      lines.push({ fields, level: 'debug', message });
+    },
+    error: (fields, message) => {
+      lines.push({ fields, level: 'error', message });
+    },
+    info: (fields, message) => {
+      lines.push({ fields, level: 'info', message });
+    },
+    warn: (fields, message) => {
+      lines.push({ fields, level: 'warn', message });
     },
   });
 
@@ -71,5 +115,102 @@ test('it labels a server error response distinctly from a success', async () => 
     Promise.resolve(new Response('boom', { status: 500 })),
   );
 
-  expect(lines[1]).toInclude('SERVER ERROR');
+  invariant(lines[0], 'one line was logged');
+  expect(lines[0].level).toBe('error');
+  expect(lines[0].fields).toContainEntry(['status', 500]);
+});
+
+test('it logs a served static asset at debug', async () => {
+  const lines: Array<{ fields: Record<string, unknown>; level: string; message: string }> = [];
+
+  const requestLogger = makeRequestLogger({
+    debug: (fields, message) => {
+      lines.push({ fields, level: 'debug', message });
+    },
+    error: (fields, message) => {
+      lines.push({ fields, level: 'error', message });
+    },
+    info: (fields, message) => {
+      lines.push({ fields, level: 'info', message });
+    },
+    warn: (fields, message) => {
+      lines.push({ fields, level: 'warn', message });
+    },
+  });
+
+  await requestLogger(new Request('https://example.test/assets/app-3f2a.js'), () =>
+    Promise.resolve(new Response('js', { status: 200 })),
+  );
+
+  invariant(lines[0], 'one line was logged');
+  expect(lines[0].level).toBe('debug');
+});
+
+test('it logs a missing asset at warn rather than debug', async () => {
+  const lines: Array<{ fields: Record<string, unknown>; level: string; message: string }> = [];
+
+  const requestLogger = makeRequestLogger({
+    debug: (fields, message) => {
+      lines.push({ fields, level: 'debug', message });
+    },
+    error: (fields, message) => {
+      lines.push({ fields, level: 'error', message });
+    },
+    info: (fields, message) => {
+      lines.push({ fields, level: 'info', message });
+    },
+    warn: (fields, message) => {
+      lines.push({ fields, level: 'warn', message });
+    },
+  });
+
+  await requestLogger(new Request('https://example.test/assets/gone.js'), () =>
+    Promise.resolve(new Response('nope', { status: 404 })),
+  );
+
+  invariant(lines[0], 'one line was logged');
+  expect(lines[0].level).toBe('warn');
+});
+
+test('it logs at error and rethrows when the handler throws', async () => {
+  const lines: Array<{ fields: Record<string, unknown>; level: string; message: string }> = [];
+
+  const requestLogger = makeRequestLogger({
+    debug: (fields, message) => {
+      lines.push({ fields, level: 'debug', message });
+    },
+    error: (fields, message) => {
+      lines.push({ fields, level: 'error', message });
+    },
+    info: (fields, message) => {
+      lines.push({ fields, level: 'info', message });
+    },
+    warn: (fields, message) => {
+      lines.push({ fields, level: 'warn', message });
+    },
+  });
+
+  const thrown = new Error('handler exploded');
+
+  const pending = requestLogger(new Request('https://example.test/nexus'), () =>
+    Promise.reject(thrown),
+  );
+
+  expect(pending).rejects.toBe(thrown);
+
+  await expect(pending).toReject();
+
+  expect(lines).toHaveLength(1);
+  invariant(lines[0], 'one line was logged');
+
+  expect(lines[0]).toStrictEqual({
+    fields: {
+      durationMs: expect.toBeNumber(),
+      err: thrown,
+      method: 'GET',
+      path: '/nexus',
+    },
+    level: 'error',
+    message: 'request failed',
+  });
 });

--- a/apps/web/src/server/make-request-logger.test.ts
+++ b/apps/web/src/server/make-request-logger.test.ts
@@ -40,7 +40,7 @@ test('it logs one structured line at info when a page request completes', async 
   });
 });
 
-test('it includes the query string in the logged path', async () => {
+test('it excludes the query string from the logged path', async () => {
   const lines: Array<{ fields: Record<string, unknown>; level: string; message: string }> = [];
 
   const requestLogger = makeRequestLogger({
@@ -62,8 +62,9 @@ test('it includes the query string in the logged path', async () => {
     Promise.resolve(new Response('ok')),
   );
 
+  expect(lines).toHaveLength(1);
   invariant(lines[0], 'one line was logged');
-  expect(lines[0].fields).toContainEntry(['path', '/login?next=/account']);
+  expect(lines[0].fields).toContainEntry(['path', '/login']);
 });
 
 test('it logs a client error response at warn', async () => {
@@ -88,6 +89,7 @@ test('it logs a client error response at warn', async () => {
     Promise.resolve(new Response('nope', { status: 404 })),
   );
 
+  expect(lines).toHaveLength(1);
   invariant(lines[0], 'one line was logged');
   expect(lines[0].level).toBe('warn');
   expect(lines[0].fields).toContainEntry(['status', 404]);
@@ -115,6 +117,7 @@ test('it logs a server error response at error', async () => {
     Promise.resolve(new Response('boom', { status: 500 })),
   );
 
+  expect(lines).toHaveLength(1);
   invariant(lines[0], 'one line was logged');
   expect(lines[0].level).toBe('error');
   expect(lines[0].fields).toContainEntry(['status', 500]);
@@ -142,6 +145,7 @@ test('it logs a served static asset at debug', async () => {
     Promise.resolve(new Response('js', { status: 200 })),
   );
 
+  expect(lines).toHaveLength(1);
   invariant(lines[0], 'one line was logged');
   expect(lines[0].level).toBe('debug');
 });
@@ -168,6 +172,7 @@ test('it logs a missing asset at warn rather than debug', async () => {
     Promise.resolve(new Response('nope', { status: 404 })),
   );
 
+  expect(lines).toHaveLength(1);
   invariant(lines[0], 'one line was logged');
   expect(lines[0].level).toBe('warn');
 });

--- a/apps/web/src/server/make-request-logger.ts
+++ b/apps/web/src/server/make-request-logger.ts
@@ -13,8 +13,10 @@ interface RequestLoggerSink {
 
 /**
  * Builds the request-lifecycle logging middleware: one structured line per request on completion,
- * carrying method, path (with query string), status, and duration as queryable fields — data
- * never rides in the message text, and presentation is the transport's job. Severity follows
+ * carrying method, path, status, and duration as queryable fields — data never rides in the
+ * message text, and presentation is the transport's job. The query string never reaches the line:
+ * query params carry emailed tokens and auth codes, and a log stream is no place for either.
+ * Severity follows
  * outcome: 5xx at error, 4xx at warn, everything else at info — except a served static asset
  * (a pathname with a file extension), which logs at debug to keep asset traffic out of the
  * shipped stream. A handler that throws still logs, at error with the thrown value, before the
@@ -24,9 +26,8 @@ export function makeRequestLogger(logger: RequestLoggerSink): Middleware {
   return async (request, next) => {
     const start = performance.now();
 
-    const url = new URL(request.url);
+    const path = new URL(request.url).pathname;
 
-    const path = url.pathname + url.search;
     let response: Response;
 
     try {
@@ -45,7 +46,7 @@ export function makeRequestLogger(logger: RequestLoggerSink): Middleware {
       throw error;
     }
 
-    logger[pickRequestLogLevel(response.status, url.pathname)](
+    logger[pickRequestLogLevel(response.status, path)](
       {
         durationMs: toDurationMs(performance.now() - start),
         method: request.method,

--- a/apps/web/src/server/make-request-logger.ts
+++ b/apps/web/src/server/make-request-logger.ts
@@ -75,7 +75,8 @@ function pickRequestLogLevel(status: number, pathname: string): keyof RequestLog
 }
 
 /**
- * Rounds an elapsed-time reading to one decimal so a fast request doesn't log a duration of zero.
+ * Rounds an elapsed-time reading to one decimal, keeping the sub-millisecond resolution that
+ * whole-millisecond rounding would discard.
  */
 function toDurationMs(elapsedMs: number): number {
   return Math.round(elapsedMs * 10) / 10;

--- a/apps/web/src/server/make-request-logger.ts
+++ b/apps/web/src/server/make-request-logger.ts
@@ -1,120 +1,81 @@
 import type { Middleware } from './middleware';
 
-const ANSI = {
-  bold: '[1m',
-  cyan: '[36m',
-  green: '[32m',
-  red: '[31m',
-  reset: '[0m',
-  yellow: '[33m',
-} as const;
-
-type Palette = Readonly<Record<keyof typeof ANSI, string>>;
-
-const PLAIN: Palette = {
-  bold: '',
-  cyan: '',
-  green: '',
-  red: '',
-  reset: '',
-  yellow: '',
-};
-
 /**
- * The one logger capability this middleware needs — satisfied structurally by the app's pino
+ * The logger capabilities this middleware needs — satisfied structurally by the app's pino
  * instance without pulling pino's own types into this module's public signature.
  */
 interface RequestLoggerSink {
-  readonly info: (message: string) => void;
-}
-
-interface MakeRequestLoggerOptions {
-  readonly colorize?: boolean;
+  readonly debug: (fields: Readonly<Record<string, unknown>>, message: string) => void;
+  readonly error: (fields: Readonly<Record<string, unknown>>, message: string) => void;
+  readonly info: (fields: Readonly<Record<string, unknown>>, message: string) => void;
+  readonly warn: (fields: Readonly<Record<string, unknown>>, message: string) => void;
 }
 
 /**
- * Builds the request-lifecycle logging middleware: one line as a request starts, one line with
- * its status and duration once it finishes. Colorized by method and status for readable console
- * output by default; pass `colorize: false` where the lines feed a structured sink, so shipped
- * logs carry no escape codes.
+ * Builds the request-lifecycle logging middleware: one structured line per request on completion,
+ * carrying method, path (with query string), status, and duration as queryable fields — data
+ * never rides in the message text, and presentation is the transport's job. Severity follows
+ * outcome: 5xx at error, 4xx at warn, everything else at info — except a served static asset
+ * (a pathname with a file extension), which logs at debug to keep asset traffic out of the
+ * shipped stream. A handler that throws still logs, at error with the thrown value, before the
+ * throw continues to the runtime.
  */
-export function makeRequestLogger(
-  logger: RequestLoggerSink,
-  options?: MakeRequestLoggerOptions,
-): Middleware {
-  const palette = options?.colorize === false ? PLAIN : ANSI;
-
+export function makeRequestLogger(logger: RequestLoggerSink): Middleware {
   return async (request, next) => {
     const start = performance.now();
-    const path = formatRequestPath(new URL(request.url));
 
-    logger.info(`${palette.bold}[<---]${palette.reset} ${request.method} ${path} processing...`);
+    const url = new URL(request.url);
 
-    const response = await next();
+    const path = url.pathname + url.search;
+    let response: Response;
 
-    const duration = performance.now() - start;
-    const methodColor = request.method === 'GET' ? palette.green : palette.yellow;
-    const methodStyled = `${palette.bold}${methodColor}${request.method}${palette.reset}`;
-    const statusColor = pickStatusColor(response.status, palette);
-    const statusStyled = `${statusColor}${response.status}${palette.reset}`;
-    const statusLabel = pickStatusLabel(response.status);
+    try {
+      response = await next();
+    } catch (error) {
+      logger.error(
+        {
+          durationMs: toDurationMs(performance.now() - start),
+          err: error,
+          method: request.method,
+          path,
+        },
+        'request failed',
+      );
 
-    logger.info(
-      `${palette.bold}[${statusLabel}]${palette.reset} ${methodStyled} ${path} ${statusStyled} (${formatDuration(duration)})`,
+      throw error;
+    }
+
+    logger[pickRequestLogLevel(response.status, url.pathname)](
+      {
+        durationMs: toDurationMs(performance.now() - start),
+        method: request.method,
+        path,
+        status: response.status,
+      },
+      'request completed',
     );
 
     return response;
   };
 }
 
-function pickStatusColor(status: number, palette: Palette): string {
-  if (status >= 200 && status < 300) {
-    return palette.green;
-  }
+const ASSET_PATH_PATTERN = /\.[a-z0-9]+$/i;
 
-  if (status >= 400 && status < 500) {
-    return palette.yellow;
-  }
-
+function pickRequestLogLevel(status: number, pathname: string): keyof RequestLoggerSink {
   if (status >= 500) {
-    return palette.red;
+    return 'error';
   }
 
-  return palette.cyan;
+  if (status >= 400) {
+    return 'warn';
+  }
+
+  return ASSET_PATH_PATTERN.test(pathname) ? 'debug' : 'info';
 }
 
-function pickStatusLabel(status: number): string {
-  if (status >= 200 && status < 300) {
-    return '--->';
-  }
-
-  if (status >= 400 && status < 500) {
-    return 'CLIENT ERROR';
-  }
-
-  if (status >= 500) {
-    return 'SERVER ERROR';
-  }
-
-  return 'OTHER';
-}
-
-function formatRequestPath(url: URL): string {
-  return url.pathname + url.search;
-}
-
-function formatDuration(duration: number): string {
-  if (duration < 1000) {
-    return `${duration.toFixed(2)}ms`;
-  }
-
-  if (duration < 60_000) {
-    return `${(duration / 1000).toFixed(2)}s`;
-  }
-
-  if (duration < 3_600_000) {
-    return `${Math.floor(duration / 60_000)}min ${((duration % 60_000) / 1000).toFixed(2)}s`;
-  }
-
-  return `${Math.floor(duration / 3_600_000)}h ${Math.floor((duration % 3_600_000) / 60_000)}min`;
+/**
+ * Rounds an elapsed-time reading to one decimal so a fast request doesn't log a duration of zero.
+ */
+function toDurationMs(elapsedMs: number): number {
+  return Math.round(elapsedMs * 10) / 10;
 }

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -36,10 +36,11 @@ request's log lines across app-web and the services it called. The line-level co
 - A failure always emits a line at the site that decides the outcome — an error folded into a result
   value, a rejected token, a failed job — carrying the reason in a field (`err`, `failure`, the
   validation issues).
-- Each request logs one line on completion with `method`, `path` (query string included), `status`,
-  and `durationMs`. The service scaffold emits it for every `/rpc` request and leaves `/health`
-  unlogged so platform probes don't dominate volume; app-web's middleware emits it for every
-  request, at `debug` for a served static asset (a pathname with a file extension).
+- Each request logs one line on completion with `method`, `path`, `status`, and `durationMs`. The
+  query string never reaches a log line — query params carry emailed tokens, auth codes, and
+  GET-mapped procedure inputs. The service scaffold emits the line for every `/rpc` request and
+  leaves `/health` unlogged so platform probes don't dominate volume; app-web's middleware emits it
+  for every request, at `debug` for a served static asset (a pathname with a file extension).
 - Presentation is the transport's job: dev consoles pretty-print through `pino-pretty`, and call
   sites never embed color codes or decoration in the message.
 

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -25,8 +25,10 @@ calls it before closing its database pool, since a final gauge collection may st
 ## Log lines
 
 Every pino logger stamps the active request's trace id onto each entry through an AsyncLocalStorage
-mixin, and every HTTP response reports the same id in `x-trace-id`, so one trace id names a
-request's log lines across app-web and the services it called. The line-level conventions:
+mixin, and HTTP responses report the same id in `x-trace-id`, so one trace id names a request's log
+lines across app-web and the services it called. A response built with immutable headers (a
+`Response.redirect`) passes through unstamped and correlates through its request line instead. The
+line-level conventions:
 
 - Data rides in structured fields, never interpolated into the message:
   `logger.info({ method, path, status, durationMs }, 'request completed')`. The message is a stable

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -22,6 +22,27 @@ per-signal headers carry the ingest token and dataset routing. Metrics route by 
 which otherwise keeps the event loop alive. An entrypoint that traps SIGTERM for a graceful drain
 calls it before closing its database pool, since a final gauge collection may still query.
 
+## Log lines
+
+Every pino logger stamps the active request's trace id onto each entry through an AsyncLocalStorage
+mixin, and every HTTP response reports the same id in `x-trace-id`, so one trace id names a
+request's log lines across app-web and the services it called. The line-level conventions:
+
+- Data rides in structured fields, never interpolated into the message:
+  `logger.info({ method, path, status, durationMs }, 'request completed')`. The message is a stable
+  label for the event; the fields are what Axiom queries filter and aggregate on.
+- Severity follows outcome: a 5xx response or a thrown handler logs at `error`, a 4xx at `warn`,
+  everything else at `info`.
+- A failure always emits a line at the site that decides the outcome — an error folded into a result
+  value, a rejected token, a failed job — carrying the reason in a field (`err`, `failure`, the
+  validation issues).
+- Each request logs one line on completion with `method`, `path` (query string included), `status`,
+  and `durationMs`. The service scaffold emits it for every `/rpc` request and leaves `/health`
+  unlogged so platform probes don't dominate volume; app-web's middleware emits it for every
+  request, at `debug` for a served static asset (a pathname with a file extension).
+- Presentation is the transport's job: dev consoles pretty-print through `pino-pretty`, and call
+  sites never embed color codes or decoration in the message.
+
 ## Metrics
 
 Instrumentation is part of a feature: work that adds a pipeline, queue, worker, or failure path

--- a/libs/service/service-runtime/src/create-service.test.ts
+++ b/libs/service/service-runtime/src/create-service.test.ts
@@ -3,6 +3,7 @@ import { implement } from '@orpc/server';
 import { authedRoute, publicRoute } from '@vers/contract-base';
 import { createServiceToken, getTestServiceKeyPair } from '@vers/service-test-utils/bun';
 import { buildRPCTestClient, collectConformanceCases } from '@vers/test-utils';
+import { updateEnv } from '@vers/test-utils/bun';
 import { expectTypeOf } from 'expect-type';
 import * as z from 'zod';
 import { createService } from './create-service';
@@ -39,6 +40,14 @@ function buildTestRouter(contract: ReturnType<typeof buildTestContract>) {
 }
 
 test('it throws at boot when SERVICE_AUTH_PUBLIC_KEY is missing', () => {
+  const originalPublicKey = process.env['SERVICE_AUTH_PUBLIC_KEY'];
+
+  onTestFinished(() => {
+    if (originalPublicKey !== undefined) {
+      process.env['SERVICE_AUTH_PUBLIC_KEY'] = originalPublicKey;
+    }
+  });
+
   delete process.env['SERVICE_AUTH_PUBLIC_KEY'];
   const contract = buildTestContract();
 
@@ -54,9 +63,22 @@ test('it throws at boot when SERVICE_AUTH_PUBLIC_KEY is missing', () => {
 test('it applies default PORT and LOG_LEVEL when unset', async () => {
   const keyPair = await getTestServiceKeyPair();
 
+  const originalLogLevel = process.env['LOG_LEVEL'];
+  const originalPort = process.env['PORT'];
+
+  onTestFinished(() => {
+    if (originalLogLevel !== undefined) {
+      process.env['LOG_LEVEL'] = originalLogLevel;
+    }
+
+    if (originalPort !== undefined) {
+      process.env['PORT'] = originalPort;
+    }
+  });
+
   delete process.env['LOG_LEVEL'];
   delete process.env['PORT'];
-  process.env['SERVICE_AUTH_PUBLIC_KEY'] = keyPair.publicKeyPEM;
+  updateEnv('SERVICE_AUTH_PUBLIC_KEY', keyPair.publicKeyPEM);
 
   const contract = buildTestContract();
 
@@ -73,8 +95,8 @@ test('it applies default PORT and LOG_LEVEL when unset', async () => {
 test('it parses a service-specific envShape variable onto env', async () => {
   const keyPair = await getTestServiceKeyPair();
 
-  process.env['CUSTOM_GREETING'] = 'hi there';
-  process.env['SERVICE_AUTH_PUBLIC_KEY'] = keyPair.publicKeyPEM;
+  updateEnv('CUSTOM_GREETING', 'hi there');
+  updateEnv('SERVICE_AUTH_PUBLIC_KEY', keyPair.publicKeyPEM);
 
   const contract = buildTestContract();
 
@@ -92,12 +114,8 @@ test('it parses a service-specific envShape variable onto env', async () => {
 test('it resolves when OTEL_EXPORTER_OTLP_ENDPOINT is set, wiring the OTel plugin and log shipping at boot', async () => {
   const keyPair = await getTestServiceKeyPair();
 
-  process.env['OTEL_EXPORTER_OTLP_ENDPOINT'] = 'http://127.0.0.1:1/';
-  process.env['SERVICE_AUTH_PUBLIC_KEY'] = keyPair.publicKeyPEM;
-
-  onTestFinished(() => {
-    delete process.env['OTEL_EXPORTER_OTLP_ENDPOINT'];
-  });
+  updateEnv('OTEL_EXPORTER_OTLP_ENDPOINT', 'http://127.0.0.1:1/');
+  updateEnv('SERVICE_AUTH_PUBLIC_KEY', keyPair.publicKeyPEM);
 
   const contract = buildTestContract();
 
@@ -113,7 +131,7 @@ test('it resolves when OTEL_EXPORTER_OTLP_ENDPOINT is set, wiring the OTel plugi
 test('it serves a router built by an async buildRouter', async () => {
   const keyPair = await getTestServiceKeyPair();
 
-  process.env['SERVICE_AUTH_PUBLIC_KEY'] = keyPair.publicKeyPEM;
+  updateEnv('SERVICE_AUTH_PUBLIC_KEY', keyPair.publicKeyPEM);
 
   const contract = buildTestContract();
 
@@ -145,7 +163,7 @@ test('it serves a router built by an async buildRouter', async () => {
 test('it rejects an /rpc call with no Authorization header with a plain 401', async () => {
   const keyPair = await getTestServiceKeyPair();
 
-  process.env['SERVICE_AUTH_PUBLIC_KEY'] = keyPair.publicKeyPEM;
+  updateEnv('SERVICE_AUTH_PUBLIC_KEY', keyPair.publicKeyPEM);
 
   const contract = buildTestContract();
 
@@ -173,7 +191,7 @@ test('it rejects an /rpc call with no Authorization header with a plain 401', as
 test('it rejects an /rpc call with a garbage token with a plain 401', async () => {
   const keyPair = await getTestServiceKeyPair();
 
-  process.env['SERVICE_AUTH_PUBLIC_KEY'] = keyPair.publicKeyPEM;
+  updateEnv('SERVICE_AUTH_PUBLIC_KEY', keyPair.publicKeyPEM);
 
   const contract = buildTestContract();
 
@@ -200,7 +218,7 @@ test('it rejects an /rpc call with a garbage token with a plain 401', async () =
 test('it rejects an /rpc call with an expired token with a plain 401', async () => {
   const keyPair = await getTestServiceKeyPair();
 
-  process.env['SERVICE_AUTH_PUBLIC_KEY'] = keyPair.publicKeyPEM;
+  updateEnv('SERVICE_AUTH_PUBLIC_KEY', keyPair.publicKeyPEM);
 
   const contract = buildTestContract();
 
@@ -233,7 +251,7 @@ test('it rejects an /rpc call with an expired token with a plain 401', async () 
 test('it rejects an /rpc call with a wrong-audience token with a plain 401', async () => {
   const keyPair = await getTestServiceKeyPair();
 
-  process.env['SERVICE_AUTH_PUBLIC_KEY'] = keyPair.publicKeyPEM;
+  updateEnv('SERVICE_AUTH_PUBLIC_KEY', keyPair.publicKeyPEM);
 
   const contract = buildTestContract();
 
@@ -265,7 +283,7 @@ test('it rejects an /rpc call with a wrong-audience token with a plain 401', asy
 test('it returns data from an authed procedure given a valid token naming an acting user', async () => {
   const keyPair = await getTestServiceKeyPair();
 
-  process.env['SERVICE_AUTH_PUBLIC_KEY'] = keyPair.publicKeyPEM;
+  updateEnv('SERVICE_AUTH_PUBLIC_KEY', keyPair.publicKeyPEM);
 
   const contract = buildTestContract();
 
@@ -293,7 +311,7 @@ test('it returns data from an authed procedure given a valid token naming an act
 test('it throws a contract-shaped UNAUTHORIZED for an authed procedure given a valid anonymous token', async () => {
   const keyPair = await getTestServiceKeyPair();
 
-  process.env['SERVICE_AUTH_PUBLIC_KEY'] = keyPair.publicKeyPEM;
+  updateEnv('SERVICE_AUTH_PUBLIC_KEY', keyPair.publicKeyPEM);
 
   const contract = buildTestContract();
 
@@ -321,7 +339,7 @@ test('it throws a contract-shaped UNAUTHORIZED for an authed procedure given a v
 test('it serves /health without any token', async () => {
   const keyPair = await getTestServiceKeyPair();
 
-  process.env['SERVICE_AUTH_PUBLIC_KEY'] = keyPair.publicKeyPEM;
+  updateEnv('SERVICE_AUTH_PUBLIC_KEY', keyPair.publicKeyPEM);
 
   const contract = buildTestContract();
 
@@ -344,7 +362,7 @@ test('it serves /health without any token', async () => {
 test('it mints a fresh trace id when no traceparent is supplied', async () => {
   const keyPair = await getTestServiceKeyPair();
 
-  process.env['SERVICE_AUTH_PUBLIC_KEY'] = keyPair.publicKeyPEM;
+  updateEnv('SERVICE_AUTH_PUBLIC_KEY', keyPair.publicKeyPEM);
 
   const contract = buildTestContract();
 
@@ -362,7 +380,7 @@ test('it mints a fresh trace id when no traceparent is supplied', async () => {
 test('it continues the trace named by an inbound traceparent header', async () => {
   const keyPair = await getTestServiceKeyPair();
 
-  process.env['SERVICE_AUTH_PUBLIC_KEY'] = keyPair.publicKeyPEM;
+  updateEnv('SERVICE_AUTH_PUBLIC_KEY', keyPair.publicKeyPEM);
 
   const contract = buildTestContract();
 
@@ -384,7 +402,7 @@ test('it continues the trace named by an inbound traceparent header', async () =
 test('it mints a fresh trace id for a malformed traceparent header', async () => {
   const keyPair = await getTestServiceKeyPair();
 
-  process.env['SERVICE_AUTH_PUBLIC_KEY'] = keyPair.publicKeyPEM;
+  updateEnv('SERVICE_AUTH_PUBLIC_KEY', keyPair.publicKeyPEM);
 
   const contract = buildTestContract();
 
@@ -406,7 +424,7 @@ test('it mints a fresh trace id for a malformed traceparent header', async () =>
 test('it masks an unexpected handler error as a bare INTERNAL_SERVER_ERROR', async () => {
   const keyPair = await getTestServiceKeyPair();
 
-  process.env['SERVICE_AUTH_PUBLIC_KEY'] = keyPair.publicKeyPEM;
+  updateEnv('SERVICE_AUTH_PUBLIC_KEY', keyPair.publicKeyPEM);
 
   const contract = buildTestContract();
 
@@ -435,7 +453,7 @@ test('it masks an unexpected handler error as a bare INTERNAL_SERVER_ERROR', asy
 test('it does not serve the dropped /api and /spec.json paths', async () => {
   const keyPair = await getTestServiceKeyPair();
 
-  process.env['SERVICE_AUTH_PUBLIC_KEY'] = keyPair.publicKeyPEM;
+  updateEnv('SERVICE_AUTH_PUBLIC_KEY', keyPair.publicKeyPEM);
 
   const contract = buildTestContract();
 
@@ -458,7 +476,7 @@ test('it does not serve the dropped /api and /spec.json paths', async () => {
 test('it passes every conformance case collected from its own contract', async () => {
   const keyPair = await getTestServiceKeyPair();
 
-  process.env['SERVICE_AUTH_PUBLIC_KEY'] = keyPair.publicKeyPEM;
+  updateEnv('SERVICE_AUTH_PUBLIC_KEY', keyPair.publicKeyPEM);
 
   const contract = buildTestContract();
 
@@ -486,7 +504,7 @@ test('it passes every conformance case collected from its own contract', async (
 test('it logs one structured request line when an /rpc call completes', async () => {
   const keyPair = await getTestServiceKeyPair();
 
-  process.env['SERVICE_AUTH_PUBLIC_KEY'] = keyPair.publicKeyPEM;
+  updateEnv('SERVICE_AUTH_PUBLIC_KEY', keyPair.publicKeyPEM);
 
   const contract = buildTestContract();
 
@@ -523,7 +541,7 @@ test('it logs one structured request line when an /rpc call completes', async ()
 test('it logs the rejection reason when the trust boundary rejects a request', async () => {
   const keyPair = await getTestServiceKeyPair();
 
-  process.env['SERVICE_AUTH_PUBLIC_KEY'] = keyPair.publicKeyPEM;
+  updateEnv('SERVICE_AUTH_PUBLIC_KEY', keyPair.publicKeyPEM);
 
   const contract = buildTestContract();
 
@@ -557,7 +575,7 @@ test('it logs the rejection reason when the trust boundary rejects a request', a
 test('it logs a failed /rpc call at error severity', async () => {
   const keyPair = await getTestServiceKeyPair();
 
-  process.env['SERVICE_AUTH_PUBLIC_KEY'] = keyPair.publicKeyPEM;
+  updateEnv('SERVICE_AUTH_PUBLIC_KEY', keyPair.publicKeyPEM);
 
   const contract = buildTestContract();
 
@@ -598,7 +616,7 @@ test('it logs a failed /rpc call at error severity', async () => {
 test('it serves /health without logging a request line', async () => {
   const keyPair = await getTestServiceKeyPair();
 
-  process.env['SERVICE_AUTH_PUBLIC_KEY'] = keyPair.publicKeyPEM;
+  updateEnv('SERVICE_AUTH_PUBLIC_KEY', keyPair.publicKeyPEM);
 
   const contract = buildTestContract();
 

--- a/libs/service/service-runtime/src/create-service.test.ts
+++ b/libs/service/service-runtime/src/create-service.test.ts
@@ -1,4 +1,4 @@
-import { expect, onTestFinished, test } from 'bun:test';
+import { expect, onTestFinished, spyOn, test } from 'bun:test';
 import { implement } from '@orpc/server';
 import { authedRoute, publicRoute } from '@vers/contract-base';
 import { createServiceToken, getTestServiceKeyPair } from '@vers/service-test-utils/bun';
@@ -481,4 +481,136 @@ test('it passes every conformance case collected from its own contract', async (
   for (const conformanceCase of cases) {
     await expect(conformanceCase.run(service.app)).toResolve();
   }
+});
+
+test('it logs one structured request line when an /rpc call completes', async () => {
+  const keyPair = await getTestServiceKeyPair();
+
+  process.env['SERVICE_AUTH_PUBLIC_KEY'] = keyPair.publicKeyPEM;
+
+  const contract = buildTestContract();
+
+  const service = await createService({
+    buildRouter: () => buildTestRouter(contract),
+    envShape: {},
+    name: 'test-service',
+  });
+
+  const infoSpy = spyOn(service.logger, 'info');
+
+  const token = await createServiceToken({
+    audience: 'test-service',
+    privateKey: keyPair.privateKey,
+  });
+
+  const client = buildRPCTestClient<ReturnType<typeof buildTestContract>>(service.app, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+
+  await client.ping();
+
+  expect(infoSpy).toHaveBeenCalledExactlyOnceWith(
+    {
+      durationMs: expect.toBeNumber(),
+      method: 'POST',
+      path: '/rpc/ping',
+      status: 200,
+    },
+    'request completed',
+  );
+});
+
+test('it logs the rejection reason when the trust boundary rejects a request', async () => {
+  const keyPair = await getTestServiceKeyPair();
+
+  process.env['SERVICE_AUTH_PUBLIC_KEY'] = keyPair.publicKeyPEM;
+
+  const contract = buildTestContract();
+
+  const service = await createService({
+    buildRouter: () => buildTestRouter(contract),
+    envShape: {},
+    name: 'test-service',
+  });
+
+  const warnSpy = spyOn(service.logger, 'warn');
+
+  await service.app.handle(
+    new Request('http://test.local/rpc/ping', {
+      headers: { authorization: 'Bearer not-a-real-token' },
+      method: 'POST',
+    }),
+  );
+
+  expect(warnSpy).toHaveBeenCalledExactlyOnceWith(
+    {
+      durationMs: expect.toBeNumber(),
+      failure: 'invalid-service-token',
+      method: 'POST',
+      path: '/rpc/ping',
+      status: 401,
+    },
+    'service token rejected',
+  );
+});
+
+test('it logs a failed /rpc call at error severity', async () => {
+  const keyPair = await getTestServiceKeyPair();
+
+  process.env['SERVICE_AUTH_PUBLIC_KEY'] = keyPair.publicKeyPEM;
+
+  const contract = buildTestContract();
+
+  const service = await createService({
+    buildRouter: () => buildTestRouter(contract),
+    envShape: {},
+    name: 'test-service',
+  });
+
+  const errorSpy = spyOn(service.logger, 'error');
+
+  const token = await createServiceToken({
+    audience: 'test-service',
+    privateKey: keyPair.privateKey,
+  });
+
+  const client = buildRPCTestClient<ReturnType<typeof buildTestContract>>(service.app, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+
+  const pending = client.throwPlainError({});
+
+  expect(pending).rejects.toMatchObject({ code: 'INTERNAL_SERVER_ERROR' });
+
+  await expect(pending).toReject();
+
+  expect(errorSpy).toHaveBeenCalledWith(
+    {
+      durationMs: expect.toBeNumber(),
+      method: 'POST',
+      path: '/rpc/throwPlainError',
+      status: 500,
+    },
+    'request completed',
+  );
+});
+
+test('it serves /health without logging a request line', async () => {
+  const keyPair = await getTestServiceKeyPair();
+
+  process.env['SERVICE_AUTH_PUBLIC_KEY'] = keyPair.publicKeyPEM;
+
+  const contract = buildTestContract();
+
+  const service = await createService({
+    buildRouter: () => buildTestRouter(contract),
+    envShape: {},
+    name: 'test-service',
+  });
+
+  const infoSpy = spyOn(service.logger, 'info');
+
+  await service.app.handle(new Request('http://test.local/health'));
+
+  expect(infoSpy).not.toHaveBeenCalled();
 });

--- a/libs/service/service-runtime/src/create-service.ts
+++ b/libs/service/service-runtime/src/create-service.ts
@@ -222,6 +222,8 @@ interface RegisterORPCHandlerDeps {
  * circuits with a plain 401 before the handler ever runs, per the auth/trust-boundary split in
  * docs/architecture/service-contracts.md. Every response — including that 401 — carries the request's trace id
  * in `x-trace-id`, and the whole request runs inside its trace-context scope so logs correlate.
+ * Every request logs one structured line on completion (method, path, status, duration), severity
+ * following the response status; a trust-boundary rejection's line carries the rejection reason.
  */
 function registerORPCHandler(
   // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- elysia app is a live framework instance with mutable routing state; no readonly form
@@ -236,6 +238,13 @@ function registerORPCHandler(
       const trace = createTrace(context.request);
 
       return withTraceContext(trace, async () => {
+        const start = performance.now();
+        const method = context.request.method;
+
+        const url = new URL(context.request.url);
+
+        const path = url.pathname + url.search;
+
         const resolution = await parseServiceToken(context.request, {
           audience: deps.serviceName,
           publicKey: deps.publicKey,
@@ -245,6 +254,17 @@ function registerORPCHandler(
           const response = Response.json({ error: resolution.failure }, { status: 401 });
 
           response.headers.set('x-trace-id', trace.traceID);
+
+          deps.logger.warn(
+            {
+              durationMs: toDurationMs(performance.now() - start),
+              failure: resolution.failure,
+              method,
+              path,
+              status: 401,
+            },
+            'service token rejected',
+          );
 
           return response;
         }
@@ -265,9 +285,35 @@ function registerORPCHandler(
 
         finalResponse.headers.set('x-trace-id', trace.traceID);
 
+        deps.logger[pickRequestLogLevel(finalResponse.status)](
+          {
+            durationMs: toDurationMs(performance.now() - start),
+            method,
+            path,
+            status: finalResponse.status,
+          },
+          'request completed',
+        );
+
         return finalResponse;
       });
     },
     { parse: 'none' },
   );
+}
+
+function pickRequestLogLevel(status: number): 'error' | 'info' | 'warn' {
+  if (status >= 500) {
+    return 'error';
+  }
+
+  return status >= 400 ? 'warn' : 'info';
+}
+
+/**
+ * Rounds an elapsed-time reading to one decimal so sub-millisecond RPC handling doesn't log as
+ * zero.
+ */
+function toDurationMs(elapsedMs: number): number {
+  return Math.round(elapsedMs * 10) / 10;
 }

--- a/libs/service/service-runtime/src/create-service.ts
+++ b/libs/service/service-runtime/src/create-service.ts
@@ -241,9 +241,9 @@ function registerORPCHandler(
         const start = performance.now();
         const method = context.request.method;
 
-        const url = new URL(context.request.url);
-
-        const path = url.pathname + url.search;
+        // pathname only: a GET-mapped procedure encodes its input in the query string, and logged
+        // inputs belong to the handler's own lines, not the transport's
+        const path = new URL(context.request.url).pathname;
 
         const resolution = await parseServiceToken(context.request, {
           audience: deps.serviceName,

--- a/libs/service/service-runtime/src/create-service.ts
+++ b/libs/service/service-runtime/src/create-service.ts
@@ -269,15 +269,26 @@ function registerORPCHandler(
           return response;
         }
 
-        const handled = await handler.handle(context.request, {
-          context: {
-            actingSessionId: resolution.actingSessionId,
-            actingUserId: resolution.actingUserId,
-            logger: deps.logger,
-            traceID: trace.traceID,
-          },
-          prefix,
-        });
+        let handled: Awaited<ReturnType<typeof handler.handle>>;
+
+        try {
+          handled = await handler.handle(context.request, {
+            context: {
+              actingSessionId: resolution.actingSessionId,
+              actingUserId: resolution.actingUserId,
+              logger: deps.logger,
+              traceID: trace.traceID,
+            },
+            prefix,
+          });
+        } catch (error) {
+          deps.logger.error(
+            { durationMs: toDurationMs(performance.now() - start), err: error, method, path },
+            'request failed',
+          );
+
+          throw error;
+        }
 
         const finalResponse = handled.matched
           ? handled.response
@@ -311,8 +322,8 @@ function pickRequestLogLevel(status: number): 'error' | 'info' | 'warn' {
 }
 
 /**
- * Rounds an elapsed-time reading to one decimal so sub-millisecond RPC handling doesn't log as
- * zero.
+ * Rounds an elapsed-time reading to one decimal, keeping the sub-millisecond resolution that
+ * whole-millisecond rounding would discard.
  */
 function toDurationMs(elapsedMs: number): number {
   return Math.round(elapsedMs * 10) / 10;

--- a/libs/service/service-runtime/test-setup.ts
+++ b/libs/service/service-runtime/test-setup.ts
@@ -1,17 +1,3 @@
-import { afterEach, beforeEach } from 'bun:test';
+import { registerBunTestCleanup } from '@vers/test-utils/bun';
 
-let envSnapshot: NodeJS.ProcessEnv;
-
-beforeEach(() => {
-  envSnapshot = { ...process.env };
-});
-
-afterEach(() => {
-  for (const key of Object.keys(process.env)) {
-    if (!(key in envSnapshot)) {
-      delete process.env[key];
-    }
-  }
-
-  Object.assign(process.env, envSnapshot);
-});
+registerBunTestCleanup();


### PR DESCRIPTION
## Description

Defines the log-line standard in `docs/architecture/observability.md` and applies it to request lifecycles on both sides, so every request produces one queryable line. First of two PRs for #380 — the silent-failure backfill follows and this PR's standard governs it, so no `Closes` here.

- Service runtime logs one structured completion line per `/rpc` request (method, path, status, duration); `/health` stays unlogged so platform probes don't dominate volume.
- The s2s rejection reason, previously computed and returned but never logged, rides on that line at warn.
- app-web's request logger is rebuilt to the standard: structured fields, severity from status (4xx warn, 5xx error), an error line when the handler throws, assets at debug, ANSI decoration removed — dev prettiness is pino-pretty's job.
- Start-of-request lines are dropped: doubled volume for near-zero value.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/zgeoff/vers/pull/614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

