### PR TITLE
fix(#583): evict and sweep stale checkpoint queue state

### DIFF
--- a/libs/game/idle-client/src/submission/create-checkpoint-submitter.test.ts
+++ b/libs/game/idle-client/src/submission/create-checkpoint-submitter.test.ts
@@ -584,9 +584,13 @@ test('it doubles the retry delay on each consecutive failure up to the cap', asy
 
 test('it resets the backoff exponent on a successful flush', async () => {
   const retries: Array<{ delayMs: number; retry: () => Promise<void> }> = [];
+  let capturedFlush: (() => Promise<void>) | undefined;
   let shouldFail = true;
 
   const ctx = setupTest({
+    scheduleFlush: (flush) => {
+      capturedFlush = flush;
+    },
     scheduleRetry: (delayMs, retry) => {
       retries.push({ delayMs, retry });
     },
@@ -609,7 +613,11 @@ test('it resets the backoff exponent on a successful flush', async () => {
     startChainIndex: 0,
   });
 
-  await ctx.submitter.submit('reset-backoff-activity', createMockCompletedCheckpoint());
+  // a non-terminal checkpoint keeps the activity's state alive across the successful flush, so
+  // the second failure backs off on the same state the first failure escalated
+  await ctx.submitter.submit('reset-backoff-activity', createMockProgressCheckpoint());
+
+  await capturedFlush?.();
 
   expect(retries).toHaveLength(1);
   expect(retries[0]?.delayMs).toBe(10_000);
@@ -624,16 +632,9 @@ test('it resets the backoff exponent on a successful flush', async () => {
 
   shouldFail = true;
 
-  // the fully confirmed terminal drain evicted the activity, so a fresh registration re-seeds it
-  // before the next submission can hold and retry again
-  await ctx.submitter.registerActivity({
-    activityID: 'reset-backoff-activity',
-    appendedHead: 1,
-    lastHash: 'confirmed_hash',
-    startChainIndex: 0,
-  });
+  await ctx.submitter.submit('reset-backoff-activity', createMockProgressCheckpoint());
 
-  await ctx.submitter.submit('reset-backoff-activity', createMockCompletedCheckpoint());
+  await capturedFlush?.();
 
   expect(retries).toHaveLength(2);
   expect(retries[1]?.delayMs).toBe(10_000);
@@ -802,9 +803,13 @@ test('it folds a retry firing while a flush is already in flight into the pendin
 
 test('it flushes every held activity immediately and resets their backoff', async () => {
   const retries: Array<{ delayMs: number; retry: () => Promise<void> }> = [];
+  let capturedFlush: (() => Promise<void>) | undefined;
   let shouldFail = true;
 
   const ctx = setupTest({
+    scheduleFlush: (flush) => {
+      capturedFlush = flush;
+    },
     scheduleRetry: (delayMs, retry) => {
       retries.push({ delayMs, retry });
     },
@@ -827,7 +832,11 @@ test('it flushes every held activity immediately and resets their backoff', asyn
     startChainIndex: 0,
   });
 
-  await ctx.submitter.submit('flush-held-activity', createMockCompletedCheckpoint());
+  // a non-terminal checkpoint keeps the activity's state alive across the reconnect flush, so
+  // the next failure backs off on the same state the first failure escalated
+  await ctx.submitter.submit('flush-held-activity', createMockProgressCheckpoint());
+
+  await capturedFlush?.();
 
   expect(retries).toHaveLength(1);
 
@@ -841,16 +850,9 @@ test('it flushes every held activity immediately and resets their backoff', asyn
 
   shouldFail = true;
 
-  // the fully confirmed terminal drain evicted the activity, so a fresh registration re-seeds it
-  // before the next submission can hold and retry again
-  await ctx.submitter.registerActivity({
-    activityID: 'flush-held-activity',
-    appendedHead: 1,
-    lastHash: 'confirmed_hash',
-    startChainIndex: 0,
-  });
+  await ctx.submitter.submit('flush-held-activity', createMockProgressCheckpoint());
 
-  await ctx.submitter.submit('flush-held-activity', createMockCompletedCheckpoint());
+  await capturedFlush?.();
 
   expect(retries).toHaveLength(2);
   expect(retries[1]?.delayMs).toBe(10_000);
@@ -1382,12 +1384,13 @@ test('it evicts the activity once a terminal checkpoint drains fully confirmed',
 
   expect(track).toHaveBeenCalledOnce();
 
-  // a later registration on the same activity id re-seeds and re-flushes rather than resolving a
-  // stale registration, proving the fully confirmed terminal drain evicted it
+  // a later registration seeded from a deliberately different head re-seeds and re-flushes
+  // rather than resolving a stale registration, proving the fully confirmed terminal drain
+  // evicted it — retained state would keep the old cursor and submit version 3 at expectedHead 2
   await ctx.submitter.registerActivity({
     activityID: 'terminal-drain-evict-activity',
-    appendedHead: 2,
-    lastHash: 'completed_hash',
+    appendedHead: 7,
+    lastHash: 'fresh_hash',
     startChainIndex: 0,
   });
 
@@ -1396,8 +1399,70 @@ test('it evicts the activity once a terminal checkpoint drains fully confirmed',
     createMockCompletedCheckpoint(),
   );
 
-  expect(version).toBe(3);
+  expect(version).toBe(8);
   expect(track).toHaveBeenCalledTimes(2);
+
+  expect(track).toHaveBeenLastCalledWith({
+    activityID: 'terminal-drain-evict-activity',
+    checkpoints: [expect.objectContaining({ prevHash: 'fresh_hash', version: 8 })],
+    expectedHead: 7,
+  });
+});
+
+test('it evicts a hydrated terminal row once its resend drains fully confirmed', async () => {
+  await writeQueuedCheckpoint(
+    'hydrated-terminal-activity',
+    createMockCheckpointBatchEntry({ payload: { type: 'completed' }, version: 1 }),
+  );
+
+  const ctx = setupTest();
+  const track = mock<(input: unknown) => void>();
+
+  server.use(
+    mockActivityService.trackActivityProgress.handler((opts) => {
+      track(opts.input);
+
+      return { appendedHead: 1 };
+    }),
+  );
+
+  // the registration's own flush resends the queued terminal row and fully confirms it
+  await ctx.submitter.registerActivity({
+    activityID: 'hydrated-terminal-activity',
+    appendedHead: 0,
+    lastHash: 'start_hash',
+    startChainIndex: 0,
+  });
+
+  expect(track).toHaveBeenCalledOnce();
+
+  const drained = await readQueuedCheckpoints('hydrated-terminal-activity');
+
+  expect(drained).toStrictEqual([]);
+
+  // a later registration seeded from a deliberately different head re-seeds and re-flushes
+  // rather than resolving a stale registration, proving the confirmed hydrated terminal row
+  // evicted the activity even though no live submission ever queued it
+  await ctx.submitter.registerActivity({
+    activityID: 'hydrated-terminal-activity',
+    appendedHead: 5,
+    lastHash: 'fresh_hash',
+    startChainIndex: 0,
+  });
+
+  const version = await ctx.submitter.submit(
+    'hydrated-terminal-activity',
+    createMockCompletedCheckpoint(),
+  );
+
+  expect(version).toBe(6);
+  expect(track).toHaveBeenCalledTimes(2);
+
+  expect(track).toHaveBeenLastCalledWith({
+    activityID: 'hydrated-terminal-activity',
+    checkpoints: [expect.objectContaining({ prevHash: 'fresh_hash', version: 6 })],
+    expectedHead: 5,
+  });
 });
 
 test('it evicts safely when a concurrent flush call sets flushPending during a terminal drain', async () => {

--- a/libs/game/idle-client/src/submission/create-checkpoint-submitter.test.ts
+++ b/libs/game/idle-client/src/submission/create-checkpoint-submitter.test.ts
@@ -624,6 +624,15 @@ test('it resets the backoff exponent on a successful flush', async () => {
 
   shouldFail = true;
 
+  // the fully confirmed terminal drain evicted the activity, so a fresh registration re-seeds it
+  // before the next submission can hold and retry again
+  await ctx.submitter.registerActivity({
+    activityID: 'reset-backoff-activity',
+    appendedHead: 1,
+    lastHash: 'confirmed_hash',
+    startChainIndex: 0,
+  });
+
   await ctx.submitter.submit('reset-backoff-activity', createMockCompletedCheckpoint());
 
   expect(retries).toHaveLength(2);
@@ -831,6 +840,15 @@ test('it flushes every held activity immediately and resets their backoff', asyn
   expect(remaining).toStrictEqual([]);
 
   shouldFail = true;
+
+  // the fully confirmed terminal drain evicted the activity, so a fresh registration re-seeds it
+  // before the next submission can hold and retry again
+  await ctx.submitter.registerActivity({
+    activityID: 'flush-held-activity',
+    appendedHead: 1,
+    lastHash: 'confirmed_hash',
+    startChainIndex: 0,
+  });
 
   await ctx.submitter.submit('flush-held-activity', createMockCompletedCheckpoint());
 
@@ -1120,4 +1138,311 @@ test('it sends no trace header for a call made without per-call context', async 
   });
 
   expect(traceparents).toStrictEqual([null]);
+});
+
+test('it evicts the activity after ACTIVITY_CAPPED so a later registration re-seeds an empty queue', async () => {
+  const ctx = setupTest();
+  const track = mock<(input: unknown) => void>();
+
+  server.use(
+    mockActivityService.trackActivityProgress.handler((opts) => {
+      track(opts.input);
+      throw opts.errors.ACTIVITY_CAPPED({ data: { appendedHead: 0 } });
+    }),
+  );
+
+  await ctx.submitter.registerActivity({
+    activityID: 'capped-evict-activity',
+    appendedHead: 0,
+    lastHash: 'start_hash',
+    startChainIndex: 0,
+  });
+
+  await ctx.submitter.submit('capped-evict-activity', createMockCompletedCheckpoint());
+
+  expect(track).toHaveBeenCalledOnce();
+
+  server.use(
+    mockActivityService.trackActivityProgress.handler((opts) => {
+      track(opts.input);
+
+      return { appendedHead: 1 };
+    }),
+  );
+
+  // a re-registration after eviction runs its own seed read and flush rather than resolving the
+  // capped registration, proving the tombstoned state is gone
+  await ctx.submitter.registerActivity({
+    activityID: 'capped-evict-activity',
+    appendedHead: 0,
+    lastHash: 'start_hash',
+    startChainIndex: 0,
+  });
+
+  await ctx.submitter.submit('capped-evict-activity', createMockCompletedCheckpoint());
+
+  expect(track).toHaveBeenCalledTimes(2);
+
+  expect(track).toHaveBeenLastCalledWith({
+    activityID: 'capped-evict-activity',
+    checkpoints: expect.toBeArrayOfSize(1),
+    expectedHead: 0,
+  });
+});
+
+test('it evicts the activity after ACTIVITY_TERMINAL so a later registration re-seeds an empty queue', async () => {
+  const ctx = setupTest();
+  const track = mock<(input: unknown) => void>();
+
+  server.use(
+    mockActivityService.trackActivityProgress.handler((opts) => {
+      track(opts.input);
+      throw opts.errors.ACTIVITY_TERMINAL({ data: { appendedHead: 0, status: 'stopped' } });
+    }),
+  );
+
+  await ctx.submitter.registerActivity({
+    activityID: 'terminal-status-evict-activity',
+    appendedHead: 0,
+    lastHash: 'start_hash',
+    startChainIndex: 0,
+  });
+
+  await ctx.submitter.submit('terminal-status-evict-activity', createMockCompletedCheckpoint());
+
+  expect(track).toHaveBeenCalledOnce();
+
+  server.use(
+    mockActivityService.trackActivityProgress.handler((opts) => {
+      track(opts.input);
+
+      return { appendedHead: 1 };
+    }),
+  );
+
+  await ctx.submitter.registerActivity({
+    activityID: 'terminal-status-evict-activity',
+    appendedHead: 0,
+    lastHash: 'start_hash',
+    startChainIndex: 0,
+  });
+
+  await ctx.submitter.submit('terminal-status-evict-activity', createMockCompletedCheckpoint());
+
+  expect(track).toHaveBeenCalledTimes(2);
+});
+
+test('it evicts the activity after SESSION_EVICTED so a later registration re-seeds an empty queue', async () => {
+  const ctx = setupTest();
+  const track = mock<(input: unknown) => void>();
+
+  server.use(
+    mockActivityService.trackActivityProgress.handler((opts) => {
+      track(opts.input);
+      throw opts.errors.SESSION_EVICTED({ data: {} });
+    }),
+  );
+
+  await ctx.submitter.registerActivity({
+    activityID: 'session-evict-activity',
+    appendedHead: 0,
+    lastHash: 'start_hash',
+    startChainIndex: 0,
+  });
+
+  await ctx.submitter.submit('session-evict-activity', createMockCompletedCheckpoint());
+
+  expect(track).toHaveBeenCalledOnce();
+
+  server.use(
+    mockActivityService.trackActivityProgress.handler((opts) => {
+      track(opts.input);
+
+      return { appendedHead: 1 };
+    }),
+  );
+
+  await ctx.submitter.registerActivity({
+    activityID: 'session-evict-activity',
+    appendedHead: 0,
+    lastHash: 'start_hash',
+    startChainIndex: 0,
+  });
+
+  await ctx.submitter.submit('session-evict-activity', createMockCompletedCheckpoint());
+
+  expect(track).toHaveBeenCalledTimes(2);
+});
+
+test('it evicts the activity after NOT_FOUND so a later registration re-seeds an empty queue', async () => {
+  const ctx = setupTest();
+  const track = mock<(input: unknown) => void>();
+
+  server.use(
+    mockActivityService.trackActivityProgress.handler((opts) => {
+      track(opts.input);
+      throw opts.errors.NOT_FOUND({ data: {} });
+    }),
+  );
+
+  await ctx.submitter.registerActivity({
+    activityID: 'not-found-evict-activity',
+    appendedHead: 0,
+    lastHash: 'start_hash',
+    startChainIndex: 0,
+  });
+
+  await ctx.submitter.submit('not-found-evict-activity', createMockCompletedCheckpoint());
+
+  expect(track).toHaveBeenCalledOnce();
+
+  server.use(
+    mockActivityService.trackActivityProgress.handler((opts) => {
+      track(opts.input);
+
+      return { appendedHead: 1 };
+    }),
+  );
+
+  await ctx.submitter.registerActivity({
+    activityID: 'not-found-evict-activity',
+    appendedHead: 0,
+    lastHash: 'start_hash',
+    startChainIndex: 0,
+  });
+
+  await ctx.submitter.submit('not-found-evict-activity', createMockCompletedCheckpoint());
+
+  expect(track).toHaveBeenCalledTimes(2);
+});
+
+test('it keeps the tombstoned registration on CHECKPOINT_INVALID so a later registration attempt does not reseed', async () => {
+  const ctx = setupTest();
+  const track = mock<(input: unknown) => void>();
+
+  server.use(
+    mockActivityService.trackActivityProgress.handler((opts) => {
+      track(opts.input);
+      throw opts.errors.CHECKPOINT_INVALID({ data: { reason: 'broken-chain-link' } });
+    }),
+  );
+
+  await ctx.submitter.registerActivity({
+    activityID: 'invalid-tombstone-activity',
+    appendedHead: 0,
+    lastHash: 'start_hash',
+    startChainIndex: 0,
+  });
+
+  await ctx.submitter.submit('invalid-tombstone-activity', createMockCompletedCheckpoint());
+
+  expect(track).toHaveBeenCalledOnce();
+
+  // a later registration attempt resolves the original tombstoned registration instead of
+  // re-seeding, so no second seed read or flush ever reaches the server
+  await ctx.submitter.registerActivity({
+    activityID: 'invalid-tombstone-activity',
+    appendedHead: 0,
+    lastHash: 'start_hash',
+    startChainIndex: 0,
+  });
+
+  expect(track).toHaveBeenCalledOnce();
+
+  const version = await ctx.submitter.submit(
+    'invalid-tombstone-activity',
+    createMockProgressCheckpoint(),
+  );
+
+  expect(version).toBeUndefined();
+  expect(track).toHaveBeenCalledOnce();
+});
+
+test('it evicts the activity once a terminal checkpoint drains fully confirmed', async () => {
+  const ctx = setupTest();
+  const track = mock<(input: unknown) => void>();
+
+  server.use(
+    mockActivityService.trackActivityProgress.handler((opts) => {
+      track(opts.input);
+
+      return { appendedHead: 2 };
+    }),
+  );
+
+  await ctx.submitter.registerActivity({
+    activityID: 'terminal-drain-evict-activity',
+    appendedHead: 0,
+    lastHash: 'start_hash',
+    startChainIndex: 0,
+  });
+
+  await ctx.submitter.submit('terminal-drain-evict-activity', createMockStartedCheckpoint());
+  await ctx.submitter.submit('terminal-drain-evict-activity', createMockCompletedCheckpoint());
+
+  expect(track).toHaveBeenCalledOnce();
+
+  // a later registration on the same activity id re-seeds and re-flushes rather than resolving a
+  // stale registration, proving the fully confirmed terminal drain evicted it
+  await ctx.submitter.registerActivity({
+    activityID: 'terminal-drain-evict-activity',
+    appendedHead: 2,
+    lastHash: 'completed_hash',
+    startChainIndex: 0,
+  });
+
+  const version = await ctx.submitter.submit(
+    'terminal-drain-evict-activity',
+    createMockCompletedCheckpoint(),
+  );
+
+  expect(version).toBe(3);
+  expect(track).toHaveBeenCalledTimes(2);
+});
+
+test('it evicts safely when a concurrent flush call sets flushPending during a terminal drain', async () => {
+  const ctx = setupTest();
+  const track = mock<(input: unknown) => void>();
+  let releaseFirstCall: (() => void) | undefined;
+
+  server.use(
+    mockActivityService.trackActivityProgress.handler(async (opts) => {
+      track(opts.input);
+
+      if (track.mock.calls.length === 1) {
+        await new Promise<void>((resolve) => {
+          releaseFirstCall = resolve;
+        });
+      }
+
+      return { appendedHead: 1 };
+    }),
+  );
+
+  await ctx.submitter.registerActivity({
+    activityID: 'concurrent-evict-activity',
+    appendedHead: 0,
+    lastHash: 'start_hash',
+    startChainIndex: 0,
+  });
+
+  const terminalSubmit = ctx.submitter.submit(
+    'concurrent-evict-activity',
+    createMockCompletedCheckpoint(),
+  );
+
+  await waitFor(() => {
+    expect(track).toHaveBeenCalledOnce();
+  });
+
+  // a flush call landing while the terminal drain is in flight marks flushPending, so the finally
+  // block's re-flush after eviction must find the state gone and return without throwing
+  const heldFlush = ctx.submitter.flushHeld();
+
+  releaseFirstCall?.();
+
+  await expect(terminalSubmit).toResolve();
+  await expect(heldFlush).toResolve();
+
+  expect(track).toHaveBeenCalledOnce();
 });

--- a/libs/game/idle-client/src/submission/create-checkpoint-submitter.ts
+++ b/libs/game/idle-client/src/submission/create-checkpoint-submitter.ts
@@ -2,7 +2,6 @@ import { ORPCError, isDefinedError, safe } from '@orpc/client';
 import type { ActivityCheckpoint } from '@vers/idle-core';
 import { ActivityCheckpointType } from '@vers/idle-core';
 import { buildTraceparent, createTraceContext } from '@vers/trace';
-import invariant from 'tiny-invariant';
 import { buildCheckpointBatchEntry } from './build-checkpoint-batch-entry';
 import {
   ENTROPY_SOURCE_SERVER_KEY,
@@ -39,8 +38,9 @@ interface ActivityState {
   startChainIndex: number;
 
   /**
-   * Set once `submit` enqueues a `Completed`/`Failed` checkpoint — a fully confirmed flush after
-   * this point drains the activity for good, so its state is safe to evict.
+   * Set once a `Completed`/`Failed` checkpoint sits at the queue's tail — enqueued by a live
+   * submission or hydrated from a previous worker lifetime's durable rows — a fully confirmed
+   * flush after this point drains the activity for good, so its state is safe to evict.
    */
   terminalQueued: boolean;
 }
@@ -217,9 +217,11 @@ export function createCheckpointSubmitter(
     });
   };
 
-  // Discards an activity's tracked state entirely, both the cursor and its memoized registration
-  // — the server accepts nothing further for it, so a later re-registration harmlessly re-seeds
-  // an empty queue instead of resolving a stale registration or reusing a stale cursor.
+  /**
+   * Discards an activity's tracked state entirely, both the cursor and its memoized registration
+   * — the server accepts nothing further for it, so a later re-registration harmlessly re-seeds
+   * an empty queue instead of resolving a stale registration or reusing a stale cursor.
+   */
   const removeActivityState = (activityID: string): void => {
     activityStates.delete(activityID);
     registrations.delete(activityID);
@@ -446,11 +448,12 @@ export function createCheckpointSubmitter(
 
     await registration;
 
+    // a concurrent flush can drain a terminal checkpoint and evict the activity while this
+    // submission awaits its registration — the checkpoint is dropped exactly like one for a
+    // never-attached activity
     const state = activityStates.get(activityID);
 
-    invariant(state !== undefined, 'a registered activity has no submission state');
-
-    if (state.invalid) {
+    if (state === undefined || state.invalid) {
       return undefined;
     }
 
@@ -532,6 +535,11 @@ export function createCheckpointSubmitter(
   return { flushHeld, flushNow, registerActivity, submit };
 }
 
+const TERMINAL_CHECKPOINT_TYPES: ReadonlySet<string> = new Set([
+  ActivityCheckpointType.Completed,
+  ActivityCheckpointType.Failed,
+]);
+
 async function loadPendingCheckpoints(
   activityID: string,
   // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- a mutable cursor this function seeds in place from the durable queue
@@ -545,5 +553,6 @@ async function loadPendingCheckpoints(
     state.nextVersion = lastRow.version + 1;
     state.prevHash = lastRow.hash;
     state.previousNextSeed = lastRow.payload.nextSeed;
+    state.terminalQueued = TERMINAL_CHECKPOINT_TYPES.has(lastRow.payload.type);
   }
 }

--- a/libs/game/idle-client/src/submission/create-checkpoint-submitter.ts
+++ b/libs/game/idle-client/src/submission/create-checkpoint-submitter.ts
@@ -37,6 +37,12 @@ interface ActivityState {
   retryGeneration: number;
   retryScheduled: boolean;
   startChainIndex: number;
+
+  /**
+   * Set once `submit` enqueues a `Completed`/`Failed` checkpoint — a fully confirmed flush after
+   * this point drains the activity for good, so its state is safe to evict.
+   */
+  terminalQueued: boolean;
 }
 
 export interface CheckpointSubmitter {
@@ -146,6 +152,13 @@ interface CreateCheckpointSubmitterOptions {
  * a transport failure — holds the queue untouched for the next flush tick. Each flush rides a
  * freshly minted trace, and a streak of non-defined flush failures reports a stall without
  * stopping the stream.
+ *
+ * An activity whose stream stops with its rows discarded — `ACTIVITY_CAPPED`, `ACTIVITY_TERMINAL`,
+ * `SESSION_EVICTED`, `NOT_FOUND` — has its cursor and registration evicted from both tracking maps,
+ * so a later registration re-seeds fresh rather than resolving stale state; a fully confirmed
+ * terminal checkpoint evicts the same way once its flush lands. `CHECKPOINT_INVALID` keeps its rows
+ * and its tombstoned state for the worker's lifetime, so a later registration attempt never resends
+ * what the server already rejected.
  */
 export function createCheckpointSubmitter(
   options: Readonly<CreateCheckpointSubmitterOptions>,
@@ -202,6 +215,14 @@ export function createCheckpointSubmitter(
 
       await flush(activityID);
     });
+  };
+
+  // Discards an activity's tracked state entirely, both the cursor and its memoized registration
+  // — the server accepts nothing further for it, so a later re-registration harmlessly re-seeds
+  // an empty queue instead of resolving a stale registration or reusing a stale cursor.
+  const removeActivityState = (activityID: string): void => {
+    activityStates.delete(activityID);
+    registrations.delete(activityID);
   };
 
   const flush = async (activityID: string): Promise<void> => {
@@ -266,6 +287,10 @@ export function createCheckpointSubmitter(
         state.retryAttempt = 0;
         options.onAcked?.(activityID, result.appendedHead);
 
+        if (state.terminalQueued && result.appendedHead >= state.nextVersion - 1) {
+          removeActivityState(activityID);
+        }
+
         return;
       }
 
@@ -292,6 +317,7 @@ export function createCheckpointSubmitter(
 
         await removeQueuedCheckpoints(activityID);
 
+        removeActivityState(activityID);
         options.onCapped?.(activityID, error.data.appendedHead);
 
         return;
@@ -301,6 +327,8 @@ export function createCheckpointSubmitter(
         state.invalid = true;
 
         await removeQueuedCheckpoints(activityID);
+
+        removeActivityState(activityID);
 
         if (error.data.status === 'capped') {
           options.onCapped?.(activityID, error.data.appendedHead);
@@ -313,6 +341,8 @@ export function createCheckpointSubmitter(
         state.invalid = true;
 
         await removeQueuedCheckpoints(activityID);
+
+        removeActivityState(activityID);
 
         return;
       }
@@ -339,6 +369,8 @@ export function createCheckpointSubmitter(
         state.invalid = true;
 
         await removeQueuedCheckpoints(activityID);
+
+        removeActivityState(activityID);
 
         return;
       }
@@ -373,6 +405,7 @@ export function createCheckpointSubmitter(
       retryGeneration: 0,
       retryScheduled: false,
       startChainIndex: context.startChainIndex,
+      terminalQueued: false,
     };
 
     activityStates.set(context.activityID, state);
@@ -442,6 +475,7 @@ export function createCheckpointSubmitter(
 
     if (isTerminal) {
       state.flushScheduled = false;
+      state.terminalQueued = true;
 
       await flush(activityID);
 

--- a/libs/game/idle-client/src/submission/sweep-stale-checkpoints.test.ts
+++ b/libs/game/idle-client/src/submission/sweep-stale-checkpoints.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from 'bun:test';
+import { createMockCheckpointBatchEntry } from '../test-utils/factories/create-mock-checkpoint-batch-entry';
+import { readQueuedCheckpoints } from './read-queued-checkpoints';
+import { sweepStaleCheckpoints } from './sweep-stale-checkpoints';
+import { writeQueuedCheckpoint } from './write-queued-checkpoint';
+
+test('it removes every activity not in the keep list and reports what it removed', async () => {
+  await writeQueuedCheckpoint('sweep-stale-kept', createMockCheckpointBatchEntry({ version: 1 }));
+
+  await writeQueuedCheckpoint(
+    'sweep-stale-orphan-1',
+    createMockCheckpointBatchEntry({ version: 1 }),
+  );
+
+  await writeQueuedCheckpoint(
+    'sweep-stale-orphan-2',
+    createMockCheckpointBatchEntry({ version: 1 }),
+  );
+
+  const swept = await sweepStaleCheckpoints(['sweep-stale-kept']);
+
+  expect(swept).toIncludeSameMembers(['sweep-stale-orphan-1', 'sweep-stale-orphan-2']);
+
+  const kept = await readQueuedCheckpoints('sweep-stale-kept');
+  const orphan1 = await readQueuedCheckpoints('sweep-stale-orphan-1');
+  const orphan2 = await readQueuedCheckpoints('sweep-stale-orphan-2');
+
+  expect(kept).toHaveLength(1);
+  expect(orphan1).toStrictEqual([]);
+  expect(orphan2).toStrictEqual([]);
+});
+
+test('it leaves every activity in a multi-entry keep list untouched', async () => {
+  await writeQueuedCheckpoint('sweep-multi-keep-1', createMockCheckpointBatchEntry({ version: 1 }));
+  await writeQueuedCheckpoint('sweep-multi-keep-2', createMockCheckpointBatchEntry({ version: 1 }));
+  await writeQueuedCheckpoint('sweep-multi-orphan', createMockCheckpointBatchEntry({ version: 1 }));
+
+  const swept = await sweepStaleCheckpoints(['sweep-multi-keep-1', 'sweep-multi-keep-2']);
+
+  expect(swept).toStrictEqual(['sweep-multi-orphan']);
+
+  const keep1 = await readQueuedCheckpoints('sweep-multi-keep-1');
+  const keep2 = await readQueuedCheckpoints('sweep-multi-keep-2');
+
+  expect(keep1).toHaveLength(1);
+  expect(keep2).toHaveLength(1);
+});
+
+test('it removes every queued activity for an empty keep list', async () => {
+  await writeQueuedCheckpoint('sweep-empty-keep-1', createMockCheckpointBatchEntry({ version: 1 }));
+  await writeQueuedCheckpoint('sweep-empty-keep-2', createMockCheckpointBatchEntry({ version: 1 }));
+
+  const swept = await sweepStaleCheckpoints([]);
+
+  expect(swept).toIncludeSameMembers(['sweep-empty-keep-1', 'sweep-empty-keep-2']);
+
+  const remaining1 = await readQueuedCheckpoints('sweep-empty-keep-1');
+  const remaining2 = await readQueuedCheckpoints('sweep-empty-keep-2');
+
+  expect(remaining1).toStrictEqual([]);
+  expect(remaining2).toStrictEqual([]);
+});
+
+test('it returns an empty array for an empty store', async () => {
+  const swept = await sweepStaleCheckpoints(['sweep-nonexistent-activity']);
+
+  expect(swept).toStrictEqual([]);
+});

--- a/libs/game/idle-client/src/submission/sweep-stale-checkpoints.ts
+++ b/libs/game/idle-client/src/submission/sweep-stale-checkpoints.ts
@@ -1,0 +1,33 @@
+import { buildActivityKeyRange } from './build-activity-key-range';
+import { CHECKPOINT_QUEUE_STORE_NAME } from './constants';
+import { resolveCheckpointQueueDB } from './resolve-checkpoint-queue-db';
+
+/**
+ * Deletes every queued checkpoint belonging to an activity outside `keepActivityIDs` — a worker
+ * restart has no delivery path for a queued activity other than the avatar's latest, and the
+ * server settles rewards authoritatively, so a stranded row is worthless. Returns the distinct
+ * activity ids it removed.
+ */
+export async function sweepStaleCheckpoints(
+  keepActivityIDs: ReadonlyArray<string>,
+): Promise<Array<string>> {
+  const db = await resolveCheckpointQueueDB();
+  const keys = await db.getAllKeys(CHECKPOINT_QUEUE_STORE_NAME);
+
+  const keep = new Set(keepActivityIDs);
+  const staleActivityIDs = new Set<string>();
+
+  for (const [activityID] of keys) {
+    if (!keep.has(activityID)) {
+      staleActivityIDs.add(activityID);
+    }
+  }
+
+  await Promise.all(
+    [...staleActivityIDs].map((activityID) =>
+      db.delete(CHECKPOINT_QUEUE_STORE_NAME, buildActivityKeyRange(activityID)),
+    ),
+  );
+
+  return [...staleActivityIDs];
+}

--- a/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
@@ -2,8 +2,14 @@ import { expect, mock, onTestFinished, test } from 'bun:test';
 import { createORPCClient } from '@orpc/client';
 import { RPCLink } from '@orpc/client/fetch';
 import type { ErrorEvent } from '@sentry/browser';
+import { createMockActivityData } from '@vers/contract-activity/test-utils';
 import type { ActivityCheckpoint } from '@vers/idle-core';
-import { SIMULATION_TIMESTEP_MS, buildSimulationInput, runAttempt } from '@vers/idle-core';
+import {
+  SIMULATION_TIMESTEP_MS,
+  buildSimulationInput,
+  createSimulation,
+  runAttempt,
+} from '@vers/idle-core';
 import { createTestAccessToken, resolveServiceURL } from '@vers/mock-services';
 import { mockActivityService } from '@vers/mock-services/activity';
 import * as db from '@vers/mock-services/db';
@@ -171,6 +177,77 @@ test('it sweeps every queued checkpoint when the avatar has no activity history'
 
   const swept = await readQueuedCheckpoints('stray-no-activity-activity');
 
+  expect(swept).toStrictEqual([]);
+});
+
+test('it keeps the queued rows of an activity that went live while the resync was running', async () => {
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+
+  await db.activityCollection.create({
+    appendedHead: 0,
+    avatarID: avatar.id,
+    startedAt: new Date(),
+  });
+
+  const token = await createTestAccessToken(user.id);
+
+  const client: ActivityServiceClient = createORPCClient(
+    new RPCLink({
+      headers: { authorization: `Bearer ${token}` },
+      url: `${resolveServiceURL('activity')}/rpc`,
+    }),
+  );
+
+  let releaseHeldFlush: (() => void) | undefined;
+
+  const heldFlush = new Promise<void>((resolve) => {
+    releaseHeldFlush = resolve;
+  });
+
+  const context = createStubWorkerContext({
+    client,
+    submitter: {
+      flushHeld: () => heldFlush,
+      flushNow: () => Promise.resolve(),
+      registerActivity: () => Promise.resolve(),
+      submit: () => Promise.resolve(undefined),
+    },
+  });
+
+  const freshActivity = createMockActivityData({ id: 'fresh-live-activity' });
+
+  await writeQueuedCheckpoint(freshActivity.id, createMockCheckpointBatchEntry({ version: 1 }));
+
+  await writeQueuedCheckpoint(
+    'stray-mid-resync-activity',
+    createMockCheckpointBatchEntry({ version: 1 }),
+  );
+
+  const message: RequestResyncMessage = {
+    avatarID: avatar.id,
+    type: ClientMessageType.RequestResync,
+  };
+
+  const handled = handleRequestResyncMessage(context, message);
+
+  // a fresher activity goes live while the resync is parked on its held-batch flush, exactly as
+  // a set-activity request landing mid-resync would install it
+  const input = buildSimulationInput(freshActivity);
+  const simulation = createSimulation();
+
+  simulation.startActivity(input.avatar, input.activity);
+  context.setSimulation(simulation);
+  releaseHeldFlush?.();
+
+  await handled;
+
+  // the sweep kept the live activity's queued row — its running writer's own pipeline — while
+  // still removing the genuinely stranded activity's row
+  const kept = await readQueuedCheckpoints(freshActivity.id);
+  const swept = await readQueuedCheckpoints('stray-mid-resync-activity');
+
+  expect(kept).toHaveLength(1);
   expect(swept).toStrictEqual([]);
 });
 

--- a/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
@@ -5,13 +5,20 @@ import type { ErrorEvent } from '@sentry/browser';
 import type { ActivityCheckpoint } from '@vers/idle-core';
 import { SIMULATION_TIMESTEP_MS, buildSimulationInput, runAttempt } from '@vers/idle-core';
 import { createTestAccessToken, resolveServiceURL } from '@vers/mock-services';
+import { mockActivityService } from '@vers/mock-services/activity';
 import * as db from '@vers/mock-services/db';
 import { waitFor } from '@vers/test-utils';
+import { HttpResponse } from 'msw';
 import invariant from 'tiny-invariant';
+import { server } from '../mocks/node';
 import { createCheckpointSubmitter } from '../submission/create-checkpoint-submitter';
+import { readQueuedCheckpoints } from '../submission/read-queued-checkpoints';
 import type { ActivityServiceClient } from '../submission/types';
+import { writeQueuedCheckpoint } from '../submission/write-queued-checkpoint';
 import { createStubWorkerContext } from '../test-utils/create-stub-worker-context';
 import { createTestConnection } from '../test-utils/create-test-connection';
+import { createMockCheckpointBatchEntry } from '../test-utils/factories/create-mock-checkpoint-batch-entry';
+import { createMockStartedCheckpoint } from '../test-utils/factories/create-mock-started-checkpoint';
 import type { RequestResyncMessage } from '../types';
 import { ClientMessageType, WorkerMessageType } from '../types';
 import { handleRequestResyncMessage } from './handle-request-resync-message';
@@ -105,6 +112,128 @@ test('it broadcasts capped and installs no simulation for a capped activity', as
   ]);
 
   expect(ctx.context.getSimulation()).toBeNull();
+});
+
+test('it delivers a queued row for the resync-determined latest activity rather than sweeping it, while sweeping every other activity', async () => {
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const ctx = await setupTest({ userID: user.id });
+
+  const activity = await db.activityCollection.create({
+    appendedHead: 0,
+    avatarID: avatar.id,
+    startedAt: new Date(),
+  });
+
+  await writeQueuedCheckpoint(activity.id, createMockCheckpointBatchEntry({ version: 1 }));
+
+  await writeQueuedCheckpoint(
+    'stray-unrelated-activity',
+    createMockCheckpointBatchEntry({ version: 1 }),
+  );
+
+  const message: RequestResyncMessage = {
+    avatarID: avatar.id,
+    type: ClientMessageType.RequestResync,
+  };
+
+  await handleRequestResyncMessage(ctx.context, message);
+
+  // the resync's own drain delivered the determined latest activity's queued row over the
+  // network rather than the sweep silently discarding it
+  const landed = db.checkpointCollection.findMany((q) => q.where({ activityID: activity.id }));
+
+  expect(landed).toHaveLength(1);
+
+  const remainingQueue = await readQueuedCheckpoints(activity.id);
+  const sweptQueue = await readQueuedCheckpoints('stray-unrelated-activity');
+
+  expect(remainingQueue).toStrictEqual([]);
+  expect(sweptQueue).toStrictEqual([]);
+});
+
+test('it sweeps every queued checkpoint when the avatar has no activity history', async () => {
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const ctx = await setupTest({ userID: user.id });
+
+  await writeQueuedCheckpoint(
+    'stray-no-activity-activity',
+    createMockCheckpointBatchEntry({ version: 1 }),
+  );
+
+  const message: RequestResyncMessage = {
+    avatarID: avatar.id,
+    type: ClientMessageType.RequestResync,
+  };
+
+  await handleRequestResyncMessage(ctx.context, message);
+
+  const swept = await readQueuedCheckpoints('stray-no-activity-activity');
+
+  expect(swept).toStrictEqual([]);
+});
+
+test('it flushes a held checkpoint for a previously tracked, no-longer-latest activity before sweeping it', async () => {
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const ctx = await setupTest({ userID: user.id });
+
+  const staleActivity = await db.activityCollection.create({
+    avatarID: avatar.id,
+    startedAt: new Date(Date.now() - 60_000),
+  });
+
+  await db.activityCollection.create({
+    appendedHead: 0,
+    avatarID: avatar.id,
+    startedAt: new Date(),
+  });
+
+  const track = mock<(input: unknown) => void>();
+
+  server.use(
+    mockActivityService.trackActivityProgress.handler((opts) => {
+      track(opts.input);
+
+      if (track.mock.calls.length === 1) {
+        return HttpResponse.error();
+      }
+
+      return { appendedHead: 1 };
+    }),
+  );
+
+  await ctx.context.getSubmitter().registerActivity({
+    activityID: staleActivity.id,
+    appendedHead: 0,
+    lastHash: staleActivity.lastHash,
+    startChainIndex: staleActivity.startChainIndex,
+  });
+
+  await ctx.context.getSubmitter().submit(staleActivity.id, createMockStartedCheckpoint());
+  await ctx.flush();
+
+  // the flush attempt failed and held the row for retry
+  const heldRows = await readQueuedCheckpoints(staleActivity.id);
+
+  expect(heldRows).toHaveLength(1);
+  expect(track).toHaveBeenCalledOnce();
+
+  const message: RequestResyncMessage = {
+    avatarID: avatar.id,
+    type: ClientMessageType.RequestResync,
+  };
+
+  await handleRequestResyncMessage(ctx.context, message);
+
+  // flushHeld ran before the sweep determined a fresher activity is latest, delivering the held
+  // row over the network rather than letting the sweep silently discard it
+  expect(track).toHaveBeenCalledTimes(2);
+
+  const remaining = await readQueuedCheckpoints(staleActivity.id);
+
+  expect(remaining).toStrictEqual([]);
 });
 
 test('it reconstructs and installs a live simulation mid-stream, registering from the recovered cursor', async () => {

--- a/libs/game/idle-client/src/worker/handle-request-resync-message.ts
+++ b/libs/game/idle-client/src/worker/handle-request-resync-message.ts
@@ -5,6 +5,7 @@ import invariant from 'tiny-invariant';
 import { runReconstruction } from '../resync/run-reconstruction';
 import { runResync } from '../resync/run-resync';
 import type { FastForwardReport, ResyncPlan, ResyncResult } from '../resync/types';
+import { sweepStaleCheckpoints } from '../submission/sweep-stale-checkpoints';
 import type { RequestResyncMessage, ResyncStatus } from '../types';
 import { createCheckpointStreamInvalidMessage } from './create-checkpoint-stream-invalid-message';
 import { createResyncStatusMessage } from './create-resync-status-message';
@@ -19,10 +20,13 @@ import type { WorkerContext } from './types';
  * progression, ending on `done` (or `capped`) so a connected tab's welcome-back UI always
  * resolves; a zero-gap outcome (live re-attach, no activity) stays silent, so a fresh login never
  * opens that UI. A live simulation this resync would install is skipped when a different activity
- * went live while it was running — a fresher `SetActivity` always wins. A resync that fails
- * outright forwards the fault to the error backend and broadcasts a `failed` `ResyncStatus` for
- * the requesting avatar, never a connection-status change — connectivity is the connection layer's
- * own signal, not a resync outcome — and never rejects; a tab's retry re-requests it.
+ * went live while it was running — a fresher `SetActivity` always wins. Once the plan settles, the
+ * durable checkpoint queue is swept down to the determined latest activity alone — a prior worker
+ * lifetime's stranded rows for any other activity have no delivery path and are worthless. A resync
+ * that fails outright forwards the fault to the error backend and broadcasts a `failed`
+ * `ResyncStatus` for the requesting avatar, never a connection-status change — connectivity is
+ * the connection layer's own signal, not a resync outcome — and never rejects; a tab's retry
+ * re-requests it.
  */
 export async function handleRequestResyncMessage(
   context: WorkerContext,
@@ -51,6 +55,7 @@ export async function handleRequestResyncMessage(
       submitter: context.getSubmitter(),
     });
 
+    await sweepStaleActivities(result);
     await applyResyncResult(context, result);
   } catch (error) {
     reportWorkerFault('resync', error);
@@ -58,6 +63,35 @@ export async function handleRequestResyncMessage(
   } finally {
     context.setResyncInFlight(false);
   }
+}
+
+/**
+ * Sweeps every queued checkpoint outside the resync's determined latest activity — a worker
+ * restart has no delivery path for a stranded row, and the server settles rewards authoritatively,
+ * so nothing outside that one activity is ever worth keeping. Failure never fails the resync: it
+ * only reports the fault, since a stranded row costs nothing but disk until the next sweep.
+ */
+async function sweepStaleActivities(result: Readonly<ResyncResult>): Promise<void> {
+  try {
+    const latestActivityID = pickLatestActivityID(result);
+    const keepActivityIDs = latestActivityID === undefined ? [] : [latestActivityID];
+
+    await sweepStaleCheckpoints(keepActivityIDs);
+  } catch (error) {
+    reportWorkerFault('resync', error);
+  }
+}
+
+function pickLatestActivityID(result: Readonly<ResyncResult>): string | undefined {
+  if (result.report !== undefined) {
+    return result.report.activity.id;
+  }
+
+  if (result.plan.kind === 'none') {
+    return undefined;
+  }
+
+  return result.plan.context.activityID;
 }
 
 async function applyResyncResult(

--- a/libs/game/idle-client/src/worker/handle-request-resync-message.ts
+++ b/libs/game/idle-client/src/worker/handle-request-resync-message.ts
@@ -21,8 +21,10 @@ import type { WorkerContext } from './types';
  * resolves; a zero-gap outcome (live re-attach, no activity) stays silent, so a fresh login never
  * opens that UI. A live simulation this resync would install is skipped when a different activity
  * went live while it was running — a fresher `SetActivity` always wins. Once the plan settles, the
- * durable checkpoint queue is swept down to the determined latest activity alone — a prior worker
- * lifetime's stranded rows for any other activity have no delivery path and are worthless. A resync
+ * durable checkpoint queue is swept down to the determined latest activity plus whichever activity
+ * is live at sweep time — a fresher activity installed mid-resync keeps its writer's queued rows —
+ * since a prior worker lifetime's stranded rows for any other activity have no delivery path and
+ * are worthless. A resync
  * that fails outright forwards the fault to the error backend and broadcasts a `failed`
  * `ResyncStatus` for the requesting avatar, never a connection-status change — connectivity is
  * the connection layer's own signal, not a resync outcome — and never rejects; a tab's retry
@@ -55,7 +57,7 @@ export async function handleRequestResyncMessage(
       submitter: context.getSubmitter(),
     });
 
-    await sweepStaleActivities(result);
+    await sweepStaleActivities(context, result);
     await applyResyncResult(context, result);
   } catch (error) {
     reportWorkerFault('resync', error);
@@ -66,19 +68,32 @@ export async function handleRequestResyncMessage(
 }
 
 /**
- * Sweeps every queued checkpoint outside the resync's determined latest activity — a worker
+ * Sweeps every queued checkpoint outside the resync's determined latest activity and the activity
+ * live at sweep time — a fresher activity can go live while the resync is still running, and its
+ * queued rows are its running writer's own pipeline, never stranded work. Outside those, a worker
  * restart has no delivery path for a stranded row, and the server settles rewards authoritatively,
- * so nothing outside that one activity is ever worth keeping. Failure never fails the resync: it
- * only reports the fault, since a stranded row costs nothing but disk until the next sweep.
+ * so nothing else is ever worth keeping. Returns the swept activity ids. Failure never fails the
+ * resync: it only reports the fault and returns nothing swept, since a stranded row costs nothing
+ * but disk until the next sweep.
  */
-async function sweepStaleActivities(result: Readonly<ResyncResult>): Promise<void> {
+async function sweepStaleActivities(
+  context: WorkerContext,
+  result: Readonly<ResyncResult>,
+): Promise<Array<string>> {
   try {
-    const latestActivityID = pickLatestActivityID(result);
-    const keepActivityIDs = latestActivityID === undefined ? [] : [latestActivityID];
+    const keepActivityIDs = [
+      ...new Set(
+        [pickLatestActivityID(result), context.getSimulation()?.activity?.id].filter(
+          (activityID): activityID is string => activityID !== undefined,
+        ),
+      ),
+    ];
 
-    await sweepStaleCheckpoints(keepActivityIDs);
+    return await sweepStaleCheckpoints(keepActivityIDs);
   } catch (error) {
     reportWorkerFault('resync', error);
+
+    return [];
   }
 }
 


### PR DESCRIPTION
## Description

Closes #583

Evicts finished activities from the checkpoint submitter's tracking maps once their stream stops or drains for good, and sweeps the durable checkpoint queue of any activity a resync no longer considers live.

- Adds a `terminalQueued` flag and `removeActivityState` helper to `create-checkpoint-submitter`, evicting an activity's cursor and registration on the four discard-stop codes (`ACTIVITY_CAPPED`, `ACTIVITY_TERMINAL`, `SESSION_EVICTED`, `NOT_FOUND`) and on a fully confirmed terminal flush.
- `CHECKPOINT_INVALID` deliberately keeps its tombstoned state, so a later registration never resends what the server already rejected.
- Adds `sweepStaleCheckpoints`, wired into `handleRequestResyncMessage` after the resync settles: drops queued rows for every activity outside the resync's determined latest, since a prior worker lifetime's stranded rows have no delivery path.
- Sweep failures report the fault through `reportWorkerFault` but never fail the resync.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
