### PR TITLE
fix(#582): resume the continuation once a held terminal append drains

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -555,6 +555,7 @@
         "msw": "catalog:",
         "typescript": "catalog:",
         "vite": "catalog:",
+        "zod": "catalog:",
       },
     },
     "libs/game/idle-core": {

--- a/docs/architecture/game-simulation.md
+++ b/docs/architecture/game-simulation.md
@@ -147,6 +147,11 @@ continues from) by replaying up to the confirmed head before the worker resumes 
 A larger gap fast-forwards through one or more attempts first, then attaches the same way to
 whichever continuation is still active when the budget runs out.
 
+A continuation the worker couldn't complete — a same-row race just after a terminal checkpoint, or a
+transport failure starting the next row — leaves a pending record that the next resync consults: a
+non-active row matching it starts fresh once its terminal append is acknowledged. A player stop
+leaves no such record, so a stopped activity is never resumed.
+
 Offline progress is bounded by a per-avatar simulated-time meter, enforced on the append path — the
 server never simulates. The avatar's budget refills at wall-clock rate since it was last banked,
 never past the cap (`OFFLINE_PROGRESS_CAP_MS`, 24h), and every accepted checkpoint batch debits its

--- a/libs/game/idle-client/package.json
+++ b/libs/game/idle-client/package.json
@@ -39,6 +39,7 @@
     "happy-dom": "catalog:",
     "msw": "catalog:",
     "typescript": "catalog:",
-    "vite": "catalog:"
+    "vite": "catalog:",
+    "zod": "catalog:"
   }
 }

--- a/libs/game/idle-client/src/resync/plan-resync.test.ts
+++ b/libs/game/idle-client/src/resync/plan-resync.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'bun:test';
 import { OFFLINE_PROGRESS_CAP_MS } from '@vers/contract-activity';
 import { createMockActivityData } from '@vers/contract-activity/test-utils';
+import { ActivityFailureAction } from '@vers/idle-core';
 import { createMockLatestActivityProgress } from '../test-utils/factories/create-mock-latest-activity-progress';
 import { planResync } from './plan-resync';
 
@@ -24,6 +25,66 @@ test('it plans nothing for a stopped activity', () => {
 
   expect(planResync({ progress: createMockLatestActivityProgress({ activity }) })).toStrictEqual({
     kind: 'none',
+  });
+});
+
+test('it plans nothing for a stopped activity when the pending continuation names a different row', () => {
+  const activity = createMockActivityData({ status: 'stopped' });
+
+  const plan = planResync({
+    pendingContinuation: {
+      activityID: 'a-different-activity',
+      avatarID: activity.avatarID,
+      failureAction: ActivityFailureAction.Retry,
+      scopeID: activity.scopeID,
+      scopeType: activity.scopeType,
+    },
+    progress: createMockLatestActivityProgress({ activity }),
+  });
+
+  expect(plan).toStrictEqual({ kind: 'none' });
+});
+
+test('it continues a stopped activity matching the pending continuation', () => {
+  const activity = createMockActivityData({ status: 'stopped' });
+
+  const plan = planResync({
+    pendingContinuation: {
+      activityID: activity.id,
+      avatarID: activity.avatarID,
+      failureAction: ActivityFailureAction.Retry,
+      scopeID: activity.scopeID,
+      scopeType: activity.scopeType,
+    },
+    progress: createMockLatestActivityProgress({ activity }),
+  });
+
+  expect(plan).toStrictEqual({ activity, kind: 'continue' });
+});
+
+test('it rebases a capped activity over a matching pending continuation', () => {
+  const activity = createMockActivityData({ appendedHead: 7, status: 'capped' });
+  const progress = createMockLatestActivityProgress({ activity, appendedHead: 7 });
+
+  const plan = planResync({
+    pendingContinuation: {
+      activityID: activity.id,
+      avatarID: activity.avatarID,
+      failureAction: ActivityFailureAction.Retry,
+      scopeID: activity.scopeID,
+      scopeType: activity.scopeType,
+    },
+    progress,
+  });
+
+  expect(plan).toStrictEqual({
+    context: {
+      activityID: activity.id,
+      appendedHead: 7,
+      lastHash: activity.lastHash,
+      startChainIndex: activity.startChainIndex,
+    },
+    kind: 'rebase',
   });
 });
 

--- a/libs/game/idle-client/src/resync/plan-resync.test.ts
+++ b/libs/game/idle-client/src/resync/plan-resync.test.ts
@@ -1,7 +1,6 @@
 import { expect, test } from 'bun:test';
 import { OFFLINE_PROGRESS_CAP_MS } from '@vers/contract-activity';
 import { createMockActivityData } from '@vers/contract-activity/test-utils';
-import { ActivityFailureAction } from '@vers/idle-core';
 import { createMockLatestActivityProgress } from '../test-utils/factories/create-mock-latest-activity-progress';
 import { planResync } from './plan-resync';
 
@@ -35,7 +34,6 @@ test('it plans nothing for a stopped activity when the pending continuation name
     pendingContinuation: {
       activityID: 'a-different-activity',
       avatarID: activity.avatarID,
-      failureAction: ActivityFailureAction.Retry,
       scopeID: activity.scopeID,
       scopeType: activity.scopeType,
     },
@@ -52,7 +50,6 @@ test('it continues a stopped activity matching the pending continuation', () => 
     pendingContinuation: {
       activityID: activity.id,
       avatarID: activity.avatarID,
-      failureAction: ActivityFailureAction.Retry,
       scopeID: activity.scopeID,
       scopeType: activity.scopeType,
     },
@@ -70,7 +67,6 @@ test('it rebases a capped activity over a matching pending continuation', () => 
     pendingContinuation: {
       activityID: activity.id,
       avatarID: activity.avatarID,
-      failureAction: ActivityFailureAction.Retry,
       scopeID: activity.scopeID,
       scopeType: activity.scopeType,
     },

--- a/libs/game/idle-client/src/resync/plan-resync.ts
+++ b/libs/game/idle-client/src/resync/plan-resync.ts
@@ -1,10 +1,12 @@
 import { OFFLINE_PROGRESS_CAP_MS } from '@vers/contract-activity';
 import { PROGRESS_FLUSH_INTERVAL_MS } from '../submission/constants';
 import type { ActivitySubmissionContext } from '../submission/types';
+import type { PendingContinuation } from '../worker/types';
 import type { LatestActivityProgress, ResyncPlan } from './types';
 
 interface PlanResyncInput {
   readonly capMs?: number;
+  readonly pendingContinuation?: PendingContinuation | null;
   readonly progress: LatestActivityProgress;
 }
 
@@ -13,7 +15,10 @@ interface PlanResyncInput {
  * entirely from server data — the server clock minus the last append (or the start, for a stream
  * that never appended) — so a skewed local clock can neither inflate nor starve the budget, and
  * the budget never exceeds the cap. A capped activity resolves to a rebase from its exact stop
- * index rather than trusting any locally derived cursor.
+ * index rather than trusting any locally derived cursor, taking priority over a pending
+ * continuation. A non-active row matching a pending continuation's target plans `continue`
+ * instead of `none` — the pending intent is stale, and ignored, when it names a different row than
+ * the one fetched.
  */
 export function planResync(input: Readonly<PlanResyncInput>): ResyncPlan {
   const capMs = input.capMs ?? OFFLINE_PROGRESS_CAP_MS;
@@ -31,6 +36,10 @@ export function planResync(input: Readonly<PlanResyncInput>): ResyncPlan {
   }
 
   if (activity.status !== 'active') {
+    if (input.pendingContinuation?.activityID === activity.id) {
+      return { activity, kind: 'continue' };
+    }
+
     return { kind: 'none' };
   }
 

--- a/libs/game/idle-client/src/resync/run-resync.ts
+++ b/libs/game/idle-client/src/resync/run-resync.ts
@@ -4,6 +4,7 @@ import type { ActivityInput, AvatarData } from '@vers/idle-core';
 import type { CheckpointSubmitter } from '../submission/create-checkpoint-submitter';
 import { readQueuedCheckpoints } from '../submission/read-queued-checkpoints';
 import type { ActivityServiceClient } from '../submission/types';
+import type { PendingContinuation } from '../worker/types';
 import { planResync } from './plan-resync';
 import { runFastForward } from './run-fast-forward';
 import type { FastForwardProgress, LatestActivityProgress, ResyncResult } from './types';
@@ -44,6 +45,12 @@ interface RunResyncOptions {
    * fast-forward reads it.
    */
   readonly onProgressFetched?: (progress: LatestActivityProgress) => Promise<void>;
+
+  /**
+   * A continuation `runContinuation` couldn't complete, honored as a `continue` plan once its
+   * target row reads closed.
+   */
+  readonly pendingContinuation?: PendingContinuation | null;
 
   readonly submitter: CheckpointSubmitter;
 }
@@ -88,6 +95,9 @@ export async function runResync(
   const plan = planResync({
     progress,
     ...(options.capMs !== undefined && { capMs: options.capMs }),
+    ...(options.pendingContinuation !== undefined && {
+      pendingContinuation: options.pendingContinuation,
+    }),
   });
 
   if (plan.kind !== 'fast-forward') {

--- a/libs/game/idle-client/src/resync/types.ts
+++ b/libs/game/idle-client/src/resync/types.ts
@@ -9,6 +9,7 @@ export type LatestActivityProgress = Awaited<
  * The action a resync snapshot resolves to, decided before any simulation runs: `fast-forward`
  * re-simulates the offline gap up to its budget, `attach-live` resumes live submission with no
  * catch-up worth simulating, `rebase` restarts bookkeeping from a capped activity's stop index,
+ * `continue` starts the next row a pending continuation wanted once its target row reads closed,
  * and `none` means no resumable activity exists.
  */
 export type ResyncPlan =
@@ -19,6 +20,7 @@ export type ResyncPlan =
     }
   | { readonly context: ActivitySubmissionContext; readonly kind: 'attach-live' }
   | { readonly context: ActivitySubmissionContext; readonly kind: 'rebase' }
+  | { readonly activity: ActivityData; readonly kind: 'continue' }
   | { readonly kind: 'none' };
 
 export interface FastForwardProgress {

--- a/libs/game/idle-client/src/test-utils/create-fast-clock.ts
+++ b/libs/game/idle-client/src/test-utils/create-fast-clock.ts
@@ -1,0 +1,34 @@
+export interface FastClock {
+  /**
+   * Arms the clock's very next read to jump forward by `deltaMs` instead of staying frozen — one
+   * call through the runtime's tick loop then processes a whole `deltaMs` of simulated time.
+   * Every other read returns the same frozen value, so a jump armed before the tick loop has
+   * installed a simulation costs nothing (an idle tick with nowhere to apply it) rather than
+   * cascading through however many continuations the frame would otherwise cover.
+   */
+  readonly jump: (deltaMs: number) => void;
+
+  readonly now: () => number;
+}
+
+/**
+ * A tick-loop clock for the worker runtime's `now` option. Lets a test collapse the loop's
+ * real-time pacing into a single frame on demand, rather than waiting out an encounter's actual
+ * simulated duration in real time.
+ */
+export function createFastClock(): FastClock {
+  let value = 0;
+  let pendingJumpMs = 0;
+
+  return {
+    jump: (deltaMs) => {
+      pendingJumpMs = deltaMs;
+    },
+    now: () => {
+      value += pendingJumpMs;
+      pendingJumpMs = 0;
+
+      return value;
+    },
+  };
+}

--- a/libs/game/idle-client/src/test-utils/create-stub-worker-context.ts
+++ b/libs/game/idle-client/src/test-utils/create-stub-worker-context.ts
@@ -7,12 +7,13 @@ import { resolveServiceURL } from '@vers/mock-services';
 import type { CheckpointSubmitter } from '../submission/create-checkpoint-submitter';
 import type { ActivityServiceClient } from '../submission/types';
 import type { RewardSlotLedgerEntry } from '../types';
-import type { WorkerContext } from '../worker/types';
+import type { PendingContinuation, WorkerContext } from '../worker/types';
 
 interface CreateStubWorkerContextOptions {
   readonly client?: ActivityServiceClient;
   readonly connections?: ReadonlyArray<MessagePort>;
   readonly failureAction?: ActivityFailureAction;
+  readonly pendingContinuation?: PendingContinuation | null;
   readonly remainingBudgetMs?: number;
   readonly submitter?: Readonly<CheckpointSubmitter>;
 }
@@ -35,6 +36,7 @@ export function createStubWorkerContext(
 
   let simulation: null | Simulation = null;
   let activity: ActivityData | null = null;
+  let pendingContinuation: PendingContinuation | null = options.pendingContinuation ?? null;
   let resyncAvatarID: string | null = null;
   let resyncInFlight = false;
   let rewardSlotLedgerActivityID: null | string = null;
@@ -48,6 +50,7 @@ export function createStubWorkerContext(
     getActivity: () => activity,
     getClient: () => client,
     getFailureAction: () => failureAction,
+    getPendingContinuation: () => pendingContinuation,
     getRemainingBudgetMs: () => options.remainingBudgetMs ?? Number.MAX_SAFE_INTEGER,
     getResyncAvatarID: () => resyncAvatarID,
     getRewardSlotLedger: () => ({
@@ -83,6 +86,9 @@ export function createStubWorkerContext(
     },
     setFailureActionPushInFlight: (inFlight) => {
       failureActionPushInFlight = inFlight;
+    },
+    setPendingContinuation: (pending) => {
+      pendingContinuation = pending;
     },
     setResyncAvatarID: (avatarID) => {
       resyncAvatarID = avatarID;

--- a/libs/game/idle-client/src/test-utils/make-fail-first-match-handler.ts
+++ b/libs/game/idle-client/src/test-utils/make-fail-first-match-handler.ts
@@ -1,0 +1,37 @@
+import { HttpResponse } from 'msw';
+import * as z from 'zod';
+
+interface RequestInfo {
+  readonly request: Request;
+}
+
+const RequestEnvelopeSchema = z.object({ json: z.record(z.string(), z.unknown()).optional() });
+
+/**
+ * Fails transport-wise the first request whose JSON body satisfies `matches`, then lets every
+ * other request — including a retry of the same call and any other test's concurrent traffic on
+ * the shared mock server — fall through to the stateful backend registered underneath.
+ */
+export function makeFailFirstMatchHandler(
+  matches: (input: Readonly<Record<string, unknown>>) => boolean,
+): (info: Readonly<RequestInfo>) => Promise<Response | undefined> {
+  let failed = false;
+
+  return async (info): Promise<Response | undefined> => {
+    if (failed) {
+      return undefined;
+    }
+
+    const parsed: unknown = await info.request.clone().json();
+
+    const body = RequestEnvelopeSchema.parse(parsed);
+
+    if (!matches(body.json ?? {})) {
+      return undefined;
+    }
+
+    failed = true;
+
+    return HttpResponse.error();
+  };
+}

--- a/libs/game/idle-client/src/worker/create-worker-runtime.test.ts
+++ b/libs/game/idle-client/src/worker/create-worker-runtime.test.ts
@@ -436,3 +436,74 @@ test('it resumes into a fresh row once a reconnect drains a held terminal append
   invariant(closed !== undefined, 'expected the seeded activity to still exist');
   expect(closed.status).toBe('stopped');
 });
+
+test("it resumes the pending continuation's avatar on reconnect over an earlier avatar it resynced", async () => {
+  const user = await db.userCollection.create({});
+  const earlierAvatar = await db.avatarCollection.create({ userID: user.id });
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const client = await buildAuthedClient(user.id);
+
+  // this seed's placeholder encounter completes in exactly 60s of simulated time; the fast clock
+  // below collapses that wait into a single tick-loop frame
+  const activity = await db.activityCollection.create({
+    avatarID: avatar.id,
+    encounterNode: { difficulty: 1 },
+    seed: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaa6072',
+  });
+
+  // both this activity's terminal append and its continuation's own startActivity call fail once,
+  // standing in for the device going offline right as the run completes
+  server.use(
+    http.post(
+      `${resolveServiceURL('activity')}/rpc/trackActivityProgress`,
+      makeFailFirstMatchHandler((input) => input['activityID'] === activity.id),
+    ),
+    http.post(
+      `${resolveServiceURL('activity')}/rpc/startActivity`,
+      makeFailFirstMatchHandler((input) => input['avatarID'] === avatar.id),
+    ),
+  );
+
+  const clock = createFastClock();
+  const runtime = createWorkerRuntime({ client });
+
+  // stop the tick loop before restoring the real clock — a still-scheduled tick reading the real
+  // clock against the fake clock's small `lastFrameTime` would read a bogus, enormous frame
+  onTestFinished(() => {
+    runtime.stop();
+    clock.restore();
+  });
+
+  const connection = createConnection(runtime);
+
+  connection.post({ type: ClientMessageType.Initialize });
+
+  await connection.waitForMessages(1);
+
+  // the worker remembers this history-free avatar as its last resync target; the boundary failure
+  // below must outrank that memory on reconnect or the pending continuation strands
+  connection.post({ avatarID: earlierAvatar.id, type: ClientMessageType.RequestResync });
+  connection.post({ activity, type: ClientMessageType.SetActivity });
+
+  await waitFor(() => {
+    // re-armed every poll: a jump that lands before the tick loop installs the simulation is an
+    // idle frame, so the wait just re-arms the next one until it lands on a live tick
+    clock.jump(65_000);
+
+    expect(connection.received).toPartiallyContain({
+      online: false,
+      type: WorkerMessageType.ConnectionStatus,
+    });
+  });
+
+  globalThis.dispatchEvent(new Event('online'));
+
+  await waitFor(() => {
+    const minted = db.activityCollection.findFirst((q) =>
+      q.where({ avatarID: avatar.id, status: 'active' }),
+    );
+
+    invariant(minted !== undefined, 'expected the reconnect to resume the pending avatar');
+    expect(minted.id).not.toBe(activity.id);
+  });
+});

--- a/libs/game/idle-client/src/worker/create-worker-runtime.test.ts
+++ b/libs/game/idle-client/src/worker/create-worker-runtime.test.ts
@@ -90,9 +90,6 @@ test('it retains the cached dirty flag across boot so the next resync flushes it
 
   const token = await createTestAccessToken(user.id);
 
-  // the runtime's production client resolves its URL from `self.location.origin`, unreachable in
-  // this test env — an authed client wired at the mocked backend is the only way to route its
-  // calls, standing in for it here the way `timestep` already stands in for the tick rate
   const client: ActivityServiceClient = createORPCClient(
     new RPCLink({
       headers: { authorization: `Bearer ${token}` },
@@ -225,8 +222,6 @@ test('it resumes into a fresh row once a same-row CONFLICT resync drains a held 
   const avatar = await db.avatarCollection.create({ userID: user.id });
   const token = await createTestAccessToken(user.id);
 
-  // the runtime's production client resolves its URL from `self.location.origin`, unreachable in
-  // this test env — an authed client wired at the mocked backend is the only way to route its calls
   const client: ActivityServiceClient = createORPCClient(
     new RPCLink({
       headers: { authorization: `Bearer ${token}` },
@@ -290,8 +285,6 @@ test('it resumes into a fresh row once a reconnect drains a held terminal append
   const avatar = await db.avatarCollection.create({ userID: user.id });
   const token = await createTestAccessToken(user.id);
 
-  // the runtime's production client resolves its URL from `self.location.origin`, unreachable in
-  // this test env — an authed client wired at the mocked backend is the only way to route its calls
   const client: ActivityServiceClient = createORPCClient(
     new RPCLink({
       headers: { authorization: `Bearer ${token}` },
@@ -369,8 +362,6 @@ test("it resumes the pending continuation's avatar on reconnect over an earlier 
   const avatar = await db.avatarCollection.create({ userID: user.id });
   const token = await createTestAccessToken(user.id);
 
-  // the runtime's production client resolves its URL from `self.location.origin`, unreachable in
-  // this test env — an authed client wired at the mocked backend is the only way to route its calls
   const client: ActivityServiceClient = createORPCClient(
     new RPCLink({
       headers: { authorization: `Bearer ${token}` },

--- a/libs/game/idle-client/src/worker/create-worker-runtime.test.ts
+++ b/libs/game/idle-client/src/worker/create-worker-runtime.test.ts
@@ -8,6 +8,9 @@ import { createTestAccessToken, resolveServiceURL } from '@vers/mock-services';
 import { mockActivityService } from '@vers/mock-services/activity';
 import * as db from '@vers/mock-services/db';
 import { waitFor } from '@vers/test-utils';
+import { HttpResponse, http } from 'msw';
+import invariant from 'tiny-invariant';
+import * as z from 'zod';
 import { server } from '../mocks/node';
 import type { ActivityServiceClient } from '../submission/types';
 import { writeFailureActionCache } from '../submission/write-failure-action-cache';
@@ -25,6 +28,93 @@ function createConnection(runtime: WorkerRuntime): TestConnection {
   runtime.handleConnect(new MessageEvent('connect', { ports: [connection.port] }));
 
   return connection;
+}
+
+interface FastClock {
+  /**
+   * Arms the clock's very next `performance.now()` read to jump forward by `deltaMs` instead of
+   * the real interval since the last read — one call through the runtime's tick loop then
+   * processes a whole `deltaMs` of simulated time. Every other read returns the same frozen value,
+   * so a jump armed before the tick loop has installed a simulation costs nothing (an idle tick
+   * with nowhere to apply it) rather than cascading through however many continuations the frame
+   * would otherwise cover.
+   */
+  readonly jump: (deltaMs: number) => void;
+  readonly restore: () => void;
+}
+
+/**
+ * Replaces the runtime's tick loop clock — its own `performance.now()` calls are the only ones
+ * anywhere in this call chain, so patching the global is safe. Lets a test collapse the loop's
+ * real-time pacing into a single frame on demand, rather than waiting out an encounter's actual
+ * simulated duration in real time.
+ */
+function createFastClock(): FastClock {
+  const original = performance.now.bind(performance);
+  let value = 0;
+  let pendingJumpMs = 0;
+
+  performance.now = () => {
+    value += pendingJumpMs;
+    pendingJumpMs = 0;
+
+    return value;
+  };
+
+  return {
+    jump: (deltaMs) => {
+      pendingJumpMs = deltaMs;
+    },
+    restore: () => {
+      performance.now = original;
+    },
+  };
+}
+
+interface RequestInfo {
+  readonly request: Request;
+}
+
+const RequestEnvelopeSchema = z.object({ json: z.record(z.string(), z.unknown()).optional() });
+
+/**
+ * Fails transport-wise the first request whose JSON body satisfies `matches`, then lets every
+ * other request — including a retry of the same call and any other test's concurrent traffic on
+ * the shared mock server — fall through to the stateful backend registered underneath.
+ */
+function makeFailFirstMatchHandler(
+  matches: (input: Readonly<Record<string, unknown>>) => boolean,
+): (info: Readonly<RequestInfo>) => Promise<Response | undefined> {
+  let failed = false;
+
+  return async (info): Promise<Response | undefined> => {
+    if (failed) {
+      return undefined;
+    }
+
+    const parsed: unknown = await info.request.clone().json();
+
+    const body = RequestEnvelopeSchema.parse(parsed);
+
+    if (!matches(body.json ?? {})) {
+      return undefined;
+    }
+
+    failed = true;
+
+    return HttpResponse.error();
+  };
+}
+
+async function buildAuthedClient(userID: string): Promise<ActivityServiceClient> {
+  const token = await createTestAccessToken(userID);
+
+  return createORPCClient(
+    new RPCLink({
+      headers: { authorization: `Bearer ${token}` },
+      url: `${resolveServiceURL('activity')}/rpc`,
+    }),
+  );
 }
 
 test('it replies with the initial state to an initialize message', async () => {
@@ -214,4 +304,135 @@ test('it reports a fault to the error backend when a message makes its handler t
   });
 
   expect(recorded[0]?.tags).toMatchObject({ site: 'message-routing' });
+});
+
+test('it resumes into a fresh row once a same-row CONFLICT resync drains a held terminal append', async () => {
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const client = await buildAuthedClient(user.id);
+
+  // this seed's placeholder encounter completes in exactly 60s of simulated time; the fast clock
+  // below collapses that wait into a single tick-loop frame
+  const activity = await db.activityCollection.create({
+    avatarID: avatar.id,
+    encounterNode: { difficulty: 1 },
+    seed: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaa6072',
+  });
+
+  // holds this activity's terminal append once: the row it closes stays active server-side, so
+  // the continuation's own startActivity call races back a same-row CONFLICT
+  server.use(
+    http.post(
+      `${resolveServiceURL('activity')}/rpc/trackActivityProgress`,
+      makeFailFirstMatchHandler((input) => input['activityID'] === activity.id),
+    ),
+  );
+
+  const clock = createFastClock();
+  const runtime = createWorkerRuntime({ client });
+
+  // stop the tick loop before restoring the real clock — a still-scheduled tick reading the real
+  // clock against the fake clock's small `lastFrameTime` would read a bogus, enormous frame
+  onTestFinished(() => {
+    runtime.stop();
+    clock.restore();
+  });
+
+  const connection = createConnection(runtime);
+
+  connection.post({ type: ClientMessageType.Initialize });
+
+  await connection.waitForMessages(1);
+
+  connection.post({ activity, type: ClientMessageType.SetActivity });
+
+  await waitFor(() => {
+    // re-armed every poll: a jump that lands before the tick loop installs the simulation is an
+    // idle frame, so the wait just re-arms the next one until it lands on a live tick
+    clock.jump(65_000);
+
+    const minted = db.activityCollection.findFirst((q) =>
+      q.where({ avatarID: avatar.id, status: 'active' }),
+    );
+
+    invariant(minted !== undefined, 'expected the same-row CONFLICT resync to mint a fresh row');
+    expect(minted.id).not.toBe(activity.id);
+  });
+
+  const closed = db.activityCollection.findFirst((q) => q.where({ id: activity.id }));
+
+  invariant(closed !== undefined, 'expected the seeded activity to still exist');
+  expect(closed.status).toBe('stopped');
+});
+
+test('it resumes into a fresh row once a reconnect drains a held terminal append behind an offline continuation', async () => {
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const client = await buildAuthedClient(user.id);
+
+  // this seed's placeholder encounter completes in exactly 60s of simulated time; the fast clock
+  // below collapses that wait into a single tick-loop frame
+  const activity = await db.activityCollection.create({
+    avatarID: avatar.id,
+    encounterNode: { difficulty: 1 },
+    seed: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaa6072',
+  });
+
+  // both this activity's terminal append and its continuation's own startActivity call fail once,
+  // standing in for the device going offline right as the run completes
+  server.use(
+    http.post(
+      `${resolveServiceURL('activity')}/rpc/trackActivityProgress`,
+      makeFailFirstMatchHandler((input) => input['activityID'] === activity.id),
+    ),
+    http.post(
+      `${resolveServiceURL('activity')}/rpc/startActivity`,
+      makeFailFirstMatchHandler((input) => input['avatarID'] === avatar.id),
+    ),
+  );
+
+  const clock = createFastClock();
+  const runtime = createWorkerRuntime({ client });
+
+  // stop the tick loop before restoring the real clock — a still-scheduled tick reading the real
+  // clock against the fake clock's small `lastFrameTime` would read a bogus, enormous frame
+  onTestFinished(() => {
+    runtime.stop();
+    clock.restore();
+  });
+
+  const connection = createConnection(runtime);
+
+  connection.post({ type: ClientMessageType.Initialize });
+
+  await connection.waitForMessages(1);
+
+  connection.post({ activity, type: ClientMessageType.SetActivity });
+
+  await waitFor(() => {
+    // re-armed every poll: a jump that lands before the tick loop installs the simulation is an
+    // idle frame, so the wait just re-arms the next one until it lands on a live tick
+    clock.jump(65_000);
+
+    expect(connection.received).toPartiallyContain({
+      online: false,
+      type: WorkerMessageType.ConnectionStatus,
+    });
+  });
+
+  globalThis.dispatchEvent(new Event('online'));
+
+  await waitFor(() => {
+    const minted = db.activityCollection.findFirst((q) =>
+      q.where({ avatarID: avatar.id, status: 'active' }),
+    );
+
+    invariant(minted !== undefined, 'expected the reconnect resync to mint a fresh row');
+    expect(minted.id).not.toBe(activity.id);
+  });
+
+  const closed = db.activityCollection.findFirst((q) => q.where({ id: activity.id }));
+
+  invariant(closed !== undefined, 'expected the seeded activity to still exist');
+  expect(closed.status).toBe('stopped');
 });

--- a/libs/game/idle-client/src/worker/create-worker-runtime.test.ts
+++ b/libs/game/idle-client/src/worker/create-worker-runtime.test.ts
@@ -8,14 +8,15 @@ import { createTestAccessToken, resolveServiceURL } from '@vers/mock-services';
 import { mockActivityService } from '@vers/mock-services/activity';
 import * as db from '@vers/mock-services/db';
 import { waitFor } from '@vers/test-utils';
-import { HttpResponse, http } from 'msw';
+import { http } from 'msw';
 import invariant from 'tiny-invariant';
-import * as z from 'zod';
 import { server } from '../mocks/node';
 import type { ActivityServiceClient } from '../submission/types';
 import { writeFailureActionCache } from '../submission/write-failure-action-cache';
+import { createFastClock } from '../test-utils/create-fast-clock';
 import type { TestConnection } from '../test-utils/create-test-connection';
 import { createTestConnection } from '../test-utils/create-test-connection';
+import { makeFailFirstMatchHandler } from '../test-utils/make-fail-first-match-handler';
 import { ClientMessageType, WorkerMessageType } from '../types';
 import { createWorkerRuntime } from './create-worker-runtime';
 import type { WorkerRuntime } from './create-worker-runtime';
@@ -28,93 +29,6 @@ function createConnection(runtime: WorkerRuntime): TestConnection {
   runtime.handleConnect(new MessageEvent('connect', { ports: [connection.port] }));
 
   return connection;
-}
-
-interface FastClock {
-  /**
-   * Arms the clock's very next `performance.now()` read to jump forward by `deltaMs` instead of
-   * the real interval since the last read — one call through the runtime's tick loop then
-   * processes a whole `deltaMs` of simulated time. Every other read returns the same frozen value,
-   * so a jump armed before the tick loop has installed a simulation costs nothing (an idle tick
-   * with nowhere to apply it) rather than cascading through however many continuations the frame
-   * would otherwise cover.
-   */
-  readonly jump: (deltaMs: number) => void;
-  readonly restore: () => void;
-}
-
-/**
- * Replaces the runtime's tick loop clock — its own `performance.now()` calls are the only ones
- * anywhere in this call chain, so patching the global is safe. Lets a test collapse the loop's
- * real-time pacing into a single frame on demand, rather than waiting out an encounter's actual
- * simulated duration in real time.
- */
-function createFastClock(): FastClock {
-  const original = performance.now.bind(performance);
-  let value = 0;
-  let pendingJumpMs = 0;
-
-  performance.now = () => {
-    value += pendingJumpMs;
-    pendingJumpMs = 0;
-
-    return value;
-  };
-
-  return {
-    jump: (deltaMs) => {
-      pendingJumpMs = deltaMs;
-    },
-    restore: () => {
-      performance.now = original;
-    },
-  };
-}
-
-interface RequestInfo {
-  readonly request: Request;
-}
-
-const RequestEnvelopeSchema = z.object({ json: z.record(z.string(), z.unknown()).optional() });
-
-/**
- * Fails transport-wise the first request whose JSON body satisfies `matches`, then lets every
- * other request — including a retry of the same call and any other test's concurrent traffic on
- * the shared mock server — fall through to the stateful backend registered underneath.
- */
-function makeFailFirstMatchHandler(
-  matches: (input: Readonly<Record<string, unknown>>) => boolean,
-): (info: Readonly<RequestInfo>) => Promise<Response | undefined> {
-  let failed = false;
-
-  return async (info): Promise<Response | undefined> => {
-    if (failed) {
-      return undefined;
-    }
-
-    const parsed: unknown = await info.request.clone().json();
-
-    const body = RequestEnvelopeSchema.parse(parsed);
-
-    if (!matches(body.json ?? {})) {
-      return undefined;
-    }
-
-    failed = true;
-
-    return HttpResponse.error();
-  };
-}
-
-async function buildAuthedClient(userID: string): Promise<ActivityServiceClient> {
-  const token = await createTestAccessToken(userID);
-
-  return createORPCClient(
-    new RPCLink({
-      headers: { authorization: `Bearer ${token}` },
-      url: `${resolveServiceURL('activity')}/rpc`,
-    }),
-  );
 }
 
 test('it replies with the initial state to an initialize message', async () => {
@@ -309,7 +223,16 @@ test('it reports a fault to the error backend when a message makes its handler t
 test('it resumes into a fresh row once a same-row CONFLICT resync drains a held terminal append', async () => {
   const user = await db.userCollection.create({});
   const avatar = await db.avatarCollection.create({ userID: user.id });
-  const client = await buildAuthedClient(user.id);
+  const token = await createTestAccessToken(user.id);
+
+  // the runtime's production client resolves its URL from `self.location.origin`, unreachable in
+  // this test env — an authed client wired at the mocked backend is the only way to route its calls
+  const client: ActivityServiceClient = createORPCClient(
+    new RPCLink({
+      headers: { authorization: `Bearer ${token}` },
+      url: `${resolveServiceURL('activity')}/rpc`,
+    }),
+  );
 
   // this seed's placeholder encounter completes in exactly 60s of simulated time; the fast clock
   // below collapses that wait into a single tick-loop frame
@@ -329,13 +252,10 @@ test('it resumes into a fresh row once a same-row CONFLICT resync drains a held 
   );
 
   const clock = createFastClock();
-  const runtime = createWorkerRuntime({ client });
+  const runtime = createWorkerRuntime({ client, now: clock.now });
 
-  // stop the tick loop before restoring the real clock — a still-scheduled tick reading the real
-  // clock against the fake clock's small `lastFrameTime` would read a bogus, enormous frame
   onTestFinished(() => {
     runtime.stop();
-    clock.restore();
   });
 
   const connection = createConnection(runtime);
@@ -368,7 +288,16 @@ test('it resumes into a fresh row once a same-row CONFLICT resync drains a held 
 test('it resumes into a fresh row once a reconnect drains a held terminal append behind an offline continuation', async () => {
   const user = await db.userCollection.create({});
   const avatar = await db.avatarCollection.create({ userID: user.id });
-  const client = await buildAuthedClient(user.id);
+  const token = await createTestAccessToken(user.id);
+
+  // the runtime's production client resolves its URL from `self.location.origin`, unreachable in
+  // this test env — an authed client wired at the mocked backend is the only way to route its calls
+  const client: ActivityServiceClient = createORPCClient(
+    new RPCLink({
+      headers: { authorization: `Bearer ${token}` },
+      url: `${resolveServiceURL('activity')}/rpc`,
+    }),
+  );
 
   // this seed's placeholder encounter completes in exactly 60s of simulated time; the fast clock
   // below collapses that wait into a single tick-loop frame
@@ -392,13 +321,10 @@ test('it resumes into a fresh row once a reconnect drains a held terminal append
   );
 
   const clock = createFastClock();
-  const runtime = createWorkerRuntime({ client });
+  const runtime = createWorkerRuntime({ client, now: clock.now });
 
-  // stop the tick loop before restoring the real clock — a still-scheduled tick reading the real
-  // clock against the fake clock's small `lastFrameTime` would read a bogus, enormous frame
   onTestFinished(() => {
     runtime.stop();
-    clock.restore();
   });
 
   const connection = createConnection(runtime);
@@ -441,7 +367,16 @@ test("it resumes the pending continuation's avatar on reconnect over an earlier 
   const user = await db.userCollection.create({});
   const earlierAvatar = await db.avatarCollection.create({ userID: user.id });
   const avatar = await db.avatarCollection.create({ userID: user.id });
-  const client = await buildAuthedClient(user.id);
+  const token = await createTestAccessToken(user.id);
+
+  // the runtime's production client resolves its URL from `self.location.origin`, unreachable in
+  // this test env — an authed client wired at the mocked backend is the only way to route its calls
+  const client: ActivityServiceClient = createORPCClient(
+    new RPCLink({
+      headers: { authorization: `Bearer ${token}` },
+      url: `${resolveServiceURL('activity')}/rpc`,
+    }),
+  );
 
   // this seed's placeholder encounter completes in exactly 60s of simulated time; the fast clock
   // below collapses that wait into a single tick-loop frame
@@ -465,13 +400,10 @@ test("it resumes the pending continuation's avatar on reconnect over an earlier 
   );
 
   const clock = createFastClock();
-  const runtime = createWorkerRuntime({ client });
+  const runtime = createWorkerRuntime({ client, now: clock.now });
 
-  // stop the tick loop before restoring the real clock — a still-scheduled tick reading the real
-  // clock against the fake clock's small `lastFrameTime` would read a bogus, enormous frame
   onTestFinished(() => {
     runtime.stop();
-    clock.restore();
   });
 
   const connection = createConnection(runtime);

--- a/libs/game/idle-client/src/worker/create-worker-runtime.ts
+++ b/libs/game/idle-client/src/worker/create-worker-runtime.ts
@@ -32,6 +32,12 @@ interface CreateWorkerRuntimeOptions {
    */
   readonly client?: ActivityServiceClient;
 
+  /**
+   * The tick loop's clock, defaulting to `performance.now` — a test injects its own to collapse
+   * the loop's real-time pacing instead of waiting out simulated durations in real time.
+   */
+  readonly now?: () => number;
+
   readonly timestep?: number;
 }
 
@@ -42,6 +48,7 @@ interface CreateWorkerRuntimeOptions {
  */
 export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): WorkerRuntime {
   const timestep = options.timestep ?? SIMULATION_TIMESTEP_MS;
+  const now = options.now ?? (() => performance.now());
 
   const connections = new Set<MessagePort>();
 
@@ -50,7 +57,7 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
   let activity: ActivityData | null = null;
   let running = false;
   let stopped = false;
-  let lastFrameTime = performance.now();
+  let lastFrameTime = now();
   let accumulator = 0;
   let pendingContinuation: PendingContinuation | null = null;
   let resyncAvatarID: string | null = null;
@@ -209,8 +216,8 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
       return;
     }
 
-    const now = performance.now();
-    const frameTime = now - lastFrameTime;
+    const frameNow = now();
+    const frameTime = frameNow - lastFrameTime;
 
     accumulator += frameTime;
 
@@ -224,7 +231,7 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
       }
     }
 
-    lastFrameTime = now;
+    lastFrameTime = frameNow;
 
     await wait(1);
 

--- a/libs/game/idle-client/src/worker/create-worker-runtime.ts
+++ b/libs/game/idle-client/src/worker/create-worker-runtime.ts
@@ -17,7 +17,7 @@ import { handleClientMessage } from './handle-client-message';
 import { handleRequestResyncMessage } from './handle-request-resync-message';
 import { reportWorkerFault } from './report-worker-fault';
 import { runSimulation } from './run-simulation';
-import type { WorkerContext } from './types';
+import type { PendingContinuation, WorkerContext } from './types';
 
 export interface WorkerRuntime {
   readonly connections: ReadonlySet<MessagePort>;
@@ -52,6 +52,7 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
   let stopped = false;
   let lastFrameTime = performance.now();
   let accumulator = 0;
+  let pendingContinuation: PendingContinuation | null = null;
   let resyncAvatarID: string | null = null;
   let resyncInFlight = false;
   let failureAction: ActivityFailureAction = ActivityFailureAction.Abort;
@@ -115,6 +116,7 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
     getActivity: () => activity,
     getClient: () => client,
     getFailureAction: () => failureAction,
+    getPendingContinuation: () => pendingContinuation,
     getRemainingBudgetMs: () => OFFLINE_PROGRESS_CAP_MS - (Date.now() - lastAckAt),
     getResyncAvatarID: () => resyncAvatarID,
     getRewardSlotLedger: () => ({
@@ -150,6 +152,9 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
     },
     setFailureActionPushInFlight: (inFlight) => {
       failureActionPushInFlight = inFlight;
+    },
+    setPendingContinuation: (pending) => {
+      pendingContinuation = pending;
     },
     setResyncAvatarID: (avatarID) => {
       resyncAvatarID = avatarID;
@@ -250,8 +255,10 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
 
         await submitter.flushHeld();
 
-        if (context.getSimulation() === null && resyncAvatarID !== null) {
-          await handleRequestResyncMessage(context, createRequestResyncMessage(resyncAvatarID));
+        const avatarID = resyncAvatarID ?? pendingContinuation?.avatarID ?? null;
+
+        if (context.getSimulation() === null && avatarID !== null) {
+          await handleRequestResyncMessage(context, createRequestResyncMessage(avatarID));
         }
       } catch (error) {
         reportWorkerFault('reconnect', error);

--- a/libs/game/idle-client/src/worker/create-worker-runtime.ts
+++ b/libs/game/idle-client/src/worker/create-worker-runtime.ts
@@ -255,7 +255,9 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
 
         await submitter.flushHeld();
 
-        const avatarID = resyncAvatarID ?? pendingContinuation?.avatarID ?? null;
+        // the pending continuation is always the fresher signal: it was recorded at the most
+        // recent boundary failure, while the remembered resync avatar can predate it
+        const avatarID = pendingContinuation?.avatarID ?? resyncAvatarID ?? null;
 
         if (context.getSimulation() === null && avatarID !== null) {
           await handleRequestResyncMessage(context, createRequestResyncMessage(avatarID));

--- a/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
@@ -33,9 +33,12 @@ import { ClientMessageType, WorkerMessageType } from '../types';
 import { handleRequestResyncMessage } from './handle-request-resync-message';
 import { sentryHandle } from './sentry-handle';
 import { startErrorReporting } from './start-error-reporting';
+import type { PendingContinuation } from './types';
 
 interface SetupTestConfig {
   readonly failureAction?: ActivityFailureAction;
+  readonly pendingContinuation?: PendingContinuation | null;
+  readonly remainingBudgetMs?: number;
   readonly userID: string;
 }
 
@@ -72,6 +75,10 @@ async function setupTest(config: Readonly<SetupTestConfig>) {
     connections: [connection.port],
     submitter,
     ...(config.failureAction === undefined ? {} : { failureAction: config.failureAction }),
+    ...(config.pendingContinuation !== undefined && {
+      pendingContinuation: config.pendingContinuation,
+    }),
+    ...(config.remainingBudgetMs !== undefined && { remainingBudgetMs: config.remainingBudgetMs }),
   });
 
   return { client, connection, context, flush: () => capturedFlush?.() ?? Promise.resolve() };
@@ -723,6 +730,157 @@ test('it keeps the dirty flag when the resync push to the server fails', async (
     dirty: true,
     failureAction: ActivityFailureAction.Retry,
   });
+});
+
+test('it starts a fresh row, installs a live simulation with the pending failure action, and clears the pending continuation', async () => {
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const stopped = await db.activityCollection.create({ avatarID: avatar.id, status: 'stopped' });
+
+  const ctx = await setupTest({
+    pendingContinuation: {
+      activityID: stopped.id,
+      avatarID: avatar.id,
+      failureAction: ActivityFailureAction.Retry,
+      scopeID: stopped.scopeID,
+      scopeType: stopped.scopeType,
+    },
+    userID: user.id,
+  });
+
+  const message: RequestResyncMessage = {
+    avatarID: avatar.id,
+    type: ClientMessageType.RequestResync,
+  };
+
+  await handleRequestResyncMessage(ctx.context, message);
+
+  const minted = db.activityCollection.findFirst((q) =>
+    q.where({ avatarID: avatar.id, status: 'active' }),
+  );
+
+  invariant(minted !== undefined, 'expected the continue plan to mint a fresh row');
+  expect(minted.scopeID).toBe(stopped.scopeID);
+
+  const simulation = ctx.context.getSimulation();
+
+  invariant(simulation !== null, 'expected the continue plan to install a live simulation');
+  expect(simulation.activity?.id).toBe(minted.id);
+  expect(simulation.failureAction).toBe(ActivityFailureAction.Retry);
+  expect(ctx.context.getPendingContinuation()).toBeNull();
+});
+
+test('it halts at the boundary and keeps the pending continuation when the offline budget is spent', async () => {
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const stopped = await db.activityCollection.create({ avatarID: avatar.id, status: 'stopped' });
+
+  const pending: PendingContinuation = {
+    activityID: stopped.id,
+    avatarID: avatar.id,
+    failureAction: ActivityFailureAction.Retry,
+    scopeID: stopped.scopeID,
+    scopeType: stopped.scopeType,
+  };
+
+  const ctx = await setupTest({
+    pendingContinuation: pending,
+    remainingBudgetMs: 0,
+    userID: user.id,
+  });
+
+  const message: RequestResyncMessage = {
+    avatarID: avatar.id,
+    type: ClientMessageType.RequestResync,
+  };
+
+  await handleRequestResyncMessage(ctx.context, message);
+
+  await ctx.connection.waitForMessages(1);
+
+  expect(ctx.connection.received).toStrictEqual([
+    { halted: true, remainingMs: 0, type: WorkerMessageType.OfflineCapStatus },
+  ]);
+
+  expect(ctx.context.getSimulation()).toBeNull();
+  expect(ctx.context.getPendingContinuation()).toStrictEqual(pending);
+
+  const minted = db.activityCollection.findFirst((q) =>
+    q.where({ avatarID: avatar.id, status: 'active' }),
+  );
+
+  expect(minted).toBeUndefined();
+});
+
+test('it keeps the pending continuation and reports offline when starting the continued row fails on transport', async () => {
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const stopped = await db.activityCollection.create({ avatarID: avatar.id, status: 'stopped' });
+
+  const pending: PendingContinuation = {
+    activityID: stopped.id,
+    avatarID: avatar.id,
+    failureAction: ActivityFailureAction.Retry,
+    scopeID: stopped.scopeID,
+    scopeType: stopped.scopeType,
+  };
+
+  server.use(mockActivityService.startActivity.handler(() => HttpResponse.error()));
+
+  const ctx = await setupTest({ pendingContinuation: pending, userID: user.id });
+
+  const message: RequestResyncMessage = {
+    avatarID: avatar.id,
+    type: ClientMessageType.RequestResync,
+  };
+
+  await handleRequestResyncMessage(ctx.context, message);
+
+  await ctx.connection.waitForMessages(1);
+
+  expect(ctx.connection.received).toStrictEqual([
+    { online: false, type: WorkerMessageType.ConnectionStatus },
+  ]);
+
+  expect(ctx.context.getSimulation()).toBeNull();
+  expect(ctx.context.getPendingContinuation()).toStrictEqual(pending);
+});
+
+test('it clears the pending continuation and reports the resync failure status on a defined error other than CONFLICT', async () => {
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const stopped = await db.activityCollection.create({ avatarID: avatar.id, status: 'stopped' });
+
+  const pending: PendingContinuation = {
+    activityID: stopped.id,
+    avatarID: avatar.id,
+    failureAction: ActivityFailureAction.Retry,
+    scopeID: stopped.scopeID,
+    scopeType: stopped.scopeType,
+  };
+
+  server.use(
+    mockActivityService.startActivity.handler((opts) => {
+      throw opts.errors.CHAIN_QUARANTINED({ data: {} });
+    }),
+  );
+
+  const ctx = await setupTest({ pendingContinuation: pending, userID: user.id });
+
+  const message: RequestResyncMessage = {
+    avatarID: avatar.id,
+    type: ClientMessageType.RequestResync,
+  };
+
+  await handleRequestResyncMessage(ctx.context, message);
+
+  await ctx.connection.waitForMessages(1);
+
+  expect(ctx.connection.received).toStrictEqual([
+    { status: { avatarID: avatar.id, kind: 'failed' }, type: WorkerMessageType.ResyncStatus },
+  ]);
+
+  expect(ctx.context.getPendingContinuation()).toBeNull();
 });
 
 test('it reports a fault to the error backend and broadcasts a failed status when the resync fails outright', async () => {

--- a/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
@@ -732,16 +732,15 @@ test('it keeps the dirty flag when the resync push to the server fails', async (
   });
 });
 
-test('it starts a fresh row, installs a live simulation with the pending failure action, and clears the pending continuation', async () => {
+test("it starts a fresh row, installs a live simulation with the worker's failure action, and clears the pending continuation", async () => {
   const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const avatar = await db.avatarCollection.create({ failureAction: 'retry', userID: user.id });
   const stopped = await db.activityCollection.create({ avatarID: avatar.id, status: 'stopped' });
 
   const ctx = await setupTest({
     pendingContinuation: {
       activityID: stopped.id,
       avatarID: avatar.id,
-      failureAction: ActivityFailureAction.Retry,
       scopeID: stopped.scopeID,
       scopeType: stopped.scopeType,
     },
@@ -770,6 +769,57 @@ test('it starts a fresh row, installs a live simulation with the pending failure
   expect(ctx.context.getPendingContinuation()).toBeNull();
 });
 
+test('it adopts a fresh row another session raced in ahead of the continuation and clears the pending continuation', async () => {
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const stopped = await db.activityCollection.create({ avatarID: avatar.id, status: 'stopped' });
+
+  // the racing row lands between the resync's progress fetch and its start call, so it must not
+  // exist when the plan is computed — the scripted handler mints it at start time and answers
+  // CONFLICT with it, exactly as the real service would
+  server.use(
+    mockActivityService.startActivity.handler(async (opts) => {
+      const racing = await db.activityCollection.create({
+        appendedHead: 0,
+        avatarID: avatar.id,
+        status: 'active',
+      });
+
+      throw opts.errors.CONFLICT({ data: { activity: racing } });
+    }),
+  );
+
+  const ctx = await setupTest({
+    pendingContinuation: {
+      activityID: stopped.id,
+      avatarID: avatar.id,
+      scopeID: stopped.scopeID,
+      scopeType: stopped.scopeType,
+    },
+    userID: user.id,
+  });
+
+  const message: RequestResyncMessage = {
+    avatarID: avatar.id,
+    type: ClientMessageType.RequestResync,
+  };
+
+  await handleRequestResyncMessage(ctx.context, message);
+
+  const racing = db.activityCollection.findFirst((q) =>
+    q.where({ avatarID: avatar.id, status: 'active' }),
+  );
+
+  invariant(racing !== undefined, 'expected the scripted handler to mint the racing row');
+
+  const simulation = ctx.context.getSimulation();
+
+  invariant(simulation !== null, 'expected the racing row to be adopted into a live simulation');
+  expect(simulation.activity?.id).toBe(racing.id);
+  expect(ctx.context.getActivity()).toStrictEqual(racing);
+  expect(ctx.context.getPendingContinuation()).toBeNull();
+});
+
 test('it halts at the boundary and keeps the pending continuation when the offline budget is spent', async () => {
   const user = await db.userCollection.create({});
   const avatar = await db.avatarCollection.create({ userID: user.id });
@@ -778,7 +828,6 @@ test('it halts at the boundary and keeps the pending continuation when the offli
   const pending: PendingContinuation = {
     activityID: stopped.id,
     avatarID: avatar.id,
-    failureAction: ActivityFailureAction.Retry,
     scopeID: stopped.scopeID,
     scopeType: stopped.scopeType,
   };
@@ -820,7 +869,6 @@ test('it keeps the pending continuation and reports offline when starting the co
   const pending: PendingContinuation = {
     activityID: stopped.id,
     avatarID: avatar.id,
-    failureAction: ActivityFailureAction.Retry,
     scopeID: stopped.scopeID,
     scopeType: stopped.scopeType,
   };
@@ -854,7 +902,6 @@ test('it clears the pending continuation and reports the resync failure status o
   const pending: PendingContinuation = {
     activityID: stopped.id,
     avatarID: avatar.id,
-    failureAction: ActivityFailureAction.Retry,
     scopeID: stopped.scopeID,
     scopeType: stopped.scopeType,
   };

--- a/libs/game/idle-client/src/worker/handle-request-resync-message.ts
+++ b/libs/game/idle-client/src/worker/handle-request-resync-message.ts
@@ -1,4 +1,4 @@
-import { ORPCError, safe } from '@orpc/client';
+import { isDefinedError, ORPCError, safe } from '@orpc/client';
 import type {
   ActivityData,
   ActivityFailureAction as ContractFailureAction,
@@ -19,7 +19,9 @@ import { sweepStaleCheckpoints } from '../submission/sweep-stale-checkpoints';
 import { writeFailureActionCache } from '../submission/write-failure-action-cache';
 import type { RequestResyncMessage, ResyncStatus } from '../types';
 import { createCheckpointStreamInvalidMessage } from './create-checkpoint-stream-invalid-message';
+import { createConnectionStatusMessage } from './create-connection-status-message';
 import { createFailureActionStatusMessage } from './create-failure-action-status-message';
+import { createOfflineCapStatusMessage } from './create-offline-cap-status-message';
 import { createResyncStatusMessage } from './create-resync-status-message';
 import { registerSimulationListeners } from './register-simulation-listeners';
 import { reportWorkerFault } from './report-worker-fault';
@@ -88,6 +90,7 @@ export async function handleRequestResyncMessage(
           toActivityFailureAction(progress.failureAction),
         );
       },
+      pendingContinuation: context.getPendingContinuation(),
       submitter: context.getSubmitter(),
     });
 
@@ -208,6 +211,12 @@ async function applyResyncResult(
 
   if (result.plan.kind === 'attach-live') {
     await applyAttachLive(context, result.plan, result.progress);
+
+    return;
+  }
+
+  if (result.plan.kind === 'continue') {
+    await applyContinue(context, result.plan);
   }
 }
 
@@ -259,6 +268,88 @@ async function applyAttachLive(
   });
 
   setLiveSimulation(context, progress.activity, reconstruction.simulation);
+}
+
+/**
+ * Starts the row a pending continuation wanted, now that its target has read closed. A budget
+ * already spent halts at the boundary exactly like a live continuation would, keeping the pending
+ * record for the next reconnect. `startActivity` answering with a fresh, never-appended row is
+ * adopted directly, mirroring `runContinuation`'s own same-scope race handling; any other defined
+ * error clears the pending record and rethrows, reported through the caller's own resync-failure
+ * handling; a transport failure keeps the pending record and reports the worker offline, leaving
+ * the next reconnect to retry.
+ */
+async function applyContinue(
+  context: WorkerContext,
+  plan: Extract<ResyncPlan, { kind: 'continue' }>,
+): Promise<void> {
+  const pending = context.getPendingContinuation();
+
+  invariant(pending !== null, 'a continue plan is only reached with a pending continuation');
+
+  if (context.getRemainingBudgetMs() <= 0) {
+    emitCapStatus(context, 0, true);
+
+    return;
+  }
+
+  const [error, started] = await safe(
+    context.getClient().startActivity({
+      avatarID: plan.activity.avatarID,
+      scopeID: plan.activity.scopeID,
+      scopeType: plan.activity.scopeType,
+    }),
+  );
+
+  if (error === null) {
+    await startContinuedActivity(context, started, pending.failureAction);
+
+    context.setPendingContinuation(null);
+
+    return;
+  }
+
+  if (isDefinedError(error) && error.code === 'CONFLICT') {
+    const row = error.data.activity;
+
+    if (row.appendedHead === 0 && row.id !== plan.activity.id) {
+      await startContinuedActivity(context, row, pending.failureAction);
+
+      context.setPendingContinuation(null);
+
+      return;
+    }
+  }
+
+  if (!isDefinedError(error)) {
+    emitConnectionStatus(context, false);
+
+    return;
+  }
+
+  context.setPendingContinuation(null);
+  throw error;
+}
+
+async function startContinuedActivity(
+  context: WorkerContext,
+  row: Readonly<ActivityData>,
+  failureAction: ActivityFailureAction,
+): Promise<void> {
+  const input = buildSimulationInput(row, { failureAction });
+
+  await context.getSubmitter().registerActivity({
+    activityID: row.id,
+    appendedHead: 0,
+    lastHash: row.startHash,
+    startChainIndex: row.startChainIndex,
+  });
+
+  const simulation = createSimulation();
+
+  simulation.startActivity(input.avatar, input.activity);
+
+  setLiveSimulation(context, row, simulation);
 }
 
 async function applyFastForward(context: WorkerContext, report: FastForwardReport): Promise<void> {
@@ -380,6 +471,22 @@ function emitFailureActionStatus(
   failureAction: ActivityFailureAction,
 ): void {
   const message = createFailureActionStatusMessage(failureAction);
+
+  for (const connection of context.connections) {
+    connection.postMessage(message);
+  }
+}
+
+function emitCapStatus(context: WorkerContext, remainingMs: number, halted: boolean): void {
+  const message = createOfflineCapStatusMessage(remainingMs, halted);
+
+  for (const connection of context.connections) {
+    connection.postMessage(message);
+  }
+}
+
+function emitConnectionStatus(context: WorkerContext, online: boolean): void {
+  const message = createConnectionStatusMessage(online);
 
   for (const connection of context.connections) {
     connection.postMessage(message);

--- a/libs/game/idle-client/src/worker/handle-request-resync-message.ts
+++ b/libs/game/idle-client/src/worker/handle-request-resync-message.ts
@@ -1,4 +1,4 @@
-import { isDefinedError, ORPCError, safe } from '@orpc/client';
+import { ORPCError, isDefinedError, safe } from '@orpc/client';
 import type {
   ActivityData,
   ActivityFailureAction as ContractFailureAction,
@@ -188,6 +188,10 @@ function pickLatestActivityID(result: Readonly<ResyncResult>): string | undefine
 
   if (result.plan.kind === 'none') {
     return undefined;
+  }
+
+  if (result.plan.kind === 'continue') {
+    return result.plan.activity.id;
   }
 
   return result.plan.context.activityID;

--- a/libs/game/idle-client/src/worker/handle-request-resync-message.ts
+++ b/libs/game/idle-client/src/worker/handle-request-resync-message.ts
@@ -287,9 +287,10 @@ async function applyContinue(
   context: WorkerContext,
   plan: Extract<ResyncPlan, { kind: 'continue' }>,
 ): Promise<void> {
-  const pending = context.getPendingContinuation();
-
-  invariant(pending !== null, 'a continue plan is only reached with a pending continuation');
+  invariant(
+    context.getPendingContinuation() !== null,
+    'a continue plan is only reached with a pending continuation',
+  );
 
   if (context.getRemainingBudgetMs() <= 0) {
     emitCapStatus(context, 0, true);
@@ -306,7 +307,7 @@ async function applyContinue(
   );
 
   if (error === null) {
-    await startContinuedActivity(context, started, pending.failureAction);
+    await startContinuedActivity(context, started);
 
     context.setPendingContinuation(null);
 
@@ -317,7 +318,7 @@ async function applyContinue(
     const row = error.data.activity;
 
     if (row.appendedHead === 0 && row.id !== plan.activity.id) {
-      await startContinuedActivity(context, row, pending.failureAction);
+      await startContinuedActivity(context, row);
 
       context.setPendingContinuation(null);
 
@@ -338,9 +339,8 @@ async function applyContinue(
 async function startContinuedActivity(
   context: WorkerContext,
   row: Readonly<ActivityData>,
-  failureAction: ActivityFailureAction,
 ): Promise<void> {
-  const input = buildSimulationInput(row, { failureAction });
+  const input = buildSimulationInput(row, { failureAction: context.getFailureAction() });
 
   await context.getSubmitter().registerActivity({
     activityID: row.id,

--- a/libs/game/idle-client/src/worker/handle-set-activity-message.ts
+++ b/libs/game/idle-client/src/worker/handle-set-activity-message.ts
@@ -29,6 +29,7 @@ export async function handleSetActivityMessage(
   });
 
   context.setActivity(message.activity);
+  context.setPendingContinuation(null);
   simulation.startActivity(input.avatar, input.activity);
 
   await registration;

--- a/libs/game/idle-client/src/worker/run-continuation.test.ts
+++ b/libs/game/idle-client/src/worker/run-continuation.test.ts
@@ -2,7 +2,7 @@ import { expect, mock, test } from 'bun:test';
 import { createORPCClient } from '@orpc/client';
 import { RPCLink } from '@orpc/client/fetch';
 import { createMockActivityData } from '@vers/contract-activity/test-utils';
-import { ActivityFailureAction, createSimulation } from '@vers/idle-core';
+import { createSimulation } from '@vers/idle-core';
 import { createMockActivityInput, createMockAvatarData } from '@vers/idle-core/test-utils';
 import { createTestAccessToken, resolveServiceURL } from '@vers/mock-services';
 import { mockActivityService } from '@vers/mock-services/activity';
@@ -147,7 +147,6 @@ test('it records a pending continuation on a transport failure', async () => {
   expect(context.getPendingContinuation()).toStrictEqual({
     activityID: previousActivity.id,
     avatarID: previousActivity.avatarID,
-    failureAction: ActivityFailureAction.Retry,
     scopeID: previousActivity.scopeID,
     scopeType: previousActivity.scopeType,
   });
@@ -172,7 +171,6 @@ test('it stops the simulation and records a pending continuation on a same-row C
   expect(context.getPendingContinuation()).toStrictEqual({
     activityID: activity.id,
     avatarID: activity.avatarID,
-    failureAction: ActivityFailureAction.Retry,
     scopeID: activity.scopeID,
     scopeType: activity.scopeType,
   });

--- a/libs/game/idle-client/src/worker/run-continuation.test.ts
+++ b/libs/game/idle-client/src/worker/run-continuation.test.ts
@@ -2,7 +2,7 @@ import { expect, mock, test } from 'bun:test';
 import { createORPCClient } from '@orpc/client';
 import { RPCLink } from '@orpc/client/fetch';
 import { createMockActivityData } from '@vers/contract-activity/test-utils';
-import { createSimulation } from '@vers/idle-core';
+import { ActivityFailureAction, createSimulation } from '@vers/idle-core';
 import { createMockActivityInput, createMockAvatarData } from '@vers/idle-core/test-utils';
 import { createTestAccessToken, resolveServiceURL } from '@vers/mock-services';
 import { mockActivityService } from '@vers/mock-services/activity';
@@ -130,4 +130,92 @@ test('it stops the simulation and broadcasts offline on a transport failure', as
   expect(connection.received).toStrictEqual([
     { online: false, type: WorkerMessageType.ConnectionStatus },
   ]);
+});
+
+test('it records a pending continuation on a transport failure', async () => {
+  server.use(mockActivityService.startActivity.handler(() => HttpResponse.error()));
+
+  const submitter = buildSpySubmitter();
+  const context = createStubWorkerContext({ submitter });
+  const simulation = createSimulation();
+  const previousActivity = createMockActivityData();
+
+  simulation.startActivity(createMockAvatarData(), createMockActivityInput());
+
+  await runContinuation(context, simulation, previousActivity);
+
+  expect(context.getPendingContinuation()).toStrictEqual({
+    activityID: previousActivity.id,
+    avatarID: previousActivity.avatarID,
+    failureAction: ActivityFailureAction.Retry,
+    scopeID: previousActivity.scopeID,
+    scopeType: previousActivity.scopeType,
+  });
+});
+
+test('it stops the simulation and records a pending continuation on a same-row CONFLICT', async () => {
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const ctx = await setupTest({ userID: user.id });
+  const activity = await db.activityCollection.create({ avatarID: avatar.id, status: 'active' });
+
+  const submitter = buildSpySubmitter();
+  const context = createStubWorkerContext({ client: ctx.client, submitter });
+  const simulation = createSimulation();
+
+  simulation.startActivity(createMockAvatarData(), createMockActivityInput());
+
+  await runContinuation(context, simulation, activity);
+
+  expect(simulation.activity).toBeNull();
+
+  expect(context.getPendingContinuation()).toStrictEqual({
+    activityID: activity.id,
+    avatarID: activity.avatarID,
+    failureAction: ActivityFailureAction.Retry,
+    scopeID: activity.scopeID,
+    scopeType: activity.scopeType,
+  });
+});
+
+test('it records no pending continuation when the CONFLICT names a different, already-progressed row', async () => {
+  const user = await db.userCollection.create({});
+  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const ctx = await setupTest({ userID: user.id });
+
+  await db.activityCollection.create({
+    appendedHead: 3,
+    avatarID: avatar.id,
+    status: 'active',
+  });
+
+  const submitter = buildSpySubmitter();
+  const context = createStubWorkerContext({ client: ctx.client, submitter });
+  const simulation = createSimulation();
+  const previousActivity = createMockActivityData({ avatarID: avatar.id });
+
+  simulation.startActivity(createMockAvatarData(), createMockActivityInput());
+
+  await runContinuation(context, simulation, previousActivity);
+
+  expect(context.getPendingContinuation()).toBeNull();
+});
+
+test('it records no pending continuation on a defined error other than CONFLICT', async () => {
+  server.use(
+    mockActivityService.startActivity.handler((opts) => {
+      throw opts.errors.CHAIN_QUARANTINED({ data: {} });
+    }),
+  );
+
+  const submitter = buildSpySubmitter();
+  const context = createStubWorkerContext({ submitter });
+  const simulation = createSimulation();
+  const previousActivity = createMockActivityData();
+
+  simulation.startActivity(createMockAvatarData(), createMockActivityInput());
+
+  await runContinuation(context, simulation, previousActivity);
+
+  expect(context.getPendingContinuation()).toBeNull();
 });

--- a/libs/game/idle-client/src/worker/run-continuation.ts
+++ b/libs/game/idle-client/src/worker/run-continuation.ts
@@ -1,6 +1,6 @@
 import { isDefinedError, safe } from '@orpc/client';
 import type { ActivityData } from '@vers/contract-activity';
-import type { ActivityFailureAction, Simulation } from '@vers/idle-core';
+import type { Simulation } from '@vers/idle-core';
 import { buildSimulationInput } from '@vers/idle-core';
 import { createConnectionStatusMessage } from './create-connection-status-message';
 import { createRequestResyncMessage } from './create-request-resync-message';
@@ -55,7 +55,7 @@ export async function runContinuation(
     }
 
     if (row.id === activity.id) {
-      setPendingContinuation(context, activity, simulation.failureAction);
+      setPendingContinuation(context, activity);
     }
 
     await simulation.stopActivity();
@@ -72,7 +72,7 @@ export async function runContinuation(
   context.setSimulation(null);
 
   if (!isDefinedError(error)) {
-    setPendingContinuation(context, activity, simulation.failureAction);
+    setPendingContinuation(context, activity);
     emitConnectionStatus(context, false);
   }
 }
@@ -95,15 +95,10 @@ async function startContinuationFrom(
   });
 }
 
-function setPendingContinuation(
-  context: WorkerContext,
-  activity: Readonly<ActivityData>,
-  failureAction: ActivityFailureAction,
-): void {
+function setPendingContinuation(context: WorkerContext, activity: Readonly<ActivityData>): void {
   context.setPendingContinuation({
     activityID: activity.id,
     avatarID: activity.avatarID,
-    failureAction,
     scopeID: activity.scopeID,
     scopeType: activity.scopeType,
   });

--- a/libs/game/idle-client/src/worker/run-continuation.ts
+++ b/libs/game/idle-client/src/worker/run-continuation.ts
@@ -1,6 +1,6 @@
 import { isDefinedError, safe } from '@orpc/client';
 import type { ActivityData } from '@vers/contract-activity';
-import type { Simulation } from '@vers/idle-core';
+import type { ActivityFailureAction, Simulation } from '@vers/idle-core';
 import { buildSimulationInput } from '@vers/idle-core';
 import { createConnectionStatusMessage } from './create-connection-status-message';
 import { createRequestResyncMessage } from './create-request-resync-message';
@@ -17,10 +17,13 @@ import type { WorkerContext } from './types';
  * live for the avatar: a different, never-appended row is adopted directly from its start fields,
  * while a progressed row — or this same row, its terminal append still unacknowledged — is handed
  * to a full resync, which reconstructs its confirmed checkpoints before attaching; adopting either
- * from a zero cursor would fork the checkpoint chain. A transport failure stops and uninstalls the
- * simulation and reports the worker offline rather than retrying inline — the next reconnect
- * resync rebuilds from the server's confirmed state. Any other rejection also stops and uninstalls
- * the simulation, but without the offline signal: the service answered, so the failure is the
+ * from a zero cursor would fork the checkpoint chain. The same-row case also records a pending
+ * continuation, so a resync that finds the row still closed once the terminal append drains plans
+ * to start the next row itself rather than idling. A transport failure stops and uninstalls the
+ * simulation, records the same pending continuation, and reports the worker offline rather than
+ * retrying inline — the next reconnect resync rebuilds from the server's confirmed state and
+ * honors the pending intent. Any other rejection also stops and uninstalls the simulation, but
+ * without the offline signal or a pending record: the service answered, so the failure is the
  * activity's, not the connection's.
  */
 export async function runContinuation(
@@ -51,6 +54,10 @@ export async function runContinuation(
       return;
     }
 
+    if (row.id === activity.id) {
+      setPendingContinuation(context, activity, simulation.failureAction);
+    }
+
     await simulation.stopActivity();
 
     context.setSimulation(null);
@@ -65,6 +72,7 @@ export async function runContinuation(
   context.setSimulation(null);
 
   if (!isDefinedError(error)) {
+    setPendingContinuation(context, activity, simulation.failureAction);
     emitConnectionStatus(context, false);
   }
 }
@@ -84,6 +92,20 @@ async function startContinuationFrom(
     appendedHead: 0,
     lastHash: row.startHash,
     startChainIndex: row.startChainIndex,
+  });
+}
+
+function setPendingContinuation(
+  context: WorkerContext,
+  activity: Readonly<ActivityData>,
+  failureAction: ActivityFailureAction,
+): void {
+  context.setPendingContinuation({
+    activityID: activity.id,
+    avatarID: activity.avatarID,
+    failureAction,
+    scopeID: activity.scopeID,
+    scopeType: activity.scopeType,
   });
 }
 

--- a/libs/game/idle-client/src/worker/types.ts
+++ b/libs/game/idle-client/src/worker/types.ts
@@ -5,6 +5,22 @@ import type { ActivityServiceClient } from '../submission/types';
 import type { RewardSlotLedgerEntry, RewardSlotLedgerSnapshot } from '../types';
 
 /**
+ * A continuation `runContinuation` wanted to start but couldn't complete — a same-row `CONFLICT`
+ * (the terminal append that closes the row is still unacknowledged) or a transport failure on its
+ * own `startActivity` call. `activityID` names the row the pending intent was raised against, so a
+ * resync plans `continue` only once that exact row reads closed, never a different one;
+ * `failureAction` carries the dying simulation's setting forward, since it lives nowhere durable
+ * once the simulation is gone.
+ */
+export interface PendingContinuation {
+  readonly activityID: string;
+  readonly avatarID: string;
+  readonly failureAction: ActivityFailureAction;
+  readonly scopeID: string;
+  readonly scopeType: string;
+}
+
+/**
  * Accessors over the runtime's closure state, threaded to every message and simulation event
  * handler. `connections` is exposed read-only — `removeConnection` is the one mutation a handler
  * needs. `getSubmitter` and `getClient` always return the same instance: both exist for the
@@ -28,6 +44,12 @@ export interface WorkerContext {
    * the worker's lifetime — a live simulation mirrors it, it never reads back from one.
    */
   readonly getFailureAction: () => ActivityFailureAction;
+
+  /**
+   * The continuation intent a resync should honor once its target row reads closed — `null` when
+   * no continuation is outstanding.
+   */
+  readonly getPendingContinuation: () => PendingContinuation | null;
 
   /**
    * The worker's conservative view of the avatar's offline-progress budget: the cap minus the
@@ -80,6 +102,7 @@ export interface WorkerContext {
   readonly setFailureAction: (action: ActivityFailureAction) => void;
   readonly setFailureActionDirty: (dirty: boolean) => void;
   readonly setFailureActionPushInFlight: (inFlight: boolean) => void;
+  readonly setPendingContinuation: (pending: PendingContinuation | null) => void;
   readonly setResyncAvatarID: (avatarID: string) => void;
   readonly setResyncInFlight: (inFlight: boolean) => void;
   readonly setSimulation: (simulation: null | Simulation) => void;

--- a/libs/game/idle-client/src/worker/types.ts
+++ b/libs/game/idle-client/src/worker/types.ts
@@ -8,14 +8,13 @@ import type { RewardSlotLedgerEntry, RewardSlotLedgerSnapshot } from '../types';
  * A continuation `runContinuation` wanted to start but couldn't complete — a same-row `CONFLICT`
  * (the terminal append that closes the row is still unacknowledged) or a transport failure on its
  * own `startActivity` call. `activityID` names the row the pending intent was raised against, so a
- * resync plans `continue` only once that exact row reads closed, never a different one;
- * `failureAction` carries the dying simulation's setting forward, since it lives nowhere durable
- * once the simulation is gone.
+ * resync plans `continue` only once that exact row reads closed, never a different one. The row
+ * it eventually starts takes the worker's current failure action, not a snapshot from raise time,
+ * so a preference changed while the intent waited still applies.
  */
 export interface PendingContinuation {
   readonly activityID: string;
   readonly avatarID: string;
-  readonly failureAction: ActivityFailureAction;
   readonly scopeID: string;
   readonly scopeType: string;
 }


### PR DESCRIPTION
## Description

Closes #582

A continuation that couldn't start after a terminal checkpoint (a same-row race, or a transport
failure on the follow-up `startActivity`) now leaves a pending record instead of dead-ending the
avatar; the next resync consults it and starts the row once it reads closed.

- `WorkerContext` gains a `PendingContinuation` record; `runContinuation` sets it on a same-row
  `CONFLICT` or a transport failure, and clears it when the player picks a new activity.
- A new `continue` `ResyncPlan` kind targets a non-active row matching the pending continuation
  (a stale pending naming a different row is ignored, and a cap still wins); reconnect now also
  resyncs when a pending continuation exists, not only a remembered `resyncAvatarID`.
- The resync handler applies `continue`: budget gate mirrors halt-at-boundary, adopts a fresh
  `CONFLICT` row like `runContinuation` itself, and clears/reports through the existing
  resync-failure and offline paths on other outcomes.
- Doc note in `docs/architecture/game-simulation.md`'s offline-progress section.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
