### PR TITLE
feat(#581): persist the avatar's offline retry preference server-side

### DIFF
--- a/apps/web/src/lib/idle/send-idle-set-failure-action.ts
+++ b/apps/web/src/lib/idle/send-idle-set-failure-action.ts
@@ -3,7 +3,8 @@ import type { ActivityFailureAction } from '@vers/idle-core';
 
 export function sendIdleSetFailureAction(
   worker: Pick<SharedWorker, 'port'>,
+  avatarID: string,
   failureAction: ActivityFailureAction,
 ): void {
-  worker.port.postMessage(createSetFailureActionMessage(failureAction));
+  worker.port.postMessage(createSetFailureActionMessage(avatarID, failureAction));
 }

--- a/apps/web/src/routes/-explore-current/explore-current-panel.test.tsx
+++ b/apps/web/src/routes/-explore-current/explore-current-panel.test.tsx
@@ -299,8 +299,7 @@ test('it offers a retry instead of spinning forever when starting fails, and ret
 
 test('it renders the auto-retry checkbox unchecked by default and dispatches the toggle', async () => {
   const signedIn = await createSignedInUser();
-
-  await db.avatarCollection.create({ userID: signedIn.userID });
+  const avatar = await db.avatarCollection.create({ userID: signedIn.userID });
 
   setSelectedNode(createMockWorldMapNode({ id: 'a9lp75' }));
 
@@ -340,6 +339,7 @@ test('it renders the auto-retry checkbox unchecked by default and dispatches the
     await user.click(checkbox);
 
     expect(calls).toContainEqual({
+      avatarID: avatar.id,
       failureAction: ActivityFailureAction.Retry,
       type: ClientMessageType.SetFailureAction,
     });

--- a/apps/web/src/routes/-explore-current/explore-current-panel.tsx
+++ b/apps/web/src/routes/-explore-current/explore-current-panel.tsx
@@ -167,7 +167,7 @@ export function ExploreCurrentPanel(props: ExploreCurrentPanelProps) {
           checked: isAutoRetryChecked,
           id: 'auto-retry-on-failure',
           onClick: () => {
-            if (idleWorkerHandle.worker === undefined) {
+            if (idleWorkerHandle.worker === undefined || avatarID === undefined) {
               return;
             }
 
@@ -175,7 +175,7 @@ export function ExploreCurrentPanel(props: ExploreCurrentPanelProps) {
               ? ActivityFailureAction.Abort
               : ActivityFailureAction.Retry;
 
-            sendIdleSetFailureAction(idleWorkerHandle.worker, nextFailureAction);
+            sendIdleSetFailureAction(idleWorkerHandle.worker, avatarID, nextFailureAction);
           },
         }}
         errors={[]}

--- a/contracts/activity/src/activity-contract.ts
+++ b/contracts/activity/src/activity-contract.ts
@@ -1,6 +1,7 @@
 import { authedRoute, defineErrors } from '@vers/contract-base';
 import * as z from 'zod';
 import { ActivityDataSchema } from './activity-data-schema';
+import { ActivityFailureActionSchema } from './activity-failure-action-schema';
 import { ActivityStatusSchema } from './activity-status-schema';
 import { CheckpointBatchEntrySchema } from './checkpoint-batch-entry-schema';
 import { CheckpointSchema } from './checkpoint-schema';
@@ -88,6 +89,7 @@ export const activityContract = {
         activity: ActivityDataSchema,
         anchor: CheckpointSchema.nullable(),
         appendedHead: z.int(),
+        failureAction: ActivityFailureActionSchema,
         serverTime: z.date(),
         verifiedHead: z.int(),
       }),
@@ -212,6 +214,20 @@ export const activityContract = {
           message: "The submitting session is no longer the activity's writer",
           status: 403,
         },
+      }),
+    ),
+
+  updateFailureAction: authedRoute
+    .route({
+      method: 'PUT',
+      path: '/avatars/{avatarID}/activity/failure-action',
+      summary: "Persist an avatar's failure-action preference",
+    })
+    .input(z.object({ avatarID: z.string(), failureAction: ActivityFailureActionSchema }))
+    .output(z.object({ failureAction: ActivityFailureActionSchema }))
+    .errors(
+      defineErrors({
+        NOT_FOUND: { data: z.object({}), message: 'Avatar not found' },
       }),
     ),
 };

--- a/contracts/activity/src/activity-failure-action-schema.test.ts
+++ b/contracts/activity/src/activity-failure-action-schema.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'bun:test';
+import { ActivityFailureActionSchema } from './activity-failure-action-schema';
+
+test('it accepts every declared failure-action value', () => {
+  for (const failureAction of ['abort', 'retry']) {
+    expect(ActivityFailureActionSchema.safeParse(failureAction).success).toBeTrue();
+  }
+});
+
+test('it rejects a failure action outside the enum', () => {
+  const result = ActivityFailureActionSchema.safeParse('ignore');
+
+  expect(result.success).toBeFalse();
+  expect(result.error?.issues).toPartiallyContain(expect.objectContaining({ path: [] }));
+});

--- a/contracts/activity/src/activity-failure-action-schema.ts
+++ b/contracts/activity/src/activity-failure-action-schema.ts
@@ -1,0 +1,9 @@
+import * as z from 'zod';
+
+/**
+ * An avatar's persisted policy for a failed attempt: `abort` stops the stream at the failure,
+ * `retry` starts a fresh continuation from the same scope.
+ */
+export const ActivityFailureActionSchema = z.enum(['abort', 'retry']);
+
+export type ActivityFailureAction = z.infer<typeof ActivityFailureActionSchema>;

--- a/contracts/activity/src/index.ts
+++ b/contracts/activity/src/index.ts
@@ -2,6 +2,8 @@ export type { ActivityContract } from './activity-contract';
 export { activityContract } from './activity-contract';
 export type { ActivityData } from './activity-data-schema';
 export { ActivityDataSchema } from './activity-data-schema';
+export type { ActivityFailureAction } from './activity-failure-action-schema';
+export { ActivityFailureActionSchema } from './activity-failure-action-schema';
 export type { ActivityStatus } from './activity-status-schema';
 export { ActivityStatusSchema } from './activity-status-schema';
 export { buildCheckpointHash } from './build-checkpoint-hash';

--- a/libs/data/db/migrations/1784357566065_avatars_failure_action.ts
+++ b/libs/data/db/migrations/1784357566065_avatars_failure_action.ts
@@ -1,0 +1,22 @@
+import type { Kysely } from 'kysely';
+import { sql } from 'kysely';
+
+/**
+ * Creates the `activity_failure_action` enum and adds the `failure_action` column to `avatars`,
+ * defaulted to `abort` for every existing row.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema.createType('activity_failure_action').asEnum(['abort', 'retry']).execute();
+
+  await db.schema
+    .alterTable('avatars')
+    .addColumn('failure_action', sql`activity_failure_action`, (col) =>
+      col.notNull().defaultTo('abort'),
+    )
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.alterTable('avatars').dropColumn('failure_action').execute();
+  await db.schema.dropType('activity_failure_action').execute();
+}

--- a/libs/data/db/src/schema.generated.ts
+++ b/libs/data/db/src/schema.generated.ts
@@ -5,6 +5,8 @@
 
 import type { ColumnType } from 'kysely';
 
+export type ActivityFailureAction = 'abort' | 'retry';
+
 export type ActivityStatus =
   | 'active'
   | 'capped'
@@ -99,6 +101,7 @@ export interface AvatarItems {
 
 export interface Avatars {
   createdAt: Generated<Timestamp>;
+  failureAction: Generated<ActivityFailureAction>;
   id: string;
   level: Generated<number>;
   mode: Generated<AvatarMode>;

--- a/libs/game/idle-client/src/index.ts
+++ b/libs/game/idle-client/src/index.ts
@@ -14,6 +14,7 @@ export type {
 
 export { setCheckpointFlushStall } from './state/set-checkpoint-flush-stall';
 export { setConnectionStatus } from './state/set-connection-status';
+export { setFailureAction } from './state/set-failure-action';
 export { setOfflineCapStatus } from './state/set-offline-cap-status';
 export { setResyncStatus } from './state/set-resync-status';
 export { setRewardSlotLedger } from './state/set-reward-slot-ledger';

--- a/libs/game/idle-client/src/resync/run-fast-forward.test.ts
+++ b/libs/game/idle-client/src/resync/run-fast-forward.test.ts
@@ -15,8 +15,9 @@ import invariant from 'tiny-invariant';
 import { server } from '../mocks/node';
 import { createCheckpointSubmitter } from '../submission/create-checkpoint-submitter';
 import type { ActivityServiceClient } from '../submission/types';
+import { createMockLatestActivityProgress } from '../test-utils/factories/create-mock-latest-activity-progress';
 import { runFastForward } from './run-fast-forward';
-import type { FastForwardProgress, LatestActivityProgress } from './types';
+import type { FastForwardProgress } from './types';
 
 interface TrackedBatch {
   readonly checkpoints: ReadonlyArray<CheckpointBatchEntry>;
@@ -58,15 +59,7 @@ function setupTest() {
 
 test('it discards a partial attempt and submits nothing when the budget is too small', async () => {
   const ctx = setupTest();
-
-  const progress: LatestActivityProgress = {
-    activity: createMockActivityData(),
-    anchor: null,
-    appendedHead: 0,
-    failureAction: 'abort',
-    serverTime: new Date(),
-    verifiedHead: 0,
-  };
+  const progress = createMockLatestActivityProgress();
 
   const report = await runFastForward({
     budgetMs: 3000,
@@ -105,15 +98,7 @@ test('it discards a partial attempt and submits nothing when the budget is too s
 
 test('it reports the final row terminal when a reconstructed tail lands exactly on the budget', async () => {
   const ctx = setupTest();
-
-  const progress: LatestActivityProgress = {
-    activity: createMockActivityData(),
-    anchor: null,
-    appendedHead: 1,
-    failureAction: 'abort',
-    serverTime: new Date(),
-    verifiedHead: 0,
-  };
+  const progress = createMockLatestActivityProgress({ appendedHead: 1 });
 
   // One fixed input template, deep-copied per call: the probe attempt below and the
   // fast-forward's reconstruction must simulate byte-identically for the budget to land exactly.
@@ -165,15 +150,7 @@ test('it reports the final row terminal when a reconstructed tail lands exactly 
 test('it stops after the first failed attempt under the abort policy', async () => {
   const ctx = setupTest();
   const onProgress = mock<(progress: FastForwardProgress) => void>();
-
-  const progress: LatestActivityProgress = {
-    activity: createMockActivityData(),
-    anchor: null,
-    appendedHead: 0,
-    failureAction: 'abort',
-    serverTime: new Date(),
-    verifiedHead: 0,
-  };
+  const progress = createMockLatestActivityProgress();
 
   const report = await runFastForward({
     budgetMs: 60_000,
@@ -215,15 +192,7 @@ test('it stops after the first failed attempt under the abort policy', async () 
 
 test('it chains fresh server-started attempts through failures under the retry policy', async () => {
   const ctx = setupTest();
-
-  const progress: LatestActivityProgress = {
-    activity: createMockActivityData(),
-    anchor: null,
-    appendedHead: 0,
-    failureAction: 'abort',
-    serverTime: new Date(),
-    verifiedHead: 0,
-  };
+  const progress = createMockLatestActivityProgress();
 
   const report = await runFastForward({
     budgetMs: 30_000,
@@ -261,14 +230,10 @@ test('it chains fresh server-started attempts through failures under the retry p
 test('it resumes a mid-stream activity submitting only the tail past the appended head', async () => {
   const ctx = setupTest();
 
-  const progress: LatestActivityProgress = {
+  const progress = createMockLatestActivityProgress({
     activity: createMockActivityData({ appendedHead: 1 }),
-    anchor: null,
     appendedHead: 1,
-    failureAction: 'abort',
-    serverTime: new Date(),
-    verifiedHead: 0,
-  };
+  });
 
   const report = await runFastForward({
     budgetMs: 60_000,
@@ -301,15 +266,7 @@ test('it resumes a mid-stream activity submitting only the tail past the appende
 
 test('it reports the final row it left off at, for a caller to attach directly', async () => {
   const ctx = setupTest();
-
-  const progress: LatestActivityProgress = {
-    activity: createMockActivityData(),
-    anchor: null,
-    appendedHead: 0,
-    failureAction: 'abort',
-    serverTime: new Date(),
-    verifiedHead: 0,
-  };
+  const progress = createMockLatestActivityProgress();
 
   const report = await runFastForward({
     budgetMs: 30_000,

--- a/libs/game/idle-client/src/resync/run-fast-forward.test.ts
+++ b/libs/game/idle-client/src/resync/run-fast-forward.test.ts
@@ -63,6 +63,7 @@ test('it discards a partial attempt and submits nothing when the budget is too s
     activity: createMockActivityData(),
     anchor: null,
     appendedHead: 0,
+    failureAction: 'abort',
     serverTime: new Date(),
     verifiedHead: 0,
   };
@@ -109,6 +110,7 @@ test('it reports the final row terminal when a reconstructed tail lands exactly 
     activity: createMockActivityData(),
     anchor: null,
     appendedHead: 1,
+    failureAction: 'abort',
     serverTime: new Date(),
     verifiedHead: 0,
   };
@@ -168,6 +170,7 @@ test('it stops after the first failed attempt under the abort policy', async () 
     activity: createMockActivityData(),
     anchor: null,
     appendedHead: 0,
+    failureAction: 'abort',
     serverTime: new Date(),
     verifiedHead: 0,
   };
@@ -217,6 +220,7 @@ test('it chains fresh server-started attempts through failures under the retry p
     activity: createMockActivityData(),
     anchor: null,
     appendedHead: 0,
+    failureAction: 'abort',
     serverTime: new Date(),
     verifiedHead: 0,
   };
@@ -261,6 +265,7 @@ test('it resumes a mid-stream activity submitting only the tail past the appende
     activity: createMockActivityData({ appendedHead: 1 }),
     anchor: null,
     appendedHead: 1,
+    failureAction: 'abort',
     serverTime: new Date(),
     verifiedHead: 0,
   };
@@ -301,6 +306,7 @@ test('it reports the final row it left off at, for a caller to attach directly',
     activity: createMockActivityData(),
     anchor: null,
     appendedHead: 0,
+    failureAction: 'abort',
     serverTime: new Date(),
     verifiedHead: 0,
   };

--- a/libs/game/idle-client/src/resync/run-resync.test.ts
+++ b/libs/game/idle-client/src/resync/run-resync.test.ts
@@ -10,6 +10,7 @@ import {
 import { createTestAccessToken, resolveServiceURL } from '@vers/mock-services';
 import { mockActivityService } from '@vers/mock-services/activity';
 import * as db from '@vers/mock-services/db';
+import { waitFor } from '@vers/test-utils';
 import { server } from '../mocks/node';
 import { createCheckpointSubmitter } from '../submission/create-checkpoint-submitter';
 import { readQueuedCheckpoints } from '../submission/read-queued-checkpoints';
@@ -233,17 +234,18 @@ test('it awaits onProgressFetched with the settled progress before planning a fa
     verifiedHead: 0,
   });
 
-  const callOrder: Array<string> = [];
+  // a promise the test controls: while it stays pending, a dropped await on the reconcile would let
+  // the fast-forward's progress fire before the reconcile settled
+  const reconcileGate = Promise.withResolvers<void>();
+  const onProgress = mock(() => {});
 
   const onProgressFetched = mock((progress: LatestActivityProgress) => {
     expect(progress.activity.id).toBe(activity.id);
 
-    callOrder.push('onProgressFetched');
-
-    return Promise.resolve();
+    return reconcileGate.promise;
   });
 
-  await runResync({
+  const resync = runResync({
     avatarID: avatar.id,
     buildSimulationInput: (started) => ({
       activity: createMockActivityInput({
@@ -264,16 +266,22 @@ test('it awaits onProgressFetched with the settled progress before planning a fa
       avatar: createMockAvatarData({ life: 1 }),
     }),
     client: ctx.client,
-    onProgress: () => {
-      callOrder.push('onProgress');
-    },
+    onProgress,
     onProgressFetched,
     submitter: ctx.submitter,
   });
 
-  expect(onProgressFetched).toHaveBeenCalledOnce();
-  expect(callOrder[0]).toBe('onProgressFetched');
-  expect(callOrder).toIncludeAllMembers(['onProgress']);
+  await waitFor(() => {
+    expect(onProgressFetched).toHaveBeenCalledOnce();
+  });
+
+  expect(onProgress).not.toHaveBeenCalled();
+
+  reconcileGate.resolve();
+
+  await resync;
+
+  expect(onProgress).toHaveBeenCalled();
 });
 
 test('it delivers checkpoints a previous worker left queued and plans against the head they advanced', async () => {

--- a/libs/game/idle-client/src/resync/run-resync.test.ts
+++ b/libs/game/idle-client/src/resync/run-resync.test.ts
@@ -18,6 +18,7 @@ import { writeQueuedCheckpoint } from '../submission/write-queued-checkpoint';
 import { createMockCheckpointBatchEntry } from '../test-utils/factories/create-mock-checkpoint-batch-entry';
 import { createMockProgressCheckpoint } from '../test-utils/factories/create-mock-progress-checkpoint';
 import { runResync } from './run-resync';
+import type { LatestActivityProgress } from './types';
 
 interface SetupTestConfig {
   readonly scheduleRetry?: (delayMs: number, retry: () => Promise<void>) => void;
@@ -217,6 +218,62 @@ test('it fast-forwards a real offline gap and reports the outcome', async () => 
   });
 
   expect(result.report).toMatchObject({ attempts: 1, reason: 'aborted-on-failure' });
+});
+
+test('it awaits onProgressFetched with the settled progress before planning a fast-forward', async () => {
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const ctx = await setupTest({ userID: user.id });
+
+  const activity = await db.activityCollection.create({
+    appendedAt: new Date(Date.now() - 60_000),
+    appendedHead: 0,
+    avatarID: avatar.id,
+    status: 'active',
+    verifiedHead: 0,
+  });
+
+  const callOrder: Array<string> = [];
+
+  const onProgressFetched = mock((progress: LatestActivityProgress) => {
+    expect(progress.activity.id).toBe(activity.id);
+
+    callOrder.push('onProgressFetched');
+
+    return Promise.resolve();
+  });
+
+  await runResync({
+    avatarID: avatar.id,
+    buildSimulationInput: (started) => ({
+      activity: createMockActivityInput({
+        encounter: {
+          waves: [
+            Array.from({ length: 6 }, () => createMockEnemyData()),
+            Array.from({ length: 6 }, () => createMockEnemyData()),
+            Array.from({ length: 3 }, () => createMockEnemyData()),
+            Array.from({ length: 4 }, () => createMockEnemyData()),
+          ],
+        },
+        failureAction: ActivityFailureAction.Abort,
+        id: started.id,
+        seed: started.seed,
+      }),
+
+      // life 1 fails the first attempt fast, and the abort policy ends the fast-forward there
+      avatar: createMockAvatarData({ life: 1 }),
+    }),
+    client: ctx.client,
+    onProgress: () => {
+      callOrder.push('onProgress');
+    },
+    onProgressFetched,
+    submitter: ctx.submitter,
+  });
+
+  expect(onProgressFetched).toHaveBeenCalledOnce();
+  expect(callOrder[0]).toBe('onProgressFetched');
+  expect(callOrder).toIncludeAllMembers(['onProgress']);
 });
 
 test('it delivers checkpoints a previous worker left queued and plans against the head they advanced', async () => {

--- a/libs/game/idle-client/src/resync/run-resync.ts
+++ b/libs/game/idle-client/src/resync/run-resync.ts
@@ -38,6 +38,13 @@ interface RunResyncOptions {
    */
   readonly onProgress?: (progress: FastForwardProgress) => void;
 
+  /**
+   * Runs once the confirmed snapshot is settled, before any plan is decided — the resync's one
+   * chance to reconcile the failure-action preference against the fetched progress before a
+   * fast-forward reads it.
+   */
+  readonly onProgressFetched?: (progress: LatestActivityProgress) => Promise<void>;
+
   readonly submitter: CheckpointSubmitter;
 }
 
@@ -75,6 +82,8 @@ export async function runResync(
   if (progress === null) {
     return { plan: { kind: 'none' }, progress: null };
   }
+
+  await options.onProgressFetched?.(progress);
 
   const plan = planResync({
     progress,

--- a/libs/game/idle-client/src/state/set-failure-action.test.ts
+++ b/libs/game/idle-client/src/state/set-failure-action.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from 'bun:test';
+import { ActivityFailureAction } from '@vers/idle-core';
+import { setFailureAction } from './set-failure-action';
+import { useIdleStore } from './use-idle-store';
+
+test('it replaces the stored failure action wholesale', () => {
+  setFailureAction(ActivityFailureAction.Retry);
+  expect(useIdleStore.getState().failureAction).toBe(ActivityFailureAction.Retry);
+  setFailureAction(ActivityFailureAction.Abort);
+  expect(useIdleStore.getState().failureAction).toBe(ActivityFailureAction.Abort);
+});

--- a/libs/game/idle-client/src/state/set-failure-action.ts
+++ b/libs/game/idle-client/src/state/set-failure-action.ts
@@ -1,0 +1,6 @@
+import type { ActivityFailureAction } from '@vers/idle-core';
+import { useIdleStore } from './use-idle-store';
+
+export function setFailureAction(failureAction: ActivityFailureAction) {
+  useIdleStore.setState(() => ({ failureAction }));
+}

--- a/libs/game/idle-client/src/submission/constants.ts
+++ b/libs/game/idle-client/src/submission/constants.ts
@@ -27,8 +27,10 @@ export const CHECKPOINT_QUEUE_DB_VERSION = 2;
 export const CHECKPOINT_QUEUE_STORE_NAME = 'pending-checkpoints';
 
 /**
- * The `preferences` object store's one record key: a SharedWorker serves a single browser
- * profile, so its cached failure-action preference never needs more than one row.
+ * The `preferences` object store's one record key. A worker drives one avatar's simulation at a
+ * time, so a single record holds the failure-action preference: the last set wins, and the
+ * record's own `avatarID` decides whether a resync may flush a dirty value — a dirty value reaches
+ * the server only for the avatar it was set for.
  */
 export const FAILURE_ACTION_PREFERENCE_KEY = 'failure-action';
 export const PREFERENCES_STORE_NAME = 'preferences';

--- a/libs/game/idle-client/src/submission/constants.ts
+++ b/libs/game/idle-client/src/submission/constants.ts
@@ -23,5 +23,12 @@ export const RETRY_BACKOFF_CAP_MS = 300_000;
  */
 export const FLUSH_STALL_THRESHOLD = 3;
 export const CHECKPOINT_QUEUE_DB_NAME = 'vers-idle-checkpoint-queue';
-export const CHECKPOINT_QUEUE_DB_VERSION = 1;
+export const CHECKPOINT_QUEUE_DB_VERSION = 2;
 export const CHECKPOINT_QUEUE_STORE_NAME = 'pending-checkpoints';
+
+/**
+ * The `preferences` object store's one record key: a SharedWorker serves a single browser
+ * profile, so its cached failure-action preference never needs more than one row.
+ */
+export const FAILURE_ACTION_PREFERENCE_KEY = 'failure-action';
+export const PREFERENCES_STORE_NAME = 'preferences';

--- a/libs/game/idle-client/src/submission/read-failure-action-cache.test.ts
+++ b/libs/game/idle-client/src/submission/read-failure-action-cache.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from 'bun:test';
+import { readFailureActionCache } from './read-failure-action-cache';
+
+test('it returns undefined when nothing has been cached', async () => {
+  const stored = await readFailureActionCache();
+
+  expect(stored).toBeUndefined();
+});

--- a/libs/game/idle-client/src/submission/read-failure-action-cache.ts
+++ b/libs/game/idle-client/src/submission/read-failure-action-cache.ts
@@ -1,0 +1,13 @@
+import { FAILURE_ACTION_PREFERENCE_KEY, PREFERENCES_STORE_NAME } from './constants';
+import { resolveCheckpointQueueDB } from './resolve-checkpoint-queue-db';
+import type { FailureActionPreference } from './types';
+
+/**
+ * Reads the cached failure-action preference, `undefined` when nothing has ever been written —
+ * a fresh install with no local override yet.
+ */
+export async function readFailureActionCache(): Promise<FailureActionPreference | undefined> {
+  const db = await resolveCheckpointQueueDB();
+
+  return db.get(PREFERENCES_STORE_NAME, FAILURE_ACTION_PREFERENCE_KEY);
+}

--- a/libs/game/idle-client/src/submission/resolve-checkpoint-queue-db.ts
+++ b/libs/game/idle-client/src/submission/resolve-checkpoint-queue-db.ts
@@ -4,22 +4,32 @@ import {
   CHECKPOINT_QUEUE_DB_NAME,
   CHECKPOINT_QUEUE_DB_VERSION,
   CHECKPOINT_QUEUE_STORE_NAME,
+  PREFERENCES_STORE_NAME,
 } from './constants';
 import type { CheckpointQueueSchema } from './types';
 
 let queueDB: null | Promise<IDBPDatabase<CheckpointQueueSchema>> = null;
 
 /**
- * Lazily opens, and caches, the pending-submit queue database: one object store keyed
+ * Lazily opens, and caches, the worker's durable IndexedDB database: `pending-checkpoints` keyed
  * `[activityID, version]`, so an activity's rows sort in submission order and a compound
- * read/delete addresses either a single checkpoint or an activity's whole range.
+ * read/delete addresses either a single checkpoint or an activity's whole range; `preferences`
+ * caches device-local settings — a SharedWorker has no `localStorage` — as the offline outbox for
+ * a server source of truth. Each store is created only if missing, so an upgrade from an earlier
+ * version never re-creates a store an existing install already has.
  */
 export function resolveCheckpointQueueDB(): Promise<IDBPDatabase<CheckpointQueueSchema>> {
   queueDB ??= openDB<CheckpointQueueSchema>(CHECKPOINT_QUEUE_DB_NAME, CHECKPOINT_QUEUE_DB_VERSION, {
     upgrade(database) {
-      database.createObjectStore(CHECKPOINT_QUEUE_STORE_NAME, {
-        keyPath: ['activityID', 'version'],
-      });
+      if (!database.objectStoreNames.contains(CHECKPOINT_QUEUE_STORE_NAME)) {
+        database.createObjectStore(CHECKPOINT_QUEUE_STORE_NAME, {
+          keyPath: ['activityID', 'version'],
+        });
+      }
+
+      if (!database.objectStoreNames.contains(PREFERENCES_STORE_NAME)) {
+        database.createObjectStore(PREFERENCES_STORE_NAME);
+      }
     },
   });
 

--- a/libs/game/idle-client/src/submission/types.ts
+++ b/libs/game/idle-client/src/submission/types.ts
@@ -14,9 +14,11 @@ export interface QueuedCheckpoint extends CheckpointBatchEntry {
 /**
  * The failure-action preference as the device-local cache holds it: `dirty` marks a locally set
  * value the server hasn't acknowledged yet, so a resync knows to push it rather than adopt the
- * server's.
+ * server's. `avatarID` scopes that value to the avatar it was set for, so a resync flushes a dirty
+ * value only when it belongs to the avatar being resynced.
  */
 export interface FailureActionPreference {
+  readonly avatarID: string;
   readonly dirty: boolean;
   readonly failureAction: ActivityFailureAction;
 }

--- a/libs/game/idle-client/src/submission/types.ts
+++ b/libs/game/idle-client/src/submission/types.ts
@@ -1,5 +1,6 @@
 import type { ContractRouterClient } from '@orpc/contract';
 import type { CheckpointBatchEntry, activityContract } from '@vers/contract-activity';
+import type { ActivityFailureAction } from '@vers/idle-core';
 import type { DBSchema } from 'idb';
 
 /**
@@ -10,10 +11,24 @@ export interface QueuedCheckpoint extends CheckpointBatchEntry {
   readonly activityID: string;
 }
 
+/**
+ * The failure-action preference as the device-local cache holds it: `dirty` marks a locally set
+ * value the server hasn't acknowledged yet, so a resync knows to push it rather than adopt the
+ * server's.
+ */
+export interface FailureActionPreference {
+  readonly dirty: boolean;
+  readonly failureAction: ActivityFailureAction;
+}
+
 export interface CheckpointQueueSchema extends DBSchema {
   'pending-checkpoints': {
     key: [string, number];
     value: QueuedCheckpoint;
+  };
+  preferences: {
+    key: string;
+    value: FailureActionPreference;
   };
 }
 

--- a/libs/game/idle-client/src/submission/write-failure-action-cache.test.ts
+++ b/libs/game/idle-client/src/submission/write-failure-action-cache.test.ts
@@ -4,18 +4,39 @@ import { readFailureActionCache } from './read-failure-action-cache';
 import { writeFailureActionCache } from './write-failure-action-cache';
 
 test('it stores the preference retrievable by the cache read', async () => {
-  await writeFailureActionCache({ dirty: true, failureAction: ActivityFailureAction.Retry });
+  await writeFailureActionCache({
+    avatarID: 'avatar-1',
+    dirty: true,
+    failureAction: ActivityFailureAction.Retry,
+  });
 
   const stored = await readFailureActionCache();
 
-  expect(stored).toStrictEqual({ dirty: true, failureAction: ActivityFailureAction.Retry });
+  expect(stored).toStrictEqual({
+    avatarID: 'avatar-1',
+    dirty: true,
+    failureAction: ActivityFailureAction.Retry,
+  });
 });
 
 test('it overwrites a previously cached preference', async () => {
-  await writeFailureActionCache({ dirty: true, failureAction: ActivityFailureAction.Retry });
-  await writeFailureActionCache({ dirty: false, failureAction: ActivityFailureAction.Abort });
+  await writeFailureActionCache({
+    avatarID: 'avatar-1',
+    dirty: true,
+    failureAction: ActivityFailureAction.Retry,
+  });
+
+  await writeFailureActionCache({
+    avatarID: 'avatar-2',
+    dirty: false,
+    failureAction: ActivityFailureAction.Abort,
+  });
 
   const stored = await readFailureActionCache();
 
-  expect(stored).toStrictEqual({ dirty: false, failureAction: ActivityFailureAction.Abort });
+  expect(stored).toStrictEqual({
+    avatarID: 'avatar-2',
+    dirty: false,
+    failureAction: ActivityFailureAction.Abort,
+  });
 });

--- a/libs/game/idle-client/src/submission/write-failure-action-cache.test.ts
+++ b/libs/game/idle-client/src/submission/write-failure-action-cache.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from 'bun:test';
+import { ActivityFailureAction } from '@vers/idle-core';
+import { readFailureActionCache } from './read-failure-action-cache';
+import { writeFailureActionCache } from './write-failure-action-cache';
+
+test('it stores the preference retrievable by the cache read', async () => {
+  await writeFailureActionCache({ dirty: true, failureAction: ActivityFailureAction.Retry });
+
+  const stored = await readFailureActionCache();
+
+  expect(stored).toStrictEqual({ dirty: true, failureAction: ActivityFailureAction.Retry });
+});
+
+test('it overwrites a previously cached preference', async () => {
+  await writeFailureActionCache({ dirty: true, failureAction: ActivityFailureAction.Retry });
+  await writeFailureActionCache({ dirty: false, failureAction: ActivityFailureAction.Abort });
+
+  const stored = await readFailureActionCache();
+
+  expect(stored).toStrictEqual({ dirty: false, failureAction: ActivityFailureAction.Abort });
+});

--- a/libs/game/idle-client/src/submission/write-failure-action-cache.ts
+++ b/libs/game/idle-client/src/submission/write-failure-action-cache.ts
@@ -1,0 +1,14 @@
+import { FAILURE_ACTION_PREFERENCE_KEY, PREFERENCES_STORE_NAME } from './constants';
+import { resolveCheckpointQueueDB } from './resolve-checkpoint-queue-db';
+import type { FailureActionPreference } from './types';
+
+/**
+ * Persists the failure-action preference, overwriting whatever was cached before.
+ */
+export async function writeFailureActionCache(
+  preference: Readonly<FailureActionPreference>,
+): Promise<void> {
+  const db = await resolveCheckpointQueueDB();
+
+  await db.put(PREFERENCES_STORE_NAME, preference, FAILURE_ACTION_PREFERENCE_KEY);
+}

--- a/libs/game/idle-client/src/test-utils/create-stub-worker-context.ts
+++ b/libs/game/idle-client/src/test-utils/create-stub-worker-context.ts
@@ -41,6 +41,7 @@ export function createStubWorkerContext(
   let rewardSlotLedger: ReadonlyArray<RewardSlotLedgerEntry> = [];
   let failureAction: ActivityFailureAction = options.failureAction ?? ActivityFailureAction.Abort;
   let failureActionDirty = false;
+  let failureActionPushInFlight = false;
 
   return {
     connections,
@@ -56,6 +57,7 @@ export function createStubWorkerContext(
     getSimulation: () => simulation,
     getSubmitter: () => submitter,
     isFailureActionDirty: () => failureActionDirty,
+    isFailureActionPushInFlight: () => failureActionPushInFlight,
     isResyncInFlight: () => resyncInFlight,
     recordRewardSlots: (activityID, entry) => {
       if (rewardSlotLedgerActivityID === activityID) {
@@ -78,6 +80,9 @@ export function createStubWorkerContext(
     },
     setFailureActionDirty: (dirty) => {
       failureActionDirty = dirty;
+    },
+    setFailureActionPushInFlight: (inFlight) => {
+      failureActionPushInFlight = inFlight;
     },
     setResyncAvatarID: (avatarID) => {
       resyncAvatarID = avatarID;

--- a/libs/game/idle-client/src/test-utils/create-stub-worker-context.ts
+++ b/libs/game/idle-client/src/test-utils/create-stub-worker-context.ts
@@ -2,6 +2,7 @@ import { createORPCClient } from '@orpc/client';
 import { RPCLink } from '@orpc/client/fetch';
 import type { ActivityData } from '@vers/contract-activity';
 import type { Simulation } from '@vers/idle-core';
+import { ActivityFailureAction } from '@vers/idle-core';
 import { resolveServiceURL } from '@vers/mock-services';
 import type { CheckpointSubmitter } from '../submission/create-checkpoint-submitter';
 import type { ActivityServiceClient } from '../submission/types';
@@ -11,6 +12,7 @@ import type { WorkerContext } from '../worker/types';
 interface CreateStubWorkerContextOptions {
   readonly client?: ActivityServiceClient;
   readonly connections?: ReadonlyArray<MessagePort>;
+  readonly failureAction?: ActivityFailureAction;
   readonly remainingBudgetMs?: number;
   readonly submitter?: Readonly<CheckpointSubmitter>;
 }
@@ -37,11 +39,14 @@ export function createStubWorkerContext(
   let resyncInFlight = false;
   let rewardSlotLedgerActivityID: null | string = null;
   let rewardSlotLedger: ReadonlyArray<RewardSlotLedgerEntry> = [];
+  let failureAction: ActivityFailureAction = options.failureAction ?? ActivityFailureAction.Abort;
+  let failureActionDirty = false;
 
   return {
     connections,
     getActivity: () => activity,
     getClient: () => client,
+    getFailureAction: () => failureAction,
     getRemainingBudgetMs: () => options.remainingBudgetMs ?? Number.MAX_SAFE_INTEGER,
     getResyncAvatarID: () => resyncAvatarID,
     getRewardSlotLedger: () => ({
@@ -50,6 +55,7 @@ export function createStubWorkerContext(
     }),
     getSimulation: () => simulation,
     getSubmitter: () => submitter,
+    isFailureActionDirty: () => failureActionDirty,
     isResyncInFlight: () => resyncInFlight,
     recordRewardSlots: (activityID, entry) => {
       if (rewardSlotLedgerActivityID === activityID) {
@@ -66,6 +72,12 @@ export function createStubWorkerContext(
     },
     setActivity: (newActivity) => {
       activity = newActivity;
+    },
+    setFailureAction: (action) => {
+      failureAction = action;
+    },
+    setFailureActionDirty: (dirty) => {
+      failureActionDirty = dirty;
     },
     setResyncAvatarID: (avatarID) => {
       resyncAvatarID = avatarID;

--- a/libs/game/idle-client/src/test-utils/factories/create-mock-latest-activity-progress.ts
+++ b/libs/game/idle-client/src/test-utils/factories/create-mock-latest-activity-progress.ts
@@ -9,6 +9,7 @@ export function createMockLatestActivityProgress(
     activity: createMockActivityData(),
     anchor: null,
     appendedHead: 0,
+    failureAction: 'abort',
     serverTime: faker.date.recent(),
     verifiedHead: 0,
     ...overrides,

--- a/libs/game/idle-client/src/types.ts
+++ b/libs/game/idle-client/src/types.ts
@@ -72,6 +72,7 @@ export enum WorkerMessageType {
   CheckpointFlushStalled = 'checkpoint_flush_stalled',
   CheckpointStreamInvalid = 'checkpoint_stream_invalid',
   ConnectionStatus = 'connection_status',
+  FailureActionStatus = 'failure_action_status',
   FlushCompleted = 'flush_completed',
   InitialState = 'initial_state',
   OfflineCapStatus = 'offline_cap_status',
@@ -124,6 +125,17 @@ export interface ResyncStatusMessage extends IWorkerMessage {
 export interface ConnectionStatusMessage extends IWorkerMessage {
   readonly online: boolean;
   readonly type: WorkerMessageType.ConnectionStatus;
+}
+
+/**
+ * Reports the avatar's effective failure-action preference — the worker's in-session source of
+ * truth, sent on every change (a tab's own set, a resync reconcile's adoption of the server's
+ * value) and in a connecting tab's initial state, so every tab reflects it even with no
+ * simulation running.
+ */
+export interface FailureActionStatusMessage extends IWorkerMessage {
+  readonly failureAction: ActivityFailureAction;
+  readonly type: WorkerMessageType.FailureActionStatus;
 }
 
 /**
@@ -192,6 +204,7 @@ export type WorkerMessage =
   | CheckpointFlushStalledMessage
   | CheckpointStreamInvalidMessage
   | ConnectionStatusMessage
+  | FailureActionStatusMessage
   | FlushCompletedMessage
   | InitialStateMessage
   | OfflineCapStatusMessage

--- a/libs/game/idle-client/src/types.ts
+++ b/libs/game/idle-client/src/types.ts
@@ -26,6 +26,7 @@ export interface SetActivityMessage extends IClientMessage {
 }
 
 export interface SetFailureActionMessage extends IClientMessage {
+  readonly avatarID: string;
   readonly failureAction: ActivityFailureAction;
   readonly type: ClientMessageType.SetFailureAction;
 }

--- a/libs/game/idle-client/src/worker/create-failure-action-status-message.test.ts
+++ b/libs/game/idle-client/src/worker/create-failure-action-status-message.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from 'bun:test';
+import { ActivityFailureAction } from '@vers/idle-core';
+import { WorkerMessageType } from '../types';
+import { createFailureActionStatusMessage } from './create-failure-action-status-message';
+
+test('it creates a failure-action status message', () => {
+  const message = createFailureActionStatusMessage(ActivityFailureAction.Retry);
+
+  expect(message).toStrictEqual({
+    failureAction: ActivityFailureAction.Retry,
+    type: WorkerMessageType.FailureActionStatus,
+  });
+});

--- a/libs/game/idle-client/src/worker/create-failure-action-status-message.ts
+++ b/libs/game/idle-client/src/worker/create-failure-action-status-message.ts
@@ -1,0 +1,9 @@
+import type { ActivityFailureAction } from '@vers/idle-core';
+import type { FailureActionStatusMessage } from '../types';
+import { WorkerMessageType } from '../types';
+
+export function createFailureActionStatusMessage(
+  failureAction: ActivityFailureAction,
+): FailureActionStatusMessage {
+  return { failureAction, type: WorkerMessageType.FailureActionStatus };
+}

--- a/libs/game/idle-client/src/worker/create-set-failure-action-message.test.ts
+++ b/libs/game/idle-client/src/worker/create-set-failure-action-message.test.ts
@@ -4,9 +4,10 @@ import { ClientMessageType } from '../types';
 import { createSetFailureActionMessage } from './create-set-failure-action-message';
 
 test('it creates a set failure action message', () => {
-  const message = createSetFailureActionMessage(ActivityFailureAction.Retry);
+  const message = createSetFailureActionMessage('avatar-1', ActivityFailureAction.Retry);
 
   expect(message).toStrictEqual({
+    avatarID: 'avatar-1',
     failureAction: ActivityFailureAction.Retry,
     type: ClientMessageType.SetFailureAction,
   });

--- a/libs/game/idle-client/src/worker/create-set-failure-action-message.ts
+++ b/libs/game/idle-client/src/worker/create-set-failure-action-message.ts
@@ -3,9 +3,11 @@ import type { SetFailureActionMessage } from '../types';
 import { ClientMessageType } from '../types';
 
 export function createSetFailureActionMessage(
+  avatarID: string,
   failureAction: ActivityFailureAction,
 ): SetFailureActionMessage {
   return {
+    avatarID,
     failureAction,
     type: ClientMessageType.SetFailureAction,
   };

--- a/libs/game/idle-client/src/worker/create-worker-runtime.test.ts
+++ b/libs/game/idle-client/src/worker/create-worker-runtime.test.ts
@@ -1,9 +1,16 @@
 import { expect, onTestFinished, test } from 'bun:test';
+import { createORPCClient } from '@orpc/client';
+import { RPCLink } from '@orpc/client/fetch';
 import type { ErrorEvent } from '@sentry/browser';
 import { createMockActivityData } from '@vers/contract-activity/test-utils';
+import { ActivityFailureAction } from '@vers/idle-core';
+import { createTestAccessToken, resolveServiceURL } from '@vers/mock-services';
 import { mockActivityService } from '@vers/mock-services/activity';
+import * as db from '@vers/mock-services/db';
 import { waitFor } from '@vers/test-utils';
 import { server } from '../mocks/node';
+import type { ActivityServiceClient } from '../submission/types';
+import { writeFailureActionCache } from '../submission/write-failure-action-cache';
 import type { TestConnection } from '../test-utils/create-test-connection';
 import { createTestConnection } from '../test-utils/create-test-connection';
 import { ClientMessageType, WorkerMessageType } from '../types';
@@ -34,6 +41,68 @@ test('it replies with the initial state to an initialize message', async () => {
   await connection.waitForMessages(1);
 
   expect(connection.received[0]?.type).toBe(WorkerMessageType.InitialState);
+});
+
+test('it seeds the boot state from the device-local failure-action cache before the first message runs', async () => {
+  await writeFailureActionCache({ dirty: true, failureAction: ActivityFailureAction.Retry });
+
+  const runtime = createWorkerRuntime();
+
+  onTestFinished(() => {
+    runtime.stop();
+  });
+
+  const connection = createConnection(runtime);
+
+  connection.post({ type: ClientMessageType.Initialize });
+
+  await connection.waitForMessages(2);
+
+  expect(connection.received[1]).toStrictEqual({
+    failureAction: ActivityFailureAction.Retry,
+    type: WorkerMessageType.FailureActionStatus,
+  });
+});
+
+test('it retains the cached dirty flag across boot so the next resync flushes it to the server', async () => {
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+
+  await db.activityCollection.create({
+    appendedHead: 0,
+    avatarID: avatar.id,
+    startedAt: new Date(),
+  });
+
+  await writeFailureActionCache({ dirty: true, failureAction: ActivityFailureAction.Retry });
+
+  const token = await createTestAccessToken(user.id);
+
+  // the runtime's production client resolves its URL from `self.location.origin`, unreachable in
+  // this test env — an authed client wired at the mocked backend is the only way to route its
+  // calls, standing in for it here the way `timestep` already stands in for the tick rate
+  const client: ActivityServiceClient = createORPCClient(
+    new RPCLink({
+      headers: { authorization: `Bearer ${token}` },
+      url: `${resolveServiceURL('activity')}/rpc`,
+    }),
+  );
+
+  const runtime = createWorkerRuntime({ client });
+
+  onTestFinished(() => {
+    runtime.stop();
+  });
+
+  const connection = createConnection(runtime);
+
+  connection.post({ avatarID: avatar.id, type: ClientMessageType.RequestResync });
+
+  await waitFor(() => {
+    const updatedAvatar = db.avatarCollection.findFirst((q) => q.where({ id: avatar.id }));
+
+    expect(updatedAvatar?.failureAction).toBe('retry');
+  });
 });
 
 test('it broadcasts a simulation update once an activity is set', async () => {

--- a/libs/game/idle-client/src/worker/create-worker-runtime.test.ts
+++ b/libs/game/idle-client/src/worker/create-worker-runtime.test.ts
@@ -49,16 +49,16 @@ test('it broadcasts a simulation update once an activity is set', async () => {
 
   connection.post({ type: ClientMessageType.Initialize });
 
-  await connection.waitForMessages(1);
+  await connection.waitForMessages(2);
 
   connection.post({
     activity: createMockActivityData(),
     type: ClientMessageType.SetActivity,
   });
 
-  await connection.waitForMessages(2);
+  await connection.waitForMessages(3);
 
-  expect(connection.received[1]?.type).toBe(WorkerMessageType.SimulationUpdate);
+  expect(connection.received[2]?.type).toBe(WorkerMessageType.SimulationUpdate);
 });
 
 test('it stops broadcasting to a connection after it disconnects', async () => {
@@ -75,7 +75,7 @@ test('it stops broadcasting to a connection after it disconnects', async () => {
 
   survivor.post({ type: ClientMessageType.Initialize });
 
-  await survivor.waitForMessages(1);
+  await survivor.waitForMessages(2);
 
   expect(runtime.connections.size).toBe(2);
 
@@ -90,9 +90,9 @@ test('it stops broadcasting to a connection after it disconnects', async () => {
     type: ClientMessageType.SetActivity,
   });
 
-  await survivor.waitForMessages(2);
+  await survivor.waitForMessages(3);
 
-  expect(survivor.received[1]?.type).toBe(WorkerMessageType.SimulationUpdate);
+  expect(survivor.received[2]?.type).toBe(WorkerMessageType.SimulationUpdate);
 });
 
 test('it reports a fault to the error backend when a message makes its handler throw', async () => {

--- a/libs/game/idle-client/src/worker/create-worker-runtime.test.ts
+++ b/libs/game/idle-client/src/worker/create-worker-runtime.test.ts
@@ -44,7 +44,11 @@ test('it replies with the initial state to an initialize message', async () => {
 });
 
 test('it seeds the boot state from the device-local failure-action cache before the first message runs', async () => {
-  await writeFailureActionCache({ dirty: true, failureAction: ActivityFailureAction.Retry });
+  await writeFailureActionCache({
+    avatarID: 'seeded-avatar',
+    dirty: true,
+    failureAction: ActivityFailureAction.Retry,
+  });
 
   const runtime = createWorkerRuntime();
 
@@ -74,7 +78,11 @@ test('it retains the cached dirty flag across boot so the next resync flushes it
     startedAt: new Date(),
   });
 
-  await writeFailureActionCache({ dirty: true, failureAction: ActivityFailureAction.Retry });
+  await writeFailureActionCache({
+    avatarID: avatar.id,
+    dirty: true,
+    failureAction: ActivityFailureAction.Retry,
+  });
 
   const token = await createTestAccessToken(user.id);
 

--- a/libs/game/idle-client/src/worker/create-worker-runtime.ts
+++ b/libs/game/idle-client/src/worker/create-worker-runtime.ts
@@ -56,16 +56,22 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
   let resyncInFlight = false;
   let failureAction: ActivityFailureAction = ActivityFailureAction.Abort;
   let failureActionDirty = false;
+  let failureActionPushInFlight = false;
 
   // Every client message and the self-triggered reconnect resync await this before running, so a
   // relaunch-while-offline never plans against the enum's Abort default while the real cached
-  // preference is still in flight.
+  // preference is still in flight. A failed read falls back to that default rather than rejecting
+  // forever, which would strand every handler that awaits this.
   const failureActionSeeded = (async () => {
-    const cached = await readFailureActionCache();
+    try {
+      const cached = await readFailureActionCache();
 
-    if (cached !== undefined) {
-      failureAction = cached.failureAction;
-      failureActionDirty = cached.dirty;
+      if (cached !== undefined) {
+        failureAction = cached.failureAction;
+        failureActionDirty = cached.dirty;
+      }
+    } catch (error) {
+      reportWorkerFault('preference-seed', error);
     }
   })();
 
@@ -118,6 +124,7 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
     getSimulation: () => simulation,
     getSubmitter: () => submitter,
     isFailureActionDirty: () => failureActionDirty,
+    isFailureActionPushInFlight: () => failureActionPushInFlight,
     isResyncInFlight: () => resyncInFlight,
     recordRewardSlots: (activityID, entry) => {
       if (rewardSlotLedgerActivityID === activityID) {
@@ -140,6 +147,9 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
     },
     setFailureActionDirty: (dirty) => {
       failureActionDirty = dirty;
+    },
+    setFailureActionPushInFlight: (inFlight) => {
+      failureActionPushInFlight = inFlight;
     },
     setResyncAvatarID: (avatarID) => {
       resyncAvatarID = avatarID;

--- a/libs/game/idle-client/src/worker/create-worker-runtime.ts
+++ b/libs/game/idle-client/src/worker/create-worker-runtime.ts
@@ -1,10 +1,11 @@
 import type { ActivityData } from '@vers/contract-activity';
 import { OFFLINE_PROGRESS_CAP_MS } from '@vers/contract-activity';
 import type { Simulation } from '@vers/idle-core';
-import { SIMULATION_TIMESTEP_MS } from '@vers/idle-core';
+import { ActivityFailureAction, SIMULATION_TIMESTEP_MS } from '@vers/idle-core';
 import invariant from 'tiny-invariant';
 import { createActivityServiceClient } from '../submission/create-activity-service-client';
 import { createCheckpointSubmitter } from '../submission/create-checkpoint-submitter';
+import { readFailureActionCache } from '../submission/read-failure-action-cache';
 import type { ClientMessage, RewardSlotLedgerEntry, WorkerMessage } from '../types';
 import { createCheckpointFlushStalledMessage } from './create-checkpoint-flush-stalled-message';
 import { createCheckpointStreamInvalidMessage } from './create-checkpoint-stream-invalid-message';
@@ -46,6 +47,20 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
   let accumulator = 0;
   let resyncAvatarID: string | null = null;
   let resyncInFlight = false;
+  let failureAction: ActivityFailureAction = ActivityFailureAction.Abort;
+  let failureActionDirty = false;
+
+  // Every client message and the self-triggered reconnect resync await this before running, so a
+  // relaunch-while-offline never plans against the enum's Abort default while the real cached
+  // preference is still in flight.
+  const failureActionSeeded = (async () => {
+    const cached = await readFailureActionCache();
+
+    if (cached !== undefined) {
+      failureAction = cached.failureAction;
+      failureActionDirty = cached.dirty;
+    }
+  })();
 
   // A fresh worker starts fully funded and drains toward the cap until its first acknowledged
   // submission; every ack re-anchors the budget at the cap.
@@ -86,6 +101,7 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
     connections,
     getActivity: () => activity,
     getClient: () => client,
+    getFailureAction: () => failureAction,
     getRemainingBudgetMs: () => OFFLINE_PROGRESS_CAP_MS - (Date.now() - lastAckAt),
     getResyncAvatarID: () => resyncAvatarID,
     getRewardSlotLedger: () => ({
@@ -94,6 +110,7 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
     }),
     getSimulation: () => simulation,
     getSubmitter: () => submitter,
+    isFailureActionDirty: () => failureActionDirty,
     isResyncInFlight: () => resyncInFlight,
     recordRewardSlots: (activityID, entry) => {
       if (rewardSlotLedgerActivityID === activityID) {
@@ -110,6 +127,12 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
     },
     setActivity: (newActivity) => {
       activity = newActivity;
+    },
+    setFailureAction: (action) => {
+      failureAction = action;
+    },
+    setFailureActionDirty: (dirty) => {
+      failureActionDirty = dirty;
     },
     setResyncAvatarID: (avatarID) => {
       resyncAvatarID = avatarID;
@@ -134,6 +157,7 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
     port.addEventListener('message', (messageEvent: MessageEvent<ClientMessage>) => {
       void (async () => {
         try {
+          await failureActionSeeded;
           await handleClientMessage(context, port, messageEvent);
         } catch (error) {
           reportWorkerFault('message-routing', error);
@@ -205,6 +229,8 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
 
     void (async () => {
       try {
+        await failureActionSeeded;
+
         await submitter.flushHeld();
 
         if (context.getSimulation() === null && resyncAvatarID !== null) {

--- a/libs/game/idle-client/src/worker/create-worker-runtime.ts
+++ b/libs/game/idle-client/src/worker/create-worker-runtime.ts
@@ -6,6 +6,7 @@ import invariant from 'tiny-invariant';
 import { createActivityServiceClient } from '../submission/create-activity-service-client';
 import { createCheckpointSubmitter } from '../submission/create-checkpoint-submitter';
 import { readFailureActionCache } from '../submission/read-failure-action-cache';
+import type { ActivityServiceClient } from '../submission/types';
 import type { ClientMessage, RewardSlotLedgerEntry, WorkerMessage } from '../types';
 import { createCheckpointFlushStalledMessage } from './create-checkpoint-flush-stalled-message';
 import { createCheckpointStreamInvalidMessage } from './create-checkpoint-stream-invalid-message';
@@ -25,6 +26,12 @@ export interface WorkerRuntime {
 }
 
 interface CreateWorkerRuntimeOptions {
+  /**
+   * Overrides the production same-origin proxy client — a test's only way to route the runtime's
+   * calls at a mocked backend, since the real client resolves its URL from `self.location.origin`.
+   */
+  readonly client?: ActivityServiceClient;
+
   readonly timestep?: number;
 }
 
@@ -38,7 +45,7 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
 
   const connections = new Set<MessagePort>();
 
-  const client = createActivityServiceClient();
+  const client = options.client ?? createActivityServiceClient();
   let simulation: null | Simulation = null;
   let activity: ActivityData | null = null;
   let running = false;

--- a/libs/game/idle-client/src/worker/handle-client-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-client-message.test.ts
@@ -69,6 +69,7 @@ test('it applies the sent failure action to the live simulation', async () => {
   context.setSimulation(simulation);
 
   const message: SetFailureActionMessage = {
+    avatarID: 'avatar-1',
     failureAction: ActivityFailureAction.Retry,
     type: ClientMessageType.SetFailureAction,
   };

--- a/libs/game/idle-client/src/worker/handle-client-message.ts
+++ b/libs/game/idle-client/src/worker/handle-client-message.ts
@@ -27,7 +27,7 @@ export async function handleClientMessage(
   }
 
   if (isSetFailureActionMessage(event.data)) {
-    handleSetFailureActionMessage(context, event.data);
+    await handleSetFailureActionMessage(context, event.data);
   }
 
   if (isRequestResyncMessage(event.data)) {

--- a/libs/game/idle-client/src/worker/handle-initialize-message.ts
+++ b/libs/game/idle-client/src/worker/handle-initialize-message.ts
@@ -1,6 +1,7 @@
 import type { Simulation } from '@vers/idle-core';
 import { createSimulation } from '@vers/idle-core';
 import type { InitializeMessage } from '../types';
+import { createFailureActionStatusMessage } from './create-failure-action-status-message';
 import { createInitialStateMessage } from './create-initial-state-message';
 import { registerSimulationListeners } from './register-simulation-listeners';
 import type { WorkerContext } from './types';
@@ -9,7 +10,8 @@ import type { WorkerContext } from './types';
  * Answers an initialize with the worker's current state: it creates the one simulation on the
  * first initialize and reuses it afterward, then broadcasts the snapshot and the retained
  * reward-slot ledger to every connection — so a tab connecting mid-run catches up rather than
- * starting empty.
+ * starting empty. Also broadcasts the effective failure-action preference, so a connecting tab
+ * reflects it even before any simulation snapshot carries one.
  */
 export function handleInitializeMessage(context: WorkerContext, _message: InitializeMessage) {
   const simulation = context.getSimulation() ?? createSimulationForContext(context);
@@ -19,8 +21,11 @@ export function handleInitializeMessage(context: WorkerContext, _message: Initia
     context.getRewardSlotLedger(),
   );
 
+  const failureActionStatusMessage = createFailureActionStatusMessage(context.getFailureAction());
+
   for (const connection of context.connections) {
     connection.postMessage(initialStateMessage);
+    connection.postMessage(failureActionStatusMessage);
   }
 }
 

--- a/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
@@ -5,6 +5,7 @@ import type { ErrorEvent } from '@sentry/browser';
 import { createMockActivityData } from '@vers/contract-activity/test-utils';
 import type { ActivityCheckpoint } from '@vers/idle-core';
 import {
+  ActivityFailureAction,
   SIMULATION_TIMESTEP_MS,
   buildSimulationInput,
   createSimulation,
@@ -18,6 +19,7 @@ import { HttpResponse } from 'msw';
 import invariant from 'tiny-invariant';
 import { server } from '../mocks/node';
 import { createCheckpointSubmitter } from '../submission/create-checkpoint-submitter';
+import { readFailureActionCache } from '../submission/read-failure-action-cache';
 import { readQueuedCheckpoints } from '../submission/read-queued-checkpoints';
 import type { ActivityServiceClient } from '../submission/types';
 import { writeQueuedCheckpoint } from '../submission/write-queued-checkpoint';
@@ -32,6 +34,7 @@ import { sentryHandle } from './sentry-handle';
 import { startErrorReporting } from './start-error-reporting';
 
 interface SetupTestConfig {
+  readonly failureAction?: ActivityFailureAction;
   readonly userID: string;
 }
 
@@ -62,7 +65,13 @@ async function setupTest(config: Readonly<SetupTestConfig>) {
   });
 
   const connection = createTestConnection();
-  const context = createStubWorkerContext({ client, connections: [connection.port], submitter });
+
+  const context = createStubWorkerContext({
+    client,
+    connections: [connection.port],
+    submitter,
+    ...(config.failureAction === undefined ? {} : { failureAction: config.failureAction }),
+  });
 
   return { client, connection, context, flush: () => capturedFlush?.() ?? Promise.resolve() };
 }
@@ -588,6 +597,103 @@ test('it attaches a fresh login live without broadcasting any catch-up status', 
 
   invariant(simulation !== null, 'expected the resync to install a live simulation');
   expect(simulation.activity?.id).toBe(activity.id);
+});
+
+test('it adopts a server-persisted retry preference during resync, caching and broadcasting the change', async () => {
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ failureAction: 'retry', userID: user.id });
+  const ctx = await setupTest({ userID: user.id });
+
+  await db.activityCollection.create({
+    appendedHead: 0,
+    avatarID: avatar.id,
+    startedAt: new Date(),
+  });
+
+  const message: RequestResyncMessage = {
+    avatarID: avatar.id,
+    type: ClientMessageType.RequestResync,
+  };
+
+  await handleRequestResyncMessage(ctx.context, message);
+
+  await ctx.connection.waitForMessages(1);
+
+  expect(ctx.connection.received).toStrictEqual([
+    { failureAction: ActivityFailureAction.Retry, type: WorkerMessageType.FailureActionStatus },
+  ]);
+
+  expect(ctx.context.getFailureAction()).toBe(ActivityFailureAction.Retry);
+
+  const cached = await readFailureActionCache();
+
+  expect(cached).toStrictEqual({ dirty: false, failureAction: ActivityFailureAction.Retry });
+});
+
+test('it flushes a dirty local failure action to the server during resync, clearing dirty on success', async () => {
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const ctx = await setupTest({ failureAction: ActivityFailureAction.Retry, userID: user.id });
+
+  ctx.context.setFailureActionDirty(true);
+
+  await db.activityCollection.create({
+    appendedHead: 0,
+    avatarID: avatar.id,
+    startedAt: new Date(),
+  });
+
+  const message: RequestResyncMessage = {
+    avatarID: avatar.id,
+    type: ClientMessageType.RequestResync,
+  };
+
+  await handleRequestResyncMessage(ctx.context, message);
+
+  expect(ctx.context.isFailureActionDirty()).toBeFalse();
+
+  const cached = await readFailureActionCache();
+
+  expect(cached).toStrictEqual({ dirty: false, failureAction: ActivityFailureAction.Retry });
+
+  const updatedAvatar = db.avatarCollection.findFirst((q) => q.where({ id: avatar.id }));
+
+  invariant(updatedAvatar !== undefined, 'expected the seeded avatar to still exist');
+  expect(updatedAvatar.failureAction).toBe('retry');
+});
+
+test('it keeps the dirty flag when the resync push to the server fails', async () => {
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const ctx = await setupTest({ failureAction: ActivityFailureAction.Retry, userID: user.id });
+
+  ctx.context.setFailureActionDirty(true);
+
+  server.use(
+    mockActivityService.updateFailureAction.handler(() => {
+      throw new Error('unreachable service');
+    }),
+  );
+
+  await db.activityCollection.create({
+    appendedHead: 0,
+    avatarID: avatar.id,
+    startedAt: new Date(),
+  });
+
+  const message: RequestResyncMessage = {
+    avatarID: avatar.id,
+    type: ClientMessageType.RequestResync,
+  };
+
+  await handleRequestResyncMessage(ctx.context, message);
+
+  expect(ctx.context.isFailureActionDirty()).toBeTrue();
+  expect(ctx.context.getFailureAction()).toBe(ActivityFailureAction.Retry);
+
+  const cached = await readFailureActionCache();
+
+  expect(cached).toBeUndefined();
 });
 
 test('it reports a fault to the error backend and broadcasts a failed status when the resync fails outright', async () => {

--- a/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
@@ -22,6 +22,7 @@ import { createCheckpointSubmitter } from '../submission/create-checkpoint-submi
 import { readFailureActionCache } from '../submission/read-failure-action-cache';
 import { readQueuedCheckpoints } from '../submission/read-queued-checkpoints';
 import type { ActivityServiceClient } from '../submission/types';
+import { writeFailureActionCache } from '../submission/write-failure-action-cache';
 import { writeQueuedCheckpoint } from '../submission/write-queued-checkpoint';
 import { createStubWorkerContext } from '../test-utils/create-stub-worker-context';
 import { createTestConnection } from '../test-utils/create-test-connection';
@@ -627,7 +628,11 @@ test('it adopts a server-persisted retry preference during resync, caching and b
 
   const cached = await readFailureActionCache();
 
-  expect(cached).toStrictEqual({ dirty: false, failureAction: ActivityFailureAction.Retry });
+  expect(cached).toStrictEqual({
+    avatarID: avatar.id,
+    dirty: false,
+    failureAction: ActivityFailureAction.Retry,
+  });
 });
 
 test('it flushes a dirty local failure action to the server during resync, clearing dirty on success', async () => {
@@ -636,6 +641,14 @@ test('it flushes a dirty local failure action to the server during resync, clear
   const ctx = await setupTest({ failureAction: ActivityFailureAction.Retry, userID: user.id });
 
   ctx.context.setFailureActionDirty(true);
+
+  // the dirty value lives in the persisted outbox, scoped to this avatar — the record's avatar is
+  // what lets the resync flush it rather than adopt the server's
+  await writeFailureActionCache({
+    avatarID: avatar.id,
+    dirty: true,
+    failureAction: ActivityFailureAction.Retry,
+  });
 
   await db.activityCollection.create({
     appendedHead: 0,
@@ -654,7 +667,11 @@ test('it flushes a dirty local failure action to the server during resync, clear
 
   const cached = await readFailureActionCache();
 
-  expect(cached).toStrictEqual({ dirty: false, failureAction: ActivityFailureAction.Retry });
+  expect(cached).toStrictEqual({
+    avatarID: avatar.id,
+    dirty: false,
+    failureAction: ActivityFailureAction.Retry,
+  });
 
   const updatedAvatar = db.avatarCollection.findFirst((q) => q.where({ id: avatar.id }));
 
@@ -668,6 +685,14 @@ test('it keeps the dirty flag when the resync push to the server fails', async (
   const ctx = await setupTest({ failureAction: ActivityFailureAction.Retry, userID: user.id });
 
   ctx.context.setFailureActionDirty(true);
+
+  // the dirty value lives in the persisted outbox, scoped to this avatar — a failed push must leave
+  // that record intact for the next resync to retry
+  await writeFailureActionCache({
+    avatarID: avatar.id,
+    dirty: true,
+    failureAction: ActivityFailureAction.Retry,
+  });
 
   server.use(
     mockActivityService.updateFailureAction.handler(() => {
@@ -693,7 +718,11 @@ test('it keeps the dirty flag when the resync push to the server fails', async (
 
   const cached = await readFailureActionCache();
 
-  expect(cached).toBeUndefined();
+  expect(cached).toStrictEqual({
+    avatarID: avatar.id,
+    dirty: true,
+    failureAction: ActivityFailureAction.Retry,
+  });
 });
 
 test('it reports a fault to the error backend and broadcasts a failed status when the resync fails outright', async () => {

--- a/libs/game/idle-client/src/worker/handle-request-resync-message.ts
+++ b/libs/game/idle-client/src/worker/handle-request-resync-message.ts
@@ -1,13 +1,16 @@
+import { safe } from '@orpc/client';
 import type { ActivityData } from '@vers/contract-activity';
-import type { ActivityCheckpoint, Simulation } from '@vers/idle-core';
+import type { ActivityCheckpoint, ActivityFailureAction, Simulation } from '@vers/idle-core';
 import { ActivityCheckpointType, buildSimulationInput, createSimulation } from '@vers/idle-core';
 import invariant from 'tiny-invariant';
 import { runReconstruction } from '../resync/run-reconstruction';
 import { runResync } from '../resync/run-resync';
 import type { FastForwardReport, ResyncPlan, ResyncResult } from '../resync/types';
 import { sweepStaleCheckpoints } from '../submission/sweep-stale-checkpoints';
+import { writeFailureActionCache } from '../submission/write-failure-action-cache';
 import type { RequestResyncMessage, ResyncStatus } from '../types';
 import { createCheckpointStreamInvalidMessage } from './create-checkpoint-stream-invalid-message';
+import { createFailureActionStatusMessage } from './create-failure-action-status-message';
 import { createResyncStatusMessage } from './create-resync-status-message';
 import { registerSimulationListeners } from './register-simulation-listeners';
 import { reportWorkerFault } from './report-worker-fault';
@@ -48,12 +51,17 @@ export async function handleRequestResyncMessage(
 
     const result = await runResync({
       avatarID: message.avatarID,
-      buildSimulationInput,
+      buildSimulationInput: (activity) =>
+        buildSimulationInput(activity, { failureAction: context.getFailureAction() }),
       client: context.getClient(),
       isActivityLive: (activityID) => context.getSimulation()?.activity?.id === activityID,
       onProgress: (progress) => {
         emitResyncStatus(context, { ...progress, kind: 'fast-forwarding' });
       },
+      onProgressFetched: (progress) =>
+        context.isFailureActionDirty()
+          ? flushFailureAction(context, message.avatarID)
+          : updateFailureAction(context, progress.failureAction as ActivityFailureAction),
       submitter: context.getSubmitter(),
     });
 
@@ -65,6 +73,43 @@ export async function handleRequestResyncMessage(
   } finally {
     context.setResyncInFlight(false);
   }
+}
+
+/**
+ * Pushes a dirty local failure-action value to the server as the offline outbox's one entry:
+ * best-effort, so a delivery failure leaves it dirty for the next resync's reconcile to retry.
+ */
+async function flushFailureAction(context: WorkerContext, avatarID: string): Promise<void> {
+  const failureAction = context.getFailureAction();
+
+  const [error] = await safe(context.getClient().updateFailureAction({ avatarID, failureAction }));
+
+  if (error !== null) {
+    return;
+  }
+
+  context.setFailureActionDirty(false);
+
+  await writeFailureActionCache({ dirty: false, failureAction });
+}
+
+/**
+ * Adopts the server's failure action as the in-session and cached truth, broadcasting only when
+ * it actually changed.
+ */
+async function updateFailureAction(
+  context: WorkerContext,
+  failureAction: ActivityFailureAction,
+): Promise<void> {
+  if (failureAction === context.getFailureAction()) {
+    return;
+  }
+
+  context.setFailureAction(failureAction);
+
+  await writeFailureActionCache({ dirty: false, failureAction });
+
+  emitFailureActionStatus(context, failureAction);
 }
 
 /**
@@ -144,7 +189,9 @@ async function applyAttachLive(
     'an attach-live plan always carries the progress it was decided from',
   );
 
-  const input = buildSimulationInput(progress.activity);
+  const input = buildSimulationInput(progress.activity, {
+    failureAction: context.getFailureAction(),
+  });
 
   if (plan.context.appendedHead === 0) {
     await context.getSubmitter().registerActivity(plan.context);
@@ -204,7 +251,9 @@ async function applyFastForwardAttach(
   context: WorkerContext,
   report: FastForwardReport,
 ): Promise<void> {
-  const input = buildSimulationInput(report.activity);
+  const input = buildSimulationInput(report.activity, {
+    failureAction: context.getFailureAction(),
+  });
 
   if (report.appendedHead === 0) {
     await context.getSubmitter().registerActivity({
@@ -284,6 +333,17 @@ function emitResyncStatus(context: WorkerContext, status: Readonly<ResyncStatus>
 
 function emitDivergence(context: WorkerContext, activityID: string): void {
   const message = createCheckpointStreamInvalidMessage(activityID, 'reconstruction-divergence');
+
+  for (const connection of context.connections) {
+    connection.postMessage(message);
+  }
+}
+
+function emitFailureActionStatus(
+  context: WorkerContext,
+  failureAction: ActivityFailureAction,
+): void {
+  const message = createFailureActionStatusMessage(failureAction);
 
   for (const connection of context.connections) {
     connection.postMessage(message);

--- a/libs/game/idle-client/src/worker/handle-request-resync-message.ts
+++ b/libs/game/idle-client/src/worker/handle-request-resync-message.ts
@@ -1,7 +1,15 @@
 import { safe } from '@orpc/client';
-import type { ActivityData } from '@vers/contract-activity';
-import type { ActivityCheckpoint, ActivityFailureAction, Simulation } from '@vers/idle-core';
-import { ActivityCheckpointType, buildSimulationInput, createSimulation } from '@vers/idle-core';
+import type {
+  ActivityData,
+  ActivityFailureAction as ContractFailureAction,
+} from '@vers/contract-activity';
+import type { ActivityCheckpoint, Simulation } from '@vers/idle-core';
+import {
+  ActivityCheckpointType,
+  ActivityFailureAction,
+  buildSimulationInput,
+  createSimulation,
+} from '@vers/idle-core';
 import invariant from 'tiny-invariant';
 import { runReconstruction } from '../resync/run-reconstruction';
 import { runResync } from '../resync/run-resync';
@@ -61,7 +69,7 @@ export async function handleRequestResyncMessage(
       onProgressFetched: (progress) =>
         context.isFailureActionDirty()
           ? flushFailureAction(context, message.avatarID)
-          : updateFailureAction(context, progress.failureAction as ActivityFailureAction),
+          : updateFailureAction(context, toActivityFailureAction(progress.failureAction)),
       submitter: context.getSubmitter(),
     });
 
@@ -73,6 +81,10 @@ export async function handleRequestResyncMessage(
   } finally {
     context.setResyncInFlight(false);
   }
+}
+
+function toActivityFailureAction(failureAction: ContractFailureAction): ActivityFailureAction {
+  return failureAction === 'retry' ? ActivityFailureAction.Retry : ActivityFailureAction.Abort;
 }
 
 /**

--- a/libs/game/idle-client/src/worker/handle-request-resync-message.ts
+++ b/libs/game/idle-client/src/worker/handle-request-resync-message.ts
@@ -14,6 +14,7 @@ import invariant from 'tiny-invariant';
 import { runReconstruction } from '../resync/run-reconstruction';
 import { runResync } from '../resync/run-resync';
 import type { FastForwardReport, ResyncPlan, ResyncResult } from '../resync/types';
+import { readFailureActionCache } from '../submission/read-failure-action-cache';
 import { sweepStaleCheckpoints } from '../submission/sweep-stale-checkpoints';
 import { writeFailureActionCache } from '../submission/write-failure-action-cache';
 import type { RequestResyncMessage, ResyncStatus } from '../types';
@@ -66,10 +67,25 @@ export async function handleRequestResyncMessage(
       onProgress: (progress) => {
         emitResyncStatus(context, { ...progress, kind: 'fast-forwarding' });
       },
-      onProgressFetched: (progress) =>
-        context.isFailureActionDirty()
-          ? flushFailureAction(context, message.avatarID)
-          : updateFailureAction(context, toActivityFailureAction(progress.failureAction)),
+      onProgressFetched: async (progress) => {
+        // The dirty local value is flushed only when the cached record was set for this avatar;
+        // otherwise the server's value wins, and the cache is rewritten clean for this avatar so a
+        // dirty value left over from a different avatar this worker drove earlier is discarded
+        // rather than delivered to the wrong row.
+        const cached = await readFailureActionCache();
+
+        if (context.isFailureActionDirty() && cached?.avatarID === message.avatarID) {
+          await flushFailureAction(context, message.avatarID);
+
+          return;
+        }
+
+        await updateFailureActionFromServer(
+          context,
+          message.avatarID,
+          toActivityFailureAction(progress.failureAction),
+        );
+      },
       submitter: context.getSubmitter(),
     });
 
@@ -88,7 +104,7 @@ function toActivityFailureAction(failureAction: ContractFailureAction): Activity
 }
 
 /**
- * Pushes a dirty local failure-action value to the server as the offline outbox's one entry:
+ * Delivers a dirty local failure-action value to the server as the offline outbox's one entry:
  * best-effort, so a delivery failure leaves it dirty for the next resync's reconcile to retry.
  */
 async function flushFailureAction(context: WorkerContext, avatarID: string): Promise<void> {
@@ -102,26 +118,28 @@ async function flushFailureAction(context: WorkerContext, avatarID: string): Pro
 
   context.setFailureActionDirty(false);
 
-  await writeFailureActionCache({ dirty: false, failureAction });
+  await writeFailureActionCache({ avatarID, dirty: false, failureAction });
 }
 
 /**
- * Adopts the server's failure action as the in-session and cached truth, broadcasting only when
- * it actually changed.
+ * Adopts the server's failure action as the in-session and cached truth for the resyncing avatar,
+ * clearing any dirty flag and broadcasting only when the effective value actually changed.
  */
-async function updateFailureAction(
+async function updateFailureActionFromServer(
   context: WorkerContext,
+  avatarID: string,
   failureAction: ActivityFailureAction,
 ): Promise<void> {
-  if (failureAction === context.getFailureAction()) {
-    return;
-  }
+  const changed = failureAction !== context.getFailureAction();
 
   context.setFailureAction(failureAction);
+  context.setFailureActionDirty(false);
 
-  await writeFailureActionCache({ dirty: false, failureAction });
+  await writeFailureActionCache({ avatarID, dirty: false, failureAction });
 
-  emitFailureActionStatus(context, failureAction);
+  if (changed) {
+    emitFailureActionStatus(context, failureAction);
+  }
 }
 
 /**

--- a/libs/game/idle-client/src/worker/handle-set-activity-message.ts
+++ b/libs/game/idle-client/src/worker/handle-set-activity-message.ts
@@ -14,7 +14,9 @@ export async function handleSetActivityMessage(
     return;
   }
 
-  const input = buildSimulationInput(message.activity, { failureAction: simulation.failureAction });
+  const input = buildSimulationInput(message.activity, {
+    failureAction: context.getFailureAction(),
+  });
 
   // The registration starts before the activity installs but is awaited only after: installing
   // synchronously means a resync finishing during the seed read finds this fresher activity live

--- a/libs/game/idle-client/src/worker/handle-set-failure-action-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-set-failure-action-message.test.ts
@@ -13,10 +13,16 @@ import type { SetFailureActionMessage } from '../types';
 import { ClientMessageType, WorkerMessageType } from '../types';
 import { handleSetFailureActionMessage } from './handle-set-failure-action-message';
 
-async function setupTest() {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const token = await createTestAccessToken(user.id);
+interface SetupTestConfig {
+  readonly userID: string;
+}
+
+/**
+ * Builds an authed client acting as the given user, so the handler's push hits the same state
+ * transitions the real service applies to the avatar rows the test seeds in the mock db.
+ */
+async function setupTest(config: Readonly<SetupTestConfig>) {
+  const token = await createTestAccessToken(config.userID);
 
   const client: ActivityServiceClient = createORPCClient(
     new RPCLink({
@@ -25,19 +31,21 @@ async function setupTest() {
     }),
   );
 
-  return { avatar, client };
+  return { client };
 }
 
 test('it forwards the change to a live simulation instead of dropping it', async () => {
-  const ctx = await setupTest();
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const ctx = await setupTest({ userID: user.id });
 
   const simulation = createSimulation();
   const context = createStubWorkerContext({ client: ctx.client });
 
   context.setSimulation(simulation);
-  context.setResyncAvatarID(ctx.avatar.id);
 
   const message: SetFailureActionMessage = {
+    avatarID: avatar.id,
     failureAction: ActivityFailureAction.Retry,
     type: ClientMessageType.SetFailureAction,
   };
@@ -48,13 +56,14 @@ test('it forwards the change to a live simulation instead of dropping it', async
 });
 
 test('it applies the change with no live simulation instead of warning and dropping it', async () => {
-  const ctx = await setupTest();
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const ctx = await setupTest({ userID: user.id });
 
   const context = createStubWorkerContext({ client: ctx.client });
 
-  context.setResyncAvatarID(ctx.avatar.id);
-
   const message: SetFailureActionMessage = {
+    avatarID: avatar.id,
     failureAction: ActivityFailureAction.Retry,
     type: ClientMessageType.SetFailureAction,
   };
@@ -65,13 +74,14 @@ test('it applies the change with no live simulation instead of warning and dropp
 });
 
 test('it clears the dirty flag once the server push succeeds', async () => {
-  const ctx = await setupTest();
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const ctx = await setupTest({ userID: user.id });
 
   const context = createStubWorkerContext({ client: ctx.client });
 
-  context.setResyncAvatarID(ctx.avatar.id);
-
   const message: SetFailureActionMessage = {
+    avatarID: avatar.id,
     failureAction: ActivityFailureAction.Retry,
     type: ClientMessageType.SetFailureAction,
   };
@@ -82,11 +92,17 @@ test('it clears the dirty flag once the server push succeeds', async () => {
 
   const cached = await readFailureActionCache();
 
-  expect(cached).toStrictEqual({ dirty: false, failureAction: ActivityFailureAction.Retry });
+  expect(cached).toStrictEqual({
+    avatarID: avatar.id,
+    dirty: false,
+    failureAction: ActivityFailureAction.Retry,
+  });
 });
 
 test('it keeps the dirty flag when the server push fails', async () => {
-  const ctx = await setupTest();
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const ctx = await setupTest({ userID: user.id });
 
   server.use(
     mockActivityService.updateFailureAction.handler(() => {
@@ -96,9 +112,8 @@ test('it keeps the dirty flag when the server push fails', async () => {
 
   const context = createStubWorkerContext({ client: ctx.client });
 
-  context.setResyncAvatarID(ctx.avatar.id);
-
   const message: SetFailureActionMessage = {
+    avatarID: avatar.id,
     failureAction: ActivityFailureAction.Retry,
     type: ClientMessageType.SetFailureAction,
   };
@@ -109,17 +124,22 @@ test('it keeps the dirty flag when the server push fails', async () => {
 
   const cached = await readFailureActionCache();
 
-  expect(cached).toStrictEqual({ dirty: true, failureAction: ActivityFailureAction.Retry });
+  expect(cached).toStrictEqual({
+    avatarID: avatar.id,
+    dirty: true,
+    failureAction: ActivityFailureAction.Retry,
+  });
 });
 
 test('it broadcasts the effective failure action to every connection', async () => {
-  const ctx = await setupTest();
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const ctx = await setupTest({ userID: user.id });
 
   const channel = new MessageChannel();
 
   const context = createStubWorkerContext({ client: ctx.client, connections: [channel.port2] });
 
-  context.setResyncAvatarID(ctx.avatar.id);
   channel.port1.start();
 
   const received = new Promise<MessageEvent>((resolve) => {
@@ -127,6 +147,7 @@ test('it broadcasts the effective failure action to every connection', async () 
   });
 
   const message: SetFailureActionMessage = {
+    avatarID: avatar.id,
     failureAction: ActivityFailureAction.Retry,
     type: ClientMessageType.SetFailureAction,
   };

--- a/libs/game/idle-client/src/worker/handle-set-failure-action-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-set-failure-action-message.test.ts
@@ -1,0 +1,142 @@
+import { expect, test } from 'bun:test';
+import { createORPCClient } from '@orpc/client';
+import { RPCLink } from '@orpc/client/fetch';
+import { ActivityFailureAction, createSimulation } from '@vers/idle-core';
+import { createTestAccessToken, resolveServiceURL } from '@vers/mock-services';
+import { mockActivityService } from '@vers/mock-services/activity';
+import * as db from '@vers/mock-services/db';
+import { server } from '../mocks/node';
+import { readFailureActionCache } from '../submission/read-failure-action-cache';
+import type { ActivityServiceClient } from '../submission/types';
+import { createStubWorkerContext } from '../test-utils/create-stub-worker-context';
+import type { SetFailureActionMessage } from '../types';
+import { ClientMessageType, WorkerMessageType } from '../types';
+import { handleSetFailureActionMessage } from './handle-set-failure-action-message';
+
+async function setupTest() {
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const token = await createTestAccessToken(user.id);
+
+  const client: ActivityServiceClient = createORPCClient(
+    new RPCLink({
+      headers: { authorization: `Bearer ${token}` },
+      url: `${resolveServiceURL('activity')}/rpc`,
+    }),
+  );
+
+  return { avatar, client };
+}
+
+test('it forwards the change to a live simulation instead of dropping it', async () => {
+  const ctx = await setupTest();
+
+  const simulation = createSimulation();
+  const context = createStubWorkerContext({ client: ctx.client });
+
+  context.setSimulation(simulation);
+  context.setResyncAvatarID(ctx.avatar.id);
+
+  const message: SetFailureActionMessage = {
+    failureAction: ActivityFailureAction.Retry,
+    type: ClientMessageType.SetFailureAction,
+  };
+
+  await handleSetFailureActionMessage(context, message);
+
+  expect(simulation.failureAction).toBe(ActivityFailureAction.Retry);
+});
+
+test('it applies the change with no live simulation instead of warning and dropping it', async () => {
+  const ctx = await setupTest();
+
+  const context = createStubWorkerContext({ client: ctx.client });
+
+  context.setResyncAvatarID(ctx.avatar.id);
+
+  const message: SetFailureActionMessage = {
+    failureAction: ActivityFailureAction.Retry,
+    type: ClientMessageType.SetFailureAction,
+  };
+
+  await handleSetFailureActionMessage(context, message);
+
+  expect(context.getFailureAction()).toBe(ActivityFailureAction.Retry);
+});
+
+test('it clears the dirty flag once the server push succeeds', async () => {
+  const ctx = await setupTest();
+
+  const context = createStubWorkerContext({ client: ctx.client });
+
+  context.setResyncAvatarID(ctx.avatar.id);
+
+  const message: SetFailureActionMessage = {
+    failureAction: ActivityFailureAction.Retry,
+    type: ClientMessageType.SetFailureAction,
+  };
+
+  await handleSetFailureActionMessage(context, message);
+
+  expect(context.isFailureActionDirty()).toBeFalse();
+
+  const cached = await readFailureActionCache();
+
+  expect(cached).toStrictEqual({ dirty: false, failureAction: ActivityFailureAction.Retry });
+});
+
+test('it keeps the dirty flag when the server push fails', async () => {
+  const ctx = await setupTest();
+
+  server.use(
+    mockActivityService.updateFailureAction.handler(() => {
+      throw new Error('unreachable service');
+    }),
+  );
+
+  const context = createStubWorkerContext({ client: ctx.client });
+
+  context.setResyncAvatarID(ctx.avatar.id);
+
+  const message: SetFailureActionMessage = {
+    failureAction: ActivityFailureAction.Retry,
+    type: ClientMessageType.SetFailureAction,
+  };
+
+  await handleSetFailureActionMessage(context, message);
+
+  expect(context.isFailureActionDirty()).toBeTrue();
+
+  const cached = await readFailureActionCache();
+
+  expect(cached).toStrictEqual({ dirty: true, failureAction: ActivityFailureAction.Retry });
+});
+
+test('it broadcasts the effective failure action to every connection', async () => {
+  const ctx = await setupTest();
+
+  const channel = new MessageChannel();
+
+  const context = createStubWorkerContext({ client: ctx.client, connections: [channel.port2] });
+
+  context.setResyncAvatarID(ctx.avatar.id);
+  channel.port1.start();
+
+  const received = new Promise<MessageEvent>((resolve) => {
+    channel.port1.addEventListener('message', resolve, { once: true });
+  });
+
+  const message: SetFailureActionMessage = {
+    failureAction: ActivityFailureAction.Retry,
+    type: ClientMessageType.SetFailureAction,
+  };
+
+  await handleSetFailureActionMessage(context, message);
+
+  const event = await received;
+
+  expect(event.data).toStrictEqual({
+    failureAction: ActivityFailureAction.Retry,
+    type: WorkerMessageType.FailureActionStatus,
+  });
+});

--- a/libs/game/idle-client/src/worker/handle-set-failure-action-message.ts
+++ b/libs/game/idle-client/src/worker/handle-set-failure-action-message.ts
@@ -1,17 +1,44 @@
+import { safe } from '@orpc/client';
+import { writeFailureActionCache } from '../submission/write-failure-action-cache';
 import type { SetFailureActionMessage } from '../types';
+import { createFailureActionStatusMessage } from './create-failure-action-status-message';
 import type { WorkerContext } from './types';
 
-export function handleSetFailureActionMessage(
+/**
+ * Applies a tab's failure-action change: the context's in-session value updates first, so every
+ * derivation reads the new preference immediately, then the device-local cache marks it dirty as
+ * an offline outbox entry. A live simulation adopts it directly rather than waiting for its next
+ * continuation. The server push is best-effort — a connectivity failure leaves the cache dirty for
+ * the next resync's reconcile to retry — and every connection hears the effective value regardless
+ * of whether the push landed.
+ */
+export async function handleSetFailureActionMessage(
   context: WorkerContext,
   message: SetFailureActionMessage,
-) {
-  const simulation = context.getSimulation();
+): Promise<void> {
+  context.setFailureAction(message.failureAction);
+  context.setFailureActionDirty(true);
 
-  if (!simulation) {
-    console.warn('-- tried setting failure action but no simulation');
+  await writeFailureActionCache({ dirty: true, failureAction: message.failureAction });
 
-    return;
+  context.getSimulation()?.setFailureAction(message.failureAction);
+  const avatarID = context.getResyncAvatarID();
+
+  if (avatarID !== null) {
+    const [error] = await safe(
+      context.getClient().updateFailureAction({ avatarID, failureAction: message.failureAction }),
+    );
+
+    if (error === null) {
+      context.setFailureActionDirty(false);
+
+      await writeFailureActionCache({ dirty: false, failureAction: message.failureAction });
+    }
   }
 
-  simulation.setFailureAction(message.failureAction);
+  const statusMessage = createFailureActionStatusMessage(message.failureAction);
+
+  for (const connection of context.connections) {
+    connection.postMessage(statusMessage);
+  }
 }

--- a/libs/game/idle-client/src/worker/handle-set-failure-action-message.ts
+++ b/libs/game/idle-client/src/worker/handle-set-failure-action-message.ts
@@ -5,12 +5,15 @@ import { createFailureActionStatusMessage } from './create-failure-action-status
 import type { WorkerContext } from './types';
 
 /**
- * Applies a tab's failure-action change: the context's in-session value updates first, so every
- * derivation reads the new preference immediately, then the device-local cache marks it dirty as
- * an offline outbox entry. A live simulation adopts it directly rather than waiting for its next
- * continuation. The server push is best-effort — a connectivity failure leaves the cache dirty for
- * the next resync's reconcile to retry — and every connection hears the effective value regardless
- * of whether the push landed.
+ * Applies a tab's failure-action change. The synchronous in-memory effects land first, before any
+ * await, so a slow persistence or push never delays them: the context's in-session value updates,
+ * a live simulation adopts it directly, and every connection hears the effective value. The
+ * device-local cache then records it dirty as an offline outbox entry, and finally the value is
+ * pushed to the server. The push is single-flight per worker: a change arriving while a push runs
+ * coalesces onto it — the running loop re-reads the context and pushes the newest value — so an
+ * older push's acknowledgement can never clear the dirty flag or cache a value already superseded.
+ * Delivery is best-effort: a connectivity failure leaves the cache dirty for the next resync's
+ * reconcile to retry.
  */
 export async function handleSetFailureActionMessage(
   context: WorkerContext,
@@ -18,27 +21,62 @@ export async function handleSetFailureActionMessage(
 ): Promise<void> {
   context.setFailureAction(message.failureAction);
   context.setFailureActionDirty(true);
-
-  await writeFailureActionCache({ dirty: true, failureAction: message.failureAction });
-
   context.getSimulation()?.setFailureAction(message.failureAction);
-  const avatarID = context.getResyncAvatarID();
-
-  if (avatarID !== null) {
-    const [error] = await safe(
-      context.getClient().updateFailureAction({ avatarID, failureAction: message.failureAction }),
-    );
-
-    if (error === null) {
-      context.setFailureActionDirty(false);
-
-      await writeFailureActionCache({ dirty: false, failureAction: message.failureAction });
-    }
-  }
-
   const statusMessage = createFailureActionStatusMessage(message.failureAction);
 
   for (const connection of context.connections) {
     connection.postMessage(statusMessage);
+  }
+
+  await writeFailureActionCache({
+    avatarID: message.avatarID,
+    dirty: true,
+    failureAction: message.failureAction,
+  });
+
+  if (context.isFailureActionPushInFlight()) {
+    return;
+  }
+
+  context.setFailureActionPushInFlight(true);
+
+  try {
+    await flushFailureAction(context, message.avatarID);
+  } finally {
+    context.setFailureActionPushInFlight(false);
+  }
+}
+
+/**
+ * Delivers the context's current failure action to the server as the offline outbox's one entry,
+ * looping until the value it confirmed still matches the context — a change that arrives mid-flight
+ * is picked up and delivered again, so the dirty flag clears only for a value the server actually
+ * holds. A delivery failure leaves the value dirty and ends the loop for the next resync's
+ * reconcile to retry.
+ */
+async function flushFailureAction(context: WorkerContext, avatarID: string): Promise<void> {
+  let pushed = context.getFailureAction();
+  let confirmed = false;
+
+  while (!confirmed) {
+    const [error] = await safe(
+      context.getClient().updateFailureAction({ avatarID, failureAction: pushed }),
+    );
+
+    if (error !== null) {
+      return;
+    }
+
+    const current = context.getFailureAction();
+
+    if (current === pushed) {
+      context.setFailureActionDirty(false);
+
+      await writeFailureActionCache({ avatarID, dirty: false, failureAction: pushed });
+
+      confirmed = true;
+    } else {
+      pushed = current;
+    }
   }
 }

--- a/libs/game/idle-client/src/worker/is-set-failure-action-message.test.ts
+++ b/libs/game/idle-client/src/worker/is-set-failure-action-message.test.ts
@@ -6,6 +6,7 @@ import { isSetFailureActionMessage } from './is-set-failure-action-message';
 
 test('it returns true if it is a set failure action message', () => {
   const message: SetFailureActionMessage = {
+    avatarID: 'avatar-1',
     failureAction: ActivityFailureAction.Retry,
     type: ClientMessageType.SetFailureAction,
   };

--- a/libs/game/idle-client/src/worker/report-worker-fault.ts
+++ b/libs/game/idle-client/src/worker/report-worker-fault.ts
@@ -1,6 +1,11 @@
 import { sentryHandle } from './sentry-handle';
 
-export type WorkerFaultSite = 'message-routing' | 'reconnect' | 'resync' | 'tick-loop';
+export type WorkerFaultSite =
+  | 'message-routing'
+  | 'preference-seed'
+  | 'reconnect'
+  | 'resync'
+  | 'tick-loop';
 
 /**
  * Forwards a worker fault to the error backend, tagged with the capture site that caught it —

--- a/libs/game/idle-client/src/worker/run-continuation.ts
+++ b/libs/game/idle-client/src/worker/run-continuation.ts
@@ -74,7 +74,7 @@ async function startContinuationFrom(
   simulation: Simulation,
   row: Readonly<ActivityData>,
 ): Promise<void> {
-  const input = buildSimulationInput(row, { failureAction: simulation.failureAction });
+  const input = buildSimulationInput(row, { failureAction: context.getFailureAction() });
 
   simulation.startActivity(input.avatar, input.activity);
   context.setActivity(row);

--- a/libs/game/idle-client/src/worker/types.ts
+++ b/libs/game/idle-client/src/worker/types.ts
@@ -1,5 +1,5 @@
 import type { ActivityData } from '@vers/contract-activity';
-import type { Simulation } from '@vers/idle-core';
+import type { ActivityFailureAction, Simulation } from '@vers/idle-core';
 import type { CheckpointSubmitter } from '../submission/create-checkpoint-submitter';
 import type { ActivityServiceClient } from '../submission/types';
 import type { RewardSlotLedgerEntry, RewardSlotLedgerSnapshot } from '../types';
@@ -23,6 +23,13 @@ export interface WorkerContext {
   readonly getClient: () => ActivityServiceClient;
 
   /**
+   * The avatar's failure-action preference: the in-session source of truth every simulation input
+   * derivation reads from. Seeded from the device-local cache at worker boot, then held here for
+   * the worker's lifetime — a live simulation mirrors it, it never reads back from one.
+   */
+  readonly getFailureAction: () => ActivityFailureAction;
+
+  /**
    * The worker's conservative view of the avatar's offline-progress budget: the cap minus the
    * wall clock elapsed since the last acknowledged submission. It can only under-estimate the
    * server's meter, never over-run it.
@@ -44,6 +51,13 @@ export interface WorkerContext {
   readonly getSubmitter: () => CheckpointSubmitter;
 
   /**
+   * Whether the held failure action is a local value the server hasn't acknowledged yet — set the
+   * instant a tab changes it, cleared once the push to the server succeeds. A resync consults this
+   * to decide whether to push the local value or adopt the server's.
+   */
+  readonly isFailureActionDirty: () => boolean;
+
+  /**
    * Whether a resync is currently running — the orchestrator's single-flight guard; a request
    * that arrives while one is in flight is dropped rather than queued.
    */
@@ -56,6 +70,8 @@ export interface WorkerContext {
   readonly recordRewardSlots: (activityID: string, entry: RewardSlotLedgerEntry) => void;
   readonly removeConnection: (port: MessagePort) => void;
   readonly setActivity: (activity: ActivityData | null) => void;
+  readonly setFailureAction: (action: ActivityFailureAction) => void;
+  readonly setFailureActionDirty: (dirty: boolean) => void;
   readonly setResyncAvatarID: (avatarID: string) => void;
   readonly setResyncInFlight: (inFlight: boolean) => void;
   readonly setSimulation: (simulation: null | Simulation) => void;

--- a/libs/game/idle-client/src/worker/types.ts
+++ b/libs/game/idle-client/src/worker/types.ts
@@ -58,6 +58,13 @@ export interface WorkerContext {
   readonly isFailureActionDirty: () => boolean;
 
   /**
+   * Whether a push of the failure action to the server is running. Overlapping tab changes coalesce
+   * onto the running push rather than racing their own — a later change is picked up by the running
+   * loop, so a stale acknowledgement never clears the dirty flag for a value already superseded.
+   */
+  readonly isFailureActionPushInFlight: () => boolean;
+
+  /**
    * Whether a resync is currently running — the orchestrator's single-flight guard; a request
    * that arrives while one is in flight is dropped rather than queued.
    */
@@ -72,6 +79,7 @@ export interface WorkerContext {
   readonly setActivity: (activity: ActivityData | null) => void;
   readonly setFailureAction: (action: ActivityFailureAction) => void;
   readonly setFailureActionDirty: (dirty: boolean) => void;
+  readonly setFailureActionPushInFlight: (inFlight: boolean) => void;
   readonly setResyncAvatarID: (avatarID: string) => void;
   readonly setResyncInFlight: (inFlight: boolean) => void;
   readonly setSimulation: (simulation: null | Simulation) => void;

--- a/libs/game/idle-client/src/worker/use-simulation-worker.ts
+++ b/libs/game/idle-client/src/worker/use-simulation-worker.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { setCheckpointFlushStall } from '../state/set-checkpoint-flush-stall';
 import { setCheckpointStreamError } from '../state/set-checkpoint-stream-error';
 import { setConnectionStatus } from '../state/set-connection-status';
+import { setFailureAction } from '../state/set-failure-action';
 import { setLastCompletedActivityID } from '../state/set-last-completed-activity-id';
 import { setOfflineCapStatus } from '../state/set-offline-cap-status';
 import { setResyncStatus } from '../state/set-resync-status';
@@ -16,6 +17,7 @@ import type {
   CheckpointFlushStalledMessage,
   CheckpointStreamInvalidMessage,
   ConnectionStatusMessage,
+  FailureActionStatusMessage,
   InitialStateMessage,
   OfflineCapStatusMessage,
   ResyncStatusMessage,
@@ -116,6 +118,10 @@ function handleWorkerMessage(event: MessageEvent<WorkerMessage>) {
     setConnectionStatus(event.data.online);
   }
 
+  if (isFailureActionStatusMessage(event.data)) {
+    setFailureAction(event.data.failureAction);
+  }
+
   if (isRewardSlotsRecordedMessage(event.data)) {
     updateRewardSlotLedger({
       activityID: event.data.activityID,
@@ -159,6 +165,12 @@ function isResyncStatusMessage(message: WorkerMessage): message is ResyncStatusM
 
 function isConnectionStatusMessage(message: WorkerMessage): message is ConnectionStatusMessage {
   return message.type === WorkerMessageType.ConnectionStatus;
+}
+
+function isFailureActionStatusMessage(
+  message: WorkerMessage,
+): message is FailureActionStatusMessage {
+  return message.type === WorkerMessageType.FailureActionStatus;
 }
 
 function isRewardSlotsRecordedMessage(

--- a/libs/game/idle-client/test-setup.ts
+++ b/libs/game/idle-client/test-setup.ts
@@ -5,7 +5,7 @@ import * as jestDOMMatchers from '@testing-library/jest-dom/matchers';
 import { registerZustandReset } from '@vers/client-test-utils';
 import { registerMSWLifecycle } from '@vers/test-utils/bun';
 import { server } from './src/mocks/node';
-import { CHECKPOINT_QUEUE_STORE_NAME } from './src/submission/constants';
+import { CHECKPOINT_QUEUE_STORE_NAME, PREFERENCES_STORE_NAME } from './src/submission/constants';
 import { resolveCheckpointQueueDB } from './src/submission/resolve-checkpoint-queue-db';
 
 // a throwaway dev-only Ed25519 PKCS8 key, so tests can mint the access tokens the stateful
@@ -30,9 +30,10 @@ afterEach(async () => {
   reactTestingLibrary.cleanup();
   mock.restore();
 
-  // fake-indexeddb persists for the whole one-process run; sweep the durable checkpoint queue so
-  // no test depends on unique activity ids for isolation
+  // fake-indexeddb persists for the whole one-process run; sweep both durable stores so no test
+  // depends on unique activity ids, or a clean preferences cache, for isolation
   const queueDB = await resolveCheckpointQueueDB();
 
   await queueDB.clear(CHECKPOINT_QUEUE_STORE_NAME);
+  await queueDB.clear(PREFERENCES_STORE_NAME);
 });

--- a/libs/testing/mock-services/src/activity/activity-router.ts
+++ b/libs/testing/mock-services/src/activity/activity-router.ts
@@ -6,6 +6,7 @@ import { resumeActivity } from './resume-activity';
 import { startActivity } from './start-activity';
 import { stopActivity } from './stop-activity';
 import { trackActivityProgress } from './track-activity-progress';
+import { updateFailureAction } from './update-failure-action';
 
 export const activityRouter = {
   getActivityRewards,
@@ -16,4 +17,5 @@ export const activityRouter = {
   startActivity,
   stopActivity,
   trackActivityProgress,
+  updateFailureAction,
 };

--- a/libs/testing/mock-services/src/activity/get-latest-activity-progress.ts
+++ b/libs/testing/mock-services/src/activity/get-latest-activity-progress.ts
@@ -42,6 +42,7 @@ export const getLatestActivityProgress = os.getLatestActivityProgress.handler((o
     activity: latest,
     anchor: anchor ?? null,
     appendedHead: latest.appendedHead,
+    failureAction: avatar.failureAction,
     serverTime: new Date(),
     verifiedHead: latest.verifiedHead,
   };

--- a/libs/testing/mock-services/src/activity/update-failure-action.ts
+++ b/libs/testing/mock-services/src/activity/update-failure-action.ts
@@ -1,0 +1,26 @@
+import * as db from '../db';
+import { os } from './os';
+
+export const updateFailureAction = os.updateFailureAction.handler(async (opts) => {
+  const actingUserId = opts.context.actingUserId;
+
+  if (actingUserId === null) {
+    throw opts.errors.UNAUTHORIZED({ data: { reason: 'missing-session' } });
+  }
+
+  const avatar = db.avatarCollection.findFirst((q) =>
+    q.where({ id: opts.input.avatarID, userID: actingUserId }),
+  );
+
+  if (avatar === undefined) {
+    throw opts.errors.NOT_FOUND({ data: {} });
+  }
+
+  await db.avatarCollection.update(avatar, {
+    data(record) {
+      record.failureAction = opts.input.failureAction;
+    },
+  });
+
+  return { failureAction: opts.input.failureAction };
+});

--- a/libs/testing/mock-services/src/db/avatar-collection.ts
+++ b/libs/testing/mock-services/src/db/avatar-collection.ts
@@ -1,15 +1,19 @@
 import { faker } from '@faker-js/faker';
 import { Collection } from '@msw/data';
 import { createId } from '@paralleldrive/cuid2';
+import { ActivityFailureActionSchema } from '@vers/contract-activity';
 import { AvatarDataSchema, AvatarModeSchema } from '@vers/contract-avatar';
 import * as z from 'zod';
 
 /**
  * A stored mock avatar row: the public `AvatarDataSchema` with every field defaulted, so tests
  * state only the fields they assert on. `userID` defaults to a random id, not a real user's.
+ * `failureAction` is the activity service's own column on this row, not part of the avatar
+ * contract's public shape.
  */
 const AvatarRowSchema = AvatarDataSchema.extend({
   createdAt: z.date().default(() => new Date()),
+  failureAction: ActivityFailureActionSchema.default('abort'),
   id: z.string().default(() => createId()),
   level: z.int().default(1),
   mode: AvatarModeSchema.default('trade'),

--- a/services/activity/src/build-router.ts
+++ b/services/activity/src/build-router.ts
@@ -11,6 +11,7 @@ import { resumeActivity } from './handlers/resume-activity';
 import { startActivity } from './handlers/start-activity';
 import { stopActivity } from './handlers/stop-activity';
 import { trackActivityProgress } from './handlers/track-activity-progress';
+import { updateFailureAction } from './handlers/update-failure-action';
 
 interface BuildActivityRouterDeps {
   readonly contentVersion: string;
@@ -41,6 +42,9 @@ export function buildActivityRouter(deps: BuildActivityRouterDeps) {
     stopActivity: os.stopActivity.handler((opts) => stopActivity(deps.db, opts)),
     trackActivityProgress: os.trackActivityProgress.handler((opts) =>
       trackActivityProgress({ db: deps.db, simTimeCapMs: deps.simTimeCapMs }, opts),
+    ),
+    updateFailureAction: os.updateFailureAction.handler((opts) =>
+      updateFailureAction(deps.db, opts),
     ),
   };
 }

--- a/services/activity/src/handlers/get-latest-activity-progress.test.ts
+++ b/services/activity/src/handlers/get-latest-activity-progress.test.ts
@@ -42,9 +42,33 @@ test('it returns a fresh activity with a null anchor at verifiedHead 0', async (
     activity: started,
     anchor: null,
     appendedHead: 0,
+    failureAction: 'abort',
     serverTime: expect.toBeValidDate(),
     verifiedHead: 0,
   });
+});
+
+test("it returns the avatar's persisted failure action", async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+
+  const avatar = await createAvatarRow(ctx.db, {
+    failureAction: 'retry',
+    userId: viewer.user.id,
+  });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'a9lp75',
+    scopeType: 'world_map_node',
+  });
+
+  const progress = await client.getLatestActivityProgress({ avatarID: avatar.id });
+
+  expect(progress.failureAction).toBe('retry');
 });
 
 test('it returns the server clock beside the resume cursors', async () => {

--- a/services/activity/src/handlers/get-latest-activity-progress.ts
+++ b/services/activity/src/handlers/get-latest-activity-progress.ts
@@ -1,4 +1,4 @@
-import type { ActivityData, Checkpoint } from '@vers/contract-activity';
+import type { ActivityData, ActivityFailureAction, Checkpoint } from '@vers/contract-activity';
 import type { DB } from '@vers/db';
 import { sql } from 'kysely';
 import type { Kysely } from 'kysely';
@@ -22,6 +22,7 @@ interface GetLatestActivityProgressResult {
   readonly activity: ActivityData;
   readonly anchor: Checkpoint | null;
   readonly appendedHead: number;
+  readonly failureAction: ActivityFailureAction;
   readonly serverTime: Date;
   readonly verifiedHead: number;
 }
@@ -44,6 +45,7 @@ export async function getLatestActivityProgress(
     .selectFrom('activities')
     .innerJoin('avatars', 'avatars.id', 'activities.avatarId')
     .selectAll('activities')
+    .select('avatars.failureAction')
 
     // Cast to the row's timestamp column type so the driver parses the clock and the activity's
     // timestamps identically regardless of session timezone — clients subtract the two.
@@ -71,6 +73,7 @@ export async function getLatestActivityProgress(
     activity: toActivityData(row),
     anchor: anchor === undefined ? null : toCheckpointData(anchor),
     appendedHead: row.appendedHead,
+    failureAction: row.failureAction,
     serverTime: row.serverTime,
     verifiedHead: row.verifiedHead,
   };

--- a/services/activity/src/handlers/update-failure-action.test.ts
+++ b/services/activity/src/handlers/update-failure-action.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from 'bun:test';
+import type { ActivityContract } from '@vers/contract-activity';
+import { createAnonymousViewer, createTestDB, createViewer } from '@vers/service-test-utils/bun';
+import { buildRPCTestClient } from '@vers/test-utils';
+import { createActivityService } from '../create-activity-service';
+import { createAvatarRow } from '../test-utils/create-avatar-row';
+
+async function setupTest() {
+  const db = await createTestDB();
+  const service = await createActivityService({ db: db.db });
+
+  return { app: service.app, db: db.db, [Symbol.asyncDispose]: db[Symbol.asyncDispose] };
+}
+
+test('it persists the failure action and returns it', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const result = await client.updateFailureAction({
+    avatarID: avatar.id,
+    failureAction: 'retry',
+  });
+
+  expect(result).toStrictEqual({ failureAction: 'retry' });
+
+  const row = await ctx.db
+    .selectFrom('avatars')
+    .select('failureAction')
+    .where('id', '=', avatar.id)
+    .executeTakeFirstOrThrow();
+
+  expect(row.failureAction).toBe('retry');
+});
+
+test('it rejects an avatar owned by a different user with NOT_FOUND', async () => {
+  await using ctx = await setupTest();
+
+  const owner = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const otherViewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: owner.user.id });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: otherViewer.token });
+
+  expect(
+    client.updateFailureAction({ avatarID: avatar.id, failureAction: 'retry' }),
+  ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+});
+
+test('it rejects an unknown avatar with NOT_FOUND', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  expect(
+    client.updateFailureAction({ avatarID: 'avatar_unknown', failureAction: 'retry' }),
+  ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+});
+
+test('it rejects an anonymous acting user with UNAUTHORIZED', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createAnonymousViewer({ audience: 'service-activity' });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  expect(
+    client.updateFailureAction({ avatarID: 'avatar_1', failureAction: 'retry' }),
+  ).rejects.toMatchObject({
+    code: 'UNAUTHORIZED',
+    data: { reason: 'missing-session' },
+  });
+});

--- a/services/activity/src/handlers/update-failure-action.ts
+++ b/services/activity/src/handlers/update-failure-action.ts
@@ -1,0 +1,47 @@
+import type { ActivityFailureAction } from '@vers/contract-activity';
+import type { DB } from '@vers/db';
+import type { Kysely } from 'kysely';
+import type { EmptyErrorPayload, MissingSessionPayload } from '../types';
+
+/**
+ * oRPC handler opts for the authed `updateFailureAction` procedure.
+ */
+interface UpdateFailureActionOpts {
+  readonly context: { readonly actingUserId: null | string };
+  readonly errors: {
+    readonly NOT_FOUND: (payload: EmptyErrorPayload) => Error;
+    readonly UNAUTHORIZED: (payload: MissingSessionPayload) => Error;
+  };
+  readonly input: { readonly avatarID: string; readonly failureAction: ActivityFailureAction };
+}
+
+interface UpdateFailureActionResult {
+  readonly failureAction: ActivityFailureAction;
+}
+
+/**
+ * Persists an avatar's failure-action preference — the server's source of truth a device-local
+ * cache mirrors as an offline outbox.
+ */
+export async function updateFailureAction(
+  db: Kysely<DB>,
+  opts: UpdateFailureActionOpts,
+): Promise<UpdateFailureActionResult> {
+  if (opts.context.actingUserId === null) {
+    throw opts.errors.UNAUTHORIZED({ data: { reason: 'missing-session' } });
+  }
+
+  const row = await db
+    .updateTable('avatars')
+    .set({ failureAction: opts.input.failureAction })
+    .where('id', '=', opts.input.avatarID)
+    .where('userId', '=', opts.context.actingUserId)
+    .returning('failureAction')
+    .executeTakeFirst();
+
+  if (row === undefined) {
+    throw opts.errors.NOT_FOUND({ data: {} });
+  }
+
+  return { failureAction: row.failureAction };
+}


### PR DESCRIPTION
Closes #581

Persists the avatar's failure-action retry preference server-side and threads it through the idle worker, so an offline fast-forward honors the avatar's saved choice instead of defaulting to abort.

- New `avatars.failure_action` column (default `abort`) with a matching contract schema, `getLatestActivityProgress` output field, and an authed `updateFailureAction` procedure.
- The worker seeds its failure-action cache from IndexedDB before any client message or self-triggered resync runs, closing the relaunch-while-offline gap.
- Setting the preference updates the live simulation and best-effort pushes to the server; a resync reconciles a dirty local value against the server's, adopting whichever wins, and broadcasts a `FailureActionStatus` message so every connected tab reflects it.
- Every `buildSimulationInput` call site now reads the worker's tracked failure action instead of a stale or default value.
- Drive-by: fixed a pre-existing broken `get-avatar-progression` test on `main` (unregistered placeholder node id) — already covered by the rebase since a later `main` PR applied the same fix independently.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
