### PR TITLE
feat(#378): run the playwright pr gate against the production build

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -140,6 +140,8 @@
         "ignoreInferredTypes": true,
         "allow": [
           { "from": "package", "name": "Kysely", "package": "kysely" },
+          // a live playwright page handle: driver connection and event state, no readonly form
+          { "from": "package", "name": "Page", "package": "playwright-core" },
           // a live kysely transaction handle: same mutable connection state as Kysely above
           { "from": "package", "name": "Transaction", "package": "kysely" },
           // a live pg-boss client handle: connection pool and event emitter state, no readonly form

--- a/apps/web-e2e/package.json
+++ b/apps/web-e2e/package.json
@@ -8,9 +8,13 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "devDependencies": {
+    "@orpc/server": "catalog:",
     "@playwright/test": "catalog:",
+    "@types/bun": "catalog:",
     "@types/node": "catalog:",
     "@vers/contract-activity": "workspace:*",
+    "@vers/mock-services": "workspace:*",
+    "@vers/service-auth": "workspace:*",
     "typescript": "catalog:"
   }
 }

--- a/apps/web-e2e/playwright.config.ts
+++ b/apps/web-e2e/playwright.config.ts
@@ -2,7 +2,6 @@ import path from 'node:path';
 import { defineConfig, devices } from '@playwright/test';
 
 const baseURL = process.env['BASE_URL'] ?? 'http://localhost:3000';
-const productionBaseURL = process.env['PRODUCTION_BASE_URL'] ?? 'http://localhost:3010';
 
 // having a million issues trying to use __dirname to establish a reliable path
 // so it's easier to do this to handle the case when this file gets parsed for
@@ -46,42 +45,32 @@ export default defineConfig({
   },
   webServer: [
     {
-      // the dev server's own vite plugin starts the mock backend, giving journey specs the mock
-      // services a signed-in flow needs. Only `vite dev` fires that plugin's `configureServer`
-      // hook, so the production build below can't host it. The explicit port keeps a BASE_URL
-      // override honest — vite's config pins a default port that would win otherwise.
-      command: `bun run dev --port ${new URL(baseURL).port}`,
+      // the stateful mock backends as real HTTP listeners on the service dev ports the artifact's
+      // SERVICE_URLS defaults resolve. Never reuse an already-listening server: a service
+      // answering on these ports could be the real dev stack, and specs must never mutate it.
+      command: 'bun src/serve-mock-services.ts',
+      cwd: projectRoot,
+      reuseExistingServer: false,
+      stderr: 'pipe',
+      stdout: 'pipe',
+      timeout: 60 * 1000,
+      url: 'http://localhost:3003/health',
+    },
+    {
+      // every spec runs against the deployable artifact, exactly as built — no mock backend
+      // in-process, no build-time env overrides. The e2e turbo task depends on the app's build
+      // task, so the artifact is already on disk (cached or fresh) — serving it here must not
+      // rebuild it. Downstream service calls leave the process over HTTP and land on the mock
+      // listeners above.
+      command: 'node ./server.mjs',
       cwd: appWebRoot,
       env: {
         // canvas-persistence.spec.ts clicks through to the Market nav link
         FEATURE_MARKET: 'true',
 
-        // specs submit forms instantly; the bot-pacing floor would reject every one of them
-        VITE_HONEYPOT_MIN_FILL_TIME_MS: '0',
-
-        PLAYWRIGHT_TEST_BASE_URL: baseURL,
-
-        // Start's session sealing rejects any password under 32 characters
-        SESSION_SECRET: 'e2e-session-secret-32-characters',
-      },
-      reuseExistingServer: process.env['CI'] === undefined,
-      stderr: 'pipe',
-      stdout: 'pipe',
-      timeout: 240 * 1000,
-      url: baseURL,
-    },
-    {
-      // the real production artifact on its own port, so a smoke spec can prove the deployable
-      // build serves traffic. The e2e turbo task depends on the app's build task, so the artifact
-      // is already on disk (cached or fresh) — serving it here must not rebuild it. It hosts no
-      // mock backend, so only routes that call no downstream service (the health check, the
-      // anonymous home page) work.
-      command: 'node ./server.mjs',
-      cwd: appWebRoot,
-      env: {
         LOGGING: 'warn',
         NODE_ENV: 'production',
-        PORT: new URL(productionBaseURL).port,
+        PORT: new URL(baseURL).port,
 
         // Start's session sealing rejects any password under 32 characters
         SESSION_SECRET: 'e2e-session-secret-32-characters',
@@ -90,7 +79,7 @@ export default defineConfig({
       stderr: 'pipe',
       stdout: 'pipe',
       timeout: 240 * 1000,
-      url: `${productionBaseURL}/health`,
+      url: `${baseURL}/health`,
     },
   ],
 

--- a/apps/web-e2e/playwright.config.ts
+++ b/apps/web-e2e/playwright.config.ts
@@ -54,14 +54,18 @@ export default defineConfig({
       stderr: 'pipe',
       stdout: 'pipe',
       timeout: 60 * 1000,
-      url: 'http://localhost:3003/health',
+
+      // the same override-then-default resolution the spawned listeners apply per service
+      url: `${process.env['USER_SERVICE_URL'] ?? 'http://localhost:3003'}/health`,
     },
     {
       // every spec runs against the deployable artifact, exactly as built — no mock backend
       // in-process, no build-time env overrides. The e2e turbo task depends on the app's build
       // task, so the artifact is already on disk (cached or fresh) — serving it here must not
       // rebuild it. Downstream service calls leave the process over HTTP and land on the mock
-      // listeners above.
+      // listeners above. Never reuse an already-listening server: whatever answers on this port
+      // (a leftover vite dev, another app) is not the artifact, and reusing it silently voids
+      // the production-build guarantee.
       command: 'node ./server.mjs',
       cwd: appWebRoot,
       env: {
@@ -75,7 +79,7 @@ export default defineConfig({
         // Start's session sealing rejects any password under 32 characters
         SESSION_SECRET: 'e2e-session-secret-32-characters',
       },
-      reuseExistingServer: process.env['CI'] === undefined,
+      reuseExistingServer: false,
       stderr: 'pipe',
       stdout: 'pipe',
       timeout: 240 * 1000,

--- a/apps/web-e2e/src/avatar-satellite.spec.ts
+++ b/apps/web-e2e/src/avatar-satellite.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { waitForHoneypotWindow } from './wait-for-honeypot-window';
 
 /**
  * `/avatar` mounts its own satellite canvas alongside the persistent world canvas: two `<canvas>`
@@ -26,6 +27,9 @@ test('it mounts a second canvas for the avatar satellite and drops it on navigat
   await page.locator('html[data-hydrated]').waitFor();
   await page.getByLabel('Email').fill('e2e-avatar-satellite@vers.test');
   await page.getByLabel('Password').fill('password123');
+
+  await waitForHoneypotWindow(page);
+
   await page.getByRole('button', { exact: true, name: 'Login' }).click();
 
   await expect(page).toHaveURL(/\/avatar$/);

--- a/apps/web-e2e/src/canvas-persistence.spec.ts
+++ b/apps/web-e2e/src/canvas-persistence.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { waitForHoneypotWindow } from './wait-for-honeypot-window';
 
 /**
  * The `_game` layout mounts its canvas once and never remounts it across child-route navigation:
@@ -28,6 +29,9 @@ test('it keeps the same canvas element across client-side game navigation', asyn
   await page.locator('html[data-hydrated]').waitFor();
   await page.getByLabel('Email').fill('e2e-canvas@vers.test');
   await page.getByLabel('Password').fill('password123');
+
+  await waitForHoneypotWindow(page);
+
   await page.getByRole('button', { exact: true, name: 'Login' }).click();
 
   await expect(page).toHaveURL(/\/explore$/);

--- a/apps/web-e2e/src/game-smoke.spec.ts
+++ b/apps/web-e2e/src/game-smoke.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { waitForHoneypotWindow } from './wait-for-honeypot-window';
 
 test('it renders respite, avatar, and explore for a signed-in caller without console errors', async ({
   page,
@@ -21,6 +22,9 @@ test('it renders respite, avatar, and explore for a signed-in caller without con
   await page.locator('html[data-hydrated]').waitFor();
   await page.getByLabel('Email').fill('e2e-game@vers.test');
   await page.getByLabel('Password').fill('password123');
+
+  await waitForHoneypotWindow(page);
+
   await page.getByRole('button', { exact: true, name: 'Login' }).click();
 
   await expect(page).toHaveURL(/\/respite$/);

--- a/apps/web-e2e/src/home-smoke.spec.ts
+++ b/apps/web-e2e/src/home-smoke.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { waitForHoneypotWindow } from './wait-for-honeypot-window';
 
 /**
  * Exercises the Flight pipeline against a live dev server booted against the mock backend: the
@@ -39,6 +40,9 @@ test('it serves the signed-in home page server-rendered, lands at respite, and l
   await page.locator('html[data-hydrated]').waitFor();
   await page.getByLabel('Email').fill('demo@vers.test');
   await page.getByLabel('Password').fill('password123');
+
+  await waitForHoneypotWindow(page);
+
   await page.getByRole('button', { exact: true, name: 'Login' }).click();
   await page.waitForURL(/\/respite$/);
 

--- a/apps/web-e2e/src/production-boot-smoke.spec.ts
+++ b/apps/web-e2e/src/production-boot-smoke.spec.ts
@@ -1,15 +1,10 @@
 import { expect, test } from '@playwright/test';
 
-const PRODUCTION_BASE_URL = process.env['PRODUCTION_BASE_URL'] ?? 'http://localhost:3010';
-
 /**
- * The production server hosts no mock backend, so only routes with no downstream service call
- * can be asserted here.
+ * Serving proof for the deployable artifact needing no signed-in state and no secrets: the health
+ * check answers and the anonymous home page renders.
  */
-test('it serves the production build health check and anonymous home page', async ({
-  playwright,
-}) => {
-  const request = await playwright.request.newContext({ baseURL: PRODUCTION_BASE_URL });
+test('it serves the production build health check and anonymous home page', async ({ request }) => {
   const health = await request.get('/health');
 
   expect(health.status()).toBe(200);
@@ -20,6 +15,4 @@ test('it serves the production build health check and anonymous home page', asyn
 
   expect(root.status()).toBe(200);
   expect(root.headers()['content-type']).toContain('text/html');
-
-  await request.dispose();
 });

--- a/apps/web-e2e/src/serve-mock-services.ts
+++ b/apps/web-e2e/src/serve-mock-services.ts
@@ -60,6 +60,10 @@ for (const service of SERVICES) {
 
       return handled.matched ? handled.response : new Response(null, { status: 404 });
     },
+
+    // never the wildcard interface: these routers accept unverified bearer subjects and expose
+    // mutating procedures, so nothing beyond this host may reach them
+    hostname: url.hostname,
     port: Number(url.port),
   });
 

--- a/apps/web-e2e/src/serve-mock-services.ts
+++ b/apps/web-e2e/src/serve-mock-services.ts
@@ -1,0 +1,67 @@
+import { RPCHandler } from '@orpc/server/fetch';
+import type { MockContext } from '@vers/mock-services';
+import { createDemoSeed, resolveServiceURL, resolveSessionContext } from '@vers/mock-services';
+import { activityRouter } from '@vers/mock-services/activity';
+import { avatarRouter } from '@vers/mock-services/avatar';
+import { emailRouter } from '@vers/mock-services/email';
+import { keysRouter } from '@vers/mock-services/keys';
+import { replayRouter } from '@vers/mock-services/replay';
+import { sessionRouter } from '@vers/mock-services/session';
+import { userRouter } from '@vers/mock-services/user';
+import { verificationRouter } from '@vers/mock-services/verification';
+import type { ServiceName } from '@vers/service-auth';
+
+/**
+ * Serves the stateful mock backends over real HTTP, one listener per service on the same origins
+ * the production server's `SERVICE_URLS` defaults resolve, so `server.mjs` needs no env
+ * repointing. The vite-dev mock plugin hosts these same routers in-process; this entrypoint
+ * exists for runs against the built artifact, which can host no mock backend. Requests
+ * round-trip oRPC's real wire protocol; a procedure a router doesn't implement 404s.
+ */
+const RPC_HANDLERS: Readonly<Record<ServiceName, RPCHandler<MockContext>>> = {
+  activity: new RPCHandler(activityRouter),
+  avatar: new RPCHandler(avatarRouter),
+  email: new RPCHandler(emailRouter),
+  keys: new RPCHandler(keysRouter),
+  replay: new RPCHandler(replayRouter),
+  session: new RPCHandler(sessionRouter),
+  user: new RPCHandler(userRouter),
+  verification: new RPCHandler(verificationRouter),
+};
+
+await createDemoSeed();
+
+const SERVICES = [
+  'activity',
+  'avatar',
+  'email',
+  'keys',
+  'replay',
+  'session',
+  'user',
+  'verification',
+] as const satisfies ReadonlyArray<ServiceName>;
+
+for (const service of SERVICES) {
+  const rpcHandler = RPC_HANDLERS[service];
+
+  const url = new URL(resolveServiceURL(service));
+
+  Bun.serve({
+    fetch: async (request) => {
+      if (new URL(request.url).pathname === '/health') {
+        return Response.json({ ok: true });
+      }
+
+      const handled = await rpcHandler.handle(request, {
+        context: resolveSessionContext(request),
+        prefix: '/rpc',
+      });
+
+      return handled.matched ? handled.response : new Response(null, { status: 404 });
+    },
+    port: Number(url.port),
+  });
+
+  console.log(`mock ${service} listening on ${url.origin}`);
+}

--- a/apps/web-e2e/src/wait-for-honeypot-window.ts
+++ b/apps/web-e2e/src/wait-for-honeypot-window.ts
@@ -2,9 +2,9 @@ import type { Page } from '@playwright/test';
 
 /**
  * Waits until the page's honeypot valid-from timestamp has passed, so a form submit isn't flagged
- * as bot-speed. The suite runs the production artifact with its real 1500ms human-speed floor —
- * no build-time override — so every spec that submits an auth form must pace itself past the
- * window the freshly rendered form declares.
+ * as bot-speed. The suite runs the production artifact with its real human-speed floor — no
+ * build-time override — so every spec that submits an auth form must pace itself past the window
+ * the freshly rendered form declares.
  */
 export async function waitForHoneypotWindow(page: Page): Promise<void> {
   const validFrom = await page.locator('input[name="from__confirm"]').inputValue();

--- a/apps/web-e2e/src/wait-for-honeypot-window.ts
+++ b/apps/web-e2e/src/wait-for-honeypot-window.ts
@@ -1,0 +1,17 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Waits until the page's honeypot valid-from timestamp has passed, so a form submit isn't flagged
+ * as bot-speed. The suite runs the production artifact with its real 1500ms human-speed floor —
+ * no build-time override — so every spec that submits an auth form must pace itself past the
+ * window the freshly rendered form declares.
+ */
+export async function waitForHoneypotWindow(page: Page): Promise<void> {
+  const validFrom = await page.locator('input[name="from__confirm"]').inputValue();
+
+  const remainingMs = Number(validFrom) - Date.now();
+
+  if (remainingMs > 0) {
+    await page.waitForTimeout(remainingMs + 100);
+  }
+}

--- a/apps/web-e2e/tsconfig.json
+++ b/apps/web-e2e/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "lib": ["ES2024", "DOM"],
-    "types": ["node"]
+    "types": ["node", "bun"]
   },
   "include": ["playwright.config.ts", "src/**/*.ts"]
 }

--- a/apps/web/src/lib/auth/build-honeypot-valid-from.ts
+++ b/apps/web/src/lib/auth/build-honeypot-valid-from.ts
@@ -4,16 +4,10 @@
 const HONEYPOT_MIN_FILL_TIME_MS = 1500;
 
 /**
- * Computes the valid-from timestamp for a freshly rendered form.
- *
- * Client hydration recomputes the rendered value, so the override must reach the browser bundle:
- * `VITE_HONEYPOT_MIN_FILL_TIME_MS` lifts the human-speed floor so e2e runs can submit forms
- * instantly. Production builds never set it.
+ * Computes the valid-from timestamp for a freshly rendered form. The floor has no env override:
+ * e2e specs pace their submits past the window instead, so the artifact under test enforces the
+ * same timing it ships with.
  */
 export function buildHoneypotValidFrom(): string {
-  const envOverride: string | undefined = import.meta.env['VITE_HONEYPOT_MIN_FILL_TIME_MS'];
-  const overrideMs = Number(envOverride);
-  const minFillTimeMs = Number.isFinite(overrideMs) ? overrideMs : HONEYPOT_MIN_FILL_TIME_MS;
-
-  return String(Date.now() + minFillTimeMs);
+  return String(Date.now() + HONEYPOT_MIN_FILL_TIME_MS);
 }

--- a/bun.lock
+++ b/bun.lock
@@ -120,9 +120,13 @@
       "name": "@vers/web-e2e",
       "version": "0.0.0",
       "devDependencies": {
+        "@orpc/server": "catalog:",
         "@playwright/test": "catalog:",
+        "@types/bun": "catalog:",
         "@types/node": "catalog:",
         "@vers/contract-activity": "workspace:*",
+        "@vers/mock-services": "workspace:*",
+        "@vers/service-auth": "workspace:*",
         "typescript": "catalog:",
       },
     },

--- a/knip.json
+++ b/knip.json
@@ -41,6 +41,9 @@
       ],
       "ignoreDependencies": ["pino", "pino-pretty"]
     },
+    "apps/web-e2e": {
+      "entry": ["src/serve-mock-services.ts"]
+    },
     "libs/data/db": {
       "entry": ["kysely.config.ts", "migrations/*.ts", "seeds/*.ts"]
     },


### PR DESCRIPTION
## Description

Part of #378 (does not close it). Journey specs ran against `vite dev` because only its plugin could host the in-process MSW backend; every spec now drives the deployable artifact exactly as built.

- `serve-mock-services.ts` hosts the existing mock routers over real HTTP — one Bun listener per service on the `SERVICE_URLS` dev ports — so `server.mjs` needs no env repointing and no mock code reaches the artifact.
- MSW drops out of the e2e path entirely: the routers were always real oRPC handlers, MSW only intercepted in-process fetches.
- The build-time honeypot floor override is deleted; specs pace submits past the artifact's real 1500ms window via `waitForHoneypotWindow`, so the shipping timing gate is now under test.
- The mock-host webServer never reuses an already-listening server — ports answering there could be the real dev stack.
- The separate 3010 production smoke server is gone; its spec now runs against the same (only) server.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality (all 7 specs pass against the production artifact locally)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/zgeoff/vers/pull/623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

