### PR TITLE
feat(#660): scope the ci drift job to a dedicated vers-ci vault

### DIFF
--- a/.github/workflows/infra-drift.yml
+++ b/.github/workflows/infra-drift.yml
@@ -53,15 +53,15 @@ jobs:
           version: 2.34.1
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          CLOUDFLARE_API_TOKEN: op://vers/vers-infra/cloudflare-api-token
-          CLOUDFLARE_ACCOUNT_ID: op://vers/vers-infra/cloudflare-account-id
-          AWS_ACCESS_KEY_ID: op://vers/vers-infra/aws-access-key-id
-          AWS_SECRET_ACCESS_KEY: op://vers/vers-infra/aws-secret-access-key
-          AWS_REGION: op://vers/vers-infra/aws-region
-          R2_STATE_BUCKET: op://vers/vers-infra/r2-state-bucket
-          PULUMI_CONFIG_PASSPHRASE: op://vers/vers-infra/pulumi-passphrase
-          AXIOM_TOKEN: op://vers/axiom/iac-token
-          DISCORD_ALARMS_WEBHOOK: op://vers/discord-alarms-webhook/credential
+          CLOUDFLARE_API_TOKEN: op://vers-ci/vers-infra/cloudflare-api-token
+          CLOUDFLARE_ACCOUNT_ID: op://vers-ci/vers-infra/cloudflare-account-id
+          AWS_ACCESS_KEY_ID: op://vers-ci/vers-infra/aws-access-key-id
+          AWS_SECRET_ACCESS_KEY: op://vers-ci/vers-infra/aws-secret-access-key
+          AWS_REGION: op://vers-ci/vers-infra/aws-region
+          R2_STATE_BUCKET: op://vers-ci/vers-infra/r2-state-bucket
+          PULUMI_CONFIG_PASSPHRASE: op://vers-ci/vers-infra/pulumi-passphrase
+          AXIOM_TOKEN: op://vers-ci/axiom/iac-token
+          DISCORD_ALARMS_WEBHOOK: op://vers-ci/discord-alarms-webhook/credential
 
       - name: Preview
         uses: pulumi/actions@8e5e406f4007fca908480587cb9893c07090f58d # v7.0.0

--- a/docs/architecture/deployment.md
+++ b/docs/architecture/deployment.md
@@ -156,11 +156,11 @@ job authenticates through the `OP_SERVICE_ACCOUNT_TOKEN` repo secret, a non-expi
 service account scoped to read only the `vers-ci` vault, and resolves the stack's credentials from
 their `op://` references at run time. `vers-ci` holds exactly the items the job reads — the
 `vers-infra` credentials, the Axiom `iac-token`, and the Discord alarms webhook — so a compromised
-job step cannot reach the signing keys, database URLs, and other credentials in the `vers` vault. A
-credential CI needs lives in `vers-ci` and nowhere else; a credential CI does not need stays in
-`vers`. Fork pull requests are skipped: GitHub withholds secrets from them, so the preview cannot
-authenticate. The job only ever previews — reconciling a reported drift is a human decision, applied
-with `pulumi up` from a checkout.
+job step cannot reach the signing keys, database URLs, and other credentials in the `vers` vault.
+When the job gains a new credential, its item moves into `vers-ci` — never a copy, which rots on
+rotation — and everything the job does not read stays in `vers`. Fork pull requests are skipped:
+GitHub withholds secrets from them, so the preview cannot authenticate. The job only ever previews —
+reconciling a reported drift is a human decision, applied with `pulumi up` from a checkout.
 
 ## Sim-version registry
 

--- a/docs/architecture/deployment.md
+++ b/docs/architecture/deployment.md
@@ -153,10 +153,14 @@ its `fly.toml` `[build]` image, deployed with no build leg at all.
 touching `infra/` or the workflow file itself (a pull request gets the preview as a PR comment), and
 on a weekly schedule — console drift arrives with no commit, so only the schedule can catch it. The
 job authenticates through the `OP_SERVICE_ACCOUNT_TOKEN` repo secret, a non-expiring 1Password
-service account scoped to read the `vers` vault, and resolves the stack's credentials from their
-`op://` references at run time. Fork pull requests are skipped: GitHub withholds secrets from them,
-so the preview cannot authenticate. The job only ever previews — reconciling a reported drift is a
-human decision, applied with `pulumi up` from a checkout.
+service account scoped to read only the `vers-ci` vault, and resolves the stack's credentials from
+their `op://` references at run time. `vers-ci` holds exactly the items the job reads — the
+`vers-infra` credentials, the Axiom `iac-token`, and the Discord alarms webhook — so a compromised
+job step cannot reach the signing keys, database URLs, and other credentials in the `vers` vault. A
+credential CI needs lives in `vers-ci` and nowhere else; a credential CI does not need stays in
+`vers`. Fork pull requests are skipped: GitHub withholds secrets from them, so the preview cannot
+authenticate. The job only ever previews — reconciling a reported drift is a human decision, applied
+with `pulumi up` from a checkout.
 
 ## Sim-version registry
 

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -1,0 +1,19 @@
+# every value is an op:// reference resolved by `op run --env-file=.env` — copy to .env verbatim,
+# nothing here is a secret; the referenced items live in the vers-ci vault
+
+# cloudflare zone access and the R2 bucket holding pulumi state
+CLOUDFLARE_API_TOKEN=op://vers-ci/vers-infra/cloudflare-api-token
+CLOUDFLARE_ACCOUNT_ID=op://vers-ci/vers-infra/cloudflare-account-id
+AWS_ACCESS_KEY_ID=op://vers-ci/vers-infra/aws-access-key-id
+AWS_SECRET_ACCESS_KEY=op://vers-ci/vers-infra/aws-secret-access-key
+AWS_REGION=op://vers-ci/vers-infra/aws-region
+R2_STATE_BUCKET=op://vers-ci/vers-infra/r2-state-bucket
+
+# encrypts pulumi stack secrets at rest
+PULUMI_CONFIG_PASSPHRASE=op://vers-ci/vers-infra/pulumi-passphrase
+
+# axiom monitors/notifiers management token
+AXIOM_TOKEN=op://vers-ci/axiom/iac-token
+
+# discord webhook the axiom alarms notifier posts to
+DISCORD_ALARMS_WEBHOOK=op://vers-ci/discord-alarms-webhook/credential

--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,3 +1,4 @@
 .env
 .env.*
+!.env.example
 node_modules/

--- a/infra/README.md
+++ b/infra/README.md
@@ -20,7 +20,7 @@ disk.
 - `versidle.com` added to Cloudflare, with the registrar's nameservers pointed at the pair
   Cloudflare assigns. DNS records attach to a zone, so this comes first.
 - An R2 bucket named `vers-pulumi-state` for Pulumi state.
-- An Axiom API token (the `iac-token` field on the vault's `axiom` item) with org-level
+- An Axiom API token (the `iac-token` field on the `vers-ci` vault's `axiom` item) with org-level
   monitors/notifiers/dashboards create/read/update/delete and query permission on the `vers-*`
   datasets — Axiom rejects monitor writes unless the token can query every dataset the monitor's APL
   references.


### PR DESCRIPTION
## Description

Closes #660

Retargets the infra-drift job's credentials to a dedicated `vers-ci` 1Password vault, so the CI service account can read only what the drift preview uses — not the signing keys, roll-key roots, and database URLs that live in `vers`.

- `op://` references in the drift workflow now point at `vers-ci`; the `vers-infra` item, the Axiom `iac-token`, and the Discord alarms webhook were moved there (moved, not copied — a duplicate rots on rotation).
- Adds the missing committed `infra/.env.example` and the `!.env.example` gitignore exception that was hiding it.
- The deployment doc's drift section names the vault boundary and why it exists.
- The `OP_SERVICE_ACCOUNT_TOKEN` repo secret now carries a token scoped to `vers-ci` read-only; the vault moves and re-mint were done alongside this PR.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality — n/a, credential and doc changes only