### PR TITLE
fix(#604): keep one replay machine warm so verification never stalls

### DIFF
--- a/deploy.config.ts
+++ b/deploy.config.ts
@@ -76,6 +76,7 @@ export default defineDeployManifest({
       buildArgsFromEnv: ['SIM_ENGINE_HASH', 'BUN_VERSION'],
       configDir: 'services/replay',
       dockerfile: 'services/replay/Dockerfile',
+      minStartedMachines: 1,
       simVersionProvider: true,
       trigger: { kind: 'turbo-affected', pkg: '@vers/service-replay' },
     },

--- a/docs/architecture/deployment.md
+++ b/docs/architecture/deployment.md
@@ -13,9 +13,12 @@ private, reachable only across the organization's 6PN WireGuard mesh. Postgres i
 (see [database](./database.md)); no app runs its own database, Bugsink included. `service-keys`
 holds no database connection — its state is the `ROLL_KEY_ROOTS` secret alone.
 
-Every app scales to zero. `auto_stop_machines = 'suspend'` parks an idle machine with its memory
-snapshot for sub-second wake. `app-web` keeps one machine warm (`min_machines_running = 1`) so a
-visitor never waits on a cold start; a service wakes on its first request.
+Every app scales to zero except where a warm machine is required. `auto_stop_machines = 'suspend'`
+parks an idle machine with its memory snapshot for sub-second wake, and a service wakes on its first
+request. Two apps keep one machine warm (`min_machines_running = 1`, enforced by `deploy verify`
+through the manifest's `minStartedMachines`): `app-web`, so a visitor never waits on a cold start,
+and `service-replay`, whose poll-driven worker receives no inbound requests and would otherwise stop
+claiming chains the moment its machines suspend.
 
 ## Networking
 

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -89,4 +89,6 @@ problems needing fleet action), `elapsed-time` (replay duration cap tripped — 
 Each recording's log line carries the raw numbers behind it (heads, checkpoint counts, sim version).
 
 The `vers verification lag` threshold monitor watches `vers.verification.lag` and notifies
-`vers alarms`.
+`vers alarms`, alerting on no data as well as on the threshold: the gauge exports from
+`service-replay`'s always-warm machine (see [deployment](./deployment.md)), so a silent dataset
+means the exporter or the process around it is down — never a healthy quiet system.

--- a/services/replay/fly.toml
+++ b/services/replay/fly.toml
@@ -11,7 +11,10 @@ internal_port = 3000
 force_https = false
 auto_stop_machines = 'suspend'
 auto_start_machines = true
-min_machines_running = 0
+# The replay worker is a DB poll loop with no inbound traffic in normal play — a
+# suspended machine never wakes on its own, so one machine stays running to keep
+# verification and the lag gauge's exporter alive.
+min_machines_running = 1
 processes = ['app']
 
 [http_service.concurrency]


### PR DESCRIPTION
## Description

Closes #604

The replay worker is a DB poll loop with no inbound traffic, so scale-to-zero suspended its machines and verification stalled silently — no chain claiming, no `vers.verification.lag` export — until the app was woken by hand.

- `services/replay/fly.toml` sets `min_machines_running = 1` so one machine always runs the worker and the gauge exporter.
- `deploy.config.ts` sets `minStartedMachines: 1` on the replay app, so `deploy verify` catches a fleet state where no machine is started (the failure mode of the last secrets rollout).
- Docs: deployment's warm-machine roster and observability's lag-monitor no-data semantics.

## Testing

- [x] `bun run typecheck` passes
- [ ] `bun run test` passes
- [ ] `bun run lint` passes
- [ ] New tests added for new functionality

## Context

The Axiom `vers verification lag` monitor flips to alert-on-no-data out-of-band once this deploys — with a permanently warm exporter, a silent dataset always means a fault. Monitor-as-code follows in a separate issue.