### PR TITLE
test: drop per-test restores of preload-owned store state

### DIFF
--- a/apps/web/src/routes/-explore-current/approaching-cap-warning.test.tsx
+++ b/apps/web/src/routes/-explore-current/approaching-cap-warning.test.tsx
@@ -1,4 +1,4 @@
-import { expect, onTestFinished, test } from 'bun:test';
+import { expect, test } from 'bun:test';
 import { render, screen } from '@testing-library/react';
 import { setOfflineCapStatus } from '@vers/idle-client';
 import { ApproachingCapWarning } from './approaching-cap-warning';
@@ -10,22 +10,12 @@ test('it renders nothing while no cap status is reported', () => {
 
 test('it warns with the remaining time while the budget drains', () => {
   setOfflineCapStatus({ halted: false, remainingMs: 5_400_000 });
-
-  onTestFinished(() => {
-    setOfflineCapStatus(null);
-  });
-
   render(<ApproachingCapWarning />);
   expect(screen.getByText('Reconnect within 1h 30m to keep progressing.')).toBeInTheDocument();
 });
 
 test('it reports the pause once the worker halts at the boundary', () => {
   setOfflineCapStatus({ halted: true, remainingMs: 0 });
-
-  onTestFinished(() => {
-    setOfflineCapStatus(null);
-  });
-
   render(<ApproachingCapWarning />);
   expect(screen.getByText('Progress is paused — reconnect to continue.')).toBeInTheDocument();
 });

--- a/libs/game/idle-client/src/state/set-checkpoint-flush-stall.test.ts
+++ b/libs/game/idle-client/src/state/set-checkpoint-flush-stall.test.ts
@@ -1,12 +1,8 @@
-import { expect, onTestFinished, test } from 'bun:test';
+import { expect, test } from 'bun:test';
 import { setCheckpointFlushStall } from './set-checkpoint-flush-stall';
 import { useIdleStore } from './use-idle-store';
 
 test('it records the flush stall report', () => {
-  onTestFinished(() => {
-    useIdleStore.setState({ checkpointFlushStall: null });
-  });
-
   setCheckpointFlushStall({ activityID: 'activity_1', reason: 'network down', traceID: 'trace_1' });
 
   expect(useIdleStore.getState().checkpointFlushStall).toStrictEqual({
@@ -23,10 +19,6 @@ test('it clears a consumed flush stall report', () => {
 });
 
 test('it leaves the reward-slot ledger untouched when a flush stalls', () => {
-  onTestFinished(() => {
-    useIdleStore.setState({ checkpointFlushStall: null, rewardSlotLedger: [] });
-  });
-
   useIdleStore.setState({
     checkpointFlushStall: null,
     rewardSlotLedger: [{ count: 2, version: 1 }],

--- a/libs/game/idle-client/src/worker/use-simulation-worker.test.ts
+++ b/libs/game/idle-client/src/worker/use-simulation-worker.test.ts
@@ -148,10 +148,6 @@ test('it reports a checkpoint stream error from worker messages', async () => {
 test('it records a flush stall report from worker messages', async () => {
   registerSharedWorkerStub();
 
-  onTestFinished(() => {
-    useIdleStore.setState({ checkpointFlushStall: null });
-  });
-
   const hook = renderHook(() => useSimulationWorker());
 
   hook.rerender();


### PR DESCRIPTION
## Description

Removes per-test `onTestFinished` restores of Zustand store state that each package's preload reset already owns — per AGENTS.md, restoring preload-owned state per test is noise.

- app-web and idle-client both register the zustand `create` wrapper in their preloads, so the idle store resets between tests on its own
- the global `SharedWorker` swaps keep their restores — no preload owns that global
- the same pattern in the welcome-back modal tests is removed on PR #642, which touches that file

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality
