### PR TITLE
feat(#378): split main rollouts into build and cutover jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -219,12 +219,12 @@ jobs:
   deploy:
     name: Deploy
     needs: [checks, migrate, manifest, build]
-    # cut over only a fully green build, after the shared schema is current.
-    # The build job is an ordering edge, not a gate: its matrix result is the
-    # worst leg across all apps, and one app's failed build must not abandon
-    # the others' rollouts — an app whose own build failed cuts over to a
-    # missing ref and its leg fails alone. Legs self-gate on staleness exactly
-    # as the build phase does.
+    # cut over after the build phase completes and the shared schema is
+    # current. The build job is an ordering edge, not a gate: its matrix
+    # result is the worst leg across all apps, and one app's failed build must
+    # not abandon the others' rollouts — an app whose own build failed cuts
+    # over to a missing ref and its leg fails alone. Legs self-gate on
+    # staleness exactly as the build phase does.
     if:
       ${{ !cancelled() && needs.checks.result == 'success' && needs.migrate.result == 'success' &&
       needs.manifest.result == 'success' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,21 +163,73 @@ jobs:
         id: list
         run: echo "apps=$(bun scripts/src/bin/deploy.ts list)" >> "$GITHUB_OUTPUT"
 
+  build:
+    name: Build
+    needs: [checks, manifest]
+    # build images for every stale app as soon as checks are green — the phase
+    # has no fleet side effects, so it runs beside migrate rather than after
+    # it. Each leg self-gates inside the deploy CLI: it compares HEAD against
+    # the GIT_SHA stamped on the app's machines, so a build skipped by an
+    # earlier failure or cancellation stays "stale" and ships on the next push.
+    if: ${{ needs.checks.result == 'success' && needs.manifest.result == 'success' }}
+    runs-on: ubuntu-latest
+    environment: production
+    # worst observed leg (app-web remote build) is ~4 minutes; headroom for
+    # builder variance without holding the queue
+    timeout-minutes: 15
+    # one build per app at a time — a newer run's build overwrites the same
+    # commit-derived tag only after the earlier one finishes with it
+    concurrency:
+      group: ${{ github.workflow }}-build-${{ matrix.app }}
+      cancel-in-progress: false
+    strategy:
+      # each app is independent — one build failing must not abandon the others
+      fail-fast: false
+      matrix:
+        app: ${{ fromJSON(needs.manifest.outputs.apps) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # staleness runs turbo/git against each app's deployed SHA, which can
+          # be many pushes old — the CLI needs full history
+          fetch-depth: 0
+
+      # The image builds and pushes on Fly's remote builder (inside Fly's
+      # network, avoiding a GitHub-runner-to-registry.fly.io blob upload, which
+      # 502s on the large compiled-binary layers), tagged by commit SHA so the
+      # cutover phase derives the same ref without anything travelling between
+      # the jobs.
+      #
+      # app-web's image build bakes the browser DSN into the client bundle and
+      # uploads source maps to the error tracker; both no-op when the token/DSN
+      # aren't configured (the CLI forwards build args only when set).
+      - name: Build ${{ matrix.app }}
+        uses: ./.github/actions/fly-deploy
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
+          VITE_UMAMI_WEBSITE_ID: ${{ vars.VITE_UMAMI_WEBSITE_ID }}
+        with:
+          args: build --app ${{ matrix.app }}
+          fly-api-token: ${{ secrets.FLY_API_TOKEN }}
+
   deploy:
     name: Deploy
-    needs: [checks, migrate, manifest]
-    # deploy only a fully green build, after the shared schema is current. Each
-    # leg self-gates inside the deploy CLI: it compares HEAD against the GIT_SHA
-    # stamped on the app's machines, so a deploy skipped by an earlier failure
-    # or cancellation stays "stale" and ships on the next push instead of being
-    # lost with the push delta.
+    needs: [checks, migrate, manifest, build]
+    # cut over only a fully green build, after the shared schema is current.
+    # The build job is an ordering edge, not a gate: its matrix result is the
+    # worst leg across all apps, and one app's failed build must not abandon
+    # the others' rollouts — an app whose own build failed cuts over to a
+    # missing ref and its leg fails alone. Legs self-gate on staleness exactly
+    # as the build phase does.
     if:
-      ${{ needs.checks.result == 'success' && needs.migrate.result == 'success' &&
+      ${{ !cancelled() && needs.checks.result == 'success' && needs.migrate.result == 'success' &&
       needs.manifest.result == 'success' }}
     runs-on: ubuntu-latest
     environment: production
-    # worst observed leg (app-web remote build + bluegreen cutover) is ~5
-    # minutes; 3× headroom for builder variance without holding the queue
+    # bluegreen cutover plus probes is ~3 minutes at worst; headroom without
+    # holding the queue
     timeout-minutes: 15
     # never cancel a rollout mid-flight; a newer run's deploy waits its turn
     concurrency:
@@ -196,10 +248,7 @@ jobs:
           # be many pushes old — the CLI needs full history
           fetch-depth: 0
 
-      # The CLI splits each rollout into build and cutover: the image builds
-      # and pushes on Fly's remote builder (inside Fly's network, avoiding a
-      # GitHub-runner-to-registry.fly.io blob upload, which 502s on the large
-      # compiled-binary layers), then the fleet cuts over to the pushed ref.
+      # The fleet cuts over to the ref the build phase pushed for this commit.
       # Each app's strategy (per fly.toml) gates cutover on the /health check,
       # so a machine that fails to boot blocks the release; a release that
       # boots but fails its post-deploy probes is rolled back to the app's
@@ -208,20 +257,13 @@ jobs:
       # syd host capacity is intermittently tight: a rollout that can't reserve a
       # machine fails with "insufficient resources / could not reserve resource"
       # and Fly rolls it back cleanly — re-run the failed job.
-      #
-      # app-web's image build bakes the browser DSN into the client bundle and
-      # uploads source maps to the error tracker; both no-op when the token/DSN
-      # aren't configured (the CLI forwards build args only when set).
       - name: Deploy ${{ matrix.app }}
         uses: ./.github/actions/fly-deploy
         env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
-          VITE_UMAMI_WEBSITE_ID: ${{ vars.VITE_UMAMI_WEBSITE_ID }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           SERVICE_AUTH_PUBLIC_KEY: ${{ vars.SERVICE_AUTH_PUBLIC_KEY }}
         with:
-          args: deploy --app ${{ matrix.app }}
+          args: cutover --app ${{ matrix.app }}
           fly-api-token: ${{ secrets.FLY_API_TOKEN }}
 
   verify-fleet:
@@ -253,7 +295,7 @@ jobs:
 
   alert:
     name: Alert on failure
-    needs: [checks, migrate, manifest, deploy, verify-fleet]
+    needs: [checks, migrate, manifest, build, deploy, verify-fleet]
     # a red main pipeline pages the team channel: agent-driven pushes mean
     # nobody is necessarily watching the Actions tab, and a failed deploy or
     # fleet verification left unnoticed is exactly how version skew lingers

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -194,6 +194,8 @@ jobs:
           # staleness runs turbo/git against each app's deployed SHA, which can
           # be many pushes old — the CLI needs full history
           fetch-depth: 0
+          # no later step needs authenticated git access
+          persist-credentials: false
 
       # The image builds and pushes on Fly's remote builder (inside Fly's
       # network, avoiding a GitHub-runner-to-registry.fly.io blob upload, which
@@ -311,8 +313,8 @@ jobs:
             ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           FAILED: >-
             checks=${{ needs.checks.result }}, migrate=${{ needs.migrate.result }}, manifest=${{
-            needs.manifest.result }}, deploy=${{ needs.deploy.result }}, verify-fleet=${{
-            needs.verify-fleet.result }}
+            needs.manifest.result }}, build=${{ needs.build.result }}, deploy=${{
+            needs.deploy.result }}, verify-fleet=${{ needs.verify-fleet.result }}
           COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
           if [ -z "${WEBHOOK_URL}" ]; then

--- a/deploy.config.ts
+++ b/deploy.config.ts
@@ -104,6 +104,7 @@ export default defineDeployManifest({
     {
       app: 'vers-bugsink',
       configDir: 'apps/bugsink',
+      dockerfile: 'apps/bugsink/Dockerfile',
       trigger: { globs: ['apps/bugsink/**'], kind: 'paths' },
     },
     {

--- a/docs/architecture/deployment.md
+++ b/docs/architecture/deployment.md
@@ -92,7 +92,7 @@ rolls out:
    travels between the jobs, and re-running a leg overwrites its own tag instead of minting a new
    artifact. A stale cutover leg deploys that pushed ref (`flyctl deploy --image`), waits for the
    fleet to report the new SHA, then runs the app's post-deploy probes from `deploy.config.ts`. An
-   app with no Dockerfile (`vers-bugsink`) has no build leg work and cuts over to the image named in
+   app with no Dockerfile (`vers-umami`) has no build leg work and cuts over to the image named in
    its `fly.toml`. The CLI's `deploy` command runs both phases in one invocation for a manual
    rollout; `images` prints each buildable app's deployable ref for HEAD (the commit-derived tag
    when stale, the newest recorded release otherwise, the fleet's resolved image for an app with no
@@ -130,10 +130,11 @@ image versions".
 A rollout can fail on transient `syd` host-capacity refusals ("could not reserve resource"); Fly
 rolls back cleanly, so re-run the failed job.
 
-`vers-bugsink` and `vers-umami` deploy pinned stock images with no build. Neither sits in the turbo
-task graph, so their staleness triggers in `deploy.config.ts` are path globs (`apps/bugsink/**`,
+`vers-bugsink` and `vers-umami` ship pinned upstream images. Neither sits in the turbo task graph,
+so their staleness triggers in `deploy.config.ts` are path globs (`apps/bugsink/**`,
 `apps/umami/**`) rather than turbo affectedness. Upgrading either is a tag bump — Bugsink on its
-`Dockerfile` `FROM` line, Umami on its `fly.toml` `[build]` image.
+`Dockerfile` `FROM` line (a thin config layer its build leg bakes like any other app's), Umami on
+its `fly.toml` `[build]` image, deployed with no build leg at all.
 
 ## Sim-version registry
 

--- a/docs/architecture/deployment.md
+++ b/docs/architecture/deployment.md
@@ -95,7 +95,8 @@ rolls out:
    app with no Dockerfile (`vers-bugsink`) has no build leg work and cuts over to the image named in
    its `fly.toml`. The CLI's `deploy` command runs both phases in one invocation for a manual
    rollout; `images` prints each buildable app's deployable ref for HEAD (the commit-derived tag
-   when stale, the newest recorded release otherwise) as JSON.
+   when stale, the newest recorded release otherwise, the fleet's resolved image for an app with no
+   recorded release yet) as JSON.
 4. A rollout whose probes pass is recorded in the `releases` table (app, commit SHA, image ref, the
    digest the fleet resolved it to) — the newest row per app is that app's rollback target. The
    cutover legs require `DATABASE_URL` for this record.

--- a/docs/architecture/deployment.md
+++ b/docs/architecture/deployment.md
@@ -78,22 +78,27 @@ rolls out:
 
 1. Neon migrations apply once, in their own never-cancelled `migrate` job — several services share
    the one database, so migration never runs per service.
-2. A deploy matrix runs the deploy CLI (`bun run deploy -- deploy --app <name>`) per manifest app
-   through the `.github/actions/fly-deploy` composite action. The matrix itself is derived from
-   `deploy.config.ts` by a `manifest` job (the CLI's `list` command), so adding an app to the
-   manifest is the whole change. Each leg self-gates: the CLI compares HEAD against the `GIT_SHA`
-   stamped on the app's machines, so a rollout lost to an earlier failure ships on the next push.
-3. A stale leg rolls out in two phases. The build phase runs `flyctl deploy --build-only --push` on
-   Fly's remote builder — no image blob crosses from the GitHub runner — pushing the image as
+2. Two per-app matrix jobs run the deploy CLI through the `.github/actions/fly-deploy` composite
+   action: `build` (`bun run deploy -- build --app <name>`) as soon as checks are green, and
+   `deploy` (`bun run deploy -- cutover --app <name>`) after `migrate` and `build`. Both matrices
+   derive from `deploy.config.ts` via a `manifest` job (the CLI's `list` command), so adding an app
+   to the manifest is the whole change. Each leg self-gates: the CLI compares HEAD against the
+   `GIT_SHA` stamped on the app's machines, so a phase lost to an earlier failure ships on the next
+   push. The `build` job orders the cutovers without gating them — one app's failed build must not
+   abandon the others' rollouts, so its own cutover leg fails alone on the missing ref.
+3. A stale build leg runs `flyctl deploy --build-only --push` on Fly's remote builder — no image
+   blob crosses from the GitHub runner — pushing the image as
    `registry.fly.io/<app>:deployment-<sha>`; both phases derive the tag from the commit, so no ref
-   travels between them, and re-running a leg overwrites its own tag instead of minting a new
-   artifact. The cutover phase deploys that pushed ref (`flyctl deploy --image`), waits for the
+   travels between the jobs, and re-running a leg overwrites its own tag instead of minting a new
+   artifact. A stale cutover leg deploys that pushed ref (`flyctl deploy --image`), waits for the
    fleet to report the new SHA, then runs the app's post-deploy probes from `deploy.config.ts`. An
-   app with no Dockerfile (`vers-bugsink`) skips the build phase and cuts over to the image named in
-   its `fly.toml`.
+   app with no Dockerfile (`vers-bugsink`) has no build leg work and cuts over to the image named in
+   its `fly.toml`. The CLI's `deploy` command runs both phases in one invocation for a manual
+   rollout; `images` prints each buildable app's deployable ref for HEAD (the commit-derived tag
+   when stale, the newest recorded release otherwise) as JSON.
 4. A rollout whose probes pass is recorded in the `releases` table (app, commit SHA, image ref, the
    digest the fleet resolved it to) — the newest row per app is that app's rollback target. The
-   deploy legs require `DATABASE_URL` for this record.
+   cutover legs require `DATABASE_URL` for this record.
 5. A rollout whose probes fail rolls back: the CLI redeploys the app's newest recorded release,
    restamping that release's own `GIT_SHA` so the fleet reads stale against HEAD and the next push
    ships the fix. The leg still fails — rollback restores service, it never greens the run. A failed

--- a/scripts/src/bin/deploy.ts
+++ b/scripts/src/bin/deploy.ts
@@ -11,6 +11,7 @@ import { applyDeploy } from '../deploy/apply-deploy';
 import { applyRetentionActions } from '../deploy/apply-retention-actions';
 import { applyScheduledMachineActions } from '../deploy/apply-scheduled-machine-actions';
 import { applySimVersionActions } from '../deploy/apply-sim-version-actions';
+import { buildImageRef } from '../deploy/build-image-ref';
 import { buildProviderAppName } from '../deploy/build-provider-app-name';
 import { checkParkedApp } from '../deploy/check-parked-app';
 import { checkTarget } from '../deploy/check-target';
@@ -48,6 +49,29 @@ program
   });
 
 program
+  .command('build')
+  .description('build and push an app image when its fleet is stale relative to HEAD')
+  .requiredOption('--app <name>', 'fly app name from the manifest')
+  .action(async (options: DeployCommandOptions) => {
+    await runBuild(options.app);
+  });
+
+program
+  .command('cutover')
+  .description('cut a stale app over to the image its build phase pushed for HEAD')
+  .requiredOption('--app <name>', 'fly app name from the manifest')
+  .action(async (options: DeployCommandOptions) => {
+    await runCutover(options.app);
+  });
+
+program
+  .command('images')
+  .description("print each buildable app's deployable image ref for HEAD as JSON")
+  .action(async () => {
+    await runImages();
+  });
+
+program
   .command('verify')
   .description('assert every app is online and current; any finding fails the run')
   .action(async () => {
@@ -82,6 +106,141 @@ program
   });
 
 async function runDeploy(app: string): Promise<void> {
+  const staleness = await checkTargetStaleness(app);
+
+  if (staleness.staleReason === null) {
+    await runReconcilesForCurrentTarget(staleness);
+
+    return;
+  }
+
+  const target = staleness.target;
+
+  console.log(`deploying ${target.app} at ${staleness.sha} — ${staleness.staleReason}`);
+
+  await setEngineHashEnv(target);
+
+  const image = target.dockerfile === undefined ? null : await applyBuild(target, staleness.sha);
+
+  await withReleaseDB(async (db) => {
+    await runRollout(db, target, staleness.sha, image);
+  });
+}
+
+async function runBuild(app: string): Promise<void> {
+  const staleness = await checkTargetStaleness(app);
+
+  const target = staleness.target;
+
+  if (staleness.staleReason === null) {
+    console.log(
+      `${target.app} is current at ${staleness.state.deployedSHA ?? 'unknown'} — skipping`,
+    );
+
+    return;
+  }
+
+  if (target.dockerfile === undefined) {
+    console.log(`${target.app} has no dockerfile — nothing to build`);
+
+    return;
+  }
+
+  console.log(`building ${target.app} at ${staleness.sha} — ${staleness.staleReason}`);
+
+  await setEngineHashEnv(target);
+
+  const image = await applyBuild(target, staleness.sha);
+
+  console.log(`pushed ${image}`);
+}
+
+async function runCutover(app: string): Promise<void> {
+  const staleness = await checkTargetStaleness(app);
+
+  if (staleness.staleReason === null) {
+    await runReconcilesForCurrentTarget(staleness);
+
+    return;
+  }
+
+  const target = staleness.target;
+
+  console.log(`deploying ${target.app} at ${staleness.sha} — ${staleness.staleReason}`);
+
+  // the build phase already pushed this exact ref — both phases derive it from (app, HEAD), so
+  // nothing needs to travel between the jobs
+  const image =
+    target.dockerfile === undefined ? null : buildImageRef(target.app, staleness.sha).ref;
+
+  await withReleaseDB(async (db) => {
+    await runRollout(db, target, staleness.sha, image);
+  });
+}
+
+/**
+ * Resolves the image ref each buildable app's cutover would deploy for HEAD: a stale app's is the
+ * ref its build phase pushes for this commit, a current app's is its newest recorded release
+ * (falling back to the fleet's resolved image for an app predating release records). Consumers —
+ * the full-stack e2e harness — get every ref in one JSON object on stdout.
+ */
+async function runImages(): Promise<void> {
+  const manifest = await loadDeployManifest();
+  const sha = await readHeadSHA();
+
+  const refs: Record<string, string> = {};
+
+  await withReleaseDB(async (db) => {
+    for (const target of manifest.apps) {
+      if (target.dockerfile === undefined) {
+        continue;
+      }
+
+      const state = await readAppState(target.app);
+
+      const changes = state.deployedSHA === null ? null : await readChangesSince(state.deployedSHA);
+      const staleReason = findStaleReason(target, changes);
+
+      if (staleReason !== null) {
+        refs[target.app] = buildImageRef(target.app, sha).ref;
+        continue;
+      }
+
+      const release = await findLatestRelease(db, target.app);
+
+      if (release !== undefined) {
+        refs[target.app] = release.image;
+        continue;
+      }
+
+      const fleetImage = await readFleetImage(target.app);
+
+      if (fleetImage === null) {
+        throw new Error(
+          `${target.app} has no built ref, recorded release, or single fleet image to resolve`,
+        );
+      }
+
+      refs[target.app] = `${fleetImage.repository}:${fleetImage.tag}`;
+    }
+  });
+
+  console.log(JSON.stringify(refs));
+}
+
+interface TargetStaleness {
+  readonly sha: string;
+  readonly staleReason: string | null;
+  readonly state: Awaited<ReturnType<typeof readAppState>>;
+  readonly target: DeployTarget;
+}
+
+/**
+ * The staleness preamble every per-app phase shares: resolve the target, then compare HEAD
+ * against the SHA stamped on its machines. Each phase re-runs this rather than trusting an
+ * earlier phase's answer, so a phase skipped by a failure upstream stays self-gating.
+ */
+async function checkTargetStaleness(app: string): Promise<TargetStaleness> {
   const manifest = await loadDeployManifest();
 
   const target = requireTarget(manifest, app);
@@ -92,17 +251,24 @@ async function runDeploy(app: string): Promise<void> {
   const changes = state.deployedSHA === null ? null : await readChangesSince(state.deployedSHA);
   const staleReason = findStaleReason(target, changes);
 
-  if (staleReason === null) {
-    console.log(`${target.app} is current at ${state.deployedSHA ?? 'unknown'} — skipping`);
+  return { sha, staleReason, state, target };
+}
 
-    await runScheduledMachineReconcile(target);
-    await runSimVersionReconcile(target);
+/**
+ * The skipped-rollout path `deploy` and `cutover` share: a current fleet still gets its scheduled
+ * machines and sim version reconciled, so drift converges on the next push rather than waiting
+ * for a commit that redeploys the app.
+ */
+async function runReconcilesForCurrentTarget(staleness: TargetStaleness): Promise<void> {
+  console.log(
+    `${staleness.target.app} is current at ${staleness.state.deployedSHA ?? 'unknown'} — skipping`,
+  );
 
-    return;
-  }
+  await runScheduledMachineReconcile(staleness.target);
+  await runSimVersionReconcile(staleness.target);
+}
 
-  console.log(`deploying ${target.app} at ${sha} — ${staleReason}`);
-
+async function withReleaseDB(run: (db: Kysely<DB>) => Promise<void>): Promise<void> {
   const databaseURL = requireEnvVar(
     'DATABASE_URL',
     'the release record backing rollback lives in the shared database',
@@ -111,25 +277,26 @@ async function runDeploy(app: string): Promise<void> {
   const db = createDB({ databaseURL });
 
   try {
-    await runRollout(db, target, sha);
+    await run(db);
   } finally {
     await db.destroy();
   }
 }
 
 /**
- * One rollout: build and push the image (targets with no Dockerfile deploy their fly.toml image
- * instead), cut the fleet over to it, reconcile, probe. Probes
+ * One rollout from an already-built image (null for targets that deploy their fly.toml stock
+ * image): cut the fleet over, reconcile, probe. Probes
  * passing records the release as the app's next rollback target; probes failing rolls the fleet
  * back to the previous recorded release and leaves the run red either way, so the failure ships
  * forward on a later push instead of a broken release serving meanwhile.
  */
-async function runRollout(db: Kysely<DB>, target: DeployTarget, sha: string): Promise<void> {
-  await setEngineHashEnv(target);
-
+async function runRollout(
+  db: Kysely<DB>,
+  target: DeployTarget,
+  sha: string,
+  image: string | null,
+): Promise<void> {
   const previous = await findLatestRelease(db, target.app);
-
-  const image = target.dockerfile === undefined ? null : await applyBuild(target, sha);
 
   await applyDeploy(target, sha, image);
   await waitForDeployedSHA(target.app, sha);


### PR DESCRIPTION
## Description

Part of #378 (does not close it). The full-stack e2e suite needs every image pushed before any fleet cutover, and the fused per-app deploy leg allowed no job between the phases.

- Deploy CLI gains `build` (push the SHA-tagged image when stale), `cutover` (deploy the ref the build phase pushed, probe, record/rollback), and `images` (JSON map of each buildable app's deployable ref for HEAD — built tag when stale, newest recorded release otherwise). The fused `deploy` command stays for manual rollouts.
- main.yml runs the `build` matrix beside `migrate`; `deploy` (cutover) needs both.
- The build job orders cutovers without gating them: one app's failed build fails only its own cutover leg (missing ref), never the other apps' rollouts.
- Every phase re-runs the staleness check, so a phase lost to an earlier failure still ships on the next push.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality (bin sequencing only; decision logic unchanged and already covered)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/zgeoff/vers/pull/624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

