### PR TITLE
refactor(#650): narrow the idle send helpers to the port member they use

### DIFF
--- a/apps/web/src/lib/idle/send-idle-initialize.ts
+++ b/apps/web/src/lib/idle/send-idle-initialize.ts
@@ -3,6 +3,6 @@ import { createInitializeMessage } from '@vers/idle-client';
 /**
  * Sends the one-time message a freshly connected worker needs before it reports simulation state.
  */
-export function sendIdleInitialize(worker: SharedWorker): void {
+export function sendIdleInitialize(worker: Pick<SharedWorker, 'port'>): void {
   worker.port.postMessage(createInitializeMessage());
 }

--- a/apps/web/src/lib/idle/send-idle-request-resync.ts
+++ b/apps/web/src/lib/idle/send-idle-request-resync.ts
@@ -1,5 +1,5 @@
 import { createRequestResyncMessage } from '@vers/idle-client';
 
-export function sendIdleRequestResync(worker: SharedWorker, avatarID: string): void {
+export function sendIdleRequestResync(worker: Pick<SharedWorker, 'port'>, avatarID: string): void {
   worker.port.postMessage(createRequestResyncMessage(avatarID));
 }

--- a/apps/web/src/lib/idle/send-idle-set-activity.ts
+++ b/apps/web/src/lib/idle/send-idle-set-activity.ts
@@ -5,6 +5,9 @@ import { createSetActivityMessage } from '@vers/idle-client';
  * Tells the worker to start a fresh stream from a newly created activity row — resuming any other
  * activity, live or offline, goes through the resync request instead.
  */
-export function sendIdleSetActivity(worker: SharedWorker, activity: Readonly<ActivityData>): void {
+export function sendIdleSetActivity(
+  worker: Pick<SharedWorker, 'port'>,
+  activity: Readonly<ActivityData>,
+): void {
   worker.port.postMessage(createSetActivityMessage(activity));
 }

--- a/apps/web/src/lib/idle/send-idle-set-failure-action.ts
+++ b/apps/web/src/lib/idle/send-idle-set-failure-action.ts
@@ -2,7 +2,7 @@ import { createSetFailureActionMessage } from '@vers/idle-client';
 import type { ActivityFailureAction } from '@vers/idle-core';
 
 export function sendIdleSetFailureAction(
-  worker: SharedWorker,
+  worker: Pick<SharedWorker, 'port'>,
   failureAction: ActivityFailureAction,
 ): void {
   worker.port.postMessage(createSetFailureActionMessage(failureAction));


### PR DESCRIPTION
## Description

Closes #650

The `sendIdle*` helpers typed their parameter as the full `SharedWorker` while only reading `worker.port`, forcing any test that calls one directly with a structural fake into an `as unknown as` cast past the lint rule. Each parameter is now `Pick<SharedWorker, 'port'>`, matching the flush waiter and the duck-typed worker-handle stub.

- No call-site changes: real `SharedWorker` values satisfy the narrowed type
- No behavior change, so no new tests

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality