### PR TITLE
feat(#508): relocate xp settlement from the request path to the verifier

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -43,7 +43,6 @@
           "down",
           "seed",
           "activeAvatarQueryOptions",
-          "avatarProgressionQueryOptions",
           "changePassword",
           "consumePendingTransaction",
           "consumeTransactionToken",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -16,8 +16,7 @@
     // `up`/`down` and `seed` are Kysely-mandated migration and seed-file
     // exports; the oRPC handler exemptions mirror their contract procedure
     // names (the contract key is the public API vocabulary) and would
-    // misname the public API if renamed; the `*QueryOptions` factories
-    // follow the TanStack Query queryOptions naming convention
+    // misname the public API if renamed
     "zgeoff/function-verb": [
       "error",
       {
@@ -42,11 +41,9 @@
           "up",
           "down",
           "seed",
-          "activeAvatarQueryOptions",
           "changePassword",
           "consumePendingTransaction",
           "consumeTransactionToken",
-          "currentActivityQueryOptions",
           "replaySegment",
           "resumeActivity",
           "trackActivityProgress"

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -43,6 +43,7 @@
           "down",
           "seed",
           "activeAvatarQueryOptions",
+          "avatarProgressionQueryOptions",
           "changePassword",
           "consumePendingTransaction",
           "consumeTransactionToken",

--- a/apps/web/src/lib/activity/avatar-progression-query-options.ts
+++ b/apps/web/src/lib/activity/avatar-progression-query-options.ts
@@ -1,9 +1,14 @@
 import { orpc } from '../rpc/orpc';
 
 /**
- * An avatar's settled xp/level plus its pending terminal-but-unsettled xp deltas, or `null` when
- * the avatar doesn't exist or isn't owned by the caller.
+ * Query options for an avatar's settled xp/level plus its pending terminal-but-unsettled xp
+ * deltas, or `null` when the avatar doesn't exist or isn't owned by the caller. Refetched on a
+ * modest interval: settlement lands server-side with no client signal, so polling is what lets a
+ * pending delta quietly firm up into the settled row.
  */
 export function avatarProgressionQueryOptions(avatarID: string) {
-  return orpc.activity.getAvatarProgression.queryOptions({ input: { avatarID } });
+  return {
+    ...orpc.activity.getAvatarProgression.queryOptions({ input: { avatarID } }),
+    refetchInterval: 10_000,
+  };
 }

--- a/apps/web/src/lib/activity/avatar-progression-query-options.ts
+++ b/apps/web/src/lib/activity/avatar-progression-query-options.ts
@@ -1,0 +1,9 @@
+import { orpc } from '../rpc/orpc';
+
+/**
+ * An avatar's settled xp/level plus its pending terminal-but-unsettled xp deltas, or `null` when
+ * the avatar doesn't exist or isn't owned by the caller.
+ */
+export function avatarProgressionQueryOptions(avatarID: string) {
+  return orpc.activity.getAvatarProgression.queryOptions({ input: { avatarID } });
+}

--- a/apps/web/src/lib/activity/build-avatar-progression-query-options.ts
+++ b/apps/web/src/lib/activity/build-avatar-progression-query-options.ts
@@ -6,7 +6,7 @@ import { orpc } from '../rpc/orpc';
  * modest interval: settlement lands server-side with no client signal, so polling is what lets a
  * pending delta quietly firm up into the settled row.
  */
-export function avatarProgressionQueryOptions(avatarID: string) {
+export function buildAvatarProgressionQueryOptions(avatarID: string) {
   return {
     ...orpc.activity.getAvatarProgression.queryOptions({ input: { avatarID } }),
     refetchInterval: 10_000,

--- a/apps/web/src/lib/activity/build-current-activity-query-options.ts
+++ b/apps/web/src/lib/activity/build-current-activity-query-options.ts
@@ -3,6 +3,6 @@ import { orpc } from '../rpc/orpc';
 /**
  * An avatar's current activity row, or `null` when none is active.
  */
-export function currentActivityQueryOptions(avatarID: string) {
+export function buildCurrentActivityQueryOptions(avatarID: string) {
   return orpc.activity.getCurrentActivity.queryOptions({ input: { avatarID } });
 }

--- a/apps/web/src/lib/activity/build-optimistic-progression.test.ts
+++ b/apps/web/src/lib/activity/build-optimistic-progression.test.ts
@@ -29,7 +29,6 @@ test('it overlays the live sim delta onto the settled xp when nothing is pending
   const result = buildOptimisticProgression({
     progression: { level: 3, pending: [], xp: 400 },
     simActivity: { id: 'activity_1', rewards: { xp: 25 } },
-    simAvatar: { level: 4 },
   });
 
   expect(result).toStrictEqual({ isSettling: true, level: buildLevelFromXP(425), xp: 425 });
@@ -43,7 +42,6 @@ test('it dedupes the sim overlay against a matching pending entry, counting its 
       xp: 0,
     },
     simActivity: { id: 'activity_1', rewards: { xp: 150 } },
-    simAvatar: { level: 2 },
   });
 
   expect(result).toStrictEqual({ isSettling: true, level: buildLevelFromXP(150), xp: 150 });
@@ -57,7 +55,6 @@ test('it sums a pending entry and a differently-id sim overlay together', () => 
       xp: 0,
     },
     simActivity: { id: 'activity_2', rewards: { xp: 25 } },
-    simAvatar: { level: 1 },
   });
 
   expect(result).toStrictEqual({ isSettling: true, level: buildLevelFromXP(175), xp: 175 });

--- a/apps/web/src/lib/activity/build-optimistic-progression.test.ts
+++ b/apps/web/src/lib/activity/build-optimistic-progression.test.ts
@@ -1,44 +1,76 @@
 import { expect, test } from 'bun:test';
+import { buildLevelFromXP } from '@vers/idle-core';
 import { buildOptimisticProgression } from './build-optimistic-progression';
 
-test('it sums the anchor xp and the running sim delta when the sim matches the current activity', () => {
+test('it reports the settled row with no settling marker when nothing is pending or in flight', () => {
   const result = buildOptimisticProgression({
-    avatar: { level: 3, xp: 450 },
-    currentActivity: { buildSnapshot: { level: 3, xp: 400 }, id: 'activity_1' },
+    progression: { level: 5, pending: [], xp: 900 },
+  });
+
+  expect(result).toStrictEqual({ isSettling: false, level: 5, xp: 900 });
+});
+
+test('it sums pending deltas onto the settled xp and recomputes the level', () => {
+  const result = buildOptimisticProgression({
+    progression: {
+      level: 1,
+      pending: [
+        { activityID: 'activity_1', xpDelta: 150 },
+        { activityID: 'activity_2', xpDelta: 75 },
+      ],
+      xp: 0,
+    },
+  });
+
+  expect(result).toStrictEqual({ isSettling: true, level: buildLevelFromXP(225), xp: 225 });
+});
+
+test('it overlays the live sim delta onto the settled xp when nothing is pending', () => {
+  const result = buildOptimisticProgression({
+    progression: { level: 3, pending: [], xp: 400 },
     simActivity: { id: 'activity_1', rewards: { xp: 25 } },
     simAvatar: { level: 4 },
   });
 
-  expect(result).toStrictEqual({ level: 4, xp: 425 });
+  expect(result).toStrictEqual({ isSettling: true, level: buildLevelFromXP(425), xp: 425 });
 });
 
-test('it falls back to the anchor alone when no sim is running', () => {
+test('it dedupes the sim overlay against a matching pending entry, counting its xp once', () => {
   const result = buildOptimisticProgression({
-    avatar: { level: 3, xp: 450 },
-    currentActivity: { buildSnapshot: { level: 3, xp: 400 }, id: 'activity_1' },
+    progression: {
+      level: 1,
+      pending: [{ activityID: 'activity_1', xpDelta: 150 }],
+      xp: 0,
+    },
+    simActivity: { id: 'activity_1', rewards: { xp: 150 } },
+    simAvatar: { level: 2 },
   });
 
-  expect(result).toStrictEqual({ level: 3, xp: 400 });
+  expect(result).toStrictEqual({ isSettling: true, level: buildLevelFromXP(150), xp: 150 });
 });
 
-test('it ignores a sim delta from a different activity than the current one', () => {
+test('it sums a pending entry and a differently-id sim overlay together', () => {
   const result = buildOptimisticProgression({
-    avatar: { level: 3, xp: 450 },
-    currentActivity: { buildSnapshot: { level: 3, xp: 400 }, id: 'activity_1' },
+    progression: {
+      level: 1,
+      pending: [{ activityID: 'activity_1', xpDelta: 150 }],
+      xp: 0,
+    },
     simActivity: { id: 'activity_2', rewards: { xp: 25 } },
-    simAvatar: { level: 4 },
+    simAvatar: { level: 1 },
   });
 
-  expect(result).toStrictEqual({ level: 3, xp: 400 });
+  expect(result).toStrictEqual({ isSettling: true, level: buildLevelFromXP(175), xp: 175 });
 });
 
-test('it reports the settled avatar totals when no activity is current', () => {
-  const result = buildOptimisticProgression({
-    avatar: { level: 5, xp: 900 },
-    currentActivity: null,
-    simActivity: { id: 'activity_1', rewards: { xp: 25 } },
-    simAvatar: { level: 6 },
+test('it leaves the display xp unchanged when a delta moves from pending into the settled row', () => {
+  const beforeSettlement = buildOptimisticProgression({
+    progression: { level: 1, pending: [{ activityID: 'activity_1', xpDelta: 150 }], xp: 300 },
   });
 
-  expect(result).toStrictEqual({ level: 5, xp: 900 });
+  const afterSettlement = buildOptimisticProgression({
+    progression: { level: 1, pending: [], xp: 450 },
+  });
+
+  expect(afterSettlement.xp).toBe(beforeSettlement.xp);
 });

--- a/apps/web/src/lib/activity/build-optimistic-progression.ts
+++ b/apps/web/src/lib/activity/build-optimistic-progression.ts
@@ -1,11 +1,14 @@
-interface OptimisticProgressionAvatar {
-  readonly level: number;
-  readonly xp: number;
+import { buildLevelFromXP } from '@vers/idle-core';
+
+interface PendingXPEntry {
+  readonly activityID: string;
+  readonly xpDelta: number;
 }
 
-interface OptimisticProgressionActivity {
-  readonly buildSnapshot: { readonly level: number; readonly xp: number };
-  readonly id: string;
+interface OptimisticProgressionRead {
+  readonly level: number;
+  readonly pending: ReadonlyArray<PendingXPEntry>;
+  readonly xp: number;
 }
 
 interface OptimisticProgressionSimActivity {
@@ -18,38 +21,47 @@ interface OptimisticProgressionSimAvatar {
 }
 
 interface BuildOptimisticProgressionInput {
-  readonly avatar: Readonly<OptimisticProgressionAvatar>;
-  readonly currentActivity: Readonly<OptimisticProgressionActivity> | null;
+  readonly progression: Readonly<OptimisticProgressionRead>;
   readonly simActivity?: Readonly<OptimisticProgressionSimActivity> | undefined;
   readonly simAvatar?: Readonly<OptimisticProgressionSimAvatar> | undefined;
 }
 
+interface OptimisticProgression {
+  /**
+   * Whether the displayed total carries anything not yet on the settled row: a pending entry, a
+   * live sim overlay, or both. A screen renders its settling marker exactly when this is true.
+   */
+  readonly isSettling: boolean;
+  readonly level: number;
+  readonly xp: number;
+}
+
 /**
- * Derives the level/xp a screen renders while an activity is in flight. `buildSnapshot` is the
- * server-authored anchor pinned at the activity's start; the running simulation's level and
- * `rewards.xp` are an optimistic overlay on top of it, applied only while the live sim is still
- * driving that same activity — a stale sim left over from a different one contributes nothing.
- * With no current activity the settled avatar row is the truth: nothing is in flight to
- * optimistically project.
+ * Derives the level/xp a screen renders from the settled progression read: the settled total plus
+ * every pending entry's delta, plus the live sim's own running delta on top — deduped by activity
+ * id against the pending list so a just-terminal run's own entry, once its refetch lands, is never
+ * counted twice. The level is recomputed from the resulting total whenever anything is projected —
+ * a pending entry can carry xp from a run the live sim never drove, so only the aggregate total
+ * derives a trustworthy level; the settled row's own level is exact only once nothing projects on
+ * top of it.
  */
 export function buildOptimisticProgression(
   input: Readonly<BuildOptimisticProgressionInput>,
-): OptimisticProgressionAvatar {
-  if (input.currentActivity === null) {
-    return { level: input.avatar.level, xp: input.avatar.xp };
-  }
+): OptimisticProgression {
+  const pendingXP = input.progression.pending.reduce((total, entry) => total + entry.xpDelta, 0);
 
-  const simMatchesCurrentActivity = input.simActivity?.id === input.currentActivity.id;
+  const simIsPending = input.progression.pending.some(
+    (entry) => entry.activityID === input.simActivity?.id,
+  );
 
-  if (!simMatchesCurrentActivity) {
-    return {
-      level: input.currentActivity.buildSnapshot.level,
-      xp: input.currentActivity.buildSnapshot.xp,
-    };
-  }
+  const overlayApplies = input.simActivity !== undefined && !simIsPending;
+  const overlayXP = overlayApplies ? (input.simActivity?.rewards.xp ?? 0) : 0;
+  const displayXP = input.progression.xp + pendingXP + overlayXP;
+  const isSettling = input.progression.pending.length > 0 || overlayApplies;
 
   return {
-    level: input.simAvatar?.level ?? input.currentActivity.buildSnapshot.level,
-    xp: input.currentActivity.buildSnapshot.xp + (input.simActivity?.rewards.xp ?? 0),
+    isSettling,
+    level: isSettling ? buildLevelFromXP(displayXP) : input.progression.level,
+    xp: displayXP,
   };
 }

--- a/apps/web/src/lib/activity/build-optimistic-progression.ts
+++ b/apps/web/src/lib/activity/build-optimistic-progression.ts
@@ -16,14 +16,9 @@ interface OptimisticProgressionSimActivity {
   readonly rewards: { readonly xp: number };
 }
 
-interface OptimisticProgressionSimAvatar {
-  readonly level: number;
-}
-
 interface BuildOptimisticProgressionInput {
   readonly progression: Readonly<OptimisticProgressionRead>;
   readonly simActivity?: Readonly<OptimisticProgressionSimActivity> | undefined;
-  readonly simAvatar?: Readonly<OptimisticProgressionSimAvatar> | undefined;
 }
 
 interface OptimisticProgression {

--- a/apps/web/src/lib/avatar/build-active-avatar-query-options.ts
+++ b/apps/web/src/lib/avatar/build-active-avatar-query-options.ts
@@ -1,7 +1,7 @@
 import { orpc } from '../rpc/orpc';
 import { findActiveAvatar } from './find-active-avatar';
 
-export function activeAvatarQueryOptions() {
+export function buildActiveAvatarQueryOptions() {
   return orpc.avatar.getAvatars.queryOptions({
     input: {},
     select: findActiveAvatar,

--- a/apps/web/src/routes/-activity/activity-panel.tsx
+++ b/apps/web/src/routes/-activity/activity-panel.tsx
@@ -1,9 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 import { Heading, Spinner, Text } from '@vers/design-system';
 import { css } from '@vers/styled-system/css';
-import { currentActivityQueryOptions } from '../../lib/activity/current-activity-query-options';
+import { buildCurrentActivityQueryOptions } from '../../lib/activity/build-current-activity-query-options';
 import { useActivityRewards } from '../../lib/activity/use-activity-rewards';
-import { activeAvatarQueryOptions } from '../../lib/avatar/active-avatar-query-options';
+import { buildActiveAvatarQueryOptions } from '../../lib/avatar/build-active-avatar-query-options';
 
 const CHARACTER_FRAMES: ReadonlyArray<string> = ['Vanguard', 'Support', 'Striker'];
 
@@ -45,11 +45,11 @@ const characterFrame = css({
  * per-item cards — are a different screen's concern.
  */
 export function ActivityPanel() {
-  const avatarQuery = useQuery(activeAvatarQueryOptions());
+  const avatarQuery = useQuery(buildActiveAvatarQueryOptions());
   const avatarID = avatarQuery.data?.id;
 
   const currentActivityQuery = useQuery({
-    ...currentActivityQueryOptions(avatarID ?? ''),
+    ...buildCurrentActivityQueryOptions(avatarID ?? ''),
     enabled: avatarID !== undefined,
   });
 

--- a/apps/web/src/routes/-avatar/avatar-progression.test.tsx
+++ b/apps/web/src/routes/-avatar/avatar-progression.test.tsx
@@ -19,7 +19,7 @@ test('it renders nothing without a signed-in avatar', async () => {
   });
 });
 
-test('it renders the settled avatar row when no activity is current', async () => {
+test('it renders the settled row with no settling marker when nothing is pending', async () => {
   const signedIn = await createSignedInUser();
 
   await db.avatarCollection.create({ level: 5, userID: signedIn.userID, xp: 900 });
@@ -31,27 +31,59 @@ test('it renders the settled avatar row when no activity is current', async () =
 
     expect(level).toHaveTextContent('Level 5');
     expect(rendered.getByTestId('avatar-xp')).toHaveTextContent('XP: 900');
+    expect(rendered.queryByTestId('avatar-progression-settling')).not.toBeInTheDocument();
   });
 });
 
-test('it shows the optimistic total instead of the settled xp while an activity is current', async () => {
+test('it sums a pending entry onto the settled xp and shows the settling marker', async () => {
   const signedIn = await createSignedInUser();
+  const avatar = await db.avatarCollection.create({ level: 1, userID: signedIn.userID, xp: 400 });
 
-  const avatar = await db.avatarCollection.create({
-    level: 3,
-    userID: signedIn.userID,
-    xp: 450,
+  const activity = await db.activityCollection.create({
+    appendedHead: 1,
+    avatarID: avatar.id,
+    status: 'stopped',
   });
+
+  await db.checkpointCollection.create({
+    activityID: activity.id,
+    payload: {
+      chainIndex: 1,
+      entropySource: 'server-key',
+      nextSeed: 'a'.repeat(32),
+      rewards: { xp: 150 },
+      seed: 'a'.repeat(32),
+      time: 1000,
+      type: 'completed',
+    },
+    version: 1,
+  });
+
+  await withRequestContext({ cookies: signedIn.cookies }, async () => {
+    const rendered = render(<AvatarProgression />);
+
+    const xp = await rendered.findByTestId('avatar-xp');
+
+    await waitFor(() => {
+      expect(xp).toHaveTextContent('XP: 550');
+    });
+
+    expect(rendered.getByTestId('avatar-progression-settling')).toBeInTheDocument();
+  });
+});
+
+test('it shows the optimistic sim overlay and the settling marker while an activity is current', async () => {
+  const signedIn = await createSignedInUser();
+  const avatar = await db.avatarCollection.create({ level: 3, userID: signedIn.userID, xp: 450 });
 
   const activity = await db.activityCollection.create({
     avatarID: avatar.id,
-    buildSnapshot: { level: 3, xp: 400 },
     status: 'active',
   });
 
   setIdleWorkerHandle({
     activity: createMockActivitySnapshot({ id: activity.id, rewards: { xp: 25 } }),
-    avatar: createMockAvatarSnapshot({ level: 3 }),
+    avatar: createMockAvatarSnapshot({ level: 4 }),
     failureAction: ActivityFailureAction.Retry,
     initialized: true,
     worker: undefined,
@@ -60,13 +92,12 @@ test('it shows the optimistic total instead of the settled xp while an activity 
   await withRequestContext({ cookies: signedIn.cookies }, async () => {
     const rendered = render(<AvatarProgression />);
 
-    // the row shows the settled xp until the current-activity query resolves and overlays it
     const xp = await rendered.findByTestId('avatar-xp');
 
     await waitFor(() => {
-      expect(xp).toHaveTextContent('XP: 425');
+      expect(xp).toHaveTextContent('XP: 475');
     });
 
-    expect(xp).not.toHaveTextContent('XP: 450');
+    expect(rendered.getByTestId('avatar-progression-settling')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/routes/-avatar/avatar-progression.tsx
+++ b/apps/web/src/routes/-avatar/avatar-progression.tsx
@@ -31,7 +31,6 @@ export function AvatarProgression() {
   const progression = buildOptimisticProgression({
     progression: settled,
     simActivity: idleWorkerHandle.activity,
-    simAvatar: idleWorkerHandle.avatar,
   });
 
   return (

--- a/apps/web/src/routes/-avatar/avatar-progression.tsx
+++ b/apps/web/src/routes/-avatar/avatar-progression.tsx
@@ -1,21 +1,22 @@
 import { useQuery } from '@tanstack/react-query';
 import { Text } from '@vers/design-system';
+import { avatarProgressionQueryOptions } from '../../lib/activity/avatar-progression-query-options';
 import { buildOptimisticProgression } from '../../lib/activity/build-optimistic-progression';
-import { currentActivityQueryOptions } from '../../lib/activity/current-activity-query-options';
 import { activeAvatarQueryOptions } from '../../lib/avatar/active-avatar-query-options';
 import { useIdleWorkerHandle } from '../../lib/idle/use-idle-worker-handle';
 
 /**
- * Client island rendering the avatar's level and xp: an in-flight activity's optimistic delta on
- * top of the settled anchor, or the settled row directly once nothing is running.
+ * Client island rendering the avatar's level and xp: the settled row plus every pending
+ * terminal-but-unsettled activity's delta, plus an in-flight activity's own running delta on top —
+ * with a settling marker while anything is still projected onto the settled row.
  */
 export function AvatarProgression() {
   const idleWorkerHandle = useIdleWorkerHandle();
   const avatarQuery = useQuery(activeAvatarQueryOptions());
   const avatar = avatarQuery.data;
 
-  const currentActivityQuery = useQuery({
-    ...currentActivityQueryOptions(avatar?.id ?? ''),
+  const progressionQuery = useQuery({
+    ...avatarProgressionQueryOptions(avatar?.id ?? ''),
     enabled: avatar !== null && avatar !== undefined,
   });
 
@@ -23,9 +24,12 @@ export function AvatarProgression() {
     return null;
   }
 
+  // Settled row from the query once it resolves; the avatar row alone with no pending entries
+  // while it's still loading, so the screen shows a total immediately rather than nothing.
+  const settled = progressionQuery.data ?? { level: avatar.level, pending: [], xp: avatar.xp };
+
   const progression = buildOptimisticProgression({
-    avatar,
-    currentActivity: currentActivityQuery.data ?? null,
+    progression: settled,
     simActivity: idleWorkerHandle.activity,
     simAvatar: idleWorkerHandle.avatar,
   });
@@ -34,6 +38,7 @@ export function AvatarProgression() {
     <>
       <Text data-testid="avatar-level">Level {progression.level}</Text>
       <Text data-testid="avatar-xp">XP: {progression.xp}</Text>
+      {progression.isSettling && <Text data-testid="avatar-progression-settling">Settling…</Text>}
     </>
   );
 }

--- a/apps/web/src/routes/-avatar/avatar-progression.tsx
+++ b/apps/web/src/routes/-avatar/avatar-progression.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Text } from '@vers/design-system';
 import { buildAvatarProgressionQueryOptions } from '../../lib/activity/build-avatar-progression-query-options';
 import { buildOptimisticProgression } from '../../lib/activity/build-optimistic-progression';
-import { activeAvatarQueryOptions } from '../../lib/avatar/active-avatar-query-options';
+import { buildActiveAvatarQueryOptions } from '../../lib/avatar/build-active-avatar-query-options';
 import { useIdleWorkerHandle } from '../../lib/idle/use-idle-worker-handle';
 
 /**
@@ -12,7 +12,7 @@ import { useIdleWorkerHandle } from '../../lib/idle/use-idle-worker-handle';
  */
 export function AvatarProgression() {
   const idleWorkerHandle = useIdleWorkerHandle();
-  const avatarQuery = useQuery(activeAvatarQueryOptions());
+  const avatarQuery = useQuery(buildActiveAvatarQueryOptions());
   const avatar = avatarQuery.data;
 
   const progressionQuery = useQuery({

--- a/apps/web/src/routes/-avatar/avatar-progression.tsx
+++ b/apps/web/src/routes/-avatar/avatar-progression.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { Text } from '@vers/design-system';
-import { avatarProgressionQueryOptions } from '../../lib/activity/avatar-progression-query-options';
+import { buildAvatarProgressionQueryOptions } from '../../lib/activity/build-avatar-progression-query-options';
 import { buildOptimisticProgression } from '../../lib/activity/build-optimistic-progression';
 import { activeAvatarQueryOptions } from '../../lib/avatar/active-avatar-query-options';
 import { useIdleWorkerHandle } from '../../lib/idle/use-idle-worker-handle';
@@ -16,7 +16,7 @@ export function AvatarProgression() {
   const avatar = avatarQuery.data;
 
   const progressionQuery = useQuery({
-    ...avatarProgressionQueryOptions(avatar?.id ?? ''),
+    ...buildAvatarProgressionQueryOptions(avatar?.id ?? ''),
     enabled: avatar !== null && avatar !== undefined,
   });
 

--- a/apps/web/src/routes/-explore-current/explore-current-panel.tsx
+++ b/apps/web/src/routes/-explore-current/explore-current-panel.tsx
@@ -8,7 +8,7 @@ import { useSelectedNode } from '@vers/worldmap-client';
 import { Suspense, useEffect, useRef, useState } from 'react';
 import { SimulationUnsupportedNotice } from '../../components/simulation-unsupported-notice';
 import { WorldMapNodeCodexSlot } from '../../components/world-map-node-codex-slot';
-import { activeAvatarQueryOptions } from '../../lib/avatar/active-avatar-query-options';
+import { buildActiveAvatarQueryOptions } from '../../lib/avatar/build-active-avatar-query-options';
 import { sendIdleInitialize } from '../../lib/idle/send-idle-initialize';
 import { sendIdleRequestResync } from '../../lib/idle/send-idle-request-resync';
 import { sendIdleSetActivity } from '../../lib/idle/send-idle-set-activity';
@@ -39,7 +39,7 @@ export function ExploreCurrentPanel(props: ExploreCurrentPanelProps) {
   const isSharedWorkerSupported = useIsSharedWorkerSupported();
   const idleWorkerHandle = useIdleWorkerHandle();
   const selectedNode = useSelectedNode().node;
-  const avatarQuery = useQuery(activeAvatarQueryOptions());
+  const avatarQuery = useQuery(buildActiveAvatarQueryOptions());
   const avatarID = avatarQuery.data?.id;
   const isAutoRetryChecked = idleWorkerHandle.failureAction === ActivityFailureAction.Retry;
 

--- a/apps/web/src/routes/-game/game-simulation-mount.tsx
+++ b/apps/web/src/routes/-game/game-simulation-mount.tsx
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { setCheckpointFlushStall, useResyncStatus } from '@vers/idle-client';
 import { useEffect, useRef } from 'react';
+import { avatarProgressionQueryOptions } from '../../lib/activity/avatar-progression-query-options';
 import { currentActivityQueryOptions } from '../../lib/activity/current-activity-query-options';
 import { activeAvatarQueryOptions } from '../../lib/avatar/active-avatar-query-options';
 import { sendIdleInitialize } from '../../lib/idle/send-idle-initialize';
@@ -156,6 +157,10 @@ export function GameSimulationMount() {
       void queryClient.invalidateQueries({
         queryKey: currentActivityQueryOptions(avatarID).queryKey,
       });
+
+      void queryClient.invalidateQueries({
+        queryKey: avatarProgressionQueryOptions(avatarID).queryKey,
+      });
     }
   }, [idleWorkerHandle.activity?.id, avatarID, queryClient]);
 
@@ -171,6 +176,10 @@ export function GameSimulationMount() {
     if (avatarID !== undefined) {
       void queryClient.invalidateQueries({
         queryKey: currentActivityQueryOptions(avatarID).queryKey,
+      });
+
+      void queryClient.invalidateQueries({
+        queryKey: avatarProgressionQueryOptions(avatarID).queryKey,
       });
     }
   }, [resyncStatus, avatarID, queryClient]);

--- a/apps/web/src/routes/-game/game-simulation-mount.tsx
+++ b/apps/web/src/routes/-game/game-simulation-mount.tsx
@@ -3,8 +3,8 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { setCheckpointFlushStall, useResyncStatus } from '@vers/idle-client';
 import { useEffect, useRef } from 'react';
 import { buildAvatarProgressionQueryOptions } from '../../lib/activity/build-avatar-progression-query-options';
-import { currentActivityQueryOptions } from '../../lib/activity/current-activity-query-options';
-import { activeAvatarQueryOptions } from '../../lib/avatar/active-avatar-query-options';
+import { buildCurrentActivityQueryOptions } from '../../lib/activity/build-current-activity-query-options';
+import { buildActiveAvatarQueryOptions } from '../../lib/avatar/build-active-avatar-query-options';
 import { sendIdleInitialize } from '../../lib/idle/send-idle-initialize';
 import { sendIdleRequestResync } from '../../lib/idle/send-idle-request-resync';
 import { useIdleWorkerHandle } from '../../lib/idle/use-idle-worker-handle';
@@ -23,7 +23,7 @@ let lastEmittedCompletionID: string | undefined;
 export function GameSimulationMount() {
   const idleWorkerHandle = useIdleWorkerHandle();
   const queryClient = useQueryClient();
-  const avatarQuery = useQuery(activeAvatarQueryOptions());
+  const avatarQuery = useQuery(buildActiveAvatarQueryOptions());
   const resyncStatus = useResyncStatus();
   const avatarID = avatarQuery.data?.id;
   const hasSentResync = useRef(false);
@@ -151,11 +151,11 @@ export function GameSimulationMount() {
     }
 
     lastWorkerActivityID.current = workerActivityID;
-    void queryClient.invalidateQueries({ queryKey: activeAvatarQueryOptions().queryKey });
+    void queryClient.invalidateQueries({ queryKey: buildActiveAvatarQueryOptions().queryKey });
 
     if (avatarID !== undefined) {
       void queryClient.invalidateQueries({
-        queryKey: currentActivityQueryOptions(avatarID).queryKey,
+        queryKey: buildCurrentActivityQueryOptions(avatarID).queryKey,
       });
 
       void queryClient.invalidateQueries({
@@ -171,11 +171,11 @@ export function GameSimulationMount() {
       return;
     }
 
-    void queryClient.invalidateQueries({ queryKey: activeAvatarQueryOptions().queryKey });
+    void queryClient.invalidateQueries({ queryKey: buildActiveAvatarQueryOptions().queryKey });
 
     if (avatarID !== undefined) {
       void queryClient.invalidateQueries({
-        queryKey: currentActivityQueryOptions(avatarID).queryKey,
+        queryKey: buildCurrentActivityQueryOptions(avatarID).queryKey,
       });
 
       void queryClient.invalidateQueries({

--- a/apps/web/src/routes/-game/game-simulation-mount.tsx
+++ b/apps/web/src/routes/-game/game-simulation-mount.tsx
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { setCheckpointFlushStall, useResyncStatus } from '@vers/idle-client';
 import { useEffect, useRef } from 'react';
-import { avatarProgressionQueryOptions } from '../../lib/activity/avatar-progression-query-options';
+import { buildAvatarProgressionQueryOptions } from '../../lib/activity/build-avatar-progression-query-options';
 import { currentActivityQueryOptions } from '../../lib/activity/current-activity-query-options';
 import { activeAvatarQueryOptions } from '../../lib/avatar/active-avatar-query-options';
 import { sendIdleInitialize } from '../../lib/idle/send-idle-initialize';
@@ -159,7 +159,7 @@ export function GameSimulationMount() {
       });
 
       void queryClient.invalidateQueries({
-        queryKey: avatarProgressionQueryOptions(avatarID).queryKey,
+        queryKey: buildAvatarProgressionQueryOptions(avatarID).queryKey,
       });
     }
   }, [idleWorkerHandle.activity?.id, avatarID, queryClient]);
@@ -179,7 +179,7 @@ export function GameSimulationMount() {
       });
 
       void queryClient.invalidateQueries({
-        queryKey: avatarProgressionQueryOptions(avatarID).queryKey,
+        queryKey: buildAvatarProgressionQueryOptions(avatarID).queryKey,
       });
     }
   }, [resyncStatus, avatarID, queryClient]);

--- a/contracts/activity/src/activity-contract.ts
+++ b/contracts/activity/src/activity-contract.ts
@@ -31,6 +31,14 @@ const RevealedRewardSchema = z.object({
   ordinal: z.int().min(0),
 });
 
+const PendingXPEntrySchema = z.object({ activityID: z.string(), xpDelta: z.number() });
+
+const AvatarProgressionSchema = z.object({
+  level: z.int(),
+  pending: z.array(PendingXPEntrySchema),
+  xp: z.int(),
+});
+
 /**
  * The activities service's API: every procedure is authed and owner-scoped through the caller's
  * avatars.
@@ -49,6 +57,15 @@ export const activityContract = {
         NOT_FOUND: { data: z.object({}), message: 'No activity with that id' },
       }),
     ),
+
+  getAvatarProgression: authedRoute
+    .route({
+      method: 'GET',
+      path: '/avatars/{avatarID}/progression',
+      summary: "Get an avatar's settled xp/level plus pending unsettled xp deltas",
+    })
+    .input(z.object({ avatarID: z.string() }))
+    .output(AvatarProgressionSchema.nullable()),
 
   getCurrentActivity: authedRoute
     .route({

--- a/docs/architecture/seed-chain.md
+++ b/docs/architecture/seed-chain.md
@@ -87,6 +87,17 @@ Identity settlement and rolled-reward reveal gate on the verified anchor, never 
 head, so a suspect tail that later rejects settles nothing to claw back. A synced but unverified
 reward holds as a pending item on the client until the verifier settles it.
 
+A consequential read — a new activity's `buildSnapshot`, a future point spend, anything feeding a
+new run — anchors on the settled avatar row, never on an appended-but-unverified total. Chains are
+scoped per `(avatar, scope)` and a rejection voids only its own chain's successors, but identity is
+avatar-global: a consequential read of unverified xp would let a rejected run on one chain
+contaminate every other chain the same avatar plays. `getAvatarProgression` reads the settled row
+and its pending projection — one entry per terminal-but-unsettled activity, sourced from that
+activity's own stored checkpoint — in a single statement, so a client display is never torn between
+the two. The settlement apply moves a delta from the pending set into the settled row atomically, so
+any single read of the pair sees the same total before and after. The pending projection is
+display-only.
+
 ## Concurrency
 
 - The verifier serializes a chain's activities on the chain row, adjudicating one at a time in

--- a/libs/testing/mock-services/src/activity/activity-router.ts
+++ b/libs/testing/mock-services/src/activity/activity-router.ts
@@ -1,4 +1,5 @@
 import { getActivityRewards } from './get-activity-rewards';
+import { getAvatarProgression } from './get-avatar-progression';
 import { getCurrentActivity } from './get-current-activity';
 import { getLatestActivityProgress } from './get-latest-activity-progress';
 import { resumeActivity } from './resume-activity';
@@ -8,6 +9,7 @@ import { trackActivityProgress } from './track-activity-progress';
 
 export const activityRouter = {
   getActivityRewards,
+  getAvatarProgression,
   getCurrentActivity,
   getLatestActivityProgress,
   resumeActivity,

--- a/libs/testing/mock-services/src/activity/get-avatar-progression.ts
+++ b/libs/testing/mock-services/src/activity/get-avatar-progression.ts
@@ -1,0 +1,65 @@
+import * as z from 'zod';
+import * as db from '../db';
+import { os } from './os';
+
+/**
+ * Checkpoint types whose `rewards.xp` is a run's final earned total rather than one checkpoint's
+ * own delta — the shape a pending entry's `xpDelta` displays.
+ */
+const TERMINAL_CHECKPOINT_TYPES = new Set(['completed', 'failed']);
+
+const TerminalCheckpointPayloadSchema = z.object({
+  rewards: z.object({ xp: z.number() }),
+  type: z.string(),
+});
+
+/**
+ * Returns the avatar's settled xp/level plus one pending entry per terminal-but-unsettled activity
+ * — a non-active, non-rejected activity whose `verifiedHead` hasn't caught up to its `appendedHead`
+ * — sourced from that activity's tail checkpoint. Seed `checkpointCollection` to assert on a
+ * pending entry's `xpDelta`.
+ */
+export const getAvatarProgression = os.getAvatarProgression.handler((opts) => {
+  const actingUserId = opts.context.actingUserId;
+
+  if (actingUserId === null) {
+    throw opts.errors.UNAUTHORIZED({ data: { reason: 'missing-session' } });
+  }
+
+  const avatar = db.avatarCollection.findFirst((q) =>
+    q.where({ id: opts.input.avatarID, userID: actingUserId }),
+  );
+
+  if (avatar === undefined) {
+    return null;
+  }
+
+  const unsettled = db.activityCollection.findMany((q) =>
+    q.where({
+      avatarID: opts.input.avatarID,
+      status: (value) => value !== 'active' && value !== 'rejected',
+    }),
+  );
+
+  const pending = unsettled
+    .filter((activity) => activity.verifiedHead < activity.appendedHead)
+    .flatMap((activity) => {
+      const checkpoint = db.checkpointCollection.findFirst((q) =>
+        q.where({ activityID: activity.id, version: activity.appendedHead }),
+      );
+
+      if (checkpoint === undefined) {
+        return [];
+      }
+
+      const parsed = TerminalCheckpointPayloadSchema.safeParse(checkpoint.payload);
+
+      if (!parsed.success || !TERMINAL_CHECKPOINT_TYPES.has(parsed.data.type)) {
+        return [];
+      }
+
+      return [{ activityID: activity.id, xpDelta: parsed.data.rewards.xp }];
+    });
+
+  return { level: avatar.level, pending, xp: avatar.xp };
+});

--- a/services/activity/src/build-router.ts
+++ b/services/activity/src/build-router.ts
@@ -4,6 +4,7 @@ import type { DB } from '@vers/db';
 import type { ServiceContext } from '@vers/service-runtime';
 import type { Kysely } from 'kysely';
 import { getActivityRewards } from './handlers/get-activity-rewards';
+import { getAvatarProgression } from './handlers/get-avatar-progression';
 import { getCurrentActivity } from './handlers/get-current-activity';
 import { getLatestActivityProgress } from './handlers/get-latest-activity-progress';
 import { resumeActivity } from './handlers/resume-activity';
@@ -28,6 +29,9 @@ export function buildActivityRouter(deps: BuildActivityRouterDeps) {
 
   return {
     getActivityRewards: os.getActivityRewards.handler((opts) => getActivityRewards(deps.db, opts)),
+    getAvatarProgression: os.getAvatarProgression.handler((opts) =>
+      getAvatarProgression(deps.db, opts),
+    ),
     getCurrentActivity: os.getCurrentActivity.handler((opts) => getCurrentActivity(deps.db, opts)),
     getLatestActivityProgress: os.getLatestActivityProgress.handler((opts) =>
       getLatestActivityProgress(deps.db, opts),

--- a/services/activity/src/handlers/get-avatar-progression.test.ts
+++ b/services/activity/src/handlers/get-avatar-progression.test.ts
@@ -1,0 +1,242 @@
+import { expect, test } from 'bun:test';
+import type { ActivityContract } from '@vers/contract-activity';
+import { createAnonymousViewer, createTestDB, createViewer } from '@vers/service-test-utils/bun';
+import { createSimVersionRow } from '@vers/sim-registry/test-utils';
+import { buildRPCTestClient } from '@vers/test-utils';
+import { createActivityService } from '../create-activity-service';
+import { createAvatarRow } from '../test-utils/create-avatar-row';
+import { createMockCheckpointBatch } from '../test-utils/factories/create-mock-checkpoint-batch';
+
+/**
+ * `trackActivityProgress` opens its own `db.transaction()` for the head-row compare-and-swap, which
+ * can't nest under the default rollback-on-dispose isolation — this suite runs against a real,
+ * committed schema clone instead.
+ */
+async function setupTest() {
+  const db = await createTestDB({ isolation: 'schema' });
+
+  await createSimVersionRow(db.db);
+
+  const service = await createActivityService({ db: db.db });
+
+  return { app: service.app, db: db.db, [Symbol.asyncDispose]: db[Symbol.asyncDispose] };
+}
+
+test('it returns the settled xp and level with no pending entries for an avatar with no activities', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { level: 3, userId: viewer.user.id, xp: 450 });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const result = await client.getAvatarProgression({ avatarID: avatar.id });
+
+  expect(result).toStrictEqual({ level: 3, pending: [], xp: 450 });
+});
+
+test("it includes a pending entry carrying the terminal checkpoint's rewards.xp for an unverified terminal activity", async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id, xp: 0 });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'node_1',
+    scopeType: 'world_map_node',
+  });
+
+  const batch = createMockCheckpointBatch({
+    finalPayloadOverrides: { rewards: { xp: 150 }, type: 'completed' },
+    startPrevHash: started.startHash,
+    startVersion: 1,
+  });
+
+  await client.trackActivityProgress({
+    activityID: started.id,
+    checkpoints: batch,
+    expectedHead: 0,
+  });
+
+  const result = await client.getAvatarProgression({ avatarID: avatar.id });
+
+  expect(result).toStrictEqual({
+    level: 1,
+    pending: [{ activityID: started.id, xpDelta: 150 }],
+    xp: 0,
+  });
+});
+
+test('it excludes a verified activity from pending', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id, xp: 0 });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'node_1',
+    scopeType: 'world_map_node',
+  });
+
+  const batch = createMockCheckpointBatch({
+    finalPayloadOverrides: { rewards: { xp: 150 }, type: 'completed' },
+    startPrevHash: started.startHash,
+    startVersion: 1,
+  });
+
+  await client.trackActivityProgress({
+    activityID: started.id,
+    checkpoints: batch,
+    expectedHead: 0,
+  });
+
+  await ctx.db
+    .updateTable('activities')
+    .set({ verifiedAt: new Date(), verifiedHead: 1 })
+    .where('id', '=', started.id)
+    .execute();
+
+  const result = await client.getAvatarProgression({ avatarID: avatar.id });
+
+  expect(result).toStrictEqual({ level: 1, pending: [], xp: 0 });
+});
+
+test('it excludes a rejected activity from pending', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id, xp: 0 });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'node_1',
+    scopeType: 'world_map_node',
+  });
+
+  const batch = createMockCheckpointBatch({
+    finalPayloadOverrides: { rewards: { xp: 150 }, type: 'completed' },
+    startPrevHash: started.startHash,
+    startVersion: 1,
+  });
+
+  await client.trackActivityProgress({
+    activityID: started.id,
+    checkpoints: batch,
+    expectedHead: 0,
+  });
+
+  await ctx.db
+    .updateTable('activities')
+    .set({ status: 'rejected' })
+    .where('id', '=', started.id)
+    .execute();
+
+  const result = await client.getAvatarProgression({ avatarID: avatar.id });
+
+  expect(result).toStrictEqual({ level: 1, pending: [], xp: 0 });
+});
+
+test('it excludes an active activity from pending', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id, xp: 0 });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'node_1',
+    scopeType: 'world_map_node',
+  });
+
+  const batch = createMockCheckpointBatch({ startPrevHash: started.startHash, startVersion: 1 });
+
+  await client.trackActivityProgress({
+    activityID: started.id,
+    checkpoints: batch,
+    expectedHead: 0,
+  });
+
+  const result = await client.getAvatarProgression({ avatarID: avatar.id });
+
+  expect(result).toStrictEqual({ level: 1, pending: [], xp: 0 });
+});
+
+test('it skips a pending entry whose tail checkpoint carries no terminal rewards payload', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id, xp: 0 });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'node_1',
+    scopeType: 'world_map_node',
+  });
+
+  const batch = createMockCheckpointBatch({ startPrevHash: started.startHash, startVersion: 1 });
+
+  await client.trackActivityProgress({
+    activityID: started.id,
+    checkpoints: batch,
+    expectedHead: 0,
+  });
+
+  // a manual stop lands `stopped` on whatever checkpoint the stream was mid-run at, not a
+  // completed/failed terminal — its payload carries no `rewards` field at all
+  await client.stopActivity({ avatarID: avatar.id });
+
+  const result = await client.getAvatarProgression({ avatarID: avatar.id });
+
+  expect(result).toStrictEqual({ level: 1, pending: [], xp: 0 });
+});
+
+test('it returns null for an avatar owned by another caller', async () => {
+  await using ctx = await setupTest();
+
+  const owner = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: owner.user.id });
+  const otherViewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+
+  const otherClient = buildRPCTestClient<ActivityContract>(ctx.app, { token: otherViewer.token });
+
+  const result = await otherClient.getAvatarProgression({ avatarID: avatar.id });
+
+  expect(result).toBeNull();
+});
+
+test('it returns null for a missing avatar', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const result = await client.getAvatarProgression({ avatarID: 'avatar_missing' });
+
+  expect(result).toBeNull();
+});
+
+test('it rejects an anonymous acting user with UNAUTHORIZED', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createAnonymousViewer({ audience: 'service-activity' });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  expect(client.getAvatarProgression({ avatarID: 'avatar_1' })).rejects.toMatchObject({
+    code: 'UNAUTHORIZED',
+    data: { reason: 'missing-session' },
+  });
+});

--- a/services/activity/src/handlers/get-avatar-progression.ts
+++ b/services/activity/src/handlers/get-avatar-progression.ts
@@ -1,0 +1,107 @@
+import type { DB } from '@vers/db';
+import type { Kysely } from 'kysely';
+import * as z from 'zod';
+import type { MissingSessionPayload } from '../types';
+
+/**
+ * oRPC handler opts for the authed `getAvatarProgression` procedure.
+ */
+interface GetAvatarProgressionOpts {
+  readonly context: { readonly actingUserId: null | string };
+  readonly errors: {
+    readonly UNAUTHORIZED: (payload: MissingSessionPayload) => Error;
+  };
+  readonly input: { readonly avatarID: string };
+}
+
+interface PendingXPEntry {
+  readonly activityID: string;
+  readonly xpDelta: number;
+}
+
+interface AvatarProgression {
+  readonly level: number;
+  readonly pending: Array<PendingXPEntry>;
+  readonly xp: number;
+}
+
+/**
+ * Returns an avatar's settled xp/level plus one pending entry per terminal-but-unsettled activity
+ * — a stopped, capped, quarantined, or parked activity whose verified anchor hasn't caught up to
+ * its appended tail. The settled row and the pending set are read in one statement, so a single
+ * read always sees the same constant sum a verifier apply moves a delta across: settlement never
+ * visibly jumps. Returns null when the avatar doesn't exist or isn't owned by the acting user.
+ */
+export async function getAvatarProgression(
+  db: Kysely<DB>,
+  opts: GetAvatarProgressionOpts,
+): Promise<AvatarProgression | null> {
+  if (opts.context.actingUserId === null) {
+    throw opts.errors.UNAUTHORIZED({ data: { reason: 'missing-session' } });
+  }
+
+  const rows = await db
+    .selectFrom('avatars')
+    .leftJoin('activities', (join) =>
+      join
+        .onRef('activities.avatarId', '=', 'avatars.id')
+        .on('activities.status', '!=', 'active')
+        .on('activities.status', '!=', 'rejected')
+        .onRef('activities.verifiedHead', '<', 'activities.appendedHead'),
+    )
+    .leftJoin('activityCheckpoints', (join) =>
+      join
+        .onRef('activityCheckpoints.activityId', '=', 'activities.id')
+        .onRef('activityCheckpoints.version', '=', 'activities.appendedHead'),
+    )
+    .select(['avatars.level', 'avatars.xp', 'activities.id', 'activityCheckpoints.payload'])
+    .where('avatars.id', '=', opts.input.avatarID)
+    .where('avatars.userId', '=', opts.context.actingUserId)
+    .execute();
+
+  const [settled] = rows;
+
+  if (settled === undefined) {
+    return null;
+  }
+
+  const pending = rows.flatMap((row) => findPendingEntry(row));
+
+  return { level: settled.level, pending, xp: settled.xp };
+}
+
+/**
+ * Checkpoint types whose `rewards.xp` is a run's final earned total rather than one checkpoint's
+ * own delta — the shape a pending entry's `xpDelta` displays, matching what the verifier settles.
+ */
+const TERMINAL_CHECKPOINT_TYPES = new Set(['completed', 'failed']);
+
+const TerminalCheckpointPayloadSchema = z.object({
+  rewards: z.object({ xp: z.number() }),
+  type: z.string(),
+});
+
+interface PendingCandidateRow {
+  readonly id: null | string;
+  readonly payload: unknown;
+}
+
+/**
+ * Builds a pending entry from a candidate row, or nothing when the row carries no pending activity
+ * — a null activity id from the left join, a checkpoint that failed to append past `verifiedHead`
+ * at all, or a checkpoint whose payload doesn't parse or isn't a terminal type. Appended data is
+ * untrusted, so a malformed or non-terminal payload contributes nothing rather than throwing.
+ */
+function findPendingEntry(row: Readonly<PendingCandidateRow>): Array<PendingXPEntry> {
+  if (row.id === null) {
+    return [];
+  }
+
+  const parsed = TerminalCheckpointPayloadSchema.safeParse(row.payload);
+
+  if (!parsed.success || !TERMINAL_CHECKPOINT_TYPES.has(parsed.data.type)) {
+    return [];
+  }
+
+  return [{ activityID: row.id, xpDelta: parsed.data.rewards.xp }];
+}

--- a/services/activity/src/handlers/track-activity-progress.test.ts
+++ b/services/activity/src/handlers/track-activity-progress.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'bun:test';
 import type { ActivityContract } from '@vers/contract-activity';
-import { buildFailureXPLoss, buildLevelFromXP } from '@vers/idle-core';
+import { buildFailureXPLoss } from '@vers/idle-core';
 import {
   createAnonymousViewer,
   createServiceToken,
@@ -400,7 +400,7 @@ test('it rejects an anonymous acting user with UNAUTHORIZED', async () => {
   ).rejects.toMatchObject({ code: 'UNAUTHORIZED', data: { reason: 'missing-session' } });
 });
 
-test('it settles avatar xp and level from a completed terminal checkpoint', async () => {
+test('it leaves the avatar xp and level untouched on a completed terminal checkpoint', async () => {
   await using ctx = await setupTest();
 
   const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
@@ -414,10 +414,8 @@ test('it settles avatar xp and level from a completed terminal checkpoint', asyn
     scopeType: 'world_map_node',
   });
 
-  const rewardsXP = 150;
-
   const batch = createMockCheckpointBatch({
-    finalPayloadOverrides: { rewards: { xp: rewardsXP }, type: 'completed' },
+    finalPayloadOverrides: { rewards: { xp: 150 }, type: 'completed' },
     startPrevHash: started.startHash,
     startVersion: 1,
   });
@@ -434,8 +432,8 @@ test('it settles avatar xp and level from a completed terminal checkpoint', asyn
     .where('id', '=', avatar.id)
     .executeTakeFirstOrThrow();
 
-  expect(updated.xp).toBe(rewardsXP);
-  expect(updated.level).toBe(buildLevelFromXP(rewardsXP));
+  expect(updated.xp).toBe(0);
+  expect(updated.level).toBe(avatar.level);
 
   const updatedActivity = await ctx.db
     .selectFrom('activities')
@@ -447,12 +445,12 @@ test('it settles avatar xp and level from a completed terminal checkpoint', asyn
   expect(updatedActivity.stoppedAt).not.toBeNil();
 });
 
-test('it settles a clamped xp loss from a failed terminal checkpoint', async () => {
+test('it leaves the avatar xp and level untouched on a failed terminal checkpoint', async () => {
   await using ctx = await setupTest();
 
   const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
 
-  // partway into a level, so the failure loss is nonzero but the ratchet still holds
+  // partway into a level, so a settled failure loss would be nonzero if the request path applied it
   const startingXP = 150;
 
   const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id, xp: startingXP });
@@ -466,10 +464,9 @@ test('it settles a clamped xp loss from a failed terminal checkpoint', async () 
   });
 
   const loss = buildFailureXPLoss(startingXP);
-  const rewardsXP = -loss;
 
   const batch = createMockCheckpointBatch({
-    finalPayloadOverrides: { rewards: { xp: rewardsXP }, type: 'failed' },
+    finalPayloadOverrides: { rewards: { xp: -loss }, type: 'failed' },
     startPrevHash: started.startHash,
     startVersion: 1,
   });
@@ -487,8 +484,8 @@ test('it settles a clamped xp loss from a failed terminal checkpoint', async () 
     .executeTakeFirstOrThrow();
 
   expect(loss).toBeGreaterThan(0);
-  expect(updated.xp).toBe(startingXP + rewardsXP);
-  expect(updated.level).toBe(buildLevelFromXP(startingXP + rewardsXP));
+  expect(updated.xp).toBe(startingXP);
+  expect(updated.level).toBe(avatar.level);
 });
 
 test('it advances the chain anchor to the terminal checkpoint on a completed batch', async () => {
@@ -822,7 +819,7 @@ test('it returns the settled head when a terminal batch is resubmitted unchanged
     .where('id', '=', avatar.id)
     .executeTakeFirstOrThrow();
 
-  expect(updatedAvatar.xp).toBe(150);
+  expect(updatedAvatar.xp).toBe(0);
 
   const checkpoints = await ctx.db
     .selectFrom('activityCheckpoints')
@@ -1534,7 +1531,7 @@ test('it rejects a batch whose time regresses below the already accounted time w
   ).rejects.toMatchObject({ code: 'CHECKPOINT_INVALID', data: { reason: 'time-regression' } });
 });
 
-test('it debits the meter alongside the xp settlement on a terminal batch', async () => {
+test('it debits the meter on a terminal batch that leaves xp settlement to the verifier', async () => {
   await using ctx = await setupTest();
 
   const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
@@ -1567,7 +1564,7 @@ test('it debits the meter alongside the xp settlement on a terminal batch', asyn
     .where('id', '=', avatar.id)
     .executeTakeFirstOrThrow();
 
-  expect(updated.xp).toBe(150);
+  expect(updated.xp).toBe(0);
   expect(Number(updated.simBudgetMs)).toBeWithin(289_000, 291_000);
 });
 

--- a/services/activity/src/handlers/track-activity-progress.ts
+++ b/services/activity/src/handlers/track-activity-progress.ts
@@ -1,7 +1,6 @@
 import type { CheckpointBatchEntry, CheckpointPayload } from '@vers/contract-activity';
 import { RewardSlotSchema, buildCheckpointHash } from '@vers/contract-activity';
 import type { ActivityStatus, DB, Json } from '@vers/db';
-import { buildLevelFromXP } from '@vers/idle-core';
 import type { ServiceContext } from '@vers/service-runtime';
 import { sql } from 'kysely';
 import type { Kysely } from 'kysely';
@@ -61,9 +60,10 @@ interface TrackActivityProgressOpts {
  * Only the stamped writer session may append; an unstamped activity is claimed by the first
  * appending session.
  *
- * A terminal last checkpoint (completed or failed) claims the activity's terminal transition in
- * the same transaction and settles the avatar's xp/level from its final rewards total — the claim
- * guards a duplicate resubmission against double-applying.
+ * A terminal last checkpoint (completed or failed) claims the activity's terminal transition and
+ * advances the chain's appended anchor in the same transaction — the claim guards a duplicate
+ * resubmission against double-applying. Settlement of the avatar's xp/level lives behind the
+ * verifier, not here: this path only records what was appended.
  *
  * Every accepted batch debits the avatar's simulated-time meter: the budget refills at wall-clock
  * rate up to the cap, and the batch's delta — the last checkpoint's cumulative `time` minus the
@@ -99,7 +99,6 @@ export async function trackActivityProgress(
       'activities.writerSessionId',
       'avatars.simBudgetMs',
       'avatars.simMeteredAt',
-      'avatars.xp',
     ])
 
     // Cast to the meter columns' timestamp type so the driver parses both sides of the elapsed
@@ -263,17 +262,6 @@ export async function trackActivityProgress(
         scopeType: head.scopeType,
         startChainIndex: head.startChainIndex,
       });
-
-      const newXP = Math.max(0, Math.round(head.xp + terminalRewardsXP));
-
-      const settled = await trx
-        .updateTable('avatars')
-        .set({ level: buildLevelFromXP(newXP), xp: newXP })
-        .where('id', '=', head.avatarId)
-        .where('xp', '=', head.xp)
-        .executeTakeFirst();
-
-      invariant(settled.numUpdatedRows > 0n, 'avatar settlement must apply exactly once');
     }
 
     if (timeDelta > 0) {

--- a/services/replay/src/replay/types.ts
+++ b/services/replay/src/replay/types.ts
@@ -95,8 +95,8 @@ type DivergenceReason =
 
 /**
  * The outcome of comparing a segment's stored checkpoints against a fresh replay. `match` carries
- * the segment's verified xp delta (the terminal checkpoint's reward, when the segment ends on one)
- * for a future settlement consumer to apply — this worker never writes it.
+ * the segment's verified xp delta (the terminal checkpoint's reward, when the segment ends on one,
+ * else zero) for the caller to fold into its `applyVerifiedSegment` call.
  */
 export type CompareVerdict =
   | {

--- a/services/replay/src/worker/run-frontier.test.ts
+++ b/services/replay/src/worker/run-frontier.test.ts
@@ -110,6 +110,13 @@ test('it settles the terminal checkpoint reward into the avatar xp and level on 
   invariant(terminal !== undefined, 'the fixture always ends on a checkpoint');
   expect(terminal.rewards.xp).toBeGreaterThan(0);
 
+  // a non-zero baseline distinguishes the delta add from an absolute overwrite
+  await ctx.db
+    .updateTable('avatars')
+    .set({ level: buildLevelFromXP(500), xp: 500 })
+    .where('id', '=', fixture.activity.avatarId)
+    .execute();
+
   const cache = createReplayCache();
 
   const deps = {
@@ -139,8 +146,8 @@ test('it settles the terminal checkpoint reward into the avatar xp and level on 
     .where('id', '=', fixture.activity.avatarId)
     .executeTakeFirstOrThrow();
 
-  expect(avatar.xp).toBe(terminal.rewards.xp);
-  expect(avatar.level).toBe(buildLevelFromXP(terminal.rewards.xp));
+  expect(avatar.xp).toBe(500 + terminal.rewards.xp);
+  expect(avatar.level).toBe(buildLevelFromXP(500 + terminal.rewards.xp));
 });
 
 test('it leaves the avatar xp and level untouched on a matched mid-run segment', async () => {

--- a/services/replay/src/worker/run-frontier.test.ts
+++ b/services/replay/src/worker/run-frontier.test.ts
@@ -1,8 +1,10 @@
 import { expect, test } from 'bun:test';
 import { buildStateFromSeed } from '@vers/game-utils';
+import { buildLevelFromXP } from '@vers/idle-core';
 import { resolveServiceURL } from '@vers/mock-services';
 import { createTestDB, getTestServiceKeyPair } from '@vers/service-test-utils/bun';
 import pino from 'pino';
+import invariant from 'tiny-invariant';
 import { createReplayCache } from '../replay/create-replay-cache';
 import { createHonestActivityFixture } from '../test-utils/create-honest-activity-fixture';
 import { runFrontier } from './run-frontier';
@@ -93,4 +95,164 @@ test('it reports idle rather than throwing when the claimed activity row is gone
   );
 
   expect(outcome).toStrictEqual({ kind: 'idle' });
+});
+
+test('it settles the terminal checkpoint reward into the avatar xp and level on a matched terminal segment', async () => {
+  await using ctx = await setupTest();
+
+  const fixture = await createHonestActivityFixture(ctx.db, {
+    duration: 80_000,
+    seed: buildStateFromSeed(3_047_525_658),
+  });
+
+  const terminal = fixture.engineCheckpoints.at(-1);
+
+  invariant(terminal !== undefined, 'the fixture always ends on a checkpoint');
+  expect(terminal.rewards.xp).toBeGreaterThan(0);
+
+  const cache = createReplayCache();
+
+  const deps = {
+    db: ctx.db,
+    keysServiceURL: resolveServiceURL('keys'),
+    logger: pino({ enabled: false }),
+    privateKey: ctx.privateKey,
+    simVersion: 'test-engine-hash',
+  };
+
+  const outcome = await ctx.db.transaction().execute((trx) =>
+    runFrontier(trx, deps, cache, {
+      activityID: fixture.activity.id,
+      appendedHead: fixture.activity.appendedHead,
+      replayAttempts: 0,
+      startChainIndex: fixture.activity.startChainIndex,
+      status: fixture.activity.status,
+      verifiedHead: 0,
+    }),
+  );
+
+  expect(outcome.kind).toBe('matched');
+
+  const avatar = await ctx.db
+    .selectFrom('avatars')
+    .select(['level', 'xp'])
+    .where('id', '=', fixture.activity.avatarId)
+    .executeTakeFirstOrThrow();
+
+  expect(avatar.xp).toBe(terminal.rewards.xp);
+  expect(avatar.level).toBe(buildLevelFromXP(terminal.rewards.xp));
+});
+
+test('it leaves the avatar xp and level untouched on a matched mid-run segment', async () => {
+  await using ctx = await setupTest();
+
+  const fixture = await createHonestActivityFixture(ctx.db, {
+    duration: 80_000,
+    seed: buildStateFromSeed(3_047_525_658),
+  });
+
+  const totalCheckpoints = fixture.checkpoints.length;
+  const midRunCount = totalCheckpoints - 1;
+
+  expect(midRunCount).toBeGreaterThan(0);
+
+  await ctx.db
+    .deleteFrom('activityCheckpoints')
+    .where('activityId', '=', fixture.activity.id)
+    .where('version', '>', midRunCount)
+    .execute();
+
+  await ctx.db
+    .updateTable('activities')
+    .set({ appendedHead: midRunCount, lastHash: fixture.checkpoints[midRunCount - 1]?.hash })
+    .where('id', '=', fixture.activity.id)
+    .execute();
+
+  const cache = createReplayCache();
+
+  const deps = {
+    db: ctx.db,
+    keysServiceURL: resolveServiceURL('keys'),
+    logger: pino({ enabled: false }),
+    privateKey: ctx.privateKey,
+    simVersion: 'test-engine-hash',
+  };
+
+  const outcome = await ctx.db.transaction().execute((trx) =>
+    runFrontier(trx, deps, cache, {
+      activityID: fixture.activity.id,
+      appendedHead: midRunCount,
+      replayAttempts: 0,
+      startChainIndex: fixture.activity.startChainIndex,
+      status: fixture.activity.status,
+      verifiedHead: 0,
+    }),
+  );
+
+  expect(outcome.kind).toBe('matched');
+
+  const avatar = await ctx.db
+    .selectFrom('avatars')
+    .select(['level', 'xp'])
+    .where('id', '=', fixture.activity.avatarId)
+    .executeTakeFirstOrThrow();
+
+  expect(avatar.xp).toBe(0);
+  expect(avatar.level).toBe(1);
+});
+
+test('it settles no additional xp when a stale duplicate frontier misses the already-advanced cursor', async () => {
+  await using ctx = await setupTest();
+
+  const fixture = await createHonestActivityFixture(ctx.db, {
+    duration: 80_000,
+    seed: buildStateFromSeed(3_047_525_658),
+  });
+
+  const cache = createReplayCache();
+
+  const deps = {
+    db: ctx.db,
+    keysServiceURL: resolveServiceURL('keys'),
+    logger: pino({ enabled: false }),
+    privateKey: ctx.privateKey,
+    simVersion: 'test-engine-hash',
+  };
+
+  const staleFrontier = {
+    activityID: fixture.activity.id,
+    appendedHead: fixture.activity.appendedHead,
+    replayAttempts: 0,
+    startChainIndex: fixture.activity.startChainIndex,
+    status: fixture.activity.status,
+    verifiedHead: 0,
+  };
+
+  const first = await ctx.db
+    .transaction()
+    .execute((trx) => runFrontier(trx, deps, cache, staleFrontier));
+
+  expect(first.kind).toBe('matched');
+
+  const afterFirst = await ctx.db
+    .selectFrom('avatars')
+    .select('xp')
+    .where('id', '=', fixture.activity.avatarId)
+    .executeTakeFirstOrThrow();
+
+  // replays the same stale frontier, whose `verifiedHead` no longer matches the cursor the first
+  // apply already advanced
+  const second = await ctx.db
+    .transaction()
+    .execute((trx) => runFrontier(trx, deps, cache, staleFrontier));
+
+  expect(second.kind).toBe('matched');
+
+  const afterSecond = await ctx.db
+    .selectFrom('avatars')
+    .select('xp')
+    .where('id', '=', fixture.activity.avatarId)
+    .executeTakeFirstOrThrow();
+
+  expect(afterSecond.xp).toBe(afterFirst.xp);
 });

--- a/services/replay/src/worker/run-frontier.ts
+++ b/services/replay/src/worker/run-frontier.ts
@@ -149,7 +149,15 @@ async function runFrontierInProcess(
     : compareReplaySegment(unverified, replayed, compareContext);
 
   if (verdict?.kind === 'match') {
-    return applyMatch(trx, deps, segment, replayed, driver, verdict.rewardFacts);
+    return applyMatch(
+      trx,
+      deps,
+      segment,
+      replayed,
+      driver,
+      verdict.rewardFacts,
+      verdict.verifiedXPDelta,
+    );
   }
 
   const confirmDriver = buildFreshDriver(segment);
@@ -209,7 +217,15 @@ async function runFrontierCrossVersion(
       : compareReplaySegment(unverified, replayed, compareContext);
 
   if (verdict?.kind === 'match') {
-    return applyMatch(trx, deps, segment, replayed, undefined, verdict.rewardFacts);
+    return applyMatch(
+      trx,
+      deps,
+      segment,
+      replayed,
+      undefined,
+      verdict.rewardFacts,
+      verdict.verifiedXPDelta,
+    );
   }
 
   const confirmOutcome = await runReplaySegment(runDeps, job);
@@ -239,6 +255,7 @@ async function applyMatch(
   replayed: ReadonlyArray<ReplayedCheckpoint>,
   driver: SimulationDriver | undefined,
   rewardFacts: ReadonlyArray<RewardFact>,
+  verifiedXPDelta: number,
 ): Promise<ReplayIterationOutcome> {
   const lastReplayed = replayed.at(-1);
   const lastStored = segment.checkpoints.at(-1);
@@ -277,6 +294,7 @@ async function applyMatch(
         scopeType: segment.activity.scopeType,
       },
     }),
+    xpDelta: verifiedXPDelta,
   });
 
   const effect: PendingCacheEffect =

--- a/services/replay/src/worker/run-replay-iteration.test.ts
+++ b/services/replay/src/worker/run-replay-iteration.test.ts
@@ -3,7 +3,7 @@ import type { ErrorEvent } from '@sentry/bun';
 import { buildCheckpointHash } from '@vers/contract-activity';
 import type { Json } from '@vers/db';
 import { buildStateFromSeed } from '@vers/game-utils';
-import { buildSimulationInput } from '@vers/idle-core';
+import { buildLevelFromXP, buildSimulationInput } from '@vers/idle-core';
 import { createSimulationDriver } from '@vers/idle-core/replay';
 import { resolveServiceURL } from '@vers/mock-services';
 import { setSentryHandleForTesting, startErrorReporting } from '@vers/service-runtime';
@@ -337,6 +337,14 @@ test('it settles no xp and drops the rejected activity from the pending anchor w
     .where('version', '=', targetVersion)
     .execute();
 
+  // a non-zero baseline proves rejection preserves legitimately settled progression rather than
+  // passing because there was nothing to lose
+  await ctx.db
+    .updateTable('avatars')
+    .set({ level: buildLevelFromXP(500), xp: 500 })
+    .where('id', '=', fixture.activity.avatarId)
+    .execute();
+
   const deps = {
     db: ctx.db,
     keysServiceURL: resolveServiceURL('keys'),
@@ -368,8 +376,8 @@ test('it settles no xp and drops the rejected activity from the pending anchor w
     .where('id', '=', fixture.activity.avatarId)
     .executeTakeFirstOrThrow();
 
-  expect(avatar.xp).toBe(0);
-  expect(avatar.level).toBe(1);
+  expect(avatar.xp).toBe(500);
+  expect(avatar.level).toBe(buildLevelFromXP(500));
 });
 
 test('it rejects a checkpoint with a forged chain position', async () => {

--- a/services/replay/src/worker/run-replay-iteration.test.ts
+++ b/services/replay/src/worker/run-replay-iteration.test.ts
@@ -300,6 +300,78 @@ test('it rejects a checkpoint with a forged continuation seed, rewinds the chain
   expect(updatedSuccessor.status).toBe('rejected');
 });
 
+test('it settles no xp and drops the rejected activity from the pending anchor when a checkpoint is forged', async () => {
+  await using ctx = await setupTest();
+
+  const fixture = await createHonestActivityFixture(ctx.db, {
+    duration: 80_000,
+    seed: buildStateFromSeed(3_047_525_658),
+  });
+
+  const targetVersion = 1;
+  const target = fixture.checkpoints.find((checkpoint) => checkpoint.version === targetVersion);
+
+  expect(target).toBeDefined();
+
+  const tamperedPayload: Record<string, unknown> = { ...target?.payload, chainIndex: 999 };
+
+  // oxlint-disable typescript/no-unsafe-type-assertion -- the fixture's payload is a hand-built, schema-shaped object
+  const tamperedHash = buildCheckpointHash({
+    chainIndex: 999,
+    entropySource: 'server-key',
+    nextSeed: tamperedPayload['nextSeed'] as string,
+    prevHash: target?.prevHash ?? '',
+    seed: tamperedPayload['seed'] as string,
+    time: tamperedPayload['time'] as number,
+    type: tamperedPayload['type'] as string,
+    version: targetVersion,
+  });
+
+  // oxlint-enable typescript/no-unsafe-type-assertion
+
+  await ctx.db
+    .updateTable('activityCheckpoints')
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the column is untyped jsonb; the value is a hand-tampered, schema-shaped payload
+    .set({ hash: tamperedHash, payload: tamperedPayload as Json })
+    .where('activityId', '=', fixture.activity.id)
+    .where('version', '=', targetVersion)
+    .execute();
+
+  const deps = {
+    db: ctx.db,
+    keysServiceURL: resolveServiceURL('keys'),
+    logger: buildSilentLogger(),
+    privateKey: ctx.privateKey,
+    simVersion: 'test-engine-hash',
+  };
+
+  const cache = createReplayCache();
+
+  const outcome = await runReplayIteration(deps, cache);
+
+  expect(outcome).toStrictEqual({ kind: 'rejected' });
+
+  const updatedActivity = await ctx.db
+    .selectFrom('activities')
+    .select(['appendedHead', 'status', 'verifiedHead'])
+    .where('id', '=', fixture.activity.id)
+    .executeTakeFirstOrThrow();
+
+  // rejected excludes the activity from the pending predicate outright, regardless of its
+  // unsettled head gap
+  expect(updatedActivity.status).toBe('rejected');
+  expect(updatedActivity.verifiedHead).toBeLessThan(updatedActivity.appendedHead);
+
+  const avatar = await ctx.db
+    .selectFrom('avatars')
+    .select(['level', 'xp'])
+    .where('id', '=', fixture.activity.avatarId)
+    .executeTakeFirstOrThrow();
+
+  expect(avatar.xp).toBe(0);
+  expect(avatar.level).toBe(1);
+});
+
 test('it rejects a checkpoint with a forged chain position', async () => {
   await using ctx = await setupTest();
 


### PR DESCRIPTION
## Description

Closes #508

Moves xp/level settlement off the activity request path and onto the replay verifier, so an avatar's progression only changes once its segment is verified. Adds a progression procedure that layers pending unsettled xp on top of the settled value for the client to project.

- `applyVerifiedSegment` takes the verifier's `verifiedXPDelta` and settles xp/level itself; `trackActivityProgress` only advances the appended anchor and status
- new `getAvatarProgression` procedure: one left-join query for settled xp/level plus a pending entry per terminal-but-unsettled activity, parsed from that activity's tail checkpoint
- worked around a Kysely `CamelCasePlugin` bug where a string column alias corrupted the rest of the select array
- client sums pending deltas against the live sim (deduped by activity id), derives level from the aggregate, and shows a "Settling…" marker
- docs: state the settled-anchor principle in the seed-chain doc

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
