### PR TITLE
feat(#380): log the silent failure paths across services and app-web

### DIFF
--- a/apps/web/src/lib/auth/check-honeypot.test.ts
+++ b/apps/web/src/lib/auth/check-honeypot.test.ts
@@ -1,4 +1,4 @@
-import { expect, spyOn, test } from 'bun:test';
+import { expect, onTestFinished, spyOn, test } from 'bun:test';
 import { logger } from '../../server/logger';
 import { checkHoneypot } from './check-honeypot';
 import { HONEYPOT_FIELD_NAME, HONEYPOT_VALID_FROM_FIELD_NAME } from './honeypot-field-names';
@@ -60,6 +60,35 @@ test('it flags a submission whose valid-from field is an empty string outside te
       process.env.NODE_ENV = previousNodeEnv;
     }
   }
+});
+
+test('it logs a timing spam flag with its reason outside test mode', () => {
+  const warnSpy = spyOn(logger, 'warn');
+
+  const formData = new FormData();
+
+  formData.set(HONEYPOT_VALID_FROM_FIELD_NAME, String(Date.now() + 60_000));
+
+  const previousNodeEnv = process.env.NODE_ENV;
+
+  onTestFinished(() => {
+    if (previousNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = previousNodeEnv;
+    }
+  });
+
+  process.env.NODE_ENV = 'production';
+
+  expect(() => {
+    checkHoneypot(formData);
+  }).toThrow();
+
+  expect(warnSpy).toHaveBeenCalledExactlyOnceWith(
+    { reason: 'timing' },
+    'form submission flagged as spam',
+  );
 });
 
 test('it flags a submission arriving before its form-render valid-from timestamp outside test mode', () => {

--- a/apps/web/src/lib/auth/check-honeypot.test.ts
+++ b/apps/web/src/lib/auth/check-honeypot.test.ts
@@ -1,4 +1,5 @@
-import { expect, test } from 'bun:test';
+import { expect, spyOn, test } from 'bun:test';
+import { logger } from '../../server/logger';
 import { checkHoneypot } from './check-honeypot';
 import { HONEYPOT_FIELD_NAME, HONEYPOT_VALID_FROM_FIELD_NAME } from './honeypot-field-names';
 
@@ -20,6 +21,23 @@ test('it flags a submission with a filled-in honeypot field', () => {
   expect(() => {
     checkHoneypot(formData);
   }).toThrowWithMessage(Error, 'Form not submitted properly');
+});
+
+test('it logs a spam flag with its reason', () => {
+  const warnSpy = spyOn(logger, 'warn');
+
+  const formData = new FormData();
+
+  formData.set(HONEYPOT_FIELD_NAME, 'a bot filled this in');
+
+  expect(() => {
+    checkHoneypot(formData);
+  }).toThrow();
+
+  expect(warnSpy).toHaveBeenCalledExactlyOnceWith(
+    { reason: 'honeypot-field' },
+    'form submission flagged as spam',
+  );
 });
 
 test('it flags a submission whose valid-from field is an empty string outside test mode', () => {

--- a/apps/web/src/lib/auth/check-honeypot.ts
+++ b/apps/web/src/lib/auth/check-honeypot.ts
@@ -1,15 +1,18 @@
+import { logger } from '../../server/logger';
 import { HONEYPOT_FIELD_NAME, HONEYPOT_VALID_FROM_FIELD_NAME } from './honeypot-field-names';
 import { SpamError } from './spam-error';
 
 /**
  * Throws {@link SpamError} for a filled-in honeypot field or a submission that arrived before its
- * form's `valid-from` timestamp. Skips the timing check under `NODE_ENV=test`: tests submit forms
- * instantly, well inside the window a bot would be flagged for.
+ * form's `valid-from` timestamp, logging the flag so spam pressure is visible. Skips the timing
+ * check under `NODE_ENV=test`: tests submit forms instantly, well inside the window a bot would
+ * be flagged for.
  */
 export function checkHoneypot(formData: FormData): void {
   const honeypotValue = formData.get(HONEYPOT_FIELD_NAME);
 
   if (typeof honeypotValue === 'string' && honeypotValue !== '') {
+    logger.warn({ reason: 'honeypot-field' }, 'form submission flagged as spam');
     throw new SpamError('Form not submitted properly');
   }
 
@@ -21,6 +24,7 @@ export function checkHoneypot(formData: FormData): void {
   const validFromMs = typeof validFrom === 'string' ? Number(validFrom) : Number.NaN;
 
   if (!Number.isFinite(validFromMs) || validFromMs <= 0 || Date.now() < validFromMs) {
+    logger.warn({ reason: 'timing' }, 'form submission flagged as spam');
     throw new SpamError('Form not submitted properly');
   }
 }

--- a/apps/web/src/lib/auth/check-step-up.ts
+++ b/apps/web/src/lib/auth/check-step-up.ts
@@ -1,6 +1,7 @@
 import { createId } from '@paralleldrive/cuid2';
 import { getRequestIP } from '@tanstack/react-start/server';
 import type { SecureAction } from '@vers/contract-session';
+import { logger } from '../../server/logger';
 import { sessionClient } from '../rpc/clients/session-client';
 import { verificationClient } from '../rpc/clients/verification-client';
 import { verifyStepUpTransactionToken } from './create-step-up-transaction-token';
@@ -61,7 +62,11 @@ async function tryConsumeStepUpToken(
   token: string,
   sessionID: string | null,
 ): Promise<boolean> {
-  const claims = await verifyStepUpTransactionToken(token).catch(() => null);
+  const claims = await verifyStepUpTransactionToken(token).catch((error: unknown) => {
+    logger.warn({ err: error }, 'step-up token verification failed');
+
+    return null;
+  });
 
   if (
     claims === null ||

--- a/apps/web/src/lib/auth/run-logout.ts
+++ b/apps/web/src/lib/auth/run-logout.ts
@@ -1,4 +1,5 @@
 import { redirect } from '@tanstack/react-router';
+import { logger } from '../../server/logger';
 import { sessionClient } from '../rpc/clients/session-client';
 import { getAuthSession } from './get-auth-session';
 import { removeAuthSession } from './remove-auth-session';
@@ -23,7 +24,9 @@ export async function runLogout(options: LogoutOptions = {}): Promise<never> {
 
     await sessionClient
       .deleteSession({ id: sessionID }, { context: { actingUserID } })
-      .catch(() => {});
+      .catch((error: unknown) => {
+        logger.warn({ err: error }, 'session delete during logout failed');
+      });
   }
 
   await removeAuthSession();

--- a/apps/web/src/lib/auth/verify-step-up-handler.ts
+++ b/apps/web/src/lib/auth/verify-step-up-handler.ts
@@ -1,7 +1,8 @@
-import { safe } from '@orpc/client';
+import { isDefinedError, safe } from '@orpc/client';
 import { getRequestIP } from '@tanstack/react-start/server';
 import { SecureActionSchema } from '@vers/contract-session';
 import * as z from 'zod';
+import { logger } from '../../server/logger';
 import { sessionClient } from '../rpc/clients/session-client';
 import { verificationClient } from '../rpc/clients/verification-client';
 import { createStepUpTransactionToken } from './create-step-up-transaction-token';
@@ -31,6 +32,10 @@ export async function verifyStepUpHandler(input: VerifyStepUpInput): Promise<Ver
   );
 
   if (codeError) {
+    if (!isDefinedError(codeError)) {
+      logger.error({ err: codeError }, 'step-up code check failed');
+    }
+
     const failedAttempt = await sessionClient.stepUp.recordFailedAttempt({
       id: input.transactionID,
     });

--- a/apps/web/src/lib/session/try-read-current-user.ts
+++ b/apps/web/src/lib/session/try-read-current-user.ts
@@ -1,6 +1,7 @@
 import { isDefinedError, safe } from '@orpc/client';
 import type { UnauthorizedReason } from '@vers/contract-base';
 import type { UserData } from '@vers/contract-user';
+import { logger } from '../../server/logger';
 import { userClient } from '../rpc/clients/user-client';
 
 /**
@@ -25,6 +26,8 @@ export async function tryReadCurrentUser(): Promise<CurrentUserResult> {
   if (isDefined && isDefinedError(error)) {
     return { authenticated: false, reason: error.data.reason };
   }
+
+  logger.error({ err: error }, 'current-user read failed');
 
   return { authenticated: false, reason: 'transport-error' };
 }

--- a/apps/web/src/routes/-account-2fa-verify/verify-two-factor-setup-handler.test.ts
+++ b/apps/web/src/routes/-account-2fa-verify/verify-two-factor-setup-handler.test.ts
@@ -1,6 +1,11 @@
-import { expect, test } from 'bun:test';
+import { expect, spyOn, test } from 'bun:test';
 import { isRedirect } from '@tanstack/react-router';
+import { buildContractMock } from '@vers/client-test-utils/orpc';
+import { verificationContract } from '@vers/contract-verification';
 import * as db from '@vers/mock-services/db';
+import { SERVICE_URLS } from '../../lib/rpc/service-urls';
+import { server } from '../../mocks/node';
+import { logger } from '../../server/logger';
 import { buildFormData } from '../../test-utils/build-form-data';
 import { createSignedInUser } from '../../test-utils/create-signed-in-user';
 import { withRequestContext } from '../../test-utils/with-request-context';
@@ -55,4 +60,36 @@ test('it flips the verification to 2fa and redirects to account for a correct co
   expect(
     db.verificationCollection.findFirst((q) => q.where({ target: signedIn.userID })),
   ).toMatchObject({ type: '2fa' });
+});
+
+test('it logs an unexpected code-check failure while reporting the generic form error', async () => {
+  const signedIn = await createSignedInUser();
+
+  const errorSpy = spyOn(logger, 'error');
+
+  const mockVerification = buildContractMock({
+    baseUrl: SERVICE_URLS.verification,
+    contract: verificationContract,
+    resolveContext: () => ({ actingUserId: null }),
+  });
+
+  server.use(
+    mockVerification.verifyCode.handler(() => {
+      throw new Error('the verification service is unreachable');
+    }),
+  );
+
+  const outcome = await withRequestContext({ cookies: signedIn.cookies }, () =>
+    verifyTwoFactorSetupHandler(buildFormData({ code: '123456', target: signedIn.userID })),
+  );
+
+  expect(outcome.value).toStrictEqual({
+    formError: 'Invalid or expired code',
+    status: 'invalid-fields',
+  });
+
+  expect(errorSpy).toHaveBeenCalledExactlyOnceWith(
+    { err: expect.toSatisfy((value) => value instanceof Error) },
+    'two-factor setup verification failed',
+  );
 });

--- a/apps/web/src/routes/-account-2fa-verify/verify-two-factor-setup-handler.ts
+++ b/apps/web/src/routes/-account-2fa-verify/verify-two-factor-setup-handler.ts
@@ -1,7 +1,8 @@
-import { safe } from '@orpc/client';
+import { isDefinedError, safe } from '@orpc/client';
 import { redirect } from '@tanstack/react-router';
 import { requireAuth } from '../../lib/auth/require-auth';
 import { verificationClient } from '../../lib/rpc/clients/verification-client';
+import { logger } from '../../server/logger';
 import type { VerifyTwoFactorSetupResult } from './types';
 import { VerifyTwoFactorSetupFormSchema } from './verify-two-factor-setup-form-schema';
 
@@ -33,6 +34,10 @@ export async function verifyTwoFactorSetupHandler(
   );
 
   if (error) {
+    if (!isDefinedError(error)) {
+      logger.error({ err: error }, 'two-factor setup verification failed');
+    }
+
     return { formError: 'Invalid or expired code', status: 'invalid-fields' };
   }
 

--- a/apps/web/src/routes/-avatar-create/run-avatar-create.ts
+++ b/apps/web/src/routes/-avatar-create/run-avatar-create.ts
@@ -1,8 +1,9 @@
-import { safe } from '@orpc/client';
+import { isDefinedError, safe } from '@orpc/client';
 import { redirect } from '@tanstack/react-router';
 import type { z } from 'zod';
 import { requireAuth } from '../../lib/auth/require-auth';
 import { avatarClient } from '../../lib/rpc/clients/avatar-client';
+import { logger } from '../../server/logger';
 import { AvatarCreateFormSchema } from './avatar-create-form-schema';
 import type { AvatarCreateResult } from './types';
 
@@ -26,6 +27,10 @@ export async function runAvatarCreate(formData: FormData): Promise<AvatarCreateR
   );
 
   if (error) {
+    if (!isDefinedError(error)) {
+      logger.error({ err: error }, 'avatar creation failed');
+    }
+
     return {
       fieldErrors: { name: 'An avatar with that name already exists' },
       status: 'invalid-fields',

--- a/apps/web/src/routes/-avatar-create/run-avatar-create.ts
+++ b/apps/web/src/routes/-avatar-create/run-avatar-create.ts
@@ -27,7 +27,9 @@ export async function runAvatarCreate(formData: FormData): Promise<AvatarCreateR
   );
 
   if (error) {
-    if (!isDefinedError(error)) {
+    // only the declared name conflict is normal flow; any other failure — transport, or a defined
+    // error the conflict message would misreport — is logged
+    if (!isDefinedError(error) || error.code !== 'CONFLICT') {
       logger.error({ err: error }, 'avatar creation failed');
     }
 

--- a/apps/web/src/routes/-onboarding/run-onboarding.ts
+++ b/apps/web/src/routes/-onboarding/run-onboarding.ts
@@ -8,6 +8,7 @@ import { SpamError } from '../../lib/auth/spam-error';
 import { updateVerifySession } from '../../lib/auth/update-verify-session';
 import { sessionClient } from '../../lib/rpc/clients/session-client';
 import { userClient } from '../../lib/rpc/clients/user-client';
+import { logger } from '../../server/logger';
 import { OnboardingFormSchema } from './onboarding-form-schema';
 import { requireOnboardingSession } from './require-onboarding-session';
 
@@ -49,6 +50,8 @@ export async function runOnboarding(formData: FormData): Promise<Response | Subm
         fieldErrors: { username: ['A user with that username already exists'] },
       });
     }
+
+    logger.error({ err: error }, 'onboarding account creation failed');
 
     return submission.reply({ formErrors: ['Something went wrong. Please try again.'] });
   }

--- a/apps/web/src/routes/-reset-password/reset-password-handler.ts
+++ b/apps/web/src/routes/-reset-password/reset-password-handler.ts
@@ -1,12 +1,13 @@
 import type { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod/v4';
-import { safe } from '@orpc/client';
+import { isDefinedError, safe } from '@orpc/client';
 import { redirect } from '@tanstack/react-router';
 import { checkHoneypot } from '../../lib/auth/check-honeypot';
 import { requireAnonymous } from '../../lib/auth/require-anonymous';
 import { SpamError } from '../../lib/auth/spam-error';
 import { emailClient } from '../../lib/rpc/clients/email-client';
 import { userClient } from '../../lib/rpc/clients/user-client';
+import { logger } from '../../server/logger';
 import { ResetPasswordFormSchema } from './reset-password-form-schema';
 
 const INVALID_LINK_ERROR = 'This reset link is invalid or has expired.';
@@ -52,6 +53,10 @@ export async function resetPasswordHandler(
   );
 
   if (error) {
+    if (!isDefinedError(error)) {
+      logger.error({ err: error }, 'password reset failed');
+    }
+
     return submission.reply({ formErrors: [INVALID_LINK_ERROR] });
   }
 

--- a/apps/web/src/routes/-verify-otp/verify-otp-handler.ts
+++ b/apps/web/src/routes/-verify-otp/verify-otp-handler.ts
@@ -1,11 +1,12 @@
 import type { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod/v4';
-import { safe } from '@orpc/client';
+import { isDefinedError, safe } from '@orpc/client';
 import { redirect } from '@tanstack/react-router';
 import { checkHoneypot } from '../../lib/auth/check-honeypot';
 import { getVerifySession } from '../../lib/auth/get-verify-session';
 import { SpamError } from '../../lib/auth/spam-error';
 import { verificationClient } from '../../lib/rpc/clients/verification-client';
+import { logger } from '../../server/logger';
 import { runVerification } from './run-verification';
 import { VerifyOTPFormSchema } from './verify-otp-form-schema';
 
@@ -60,6 +61,10 @@ export async function verifyOTPHandler(formData: FormData): Promise<Response | S
   );
 
   if (verifyError) {
+    if (!isDefinedError(verifyError)) {
+      logger.error({ err: verifyError }, 'otp verification failed');
+    }
+
     return submission.reply({ formErrors: ['Invalid or expired code'] });
   }
 

--- a/apps/web/src/server/make-umami-proxy.ts
+++ b/apps/web/src/server/make-umami-proxy.ts
@@ -1,5 +1,6 @@
 import { UMAMI_PATHS } from '../lib/umami-paths';
 import { getClientIPAddress } from './get-client-ip-address';
+import { logger } from './logger';
 import type { Middleware } from './middleware';
 
 interface MakeUmamiProxyOptions {
@@ -84,7 +85,9 @@ async function sendUpstream(target: URL, init?: RelayInit): Promise<Response> {
   // reclaims the connection
   try {
     response = await Promise.race([fetch(target, init), deadline]);
-  } catch {
+  } catch (error) {
+    logger.warn({ err: error }, 'analytics upstream request failed');
+
     return new Response(null, { status: 502 });
   } finally {
     clearTimeout(timer);

--- a/apps/web/test-setup.ts
+++ b/apps/web/test-setup.ts
@@ -1,5 +1,5 @@
 import '@zgeoff/bun-test-extended';
-import { afterEach, expect } from 'bun:test';
+import { afterEach, expect, mock } from 'bun:test';
 import { faker } from '@faker-js/faker';
 import * as jestDOMMatchers from '@testing-library/jest-dom/matchers';
 import { registerZustandReset } from '@vers/client-test-utils';
@@ -61,3 +61,7 @@ registerWorldMapNodeCodexSlotMock();
 const reactTestingLibrary = await import('@testing-library/react');
 
 afterEach(reactTestingLibrary.cleanup);
+
+afterEach(() => {
+  mock.restore();
+});

--- a/libs/service/jobs/src/create-job-queue.test.ts
+++ b/libs/service/jobs/src/create-job-queue.test.ts
@@ -2,6 +2,7 @@ import { expect, onTestFinished, test } from 'bun:test';
 import { createDatabaseFromTemplate } from '@vers/service-test-utils/bun';
 import { Kysely, PostgresDialect } from 'kysely';
 import { Pool } from 'pg';
+import invariant from 'tiny-invariant';
 import * as z from 'zod';
 import { createJobQueue } from './create-job-queue';
 import { defineJobs } from './define-jobs';
@@ -306,4 +307,74 @@ test('it fails a job whose stored payload no longer parses', async () => {
 
   expect(result).toStrictEqual({ completed: 0, failed: 1 });
   expect(received).toBeEmpty();
+});
+
+test('it reports a thrown handler error with the failed delivery it belongs to', async () => {
+  const connectionString = await createDatabaseFromTemplate();
+
+  const defs = defineJobs({ email: { retryLimit: 0, schema: z.object({ to: z.string() }) } });
+  const failures: Array<{ context: { jobID: string; queue: string }; error: unknown }> = [];
+
+  const queue = createJobQueue(defs, {
+    connectionString,
+    handlers: { email: () => Promise.reject(new Error('delivery exploded')) },
+    onJobError: (error, context) => {
+      failures.push({ context, error });
+    },
+  });
+
+  await queue.start();
+
+  onTestFinished(() => queue.stop());
+
+  const jobID = await queue.send('email', { to: 'a@example.com' });
+  const result = await queue.drain();
+
+  expect(result).toStrictEqual({ completed: 0, failed: 1 });
+  expect(failures).toHaveLength(1);
+  invariant(failures[0], 'one failure was reported');
+  expect(failures[0].context).toStrictEqual({ jobID, queue: 'email' });
+  expect(failures[0].error).toMatchObject({ message: 'delivery exploded' });
+});
+
+test('it reports the validation issues of a stored payload that no longer parses', async () => {
+  const connectionString = await createDatabaseFromTemplate();
+
+  const looseDefs = defineJobs({ email: { retryLimit: 0, schema: z.object({ to: z.string() }) } });
+
+  const writer = createJobQueue(looseDefs, {
+    connectionString,
+    handlers: { email: () => Promise.resolve() },
+  });
+
+  await writer.start();
+
+  onTestFinished(() => writer.stop());
+
+  const jobID = await writer.send('email', { to: 'a@example.com' });
+
+  const strictDefs = defineJobs({
+    email: { retryLimit: 0, schema: z.object({ retries: z.number(), to: z.string() }) },
+  });
+
+  const failures: Array<{ context: { jobID: string; queue: string }; error: unknown }> = [];
+
+  const reader = createJobQueue(strictDefs, {
+    connectionString,
+    handlers: { email: () => Promise.resolve() },
+    onJobError: (error, context) => {
+      failures.push({ context, error });
+    },
+  });
+
+  await reader.start();
+
+  onTestFinished(() => reader.stop());
+
+  await reader.drain();
+
+  expect(failures).toHaveLength(1);
+  invariant(failures[0], 'one failure was reported');
+  expect(failures[0].context).toStrictEqual({ jobID, queue: 'email' });
+  expect(failures[0].error).toMatchObject({ name: 'ZodError' });
 });

--- a/libs/service/jobs/src/create-job-queue.ts
+++ b/libs/service/jobs/src/create-job-queue.ts
@@ -36,6 +36,14 @@ export interface JobContext {
   readonly jobID: string;
 }
 
+/**
+ * Identifies the failed delivery an `onJobError` call is about.
+ */
+export interface JobFailureContext {
+  readonly jobID: string;
+  readonly queue: string;
+}
+
 export interface CreateJobQueueConfig<TDefs extends JobDefs> {
   readonly connectionString: string;
   readonly handlers: {
@@ -51,6 +59,14 @@ export interface CreateJobQueueConfig<TDefs extends JobDefs> {
    * Defaults to logging via `console.error` so a fault is never silently swallowed.
    */
   readonly onError?: (error: Error) => void;
+
+  /**
+   * Called when a fetched job is failed — its handler threw, or its stored payload no longer
+   * parses against the job's schema. The drain result carries only counts, so this callback is
+   * the one place a failure's cause is reported. Defaults to logging via `console.error` so the
+   * cause is never discarded.
+   */
+  readonly onJobError?: (error: unknown, context: Readonly<JobFailureContext>) => void;
 }
 
 /**
@@ -79,17 +95,22 @@ export function createJobQueue<TDefs extends JobDefs>(
 
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- erases each job's payload type; the fetch/handle/complete loop re-correlates a handler with its schema by their shared runtime key
   const handlers = config.handlers as JobHandlers;
+  const onJobError = config.onJobError ?? printJobError;
 
   return {
     start: () => startQueues(boss, defs),
     stop: () => boss.stop(),
     send: (name, payload, opts) => sendJob(boss, defs, name, payload, opts),
-    drain: (name) => drainJobs(boss, defs, handlers, name),
+    drain: (name) => drainJobs(boss, defs, handlers, onJobError, name),
   };
 }
 
 function printJobQueueError(error: Error): void {
   console.error('[@vers/jobs] pg-boss error', error);
+}
+
+function printJobError(error: unknown, context: Readonly<JobFailureContext>): void {
+  console.error(`[@vers/jobs] job ${context.jobID} in "${context.queue}" failed`, error);
 }
 
 const DEAD_LETTER_SUFFIX = '.dead';
@@ -148,6 +169,7 @@ async function drainJobs(
   boss: PgBoss,
   defs: JobDefs,
   handlers: JobHandlers,
+  onJobError: (error: unknown, context: Readonly<JobFailureContext>) => void,
   name: string | undefined,
 ): Promise<DrainResult> {
   const names = name === undefined ? Object.keys(defs) : [name];
@@ -174,6 +196,8 @@ async function drainJobs(
         const parsed = def.schema.safeParse(job.data);
 
         if (!parsed.success) {
+          onJobError(parsed.error, { jobID: job.id, queue: queueName });
+
           await boss.fail(queueName, job.id);
 
           failed += 1;
@@ -186,7 +210,9 @@ async function drainJobs(
           await boss.complete(queueName, job.id);
 
           completed += 1;
-        } catch {
+        } catch (error) {
+          onJobError(error, { jobID: job.id, queue: queueName });
+
           await boss.fail(queueName, job.id);
 
           failed += 1;

--- a/libs/service/jobs/src/create-job-queue.ts
+++ b/libs/service/jobs/src/create-job-queue.ts
@@ -61,10 +61,10 @@ export interface CreateJobQueueConfig<TDefs extends JobDefs> {
   readonly onError?: (error: Error) => void;
 
   /**
-   * Called when a fetched job is failed — its handler threw, or its stored payload no longer
-   * parses against the job's schema. The drain result carries only counts, so this callback is
-   * the one place a failure's cause is reported. Defaults to logging via `console.error` so the
-   * cause is never discarded.
+   * Called when a fetched job is failed — its handler or completion step threw, or its stored
+   * payload no longer parses against the job's schema. The drain result carries only counts, so
+   * this callback is the one place a failure's cause is reported. Defaults to logging via
+   * `console.error` so the cause is never discarded.
    */
   readonly onJobError?: (error: unknown, context: Readonly<JobFailureContext>) => void;
 }
@@ -110,7 +110,7 @@ function printJobQueueError(error: Error): void {
 }
 
 function printJobError(error: unknown, context: Readonly<JobFailureContext>): void {
-  console.error(`[@vers/jobs] job ${context.jobID} in "${context.queue}" failed`, error);
+  console.error('[@vers/jobs] job failed', { err: error, ...context });
 }
 
 const DEAD_LETTER_SUFFIX = '.dead';

--- a/libs/service/jobs/src/index.ts
+++ b/libs/service/jobs/src/index.ts
@@ -4,6 +4,7 @@ export type {
   CreateJobQueueConfig,
   DrainResult,
   JobContext,
+  JobFailureContext,
   JobQueue,
   SendJobOptions,
 } from './create-job-queue';

--- a/services/email/src/create-email-job-queue.ts
+++ b/services/email/src/create-email-job-queue.ts
@@ -15,7 +15,7 @@ import {
   renderResetPasswordEmail,
   renderWelcomeEmail,
 } from '@vers/email';
-import type { JobQueue } from '@vers/jobs';
+import type { JobFailureContext, JobQueue } from '@vers/jobs';
 import { createJobQueue, defineJobs } from '@vers/jobs';
 
 /**
@@ -55,6 +55,12 @@ export interface CreateEmailJobQueueConfig {
    * `console.error` fallback when omitted.
    */
   readonly onError?: (error: Error) => void;
+
+  /**
+   * Called for every failed job delivery with its cause; defaults to `@vers/jobs`'s own
+   * `console.error` fallback when omitted.
+   */
+  readonly onJobError?: (error: unknown, context: Readonly<JobFailureContext>) => void;
 }
 
 /**
@@ -142,5 +148,6 @@ export function createEmailJobQueue(
       },
     },
     ...(config.onError !== undefined && { onError: config.onError }),
+    ...(config.onJobError !== undefined && { onJobError: config.onJobError }),
   });
 }

--- a/services/email/src/create-email-service.ts
+++ b/services/email/src/create-email-service.ts
@@ -44,6 +44,12 @@ export async function createEmailService(
         onError: (error) => {
           runtime.logger.error({ err: error }, 'email job queue error');
         },
+        onJobError: (error, context) => {
+          runtime.logger.error(
+            { err: error, jobID: context.jobID, queue: context.queue },
+            'email job failed',
+          );
+        },
       });
 
       return buildEmailRouter({ logger: runtime.logger, queue });

--- a/services/email/src/serve.ts
+++ b/services/email/src/serve.ts
@@ -4,6 +4,8 @@ const emailService = await createEmailService();
 
 await emailService.queue.start();
 
+emailService.service.logger.info('email job queue started');
+
 // Delivers anything enqueued while the process was down; failures are pg-boss's retry/dead-letter
 // problem, not boot's, so this never blocks `listen`.
 // oxlint-disable-next-line unicorn/prefer-top-level-await -- the boot drain is deliberately fire-and-forget so it never delays `listen`

--- a/services/replay/src/replay/create-replay-cache.test.ts
+++ b/services/replay/src/replay/create-replay-cache.test.ts
@@ -1,5 +1,6 @@
 import { expect, mock, test } from 'bun:test';
 import type { SimulationDriver } from '@vers/idle-core';
+import { waitFor } from '@vers/test-utils';
 import { createReplayCache } from './create-replay-cache';
 
 function buildFakeDriver(): SimulationDriver {
@@ -80,4 +81,27 @@ test('it does not stop a re-set entry that reuses the same driver', () => {
   cache.set('act_1', { driver, emittedCount: 2, lastHash: 'hash-2' });
 
   expect(driver.stop).not.toHaveBeenCalled();
+});
+
+test('it reports a driver stop rejection instead of leaving it unhandled', async () => {
+  const reported: Array<unknown> = [];
+
+  const cache = createReplayCache(undefined, (stopError) => {
+    reported.push(stopError);
+  });
+
+  const failure = new Error('stop exploded');
+
+  const entry = {
+    driver: { ...buildFakeDriver(), stop: mock(() => Promise.reject(failure)) },
+    emittedCount: 1,
+    lastHash: 'hash-1',
+  };
+
+  cache.set('act_1', entry);
+  cache.remove('act_1');
+
+  await waitFor(() => {
+    expect(reported).toStrictEqual([failure]);
+  });
 });

--- a/services/replay/src/replay/create-replay-cache.ts
+++ b/services/replay/src/replay/create-replay-cache.ts
@@ -32,8 +32,10 @@ export interface ReplayCache {
 }
 
 /**
- * `onStopError` receives a displaced entry's driver-stop rejection, which otherwise dies as an
- * unhandled rejection; it defaults to `console.error` so a failed cleanup is never silent.
+ * `onStopError` receives the driver-stop rejection of any entry the cache lets go — removed,
+ * replaced, or evicted past the cap — which otherwise dies as an unhandled rejection; it defaults
+ * to `console.error` so a failed cleanup is never silent. A throw from the callback itself falls
+ * back to `console.error` rather than escaping.
  */
 export function createReplayCache(
   cap: number = REPLAY_CACHE_CAP,
@@ -45,7 +47,11 @@ export function createReplayCache(
     try {
       await driver.stop();
     } catch (error) {
-      onStopError(error);
+      try {
+        onStopError(error);
+      } catch {
+        printDriverStopError(error);
+      }
     }
   };
 

--- a/services/replay/src/replay/create-replay-cache.ts
+++ b/services/replay/src/replay/create-replay-cache.ts
@@ -31,14 +31,32 @@ export interface ReplayCache {
   set: (activityID: string, entry: Readonly<CachedReplayStream>) => void;
 }
 
-export function createReplayCache(cap: number = REPLAY_CACHE_CAP): ReplayCache {
+/**
+ * `onStopError` receives a displaced entry's driver-stop rejection, which otherwise dies as an
+ * unhandled rejection; it defaults to `console.error` so a failed cleanup is never silent.
+ */
+export function createReplayCache(
+  cap: number = REPLAY_CACHE_CAP,
+  onStopError: (error: unknown) => void = printDriverStopError,
+): ReplayCache {
   const entries = new Map<string, CachedReplayStream>();
+
+  const stopDriver = async (driver: SimulationDriver): Promise<void> => {
+    try {
+      await driver.stop();
+    } catch (error) {
+      onStopError(error);
+    }
+  };
 
   const remove = (activityID: string): void => {
     const entry = entries.get(activityID);
 
     entries.delete(activityID);
-    void entry?.driver.stop();
+
+    if (entry !== undefined) {
+      void stopDriver(entry.driver);
+    }
   };
 
   const get = (activityID: string): CachedReplayStream | undefined => {
@@ -61,7 +79,7 @@ export function createReplayCache(cap: number = REPLAY_CACHE_CAP): ReplayCache {
     entries.set(activityID, entry);
 
     if (replaced !== undefined && replaced.driver !== entry.driver) {
-      void replaced.driver.stop();
+      void stopDriver(replaced.driver);
     }
 
     const oldestKey = entries.size > cap ? entries.keys().next().value : undefined;
@@ -70,9 +88,16 @@ export function createReplayCache(cap: number = REPLAY_CACHE_CAP): ReplayCache {
       const oldest = entries.get(oldestKey);
 
       entries.delete(oldestKey);
-      void oldest?.driver.stop();
+
+      if (oldest !== undefined) {
+        void stopDriver(oldest.driver);
+      }
     }
   };
 
   return { get, remove, set };
+}
+
+function printDriverStopError(error: unknown): void {
+  console.error('[service-replay] replay cache driver stop failed', error);
 }

--- a/services/replay/src/serve.ts
+++ b/services/replay/src/serve.ts
@@ -26,6 +26,8 @@ const worker = startReplayWorker({
   simVersion: service.env.SIM_ENGINE_HASH,
 });
 
+service.logger.info('replay worker started');
+
 process.on('SIGTERM', () => {
   void handleSIGTERM();
 });

--- a/services/replay/src/worker/start-replay-worker.ts
+++ b/services/replay/src/worker/start-replay-worker.ts
@@ -18,7 +18,9 @@ const MAX_POLL_INTERVAL_MS = 5000;
  * rather than waiting it out.
  */
 export function startReplayWorker(deps: Readonly<ReplayWorkerDeps>): ReplayWorkerHandle {
-  const cache = createReplayCache();
+  const cache = createReplayCache(undefined, (stopError) => {
+    deps.logger.error({ err: stopError }, 'replay cache driver stop failed');
+  });
 
   const controller = new AbortController();
 


### PR DESCRIPTION
## Description

Closes #380

Backfills a log line onto every silent failure path the audit found, each conforming to the log-line standard in `docs/architecture/observability.md`.

- `@vers/jobs` gains an `onJobError` callback reporting each failed delivery's cause — handler throw or stale-payload parse — which the drain counts previously discarded; the email service wires it to its logger.
- The replay cache reports driver-stop rejections (previously unhandled promise rejections); email queue start and replay worker start log lifecycle lines.
- app-web auth flows log unexpected `safe()` errors before folding them into user-facing messages — defined contract errors (wrong code, taken name) stay unlogged as normal flow.
- Honeypot flags, logout's best-effort session delete, step-up token verification, and the umami proxy's upstream failures all log.
- Rate-limiter 429s need no dedicated line — the request-completion line logs them at warn.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/zgeoff/vers/pull/616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

