### PR TITLE
refactor(#657): adopt sync disposal for the idle worker runtime in tests

### DIFF
--- a/libs/game/idle-client/src/worker/create-worker-runtime.test.ts
+++ b/libs/game/idle-client/src/worker/create-worker-runtime.test.ts
@@ -32,11 +32,7 @@ function createConnection(runtime: WorkerRuntime): TestConnection {
 }
 
 test('it replies with the initial state to an initialize message', async () => {
-  const runtime = createWorkerRuntime();
-
-  onTestFinished(() => {
-    runtime.stop();
-  });
+  using runtime = createWorkerRuntime();
 
   const connection = createConnection(runtime);
 
@@ -54,11 +50,7 @@ test('it seeds the boot state from the device-local failure-action cache before 
     failureAction: ActivityFailureAction.Retry,
   });
 
-  const runtime = createWorkerRuntime();
-
-  onTestFinished(() => {
-    runtime.stop();
-  });
+  using runtime = createWorkerRuntime();
 
   const connection = createConnection(runtime);
 
@@ -97,11 +89,7 @@ test('it retains the cached dirty flag across boot so the next resync flushes it
     }),
   );
 
-  const runtime = createWorkerRuntime({ client });
-
-  onTestFinished(() => {
-    runtime.stop();
-  });
+  using runtime = createWorkerRuntime({ client });
 
   const connection = createConnection(runtime);
 
@@ -117,11 +105,7 @@ test('it retains the cached dirty flag across boot so the next resync flushes it
 test('it broadcasts a simulation update once an activity is set', async () => {
   server.use(mockActivityService.trackActivityProgress.handler(() => ({ appendedHead: 0 })));
 
-  const runtime = createWorkerRuntime();
-
-  onTestFinished(() => {
-    runtime.stop();
-  });
+  using runtime = createWorkerRuntime();
 
   const connection = createConnection(runtime);
 
@@ -142,11 +126,7 @@ test('it broadcasts a simulation update once an activity is set', async () => {
 test('it stops broadcasting to a connection after it disconnects', async () => {
   server.use(mockActivityService.trackActivityProgress.handler(() => ({ appendedHead: 0 })));
 
-  const runtime = createWorkerRuntime();
-
-  onTestFinished(() => {
-    runtime.stop();
-  });
+  using runtime = createWorkerRuntime();
 
   const survivor = createConnection(runtime);
   const leaving = createConnection(runtime);
@@ -190,11 +170,7 @@ test('it reports a fault to the error backend when a message makes its handler t
     disableDefaultIntegrations: true,
   });
 
-  const runtime = createWorkerRuntime();
-
-  onTestFinished(() => {
-    runtime.stop();
-  });
+  using runtime = createWorkerRuntime();
 
   const connection = createConnection(runtime);
 
@@ -247,11 +223,8 @@ test('it resumes into a fresh row once a same-row CONFLICT resync drains a held 
   );
 
   const clock = createFastClock();
-  const runtime = createWorkerRuntime({ client, now: clock.now });
 
-  onTestFinished(() => {
-    runtime.stop();
-  });
+  using runtime = createWorkerRuntime({ client, now: clock.now });
 
   const connection = createConnection(runtime);
 
@@ -314,11 +287,8 @@ test('it resumes into a fresh row once a reconnect drains a held terminal append
   );
 
   const clock = createFastClock();
-  const runtime = createWorkerRuntime({ client, now: clock.now });
 
-  onTestFinished(() => {
-    runtime.stop();
-  });
+  using runtime = createWorkerRuntime({ client, now: clock.now });
 
   const connection = createConnection(runtime);
 
@@ -391,11 +361,8 @@ test("it resumes the pending continuation's avatar on reconnect over an earlier 
   );
 
   const clock = createFastClock();
-  const runtime = createWorkerRuntime({ client, now: clock.now });
 
-  onTestFinished(() => {
-    runtime.stop();
-  });
+  using runtime = createWorkerRuntime({ client, now: clock.now });
 
   const connection = createConnection(runtime);
 

--- a/libs/game/idle-client/src/worker/create-worker-runtime.ts
+++ b/libs/game/idle-client/src/worker/create-worker-runtime.ts
@@ -26,8 +26,9 @@ export interface WorkerRuntime {
 
   /**
    * Delegates to `stop`, so a test can acquire the runtime with `using` and have teardown run on
-   * scope exit; declared as a readonly member rather than `extends Disposable` to keep the type
-   * readonly-parameter-safe.
+   * scope exit. Declared as a readonly function-valued member rather than `extends Disposable`:
+   * the built-in interface declares a mutable method, which would make every parameter typed with
+   * this interface fail the readonly-parameter lint requirement.
    */
   readonly [Symbol.dispose]: () => void;
 }

--- a/libs/game/idle-client/src/worker/create-worker-runtime.ts
+++ b/libs/game/idle-client/src/worker/create-worker-runtime.ts
@@ -23,6 +23,13 @@ export interface WorkerRuntime {
   readonly connections: ReadonlySet<MessagePort>;
   readonly handleConnect: (event: MessageEvent) => void;
   readonly stop: () => void;
+
+  /**
+   * Delegates to `stop`, so a test can acquire the runtime with `using` and have teardown run on
+   * scope exit; declared as a readonly member rather than `extends Disposable` to keep the type
+   * readonly-parameter-safe.
+   */
+  readonly [Symbol.dispose]: () => void;
 }
 
 interface CreateWorkerRuntimeOptions {
@@ -289,7 +296,7 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
     self.removeEventListener('offline', handleOffline);
   };
 
-  return { connections, handleConnect, stop };
+  return { [Symbol.dispose]: stop, connections, handleConnect, stop };
 }
 
 function wait(ms: number) {


### PR DESCRIPTION
## Description

Closes #657

Makes `WorkerRuntime` disposable, with `[Symbol.dispose]` delegating to `stop`, and switches every test call site to `using runtime = createWorkerRuntime(...)`, dropping the repeated `onTestFinished(() => runtime.stop())` teardown.

- `[Symbol.dispose]` is declared as a readonly member instead of `extends Disposable` — the built-in's method signature is mutable and trips `prefer-readonly-parameter-types` on every parameter typed `WorkerRuntime`; the shape is still structurally `Disposable`, which is all `using` needs.
- `stop` stays the named production operation and is already safe to call after dispose.
- Zero production behavior change; the worker entrypoint never stops its runtime.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality — no new behavior; the converted suite exercises dispose on every scope exit

## Context

Merge-order note: #664 touches other lines of the same test file; whichever lands second gets a trivial rebase.