### PR TITLE
feat: declare the product-events append token in the datasource

### DIFF
--- a/infra/tinybird/datasources/product_events.datasource
+++ b/infra/tinybird/datasources/product_events.datasource
@@ -1,3 +1,5 @@
+TOKEN product_events_append APPEND
+
 DESCRIPTION >
     The behavioural product-event stream: one row per curated event, identity stamped server-side
     by app-web's ingest action. Property columns are sparse — an event writes its own and leaves


### PR DESCRIPTION
## Description

Tinybird Forward workspaces create resource-scoped tokens only through deployments, so the ingest token is declared in the datasource datafile beside the read token the funnel pipe already declares.

- validated with `tb deploy --check` against the vers workspace

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality

## Context

Datafiles have no runner coverage; `tb deploy --check` is the validation.