### PR TITLE
feat(#585): retry a failed resync instead of masking it as offline

### DIFF
--- a/apps/web/src/routes/-game/welcome-back-modal.test.tsx
+++ b/apps/web/src/routes/-game/welcome-back-modal.test.tsx
@@ -1,7 +1,10 @@
 import { expect, onTestFinished, test } from 'bun:test';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { setResyncStatus } from '@vers/idle-client';
+import type { ClientMessage } from '@vers/idle-client';
+import { ClientMessageType, setResyncStatus } from '@vers/idle-client';
+import { ActivityFailureAction } from '@vers/idle-core';
+import { setIdleWorkerHandle } from '../../test-utils/set-idle-worker-handle';
 import { WelcomeBackModal } from './welcome-back-modal';
 
 test('it renders nothing while no resync is underway', () => {
@@ -52,6 +55,44 @@ test('it explains a capped catch-up', () => {
 
   render(<WelcomeBackModal />);
   expect(screen.getByText(/reached its cap/)).toBeInTheDocument();
+});
+
+test('it offers a retry when the catch-up fails outright', () => {
+  setResyncStatus({ avatarID: 'avatar_1', kind: 'failed' });
+
+  onTestFinished(() => {
+    setResyncStatus(null);
+  });
+
+  render(<WelcomeBackModal />);
+  expect(screen.getByText('Catching up didn’t finish. Your progress is safe.')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument();
+});
+
+test('it retries by requesting a fresh resync and clearing the failed status', async () => {
+  const user = userEvent.setup();
+  const calls: Array<ClientMessage> = [];
+  const worker = { port: { postMessage: (message: ClientMessage) => calls.push(message) } };
+
+  setIdleWorkerHandle({
+    activity: undefined,
+    failureAction: ActivityFailureAction.Abort,
+    initialized: true,
+    worker,
+  });
+
+  setResyncStatus({ avatarID: 'avatar_1', kind: 'failed' });
+
+  onTestFinished(() => {
+    setResyncStatus(null);
+  });
+
+  render(<WelcomeBackModal />);
+
+  await user.click(screen.getByRole('button', { name: 'Try again' }));
+
+  expect(calls).toStrictEqual([{ avatarID: 'avatar_1', type: ClientMessageType.RequestResync }]);
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 });
 
 test('it dismisses by clearing the resync status', async () => {

--- a/apps/web/src/routes/-game/welcome-back-modal.test.tsx
+++ b/apps/web/src/routes/-game/welcome-back-modal.test.tsx
@@ -1,4 +1,4 @@
-import { expect, onTestFinished, test } from 'bun:test';
+import { expect, test } from 'bun:test';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ClientMessage } from '@vers/idle-client';
@@ -14,11 +14,6 @@ test('it renders nothing while no resync is underway', () => {
 
 test('it masks the catch-up from its zero-tally start', () => {
   setResyncStatus({ attempts: 0, kind: 'fast-forwarding', levelUps: 0 });
-
-  onTestFinished(() => {
-    setResyncStatus(null);
-  });
-
   render(<WelcomeBackModal />);
   expect(screen.getByText('Welcome back')).toBeInTheDocument();
   expect(screen.getByText('Catching up… 0 attempts, 0 level-ups so far.')).toBeInTheDocument();
@@ -26,44 +21,24 @@ test('it masks the catch-up from its zero-tally start', () => {
 
 test('it reports the running tally while fast-forwarding', () => {
   setResyncStatus({ attempts: 12, kind: 'fast-forwarding', levelUps: 1 });
-
-  onTestFinished(() => {
-    setResyncStatus(null);
-  });
-
   render(<WelcomeBackModal />);
   expect(screen.getByText('Catching up… 12 attempts, 1 level-ups so far.')).toBeInTheDocument();
 });
 
 test('it reports the final tally when the catch-up is done', () => {
   setResyncStatus({ attempts: 42, kind: 'done', levelUps: 2 });
-
-  onTestFinished(() => {
-    setResyncStatus(null);
-  });
-
   render(<WelcomeBackModal />);
   expect(screen.getByText('While you were away: 42 attempts, 2 level-ups.')).toBeInTheDocument();
 });
 
 test('it explains a capped catch-up', () => {
   setResyncStatus({ kind: 'capped' });
-
-  onTestFinished(() => {
-    setResyncStatus(null);
-  });
-
   render(<WelcomeBackModal />);
   expect(screen.getByText(/reached its cap/)).toBeInTheDocument();
 });
 
 test('it offers a retry when the catch-up fails outright', () => {
   setResyncStatus({ avatarID: 'avatar_1', kind: 'failed' });
-
-  onTestFinished(() => {
-    setResyncStatus(null);
-  });
-
   render(<WelcomeBackModal />);
   expect(screen.getByText('Catching up didn’t finish. Your progress is safe.')).toBeInTheDocument();
   expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument();
@@ -82,11 +57,6 @@ test('it retries by requesting a fresh resync and clearing the failed status', a
   });
 
   setResyncStatus({ avatarID: 'avatar_1', kind: 'failed' });
-
-  onTestFinished(() => {
-    setResyncStatus(null);
-  });
-
   render(<WelcomeBackModal />);
 
   await user.click(screen.getByRole('button', { name: 'Try again' }));
@@ -99,11 +69,6 @@ test('it dismisses by clearing the resync status', async () => {
   const user = userEvent.setup();
 
   setResyncStatus({ attempts: 42, kind: 'done', levelUps: 2 });
-
-  onTestFinished(() => {
-    setResyncStatus(null);
-  });
-
   render(<WelcomeBackModal />);
 
   await user.click(screen.getByRole('button', { name: 'Close' }));

--- a/apps/web/src/routes/-game/welcome-back-modal.tsx
+++ b/apps/web/src/routes/-game/welcome-back-modal.tsx
@@ -1,15 +1,19 @@
-import { Dialog, Text } from '@vers/design-system';
+import { Button, Dialog, Text } from '@vers/design-system';
 import { setResyncStatus, useResyncStatus } from '@vers/idle-client';
 import type { ResyncStatus } from '@vers/idle-client';
+import { sendIdleRequestResync } from '../../lib/idle/send-idle-request-resync';
+import { useIdleWorkerHandle } from '../../lib/idle/use-idle-worker-handle';
 
 /**
  * Masks the offline catch-up after an away-and-return: it opens the moment a resync starts
  * fast-forwarding a real away period, reports attempts and level-ups as they land, and stays up
  * with the final tally (or the cap notice) until dismissed. A resync with no away period to
- * report — a fresh login, a zero-gap reconnect — broadcasts no status, so it never opens this.
+ * report — a fresh login, a zero-gap reconnect — broadcasts no status, so it never opens this. A
+ * resync that fails outright opens on a retry action instead.
  */
 export function WelcomeBackModal() {
   const resyncStatus = useResyncStatus();
+  const idleWorkerHandle = useIdleWorkerHandle();
 
   if (resyncStatus === null) {
     return null;
@@ -25,12 +29,31 @@ export function WelcomeBackModal() {
       open
       title="Welcome back"
     >
-      <Text>{formatResyncStatus(resyncStatus)}</Text>
+      {resyncStatus.kind === 'failed' ? (
+        <>
+          <Text>Catching up didn’t finish. Your progress is safe.</Text>
+          <Button
+            onClick={() => {
+              if (idleWorkerHandle.worker !== undefined) {
+                sendIdleRequestResync(idleWorkerHandle.worker, resyncStatus.avatarID);
+              }
+
+              setResyncStatus(null);
+            }}
+          >
+            Try again
+          </Button>
+        </>
+      ) : (
+        <Text>{formatResyncStatus(resyncStatus)}</Text>
+      )}
     </Dialog>
   );
 }
 
-function formatResyncStatus(resyncStatus: Readonly<ResyncStatus>): string {
+function formatResyncStatus(
+  resyncStatus: Readonly<Exclude<ResyncStatus, { readonly kind: 'failed' }>>,
+): string {
   if (resyncStatus.kind === 'capped') {
     return 'Offline progress reached its cap. Your avatar held position — jump back in to continue.';
   }

--- a/libs/game/idle-client/src/types.ts
+++ b/libs/game/idle-client/src/types.ts
@@ -214,10 +214,12 @@ export interface RewardSlotLedgerSnapshot {
 
 /**
  * The catch-up flow's lifecycle as tabs observe it: fast-forwarding with running attempt and
- * level-up counts, done with the final tallies, or capped when the server stopped the stream at
- * the offline-progress bound. A resync with no real away period broadcasts nothing.
+ * level-up counts, done with the final tallies, capped when the server stopped the stream at the
+ * offline-progress bound, or failed when the catch-up couldn't complete. A resync with no real
+ * away period broadcasts nothing.
  */
 export type ResyncStatus =
   | { readonly attempts: number; readonly kind: 'done'; readonly levelUps: number }
   | { readonly attempts: number; readonly kind: 'fast-forwarding'; readonly levelUps: number }
+  | { readonly avatarID: string; readonly kind: 'failed' }
   | { readonly kind: 'capped' };

--- a/libs/game/idle-client/src/worker/create-resync-status-message.test.ts
+++ b/libs/game/idle-client/src/worker/create-resync-status-message.test.ts
@@ -10,3 +10,12 @@ test('it creates a resync status message', () => {
     type: WorkerMessageType.ResyncStatus,
   });
 });
+
+test('it creates a resync status message for a failed catch-up', () => {
+  const message = createResyncStatusMessage({ avatarID: 'avatar-1', kind: 'failed' });
+
+  expect(message).toStrictEqual({
+    status: { avatarID: 'avatar-1', kind: 'failed' },
+    type: WorkerMessageType.ResyncStatus,
+  });
+});

--- a/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
@@ -384,7 +384,7 @@ test('it attaches a fresh login live without broadcasting any catch-up status', 
   expect(simulation.activity?.id).toBe(activity.id);
 });
 
-test('it reports a fault to the error backend and folds to offline when the resync fails outright', async () => {
+test('it reports a fault to the error backend and broadcasts a failed status when the resync fails outright', async () => {
   const previousHandle = sentryHandle.current;
   const recorded: Array<Readonly<ErrorEvent>> = [];
 
@@ -419,10 +419,19 @@ test('it reports a fault to the error backend and folds to offline when the resy
 
   await handleRequestResyncMessage(context, message);
 
-  await connection.waitForMessages(1);
+  // posted on the worker's own port after the handler settles, this arrives after anything the
+  // handler broadcast on the same channel — a single failed status proves no connection-status
+  // change rode along with it
+  connection.port.postMessage({ online: true, type: WorkerMessageType.ConnectionStatus });
+
+  await connection.waitForMessages(2);
 
   expect(connection.received).toStrictEqual([
-    { online: false, type: WorkerMessageType.ConnectionStatus },
+    {
+      status: { avatarID: 'avatar-with-held-tail', kind: 'failed' },
+      type: WorkerMessageType.ResyncStatus,
+    },
+    { online: true, type: WorkerMessageType.ConnectionStatus },
   ]);
 
   await waitFor(() => {

--- a/libs/game/idle-client/src/worker/handle-request-resync-message.ts
+++ b/libs/game/idle-client/src/worker/handle-request-resync-message.ts
@@ -7,7 +7,6 @@ import { runResync } from '../resync/run-resync';
 import type { FastForwardReport, ResyncPlan, ResyncResult } from '../resync/types';
 import type { RequestResyncMessage, ResyncStatus } from '../types';
 import { createCheckpointStreamInvalidMessage } from './create-checkpoint-stream-invalid-message';
-import { createConnectionStatusMessage } from './create-connection-status-message';
 import { createResyncStatusMessage } from './create-resync-status-message';
 import { registerSimulationListeners } from './register-simulation-listeners';
 import { reportWorkerFault } from './report-worker-fault';
@@ -21,8 +20,9 @@ import type { WorkerContext } from './types';
  * resolves; a zero-gap outcome (live re-attach, no activity) stays silent, so a fresh login never
  * opens that UI. A live simulation this resync would install is skipped when a different activity
  * went live while it was running — a fresher `SetActivity` always wins. A resync that fails
- * outright forwards the fault to the error backend and reports the worker offline — the signal
- * tabs use to explain a stalled catch-up — and never rejects; the next reconnect retries it.
+ * outright forwards the fault to the error backend and broadcasts a `failed` `ResyncStatus` for
+ * the requesting avatar, never a connection-status change — connectivity is the connection layer's
+ * own signal, not a resync outcome — and never rejects; a tab's retry re-requests it.
  */
 export async function handleRequestResyncMessage(
   context: WorkerContext,
@@ -54,7 +54,7 @@ export async function handleRequestResyncMessage(
     await applyResyncResult(context, result);
   } catch (error) {
     reportWorkerFault('resync', error);
-    emitConnectionStatus(context, false);
+    emitResyncStatus(context, { avatarID: message.avatarID, kind: 'failed' });
   } finally {
     context.setResyncInFlight(false);
   }
@@ -227,14 +227,6 @@ function setLiveSimulation(
 
 function emitResyncStatus(context: WorkerContext, status: Readonly<ResyncStatus>): void {
   const message = createResyncStatusMessage(status);
-
-  for (const connection of context.connections) {
-    connection.postMessage(message);
-  }
-}
-
-function emitConnectionStatus(context: WorkerContext, online: boolean): void {
-  const message = createConnectionStatusMessage(online);
 
   for (const connection of context.connections) {
     connection.postMessage(message);


### PR DESCRIPTION
## Description

Closes #585

A resync that fails outright now surfaces as its own status instead of masquerading as a connection drop, so the welcome-back modal can offer a retry rather than leaving the tab looking merely offline.

- `ResyncStatus` gains a `failed` arm carrying the avatar ID it failed for
- the worker's resync orchestrator broadcasts that `failed` status on outright failure instead of a connection-status-offline signal, and drops the now-unused connection-status import/helper
- the welcome-back modal renders failure copy with a `Try again` button that re-sends `RequestResync` over the existing worker handle and clears the status, relying on the worker's single-flight guard instead of client-side debouncing

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality

## Context
