### PR TITLE
feat(#640): route session expiry out of the resync failure state

### DIFF
--- a/apps/web/src/routes/-game/welcome-back-modal.test.tsx
+++ b/apps/web/src/routes/-game/welcome-back-modal.test.tsx
@@ -44,6 +44,24 @@ test('it offers a retry when the catch-up fails outright', () => {
   expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument();
 });
 
+test('it offers a sign-in link back to this page when the session expired mid catch-up', () => {
+  setResyncStatus({ avatarID: 'avatar_1', kind: 'session-expired' });
+  render(<WelcomeBackModal />);
+
+  expect(
+    screen.getByText('Your session expired while catching up. Your progress is safe.'),
+  ).toBeInTheDocument();
+
+  const redirectTo = `${globalThis.location.pathname}${globalThis.location.search}`;
+
+  const searchParams = new URLSearchParams({ redirect: redirectTo });
+
+  expect(screen.getByRole('link', { name: 'Sign in' })).toHaveAttribute(
+    'href',
+    `/login?${searchParams.toString()}`,
+  );
+});
+
 test('it retries by requesting a fresh resync and clearing the failed status', async () => {
   const user = userEvent.setup();
   const calls: Array<ClientMessage> = [];

--- a/apps/web/src/routes/-game/welcome-back-modal.tsx
+++ b/apps/web/src/routes/-game/welcome-back-modal.tsx
@@ -1,6 +1,7 @@
 import { Button, Dialog, Text } from '@vers/design-system';
 import { setResyncStatus, useResyncStatus } from '@vers/idle-client';
 import type { ResyncStatus } from '@vers/idle-client';
+import { getLoginPathWithRedirect } from '../../lib/auth/get-login-path-with-redirect';
 import { sendIdleRequestResync } from '../../lib/idle/send-idle-request-resync';
 import { useIdleWorkerHandle } from '../../lib/idle/use-idle-worker-handle';
 
@@ -9,11 +10,12 @@ import { useIdleWorkerHandle } from '../../lib/idle/use-idle-worker-handle';
  * fast-forwarding a real away period, reports attempts and level-ups as they land, and stays up
  * with the final tally (or the cap notice) until dismissed. A resync with no away period to
  * report — a fresh login, a zero-gap reconnect — broadcasts no status, so it never opens this. A
- * resync that fails outright opens on a retry action instead.
+ * resync that fails outright opens on a retry action instead; one stopped by an expired session
+ * opens on a sign-in link, since no retry can succeed until the player signs back in — the login
+ * redirect returns them here, where the fresh session's own resync resumes the catch-up.
  */
 export function WelcomeBackModal() {
   const resyncStatus = useResyncStatus();
-  const idleWorkerHandle = useIdleWorkerHandle();
 
   if (resyncStatus === null) {
     return null;
@@ -29,30 +31,56 @@ export function WelcomeBackModal() {
       open
       title="Welcome back"
     >
-      {resyncStatus.kind === 'failed' ? (
-        <>
-          <Text>Catching up didn’t finish. Your progress is safe.</Text>
-          <Button
-            onClick={() => {
-              if (idleWorkerHandle.worker !== undefined) {
-                sendIdleRequestResync(idleWorkerHandle.worker, resyncStatus.avatarID);
-              }
-
-              setResyncStatus(null);
-            }}
-          >
-            Try again
-          </Button>
-        </>
-      ) : (
-        <Text>{formatResyncStatus(resyncStatus)}</Text>
-      )}
+      <ResyncOutcome resyncStatus={resyncStatus} />
     </Dialog>
   );
 }
 
+interface ResyncOutcomeProps {
+  readonly resyncStatus: ResyncStatus;
+}
+
+function ResyncOutcome(props: Readonly<ResyncOutcomeProps>) {
+  const resyncStatus = props.resyncStatus;
+  const idleWorkerHandle = useIdleWorkerHandle();
+
+  if (resyncStatus.kind === 'session-expired') {
+    return (
+      <>
+        <Text>Your session expired while catching up. Your progress is safe.</Text>
+        <Button as="a" href={getLoginPathWithRedirect(globalThis.location)}>
+          Sign in
+        </Button>
+      </>
+    );
+  }
+
+  if (resyncStatus.kind === 'failed') {
+    return (
+      <>
+        <Text>Catching up didn’t finish. Your progress is safe.</Text>
+        <Button
+          onClick={() => {
+            if (idleWorkerHandle.worker !== undefined) {
+              sendIdleRequestResync(idleWorkerHandle.worker, resyncStatus.avatarID);
+            }
+
+            setResyncStatus(null);
+          }}
+        >
+          Try again
+        </Button>
+      </>
+    );
+  }
+
+  return <Text>{formatResyncStatus(resyncStatus)}</Text>;
+}
+
 function formatResyncStatus(
-  resyncStatus: Readonly<Exclude<ResyncStatus, { readonly kind: 'failed' }>>,
+  resyncStatus: Readonly<
+    Exclude<ResyncStatus, { readonly kind: 'failed' } | { readonly kind: 'session-expired' }>
+  >,
 ): string {
   if (resyncStatus.kind === 'capped') {
     return 'Offline progress reached its cap. Your avatar held position — jump back in to continue.';

--- a/libs/design/design-system/src/components/button/button.tsx
+++ b/libs/design/design-system/src/components/button/button.tsx
@@ -136,8 +136,7 @@ const button = cva({
   },
 });
 
-type ButtonProps<C extends React.ElementType = 'button'> = RecipeVariantProps<typeof button> & {
-  as?: C;
+type ButtonProps = RecipeVariantProps<typeof button> & {
   children: React.ReactNode;
   css?: Styles;
 };
@@ -147,9 +146,9 @@ export type Props<C extends React.ElementType = 'button'> = PolymorphicComponent
   ButtonProps
 >;
 
-export function Button<C extends React.ElementType>(props: Readonly<Props<C>>) {
+export function Button<C extends React.ElementType = 'button'>(props: Readonly<Props<C>>) {
   const { as, className, fullWidth, size, variant, ...restProps } = props;
-  const Element = as ?? 'button';
+  const Element = (as ?? 'button') as React.ElementType<{ className?: string }>;
 
   return (
     <Element

--- a/libs/design/design-system/src/components/button/button.tsx
+++ b/libs/design/design-system/src/components/button/button.tsx
@@ -1,7 +1,6 @@
 import type { RecipeVariantProps, Styles } from '@vers/styled-system/css';
 import { cva, cx } from '@vers/styled-system/css';
 import * as React from 'react';
-import type { PolymorphicComponentProps } from '../../types';
 
 const button = cva({
   base: {
@@ -141,26 +140,39 @@ type ButtonProps = RecipeVariantProps<typeof button> & {
   css?: Styles;
 };
 
-export type Props<C extends React.ElementType = 'button'> = PolymorphicComponentProps<
-  C,
-  ButtonProps
->;
-
-export function Button<C extends React.ElementType = 'button'>(props: Readonly<Props<C>>) {
-  const { as, className, fullWidth, size, variant, ...restProps } = props;
-  const Element = (as ?? 'button') as React.ElementType<{ className?: string }>;
-
-  return (
-    <Element
-      {...restProps}
-      className={cx(
-        button({
-          ...(fullWidth !== undefined && { fullWidth }),
-          ...(size !== undefined && { size }),
-          ...(variant !== undefined && { variant }),
-        }),
-        className,
-      )}
-    />
+/**
+ * A closed union over the elements the button renders as, not an open polymorphic generic: each
+ * arm carries its own element's full attribute set, so anchor-only attributes exist exactly when
+ * `as: 'a'` is passed and the compiler checks every prop with no casts.
+ */
+export type Props = ButtonProps &
+  (
+    | ({ as: 'a' } & Omit<React.ComponentPropsWithoutRef<'a'>, keyof ButtonProps>)
+    | ({ as?: never } & Omit<React.ComponentPropsWithoutRef<'button'>, keyof ButtonProps>)
   );
+
+// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- carries React's DOM attribute types (style, dangerouslySetInnerHTML), which have no readonly form
+export function Button(props: Readonly<Props>) {
+  const composedClassName = cx(
+    button({
+      ...(props.fullWidth !== undefined && { fullWidth: props.fullWidth }),
+      ...(props.size !== undefined && { size: props.size }),
+      ...(props.variant !== undefined && { variant: props.variant }),
+    }),
+    props.className,
+  );
+
+  if (props.as === 'a') {
+    const { as, children, className, fullWidth, size, variant, ...anchorProps } = props;
+
+    return (
+      <a {...anchorProps} className={composedClassName}>
+        {children}
+      </a>
+    );
+  }
+
+  const { as, className, fullWidth, size, variant, ...buttonProps } = props;
+
+  return <button {...buttonProps} className={composedClassName} />;
 }

--- a/libs/game/idle-client/src/types.ts
+++ b/libs/game/idle-client/src/types.ts
@@ -255,11 +255,13 @@ export interface RewardSlotLedgerSnapshot {
 /**
  * The catch-up flow's lifecycle as tabs observe it: fast-forwarding with running attempt and
  * level-up counts, done with the final tallies, capped when the server stopped the stream at the
- * offline-progress bound, or failed when the catch-up couldn't complete. A resync with no real
- * away period broadcasts nothing.
+ * offline-progress bound, failed when the catch-up couldn't complete, or session-expired when the
+ * server no longer recognizes the caller's session — a state no retry can leave, only a fresh
+ * sign-in. A resync with no real away period broadcasts nothing.
  */
 export type ResyncStatus =
   | { readonly attempts: number; readonly kind: 'done'; readonly levelUps: number }
   | { readonly attempts: number; readonly kind: 'fast-forwarding'; readonly levelUps: number }
   | { readonly avatarID: string; readonly kind: 'failed' }
+  | { readonly avatarID: string; readonly kind: 'session-expired' }
   | { readonly kind: 'capped' };

--- a/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
@@ -783,3 +783,50 @@ test('it reports a fault to the error backend and broadcasts a failed status whe
   expect(recorded[0]?.tags).toMatchObject({ site: 'resync' });
   expect(context.isResyncInFlight()).toBe(false);
 });
+
+test('it broadcasts session-expired without a fault report when the session is no longer valid', async () => {
+  const previousHandle = sentryHandle.current;
+  const recorded: Array<Readonly<ErrorEvent>> = [];
+
+  onTestFinished(() => {
+    sentryHandle.current = previousHandle;
+  });
+
+  await startErrorReporting('https://testpublickey@o0.ingest.sentry.io/1', {
+    beforeSend: (event) => {
+      recorded.push(event);
+
+      return null;
+    },
+    disableDefaultIntegrations: true,
+  });
+
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const ctx = await setupTest({ userID: user.id });
+
+  server.use(
+    mockActivityService.getLatestActivityProgress.handler((opts) => {
+      throw opts.errors.UNAUTHORIZED({ data: { reason: 'expired-session' } });
+    }),
+  );
+
+  const message: RequestResyncMessage = {
+    avatarID: avatar.id,
+    type: ClientMessageType.RequestResync,
+  };
+
+  await handleRequestResyncMessage(ctx.context, message);
+
+  await ctx.connection.waitForMessages(1);
+
+  expect(ctx.connection.received).toStrictEqual([
+    {
+      status: { avatarID: avatar.id, kind: 'session-expired' },
+      type: WorkerMessageType.ResyncStatus,
+    },
+  ]);
+
+  expect(recorded).toStrictEqual([]);
+  expect(ctx.context.isResyncInFlight()).toBe(false);
+});

--- a/libs/game/idle-client/src/worker/handle-request-resync-message.ts
+++ b/libs/game/idle-client/src/worker/handle-request-resync-message.ts
@@ -1,4 +1,4 @@
-import { safe } from '@orpc/client';
+import { ORPCError, safe } from '@orpc/client';
 import type {
   ActivityData,
   ActivityFailureAction as ContractFailureAction,
@@ -36,11 +36,13 @@ import type { WorkerContext } from './types';
  * durable checkpoint queue is swept down to the determined latest activity plus whichever activity
  * is live at sweep time — a fresher activity installed mid-resync keeps its writer's queued rows —
  * since a prior worker lifetime's stranded rows for any other activity have no delivery path and
- * are worthless. A resync
- * that fails outright forwards the fault to the error backend and broadcasts a `failed`
- * `ResyncStatus` for the requesting avatar, never a connection-status change — connectivity is
- * the connection layer's own signal, not a resync outcome — and never rejects; a tab's retry
- * re-requests it.
+ * are worthless. A resync that fails outright forwards the fault to the error backend and
+ * broadcasts a `failed` `ResyncStatus` for the requesting avatar, never a connection-status change
+ * — connectivity is the connection layer's own signal, not a resync outcome — and never rejects; a
+ * tab's retry re-requests it. One failure cause is routed apart: an `UNAUTHORIZED` rejection
+ * broadcasts `session-expired` instead, with no fault report — the session lapsing is expected
+ * behaviour whose only remedy is a fresh sign-in, so a tab renders a sign-in path rather than a
+ * retry that can never succeed.
  */
 export async function handleRequestResyncMessage(
   context: WorkerContext,
@@ -92,8 +94,12 @@ export async function handleRequestResyncMessage(
     await sweepStaleActivities(context, result);
     await applyResyncResult(context, result);
   } catch (error) {
-    reportWorkerFault('resync', error);
-    emitResyncStatus(context, { avatarID: message.avatarID, kind: 'failed' });
+    if (error instanceof ORPCError && error.code === 'UNAUTHORIZED') {
+      emitResyncStatus(context, { avatarID: message.avatarID, kind: 'session-expired' });
+    } else {
+      reportWorkerFault('resync', error);
+      emitResyncStatus(context, { avatarID: message.avatarID, kind: 'failed' });
+    }
   } finally {
     context.setResyncInFlight(false);
   }


### PR DESCRIPTION
## Description

Closes #640

An `UNAUTHORIZED` rejection during resync now broadcasts its own `session-expired` status instead of the generic `failed` one, so the welcome-back modal offers a sign-in link rather than a retry that can never succeed.

- the resync orchestrator narrows `UNAUTHORIZED` in its catch and skips the fault report for it — a lapsed session is expected behaviour, not an error-backend event
- the modal's `session-expired` branch links to `/login?redirect=<current page>` via the existing `getLoginPathWithRedirect`; the session proxy has already cleared the cookie by then, so the login route's anonymous guard doesn't bounce
- checkpoint submission's hold-on-`UNAUTHORIZED` behaviour is untouched — held batches still deliver after re-auth
- `Button` gains a working `as` prop: its old props type intersected `as` with the literal `'button'`, collapsing any other element to `never`

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality

## Context

A session expiring in the window between the progress fetch and the queued-checkpoint drain still reports as `failed` (the submitter holds the batch silently and the drain throws a generic error); the retry it offers re-requests a resync whose first fetch then yields the sign-in prompt. Routing that race would change the submitter API the issue scopes out.