### PR TITLE
fix(#639): start progression-suite activities at a registered node

### DIFF
--- a/services/activity/src/handlers/get-avatar-progression.test.ts
+++ b/services/activity/src/handlers/get-avatar-progression.test.ts
@@ -45,7 +45,7 @@ test("it includes a pending entry carrying the terminal checkpoint's rewards.xp 
 
   const started = await client.startActivity({
     avatarID: avatar.id,
-    scopeID: 'node_1',
+    scopeID: 'a9lp75',
     scopeType: 'world_map_node',
   });
 
@@ -80,7 +80,7 @@ test('it excludes a verified activity from pending', async () => {
 
   const started = await client.startActivity({
     avatarID: avatar.id,
-    scopeID: 'node_1',
+    scopeID: 'a9lp75',
     scopeType: 'world_map_node',
   });
 
@@ -117,7 +117,7 @@ test('it excludes a rejected activity from pending', async () => {
 
   const started = await client.startActivity({
     avatarID: avatar.id,
-    scopeID: 'node_1',
+    scopeID: 'a9lp75',
     scopeType: 'world_map_node',
   });
 
@@ -154,7 +154,7 @@ test('it excludes an active activity from pending', async () => {
 
   const started = await client.startActivity({
     avatarID: avatar.id,
-    scopeID: 'node_1',
+    scopeID: 'a9lp75',
     scopeType: 'world_map_node',
   });
 
@@ -181,7 +181,7 @@ test('it skips a pending entry whose tail checkpoint carries no terminal rewards
 
   const started = await client.startActivity({
     avatarID: avatar.id,
-    scopeID: 'node_1',
+    scopeID: 'a9lp75',
     scopeType: 'world_map_node',
   });
 


### PR DESCRIPTION
## Description

Closes #639

The avatar-progression suite starts activities at `scopeID: 'node_1'`, which server-side encounter-node resolution rejects with `NODE_UNKNOWN` — five tests fail on main because the suite and the validation merged in adjacent PRs whose checks never ran against each other.

- Uses the registered world-map node `a9lp75` (the id the activity-start suite exercises) in all five starts.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes (`@vers/service-activity`: 121 pass, 0 fail)
- [ ] `bun run lint` passes
- [ ] New tests added for new functionality