### PR TITLE
fix(#632): give canvas mount assertions runner-speed headroom

### DIFF
--- a/apps/web-e2e/src/avatar-satellite.spec.ts
+++ b/apps/web-e2e/src/avatar-satellite.spec.ts
@@ -9,6 +9,9 @@ import { waitForHoneypotWindow } from './wait-for-honeypot-window';
 test('it mounts a second canvas for the avatar satellite and drops it on navigation away', async ({
   page,
 }) => {
+  // two software-GL canvas mounts under CI's shared CPU run well past other specs' budget
+  test.slow();
+
   const consoleErrors: Array<string> = [];
 
   page.on('console', (message) => {
@@ -36,7 +39,9 @@ test('it mounts a second canvas for the avatar satellite and drops it on navigat
 
   const canvases = page.locator('canvas');
 
-  await expect(canvases).toHaveCount(2);
+  // software-GL canvas mounts on a loaded shared runner can far outlast the suite-wide expect
+  // timeout while staying sound — slow init is not a missing satellite
+  await expect(canvases).toHaveCount(2, { timeout: 30_000 });
 
   const worldCanvas = canvases.first();
 

--- a/apps/web-e2e/src/canvas-persistence.spec.ts
+++ b/apps/web-e2e/src/canvas-persistence.spec.ts
@@ -38,7 +38,9 @@ test('it keeps the same canvas element across client-side game navigation', asyn
 
   const canvas = page.locator('canvas');
 
-  await expect(canvas).toBeVisible();
+  // software-GL canvas mounts on a loaded shared runner can far outlast the suite-wide expect
+  // timeout while staying sound — slow init is not a missing canvas
+  await expect(canvas).toBeVisible({ timeout: 30_000 });
 
   await canvas.evaluate((element) => {
     element.dataset['canvasPersistenceTag'] = 'original';


### PR DESCRIPTION
## Description

Closes #632

Both software-GL canvas specs flaked twice on the same main push (mount assertions timing out at the suite-wide 10s under runner contention), blocking the deploy pipeline while passing locally every time.

- The failing mount assertions wait up to 30s; avatar-satellite also marks itself `test.slow()` like canvas-persistence already does, so the assertion headroom fits the test budget.
- Functional assertions are untouched — only mount latency gets headroom.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality (timeout-only change; full suite passes locally)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/zgeoff/vers/pull/633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

