### PR TITLE
fix: cast the funnel timestamp for windowfunnel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ styled-system-studio
 __pycache__/
 *.pyc
 .pytest_cache/
+
+# tinybird CLI local auth state
+.tinyb

--- a/infra/tinybird/pipes/activation_funnel.pipe
+++ b/infra/tinybird/pipes/activation_funnel.pipe
@@ -11,7 +11,7 @@ SQL >
     SELECT
         user_id,
         windowFunnel({{ Int32(window_seconds, 2592000) }})(
-            timestamp,
+            toDateTime(timestamp),
             event_name = 'session_started',
             event_name = 'activity_started',
             event_name = 'activity_completed'


### PR DESCRIPTION
## Description

windowFunnel rejects a DateTime64 first argument, so the activation-funnel deploy failed validation; casting with toDateTime narrows to second precision, which stage ordering tolerates. Also ignores the Tinybird CLI's local `.tinyb` auth file.

- validated with `tb deploy --check` against the vers workspace

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality

## Context

Datafiles have no runner coverage; `tb deploy --check` is the validation.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/zgeoff/vers/pull/615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

