### PR TITLE
feat: wire tinybird and umami mcp servers

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -12,7 +12,7 @@
       "command": "sh",
       "args": [
         "-c",
-        "BUGSINK_TOKEN=\"$(op read 'op://vers/bugsink/mcp-token')\" exec npx -y @zgeoff/bugsink-mcp"
+        "BUGSINK_TOKEN=\"$(op read 'op://vers/bugsink/mcp-token')\" exec npx -y @zgeoff/bugsink-mcp@0.2.0"
       ],
       "env": {
         "BUGSINK_URL": "https://vers-bugsink.fly.dev"
@@ -26,17 +26,17 @@
       "command": "sh",
       "args": [
         "-c",
-        "exec npx -y mcp-remote \"https://mcp.tinybird.co?token=$(op read 'op://vers/tinybird/read-token')&host=https://api.us-east.tinybird.co\""
+        "exec npx -y mcp-remote@0.1.38 \"https://mcp.tinybird.co?token=$(op read 'op://vers/tinybird/read-token')&host=https://api.us-east.tinybird.co\""
       ]
     },
     "umami": {
       "command": "sh",
       "args": [
         "-c",
-        "UMAMI_USERNAME=\"$(op read 'op://vers/umami/username')\" UMAMI_PASSWORD=\"$(op read 'op://vers/umami/password')\" exec uvx umami-mcp-server"
+        "UMAMI_USERNAME=\"$(op read 'op://vers/umami/username')\" UMAMI_PASSWORD=\"$(op read 'op://vers/umami/password')\" exec uvx umami-mcp-server==0.1.1"
       ],
       "env": {
-        "UMAMI_URL": "https://vers-umami.fly.dev"
+        "UMAMI_API_BASE": "https://vers-umami.fly.dev/api"
       }
     }
   }

--- a/.mcp.json
+++ b/.mcp.json
@@ -21,6 +21,23 @@
     "postgres": {
       "command": "bun",
       "args": ["scripts/src/bin/pg-mcp-launch.ts"]
+    },
+    "tinybird": {
+      "command": "sh",
+      "args": [
+        "-c",
+        "exec npx -y mcp-remote \"https://mcp.tinybird.co?token=$(op read 'op://vers/tinybird/read-token')&host=https://api.us-east.tinybird.co\""
+      ]
+    },
+    "umami": {
+      "command": "sh",
+      "args": [
+        "-c",
+        "UMAMI_USERNAME=\"$(op read 'op://vers/umami/username')\" UMAMI_PASSWORD=\"$(op read 'op://vers/umami/password')\" exec uvx umami-mcp-server"
+      ],
+      "env": {
+        "UMAMI_URL": "https://vers-umami.fly.dev"
+      }
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -26,14 +26,14 @@
       "command": "sh",
       "args": [
         "-c",
-        "exec npx -y mcp-remote@0.1.38 \"https://mcp.tinybird.co?token=$(op read 'op://vers/tinybird/read-token')&host=https://api.us-east.tinybird.co\""
+        "exec npx -y @zgeoff/mcp-remote@0.1.38 \"https://mcp.tinybird.co?token=$(op read 'op://vers/tinybird/read-token')&host=https://api.us-east.tinybird.co\""
       ]
     },
     "umami": {
       "command": "sh",
       "args": [
         "-c",
-        "UMAMI_USERNAME=\"$(op read 'op://vers/umami/username')\" UMAMI_PASSWORD=\"$(op read 'op://vers/umami/password')\" exec uvx umami-mcp-server==0.1.1"
+        "UMAMI_USERNAME=\"$(op read 'op://vers/umami/username')\" UMAMI_PASSWORD=\"$(op read 'op://vers/umami/password')\" exec npx -y @zgeoff/umami-mcp@0.1.0"
       ],
       "env": {
         "UMAMI_API_BASE": "https://vers-umami.fly.dev/api"

--- a/docs/architecture/analytics.md
+++ b/docs/architecture/analytics.md
@@ -20,6 +20,10 @@ answered by the analytics proxy in `app-web`'s server middleware, which forwards
 paths with neutral names keep the tracker off ad-blocker lists that match Umami's default script
 name and third-party analytics origins.
 
+The `umami` MCP server (`.mcp.json`, the community `umami-mcp-server` package launched with the
+dashboard credentials from the `vers` vault's `umami` item) lets agent sessions query the
+dashboard's stats.
+
 Route changes auto-track as pageviews through the tracker's History API hooks. A play session parked
 on one route for hours reads as a single pageview — gameplay engagement is a product-analytics
 question, and pageview counts are not bent toward answering it.
@@ -91,8 +95,10 @@ Worker-broadcast events reach every connected tab, so a multi-tab player can lan
 - `TINYBIRD_URL` and `TINYBIRD_INGEST_TOKEN` — the workspace region's Events API origin and a token
   scoped to append on `product_events` — are Fly secrets on the web app; either one absent disables
   delivery.
-- Query endpoints authenticate with the read token the pipe deploy creates
-  (`product_analytics_read`).
+- Query endpoints authenticate with the read token the deployment creates
+  (`product_analytics_read`), which reads the data source and every declared endpoint.
+- The `tinybird` MCP server (`.mcp.json`, Tinybird's hosted `mcp.tinybird.co`) connects with that
+  read token, so agent sessions query endpoints and run read-only SQL over the event stream.
 - The workspace admin token lives in the `vers` 1Password vault (`tinybird` item).
 
 ### Privacy

--- a/docs/architecture/analytics.md
+++ b/docs/architecture/analytics.md
@@ -20,9 +20,8 @@ answered by the analytics proxy in `app-web`'s server middleware, which forwards
 paths with neutral names keep the tracker off ad-blocker lists that match Umami's default script
 name and third-party analytics origins.
 
-The `umami` MCP server (`.mcp.json`, the community `umami-mcp-server` package launched with the
-dashboard credentials from the `vers` vault's `umami` item) lets agent sessions query the
-dashboard's stats.
+The `umami` MCP server (`.mcp.json`, `@zgeoff/umami-mcp` launched with the dashboard credentials
+from the `vers` vault's `umami` item) lets agent sessions query the dashboard's stats.
 
 Route changes auto-track as pageviews through the tracker's History API hooks. A play session parked
 on one route for hours reads as a single pageview — gameplay engagement is a product-analytics

--- a/infra/tinybird/datasources/product_events.datasource
+++ b/infra/tinybird/datasources/product_events.datasource
@@ -1,4 +1,5 @@
 TOKEN product_events_append APPEND
+TOKEN product_analytics_read READ
 
 DESCRIPTION >
     The behavioural product-event stream: one row per curated event, identity stamped server-side


### PR DESCRIPTION
## Description

Adds `tinybird` and `umami` MCP servers to `.mcp.json` so agent sessions can query both analytics pipelines; both entries read their auth from the vers 1Password vault at launch, so the file stays secret-free.

- tinybird: Tinybird's hosted `mcp.tinybird.co` (streamable HTTP via `mcp-remote`), using the `product_analytics_read` token; the datasource datafile now also declares that token READ so `execute_query`/`explore_data` cover `product_events`
- umami: community `umami-mcp-server` (PyPI, launched via `uvx`) against `vers-umami.fly.dev` — third-party package, flagged for review
- datasource change validated with `tb deploy --check`; a `tb deploy` after merge applies the scope

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality

## Context

No official Umami MCP exists; Alurith/umami-mcp-server is the most established community option.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/zgeoff/vers/pull/620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

