### PR TITLE
feat(#654): run a pulumi preview drift check in ci

### DIFF
--- a/.github/workflows/infra-drift.yml
+++ b/.github/workflows/infra-drift.yml
@@ -18,6 +18,11 @@ permissions:
   contents: read
   pull-requests: write
 
+# every trigger previews the same prod stack — one at a time
+concurrency:
+  group: infra-drift-prod
+  cancel-in-progress: true
+
 jobs:
   preview:
     # fork PRs run without secrets, so the preview cannot authenticate — skip them
@@ -27,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
@@ -43,6 +50,7 @@ jobs:
         uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
         with:
           export-env: true
+          version: 2.34.1
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           CLOUDFLARE_API_TOKEN: op://vers/vers-infra/cloudflare-api-token
@@ -67,3 +75,4 @@ jobs:
           expect-no-changes: true
           refresh: true
           comment-on-pr: ${{ github.event_name == 'pull_request' }}
+          pulumi-version: 3.251.0

--- a/.github/workflows/infra-drift.yml
+++ b/.github/workflows/infra-drift.yml
@@ -1,0 +1,69 @@
+name: infra-drift
+
+on:
+  pull_request:
+    paths:
+      - 'infra/**'
+      - '.github/workflows/infra-drift.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'infra/**'
+      - '.github/workflows/infra-drift.yml'
+  schedule:
+    # weekly: console drift arrives with no commit, so no push can catch it
+    - cron: '17 19 * * 1'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview:
+    # fork PRs run without secrets, so the preview cannot authenticate — skip them
+    if:
+      github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name ==
+      github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: .bun-version
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.18.0
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Load stack credentials
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          CLOUDFLARE_API_TOKEN: op://vers/vers-infra/cloudflare-api-token
+          CLOUDFLARE_ACCOUNT_ID: op://vers/vers-infra/cloudflare-account-id
+          AWS_ACCESS_KEY_ID: op://vers/vers-infra/aws-access-key-id
+          AWS_SECRET_ACCESS_KEY: op://vers/vers-infra/aws-secret-access-key
+          AWS_REGION: op://vers/vers-infra/aws-region
+          R2_STATE_BUCKET: op://vers/vers-infra/r2-state-bucket
+          PULUMI_CONFIG_PASSPHRASE: op://vers/vers-infra/pulumi-passphrase
+          AXIOM_TOKEN: op://vers/axiom/iac-token
+          DISCORD_ALARMS_WEBHOOK: op://vers/discord-alarms-webhook/credential
+
+      - name: Preview
+        uses: pulumi/actions@8e5e406f4007fca908480587cb9893c07090f58d # v7.0.0
+        with:
+          command: preview
+          stack-name: prod
+          work-dir: infra
+          cloud-url:
+            s3://${{ env.R2_STATE_BUCKET }}?endpoint=${{ env.CLOUDFLARE_ACCOUNT_ID
+            }}.r2.cloudflarestorage.com&region=auto&s3ForcePathStyle=true
+          expect-no-changes: true
+          refresh: true
+          comment-on-pr: ${{ github.event_name == 'pull_request' }}

--- a/docs/architecture/deployment.md
+++ b/docs/architecture/deployment.md
@@ -146,6 +146,18 @@ so their staleness triggers in `deploy.config.ts` are path globs (`apps/bugsink/
 `Dockerfile` `FROM` line (a thin config layer its build leg bakes like any other app's), Umami on
 its `fly.toml` `[build]` image, deployed with no build leg at all.
 
+## Infra drift
+
+`.github/workflows/infra-drift.yml` runs `pulumi preview --refresh --expect-no-changes` over the
+`infra/` program's `prod` stack and fails on any diff. It runs on pull requests touching `infra/`
+(posting the preview as a PR comment), on pushes to `main` touching `infra/`, and on a weekly
+schedule — console drift arrives with no commit, so only the schedule can catch it. The job
+authenticates through the `OP_SERVICE_ACCOUNT_TOKEN` repo secret, a non-expiring 1Password service
+account scoped to read the `vers` vault, and resolves the stack's credentials from their `op://`
+references at run time. Fork pull requests are skipped: GitHub withholds secrets from them, so the
+preview cannot authenticate. The job only ever previews — reconciling a reported drift is a human
+decision, applied with `pulumi up` from a checkout.
+
 ## Sim-version registry
 
 `vers-service-replay` serves deterministic replay for one sim engine build per request; multiple

--- a/docs/architecture/deployment.md
+++ b/docs/architecture/deployment.md
@@ -149,14 +149,14 @@ its `fly.toml` `[build]` image, deployed with no build leg at all.
 ## Infra drift
 
 `.github/workflows/infra-drift.yml` runs `pulumi preview --refresh --expect-no-changes` over the
-`infra/` program's `prod` stack and fails on any diff. It runs on pull requests touching `infra/`
-(posting the preview as a PR comment), on pushes to `main` touching `infra/`, and on a weekly
-schedule — console drift arrives with no commit, so only the schedule can catch it. The job
-authenticates through the `OP_SERVICE_ACCOUNT_TOKEN` repo secret, a non-expiring 1Password service
-account scoped to read the `vers` vault, and resolves the stack's credentials from their `op://`
-references at run time. Fork pull requests are skipped: GitHub withholds secrets from them, so the
-preview cannot authenticate. The job only ever previews — reconciling a reported drift is a human
-decision, applied with `pulumi up` from a checkout.
+`infra/` program's `prod` stack and fails on any diff. It runs on pull requests and `main` pushes
+touching `infra/` or the workflow file itself (a pull request gets the preview as a PR comment), and
+on a weekly schedule — console drift arrives with no commit, so only the schedule can catch it. The
+job authenticates through the `OP_SERVICE_ACCOUNT_TOKEN` repo secret, a non-expiring 1Password
+service account scoped to read the `vers` vault, and resolves the stack's credentials from their
+`op://` references at run time. Fork pull requests are skipped: GitHub withholds secrets from them,
+so the preview cannot authenticate. The job only ever previews — reconciling a reported drift is a
+human decision, applied with `pulumi up` from a checkout.
 
 ## Sim-version registry
 


### PR DESCRIPTION
## Description

Closes #654

Adds `.github/workflows/infra-drift.yml`: `pulumi preview --refresh --expect-no-changes` over the `infra/` prod stack, failing on any diff.

- Triggers: PRs touching `infra/` (preview posted as a PR comment), pushes to `main` touching `infra/`, and a weekly schedule — console drift arrives with no commit.
- Credentials resolve from the `vers` vault via `1password/load-secrets-action` under the new long-lived read-only `OP_SERVICE_ACCOUNT_TOKEN` repo secret; values are auto-masked in logs.
- Fork PRs are skipped — GitHub withholds secrets from them, so the preview cannot authenticate.
- Preview only, never `up`: reconciling drift stays a human decision.
- All actions pinned by commit SHA.

## Testing

- [x] `bun run typecheck` passes (no TS changes)
- [x] `bun run test` passes (no test-bearing projects changed)
- [ ] `bun run lint` passes
- [ ] New tests added for new functionality

## Context

This PR touches the workflow's own path filter, so the drift job runs against this PR as a live self-test.