### PR TITLE
fix: report idle worker faults to the error backend

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -517,6 +517,7 @@
       "dependencies": {
         "@orpc/client": "catalog:",
         "@orpc/contract": "catalog:",
+        "@sentry/browser": "catalog:",
         "@vers/client-test-utils": "workspace:*",
         "@vers/contract-activity": "workspace:*",
         "@vers/design-system": "workspace:*",
@@ -542,6 +543,7 @@
         "happy-dom": "catalog:",
         "msw": "catalog:",
         "typescript": "catalog:",
+        "vite": "catalog:",
       },
     },
     "libs/game/idle-core": {
@@ -1130,6 +1132,7 @@
     "@react-three/fiber": "9.6.1",
     "@react-three/test-renderer": "9.1.0",
     "@rolldown/plugin-babel": "0.2.3",
+    "@sentry/browser": "10.63.0",
     "@sentry/bun": "10.63.0",
     "@sentry/node": "10.63.0",
     "@sentry/react": "10.63.0",

--- a/docs/architecture/error-handling.md
+++ b/docs/architecture/error-handling.md
@@ -110,7 +110,7 @@ What reports, by tier:
 | service        | `onError` interceptor in `createService`, and `reportUnexpectedError` at every background swallow point | non-`ORPCError` throws and 5xx `ORPCError`s from a request; an unexpected failure from a worker loop, job queue, drain, or sweep run |
 | app-web client | `QueryCache`/`MutationCache` `onError`                                                                  | non-`ORPCError` failures (network, client bugs) — service errors were already reported by the service that produced them             |
 | app-web render | root route `errorComponent`                                                                             | render/loader errors nothing below caught                                                                                            |
-| idle worker    | `reportWorkerFault` at each swallow point, plus the SDK's default global handlers                       | message-routing, tick-loop, reconnect-recovery, and resync failures the worker otherwise folds into an offline status                |
+| idle worker    | `reportWorkerFault` at each swallow point, plus the SDK's default global handlers                       | message-routing, tick-loop, reconnect-recovery, and resync failures the worker otherwise swallows                                    |
 
 The idle SharedWorker (`@vers/idle-client`) runs its own SDK instance: `startErrorReporting`
 initializes `@sentry/browser` inside the worker scope from `VITE_SENTRY_DSN`, a no-op when it's

--- a/docs/architecture/error-handling.md
+++ b/docs/architecture/error-handling.md
@@ -1,7 +1,7 @@
 # Error handling
 
 How failures are classified, declared, transported, retried, reported, and traced across the
-services and app-web.
+services, app-web, and the idle worker.
 
 ## Taxonomy
 
@@ -110,6 +110,16 @@ What reports, by tier:
 | service        | `onError` interceptor in `createService`, and `reportUnexpectedError` at every background swallow point | non-`ORPCError` throws and 5xx `ORPCError`s from a request; an unexpected failure from a worker loop, job queue, drain, or sweep run |
 | app-web client | `QueryCache`/`MutationCache` `onError`                                                                  | non-`ORPCError` failures (network, client bugs) — service errors were already reported by the service that produced them             |
 | app-web render | root route `errorComponent`                                                                             | render/loader errors nothing below caught                                                                                            |
+| idle worker    | `reportWorkerFault` at each swallow point, plus the SDK's default global handlers                       | message-routing, tick-loop, reconnect-recovery, and resync failures the worker otherwise folds into an offline status                |
+
+The idle SharedWorker (`@vers/idle-client`) runs its own SDK instance: `startErrorReporting`
+initializes `@sentry/browser` inside the worker scope from `VITE_SENTRY_DSN`, a no-op when it's
+undefined, so capture works with every tab closed. `reportWorkerFault` tags each event with a `site`
+tag (`message-routing`, `tick-loop`, `reconnect`, `resync`) naming the swallow point that caught it;
+the SDK's default global handlers net any throw those sites miss. Capture never changes the worker's
+failure behaviour — a failed resync still folds to an offline status, and a tick-loop crash still
+stops the loop, since restarting a simulation that throws deterministically would resubmit the same
+crash every tick.
 
 A service report carries a `traceID` event tag when the capture runs inside an active trace scope; a
 report emitted outside any scope, and every app-web capture, omits the tag. The RPC interceptor tags

--- a/libs/game/idle-client/package.json
+++ b/libs/game/idle-client/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@orpc/client": "catalog:",
     "@orpc/contract": "catalog:",
+    "@sentry/browser": "catalog:",
     "@vers/client-test-utils": "workspace:*",
     "@vers/contract-activity": "workspace:*",
     "@vers/design-system": "workspace:*",
@@ -37,6 +38,7 @@
     "fake-indexeddb": "catalog:",
     "happy-dom": "catalog:",
     "msw": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vite": "catalog:"
   }
 }

--- a/libs/game/idle-client/src/test-utils/create-test-connection.ts
+++ b/libs/game/idle-client/src/test-utils/create-test-connection.ts
@@ -20,6 +20,12 @@ export interface TestConnection {
   readonly post: (message: ClientMessage) => void;
 
   /**
+   * Posts an arbitrary payload from the test's end of the channel — the channel itself is untyped
+   * at runtime, and a peer on another build can post shapes outside this build's message union.
+   */
+  readonly postRaw: (message: unknown) => void;
+
+  /**
    * Resolves once at least `count` messages have arrived; rethrows the failed length assertion
    * when the wait times out, so a missing broadcast fails loudly at the wait itself.
    */
@@ -44,6 +50,9 @@ export function createTestConnection(): TestConnection {
   return {
     port: channel.port1,
     post: (message) => {
+      channel.port2.postMessage(message);
+    },
+    postRaw: (message) => {
       channel.port2.postMessage(message);
     },
     received,

--- a/libs/game/idle-client/src/worker/create-worker-runtime.test.ts
+++ b/libs/game/idle-client/src/worker/create-worker-runtime.test.ts
@@ -6,7 +6,6 @@ import { waitFor } from '@vers/test-utils';
 import { server } from '../mocks/node';
 import type { TestConnection } from '../test-utils/create-test-connection';
 import { createTestConnection } from '../test-utils/create-test-connection';
-import type { ClientMessage } from '../types';
 import { ClientMessageType, WorkerMessageType } from '../types';
 import { createWorkerRuntime } from './create-worker-runtime';
 import type { WorkerRuntime } from './create-worker-runtime';
@@ -128,13 +127,10 @@ test('it reports a fault to the error backend when a message makes its handler t
   // a version-skewed tab can post an activity shape this worker build cannot derive a simulation
   // input from — the handler's throw must land in the error backend, not vanish into the void'd
   // routing promise
-  connection.post(
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- a version-skewed tab posts shapes outside this build's ClientMessage union; the cast models exactly that input
-    {
-      activity: { ...createMockActivityData(), buildSnapshot: undefined },
-      type: ClientMessageType.SetActivity,
-    } as unknown as ClientMessage,
-  );
+  connection.postRaw({
+    activity: { ...createMockActivityData(), buildSnapshot: undefined },
+    type: ClientMessageType.SetActivity,
+  });
 
   await waitFor(() => {
     expect(recorded).toHaveLength(1);

--- a/libs/game/idle-client/src/worker/create-worker-runtime.test.ts
+++ b/libs/game/idle-client/src/worker/create-worker-runtime.test.ts
@@ -1,13 +1,17 @@
 import { expect, onTestFinished, test } from 'bun:test';
+import type { ErrorEvent } from '@sentry/browser';
 import { createMockActivityData } from '@vers/contract-activity/test-utils';
 import { mockActivityService } from '@vers/mock-services/activity';
 import { waitFor } from '@vers/test-utils';
 import { server } from '../mocks/node';
 import type { TestConnection } from '../test-utils/create-test-connection';
 import { createTestConnection } from '../test-utils/create-test-connection';
+import type { ClientMessage } from '../types';
 import { ClientMessageType, WorkerMessageType } from '../types';
 import { createWorkerRuntime } from './create-worker-runtime';
 import type { WorkerRuntime } from './create-worker-runtime';
+import { sentryHandle } from './sentry-handle';
+import { startErrorReporting } from './start-error-reporting';
 
 function createConnection(runtime: WorkerRuntime): TestConnection {
   const connection = createTestConnection();
@@ -90,4 +94,51 @@ test('it stops broadcasting to a connection after it disconnects', async () => {
   await survivor.waitForMessages(2);
 
   expect(survivor.received[1]?.type).toBe(WorkerMessageType.SimulationUpdate);
+});
+
+test('it reports a fault to the error backend when a message makes its handler throw', async () => {
+  const previousHandle = sentryHandle.current;
+  const recorded: Array<Readonly<ErrorEvent>> = [];
+
+  onTestFinished(() => {
+    sentryHandle.current = previousHandle;
+  });
+
+  await startErrorReporting('https://testpublickey@o0.ingest.sentry.io/1', {
+    beforeSend: (event) => {
+      recorded.push(event);
+
+      return null;
+    },
+    disableDefaultIntegrations: true,
+  });
+
+  const runtime = createWorkerRuntime();
+
+  onTestFinished(() => {
+    runtime.stop();
+  });
+
+  const connection = createConnection(runtime);
+
+  connection.post({ type: ClientMessageType.Initialize });
+
+  await connection.waitForMessages(1);
+
+  // a version-skewed tab can post an activity shape this worker build cannot derive a simulation
+  // input from — the handler's throw must land in the error backend, not vanish into the void'd
+  // routing promise
+  connection.post(
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- a version-skewed tab posts shapes outside this build's ClientMessage union; the cast models exactly that input
+    {
+      activity: { ...createMockActivityData(), buildSnapshot: undefined },
+      type: ClientMessageType.SetActivity,
+    } as unknown as ClientMessage,
+  );
+
+  await waitFor(() => {
+    expect(recorded).toHaveLength(1);
+  });
+
+  expect(recorded[0]?.tags).toMatchObject({ site: 'message-routing' });
 });

--- a/libs/game/idle-client/src/worker/create-worker-runtime.ts
+++ b/libs/game/idle-client/src/worker/create-worker-runtime.ts
@@ -13,6 +13,7 @@ import { createOfflineCapStatusMessage } from './create-offline-cap-status-messa
 import { createRequestResyncMessage } from './create-request-resync-message';
 import { handleClientMessage } from './handle-client-message';
 import { handleRequestResyncMessage } from './handle-request-resync-message';
+import { reportWorkerFault } from './report-worker-fault';
 import { runSimulation } from './run-simulation';
 import type { WorkerContext } from './types';
 
@@ -131,7 +132,13 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
     port.start();
 
     port.addEventListener('message', (messageEvent: MessageEvent<ClientMessage>) => {
-      void handleClientMessage(context, port, messageEvent);
+      void (async () => {
+        try {
+          await handleClientMessage(context, port, messageEvent);
+        } catch (error) {
+          reportWorkerFault('message-routing', error);
+        }
+      })();
     });
 
     // Chrome fires 'close' when the peer disconnects (shipped 2024); Firefox/Safari support is
@@ -144,7 +151,8 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
     // ensure we're only running one loop per worker
     if (!running) {
       running = true;
-      void runTickLoop();
+
+      scheduleTick();
     }
   };
 
@@ -174,7 +182,19 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
 
     await wait(1);
 
-    void runTickLoop();
+    scheduleTick();
+  };
+
+  // a crash still stops the loop — the fault is reported, and restarting a simulation that throws
+  // deterministically would only flood the error backend with the same crash every tick
+  const scheduleTick = () => {
+    void (async () => {
+      try {
+        await runTickLoop();
+      } catch (error) {
+        reportWorkerFault('tick-loop', error);
+      }
+    })();
   };
 
   // The worker's own reconnect recovery: a returning connection resends whatever the submitter
@@ -184,10 +204,14 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
     emitConnectionStatus(true);
 
     void (async () => {
-      await submitter.flushHeld();
+      try {
+        await submitter.flushHeld();
 
-      if (context.getSimulation() === null && resyncAvatarID !== null) {
-        await handleRequestResyncMessage(context, createRequestResyncMessage(resyncAvatarID));
+        if (context.getSimulation() === null && resyncAvatarID !== null) {
+          await handleRequestResyncMessage(context, createRequestResyncMessage(resyncAvatarID));
+        }
+      } catch (error) {
+        reportWorkerFault('reconnect', error);
       }
     })();
   };

--- a/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
@@ -1,10 +1,12 @@
-import { expect, mock, test } from 'bun:test';
+import { expect, mock, onTestFinished, test } from 'bun:test';
 import { createORPCClient } from '@orpc/client';
 import { RPCLink } from '@orpc/client/fetch';
+import type { ErrorEvent } from '@sentry/browser';
 import type { ActivityCheckpoint } from '@vers/idle-core';
 import { SIMULATION_TIMESTEP_MS, buildSimulationInput, runAttempt } from '@vers/idle-core';
 import { createTestAccessToken, resolveServiceURL } from '@vers/mock-services';
 import * as db from '@vers/mock-services/db';
+import { waitFor } from '@vers/test-utils';
 import invariant from 'tiny-invariant';
 import { createCheckpointSubmitter } from '../submission/create-checkpoint-submitter';
 import type { ActivityServiceClient } from '../submission/types';
@@ -13,6 +15,8 @@ import { createTestConnection } from '../test-utils/create-test-connection';
 import type { RequestResyncMessage } from '../types';
 import { ClientMessageType, WorkerMessageType } from '../types';
 import { handleRequestResyncMessage } from './handle-request-resync-message';
+import { sentryHandle } from './sentry-handle';
+import { startErrorReporting } from './start-error-reporting';
 
 interface SetupTestConfig {
   readonly userID: string;
@@ -373,4 +377,53 @@ test('it attaches a fresh login live without broadcasting any catch-up status', 
 
   invariant(simulation !== null, 'expected the resync to install a live simulation');
   expect(simulation.activity?.id).toBe(activity.id);
+});
+
+test('it reports a fault to the error backend and folds to offline when the resync fails outright', async () => {
+  const previousHandle = sentryHandle.current;
+  const recorded: Array<Readonly<ErrorEvent>> = [];
+
+  onTestFinished(() => {
+    sentryHandle.current = previousHandle;
+  });
+
+  await startErrorReporting('https://testpublickey@o0.ingest.sentry.io/1', {
+    beforeSend: (event) => {
+      recorded.push(event);
+
+      return null;
+    },
+    disableDefaultIntegrations: true,
+  });
+
+  const connection = createTestConnection();
+
+  const context = createStubWorkerContext({
+    connections: [connection.port],
+    submitter: {
+      flushHeld: () => Promise.reject(new Error('held flush exploded')),
+      registerActivity: () => Promise.resolve(),
+      submit: () => Promise.resolve(undefined),
+    },
+  });
+
+  const message: RequestResyncMessage = {
+    avatarID: 'avatar-with-held-tail',
+    type: ClientMessageType.RequestResync,
+  };
+
+  await handleRequestResyncMessage(context, message);
+
+  await connection.waitForMessages(1);
+
+  expect(connection.received).toStrictEqual([
+    { online: false, type: WorkerMessageType.ConnectionStatus },
+  ]);
+
+  await waitFor(() => {
+    expect(recorded).toHaveLength(1);
+  });
+
+  expect(recorded[0]?.tags).toMatchObject({ site: 'resync' });
+  expect(context.isResyncInFlight()).toBe(false);
 });

--- a/libs/game/idle-client/src/worker/handle-request-resync-message.ts
+++ b/libs/game/idle-client/src/worker/handle-request-resync-message.ts
@@ -10,6 +10,7 @@ import { createCheckpointStreamInvalidMessage } from './create-checkpoint-stream
 import { createConnectionStatusMessage } from './create-connection-status-message';
 import { createResyncStatusMessage } from './create-resync-status-message';
 import { registerSimulationListeners } from './register-simulation-listeners';
+import { reportWorkerFault } from './report-worker-fault';
 import type { WorkerContext } from './types';
 
 /**
@@ -20,8 +21,8 @@ import type { WorkerContext } from './types';
  * resolves; a zero-gap outcome (live re-attach, no activity) stays silent, so a fresh login never
  * opens that UI. A live simulation this resync would install is skipped when a different activity
  * went live while it was running — a fresher `SetActivity` always wins. A resync that fails
- * outright reports the worker offline — the signal tabs use to explain a stalled catch-up — and
- * never rejects; the next reconnect retries it.
+ * outright forwards the fault to the error backend and reports the worker offline — the signal
+ * tabs use to explain a stalled catch-up — and never rejects; the next reconnect retries it.
  */
 export async function handleRequestResyncMessage(
   context: WorkerContext,
@@ -51,7 +52,8 @@ export async function handleRequestResyncMessage(
     });
 
     await applyResyncResult(context, result);
-  } catch {
+  } catch (error) {
+    reportWorkerFault('resync', error);
     emitConnectionStatus(context, false);
   } finally {
     context.setResyncInFlight(false);

--- a/libs/game/idle-client/src/worker/report-worker-fault.test.ts
+++ b/libs/game/idle-client/src/worker/report-worker-fault.test.ts
@@ -1,0 +1,41 @@
+import { expect, onTestFinished, test } from 'bun:test';
+import type { ErrorEvent } from '@sentry/browser';
+import { waitFor } from '@vers/test-utils';
+import { reportWorkerFault } from './report-worker-fault';
+import { sentryHandle } from './sentry-handle';
+import { startErrorReporting } from './start-error-reporting';
+
+test('it does not report when reporting was never started', () => {
+  expect(sentryHandle.current).toBeUndefined();
+
+  expect(() => {
+    reportWorkerFault('tick-loop', new Error('never started'));
+  }).not.toThrow();
+});
+
+test('it reports the error tagged with its capture site', async () => {
+  const previousHandle = sentryHandle.current;
+  const recorded: Array<Readonly<ErrorEvent>> = [];
+
+  onTestFinished(() => {
+    sentryHandle.current = previousHandle;
+  });
+
+  await startErrorReporting('https://testpublickey@o0.ingest.sentry.io/1', {
+    beforeSend: (event) => {
+      recorded.push(event);
+
+      return null;
+    },
+    disableDefaultIntegrations: true,
+  });
+
+  reportWorkerFault('resync', new Error('resync exploded'));
+
+  await waitFor(() => {
+    expect(recorded).toHaveLength(1);
+  });
+
+  expect(recorded[0]?.tags).toMatchObject({ site: 'resync' });
+  expect(recorded[0]?.exception?.values?.[0]?.value).toBe('resync exploded');
+});

--- a/libs/game/idle-client/src/worker/report-worker-fault.ts
+++ b/libs/game/idle-client/src/worker/report-worker-fault.ts
@@ -3,9 +3,10 @@ import { sentryHandle } from './sentry-handle';
 export type WorkerFaultSite = 'message-routing' | 'reconnect' | 'resync' | 'tick-loop';
 
 /**
- * Forwards a worker fault to the error backend, tagged with the capture site so a tick-loop crash
- * groups apart from a resync failure. No-op when `startErrorReporting` never ran (no DSN
- * configured), so this is safe to call unconditionally from every swallow point.
+ * Forwards a worker fault to the error backend, tagged with the capture site that caught it —
+ * grouping stays stack-based, so one defect reached from two sites is still one issue. No-op when
+ * `startErrorReporting` never ran (no DSN configured), so this is safe to call unconditionally
+ * from every swallow point.
  */
 export function reportWorkerFault(site: WorkerFaultSite, error: unknown): void {
   const sentry = sentryHandle.current;

--- a/libs/game/idle-client/src/worker/report-worker-fault.ts
+++ b/libs/game/idle-client/src/worker/report-worker-fault.ts
@@ -1,0 +1,21 @@
+import { sentryHandle } from './sentry-handle';
+
+export type WorkerFaultSite = 'message-routing' | 'reconnect' | 'resync' | 'tick-loop';
+
+/**
+ * Forwards a worker fault to the error backend, tagged with the capture site so a tick-loop crash
+ * groups apart from a resync failure. No-op when `startErrorReporting` never ran (no DSN
+ * configured), so this is safe to call unconditionally from every swallow point.
+ */
+export function reportWorkerFault(site: WorkerFaultSite, error: unknown): void {
+  const sentry = sentryHandle.current;
+
+  if (sentry === undefined) {
+    return;
+  }
+
+  sentry.withScope((scope) => {
+    scope.setTag('site', site);
+    sentry.captureException(error);
+  });
+}

--- a/libs/game/idle-client/src/worker/sentry-handle.ts
+++ b/libs/game/idle-client/src/worker/sentry-handle.ts
@@ -1,0 +1,11 @@
+import type * as Sentry from '@sentry/browser';
+
+type SentryModule = typeof Sentry;
+
+/**
+ * Worker-wide holder for the lazily-imported Sentry SDK handle: `current` stays undefined until
+ * `startErrorReporting` runs with a defined DSN, so a DSN-less worker never loads the SDK.
+ * `reportWorkerFault` reads it directly; `startErrorReporting` is its only production writer, and
+ * tests swap it in place.
+ */
+export const sentryHandle: { current: SentryModule | undefined } = { current: undefined };

--- a/libs/game/idle-client/src/worker/start-error-reporting.test.ts
+++ b/libs/game/idle-client/src/worker/start-error-reporting.test.ts
@@ -1,0 +1,26 @@
+import { expect, onTestFinished, test } from 'bun:test';
+import { sentryHandle } from './sentry-handle';
+import { startErrorReporting } from './start-error-reporting';
+
+test('it leaves reporting unstarted when dsn is undefined', async () => {
+  const previousHandle = sentryHandle.current;
+
+  await startErrorReporting(undefined);
+
+  expect(sentryHandle.current).toBe(previousHandle);
+});
+
+test('it starts reporting when dsn is defined', async () => {
+  const previousHandle = sentryHandle.current;
+
+  onTestFinished(() => {
+    sentryHandle.current = previousHandle;
+  });
+
+  await startErrorReporting('https://testpublickey@o0.ingest.sentry.io/1', {
+    beforeSend: () => null,
+    disableDefaultIntegrations: true,
+  });
+
+  expect(sentryHandle.current).toBeDefined();
+});

--- a/libs/game/idle-client/src/worker/start-error-reporting.ts
+++ b/libs/game/idle-client/src/worker/start-error-reporting.ts
@@ -1,0 +1,60 @@
+import type { BrowserOptions } from '@sentry/browser';
+import { sentryHandle } from './sentry-handle';
+
+export interface StartErrorReportingOptions {
+  /**
+   * Test-only hook: intercepts every event just before send, letting a suite record and suppress
+   * delivery without a live DSN destination.
+   */
+  readonly beforeSend?: BrowserOptions['beforeSend'];
+
+  /**
+   * Test-only override: when true, passes `defaultIntegrations: false` to the SDK, suppressing
+   * its default integration set — which installs `error`/`unhandledrejection` handlers on the
+   * worker's global scope — so a suite that starts real reporting never leaks global listeners
+   * into the shared test run.
+   */
+  readonly disableDefaultIntegrations?: boolean;
+
+  /**
+   * Deploy environment stamped on every event; the worker's production wiring passes the build
+   * mode.
+   */
+  readonly environment?: string;
+}
+
+/**
+ * Initializes the Sentry SDK that `reportWorkerFault` captures through, inside the shared
+ * worker's own scope — capture must not depend on a window client being connected, since a worker
+ * can fault with every tab gone. A no-op when `dsn` is undefined, so a DSN-less worker never
+ * loads the SDK. The SDK's default global handlers stay on in production, netting any throw the
+ * explicit capture sites miss. Tracing lives on the OpenTelemetry path; the error backend drops
+ * transaction envelopes. Client reports are off: the error backend discards them, and their
+ * periodic flush would keep an idle worker chattering.
+ */
+export async function startErrorReporting(
+  dsn: string | undefined,
+  options: Readonly<StartErrorReportingOptions> = {},
+): Promise<void> {
+  if (dsn === undefined) {
+    return;
+  }
+
+  const sentry = await import('@sentry/browser');
+
+  sentryHandle.current = sentry;
+
+  sentry.init({
+    dsn,
+
+    // an explicit `dataCollection` makes the SDK's spec defaults the base, which collect every
+    // HTTP body type — and a failed checkpoint submission's body carries the session token, so
+    // body capture is switched off wholesale
+    dataCollection: { httpBodies: [], userInfo: true },
+    tracesSampleRate: 0,
+    sendClientReports: false,
+    ...(options.beforeSend !== undefined && { beforeSend: options.beforeSend }),
+    ...(options.disableDefaultIntegrations === true && { defaultIntegrations: false }),
+    ...(options.environment !== undefined && { environment: options.environment }),
+  });
+}

--- a/libs/game/idle-client/src/worker/start-error-reporting.ts
+++ b/libs/game/idle-client/src/worker/start-error-reporting.ts
@@ -42,8 +42,6 @@ export async function startErrorReporting(
 
   const sentry = await import('@sentry/browser');
 
-  sentryHandle.current = sentry;
-
   sentry.init({
     dsn,
 
@@ -57,4 +55,8 @@ export async function startErrorReporting(
     ...(options.disableDefaultIntegrations === true && { defaultIntegrations: false }),
     ...(options.environment !== undefined && { environment: options.environment }),
   });
+
+  // published only after a successful init: a throw above leaves the handle undefined, so fault
+  // reporting keeps its no-op path instead of capturing through a dead SDK
+  sentryHandle.current = sentry;
 }

--- a/libs/game/idle-client/src/worker/start-error-reporting.ts
+++ b/libs/game/idle-client/src/worker/start-error-reporting.ts
@@ -27,7 +27,9 @@ export interface StartErrorReportingOptions {
  * Initializes the Sentry SDK that `reportWorkerFault` captures through, inside the shared
  * worker's own scope — capture must not depend on a window client being connected, since a worker
  * can fault with every tab gone. A no-op when `dsn` is undefined, so a DSN-less worker never
- * loads the SDK. The SDK's default global handlers stay on in production, netting any throw the
+ * loads the SDK. Never rejects: a bootstrap failure leaves reporting off with a console warning,
+ * since an unhandled rejection from the reporting path itself is the one fault nothing can
+ * capture. The SDK's default global handlers stay on in production, netting any throw the
  * explicit capture sites miss. Tracing lives on the OpenTelemetry path; the error backend drops
  * transaction envelopes. Client reports are off: the error backend discards them, and their
  * periodic flush would keep an idle worker chattering.
@@ -40,23 +42,27 @@ export async function startErrorReporting(
     return;
   }
 
-  const sentry = await import('@sentry/browser');
+  try {
+    const sentry = await import('@sentry/browser');
 
-  sentry.init({
-    dsn,
+    sentry.init({
+      dsn,
 
-    // an explicit `dataCollection` makes the SDK's spec defaults the base, which collect every
-    // HTTP body type — and a failed checkpoint submission's body carries the session token, so
-    // body capture is switched off wholesale
-    dataCollection: { httpBodies: [], userInfo: true },
-    tracesSampleRate: 0,
-    sendClientReports: false,
-    ...(options.beforeSend !== undefined && { beforeSend: options.beforeSend }),
-    ...(options.disableDefaultIntegrations === true && { defaultIntegrations: false }),
-    ...(options.environment !== undefined && { environment: options.environment }),
-  });
+      // an explicit `dataCollection` makes the SDK's spec defaults the base, which collect every
+      // HTTP body type — and a failed checkpoint submission's body carries the session token, so
+      // body capture is switched off wholesale
+      dataCollection: { httpBodies: [], userInfo: true },
+      tracesSampleRate: 0,
+      sendClientReports: false,
+      ...(options.beforeSend !== undefined && { beforeSend: options.beforeSend }),
+      ...(options.disableDefaultIntegrations === true && { defaultIntegrations: false }),
+      ...(options.environment !== undefined && { environment: options.environment }),
+    });
 
-  // published only after a successful init: a throw above leaves the handle undefined, so fault
-  // reporting keeps its no-op path instead of capturing through a dead SDK
-  sentryHandle.current = sentry;
+    // published only after a successful init: a failure above leaves the handle undefined, so
+    // fault reporting keeps its no-op path instead of capturing through a dead SDK
+    sentryHandle.current = sentry;
+  } catch (error) {
+    console.warn('error reporting failed to start', error);
+  }
 }

--- a/libs/game/idle-client/src/worker/worker.ts
+++ b/libs/game/idle-client/src/worker/worker.ts
@@ -1,6 +1,13 @@
 import { createWorkerRuntime } from './create-worker-runtime';
+import { startErrorReporting } from './start-error-reporting';
 
 declare let self: SharedWorkerGlobalScope;
+
+// reporting boots in the background: a fault before init resolves is dropped rather than delaying
+// the first connection
+const dsn: string | undefined = import.meta.env['VITE_SENTRY_DSN'];
+
+void startErrorReporting(dsn, { environment: import.meta.env.MODE });
 const runtime = createWorkerRuntime();
 
 self.addEventListener('connect', runtime.handleConnect);

--- a/libs/game/idle-client/tsconfig.json
+++ b/libs/game/idle-client/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "lib": ["ESNext", "DOM", "DOM.Iterable", "WebWorker"],
-    "types": ["node", "bun", "@zgeoff/bun-test-extended"]
+    "types": ["node", "bun", "vite/client", "@zgeoff/bun-test-extended"]
   },
   "files": [],
   "include": ["test-setup.ts", "augment-bun-test.ts", "src/**/*.ts", "src/**/*.tsx"],

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
       "@react-three/fiber": "9.6.1",
       "@react-three/test-renderer": "9.1.0",
       "@rolldown/plugin-babel": "0.2.3",
+      "@sentry/browser": "10.63.0",
       "@sentry/bun": "10.63.0",
       "@sentry/node": "10.63.0",
       "@sentry/react": "10.63.0",


### PR DESCRIPTION
## Description

Closes #611

The idle SharedWorker loses every runtime failure silently; this initializes the Sentry SDK inside the worker's own scope and reports each swallowed fault to the error backend. A spike (recorded on #611) confirmed `@sentry/browser` initializes with default integrations inside `SharedWorkerGlobalScope` and delivers with zero tabs connected, so no relay to a window client is needed.

- `reportWorkerFault` tags each event with its capture site: message-routing, tick-loop, reconnect, resync.
- Failure behaviour is unchanged — a failed resync still folds to offline; a tick-loop crash still stops the loop, since restarting a deterministically-throwing simulation would resubmit the same crash every tick.
- The SDK's default global handlers stay on in production, netting throws the explicit sites miss.
- Mirrors the `sentry-handle` / `startErrorReporting` pattern from `@vers/service-runtime`; no-ops without `VITE_SENTRY_DSN`.
- No OTel metrics: the worker has no OTLP lane — this is error reporting, not log shipping.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/zgeoff/vers/pull/625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

