### PR TITLE
feat(#645): manage the full axiom resource set in the pulumi workspace

### DIFF
--- a/docs/architecture/deployment.md
+++ b/docs/architecture/deployment.md
@@ -396,26 +396,21 @@ In the Umami UI, create the `vers` website and set its ID as the `VITE_UMAMI_WEB
 Actions variable, then assemble the acquisition funnel report over the tracked events
 ([analytics](./analytics.md)).
 
-Stand up the telemetry backend. The Axiom account is created in its UI; its standing tokens live on
-the `axiom` item in the `vers` 1Password vault: `ingest-token` (ingest on all datasets — the fleet's
-export credential), `mcp-token` (query, for read-only investigation), and `admin-token` (an advanced
-API token with create/read/update — never delete — on datasets, monitors, notifiers, and dashboards,
-for agent-driven administration). Destructive administration (deleting any of those) uses a
-short-lived token minted in the UI with the needed scopes and revoked when the work is done. Create
-one dataset per signal and point the fleet at them — the metrics dataset needs the `otel:metrics:v1`
-kind, since an events dataset rejects OTLP metrics ingest:
+Stand up the telemetry backend. The Axiom account is created in its UI, along with one
+console-minted credential that bootstraps the rest: the `iac-token` field on the `vers-ci` vault's
+`axiom` item, the Pulumi provider's API token, with the scopes listed in `infra/README.md`. Every
+other Axiom resource — the `vers-traces`/`vers-logs`/`vers-metrics` datasets, the `vers-production`
+ingest and `vers-mcp` query tokens, the alarms notifier, the threshold monitors, and the dashboards
+— is provisioned by the `infra/` Pulumi program (`bun run up` in `infra/`); the resource registry
+and drift stance live in [observability](./observability.md). Token secret values sit on the `axiom`
+item in the `vers` 1Password vault (`ingest-token`, `mcp-token`); a scope change in the program
+regenerates a token's value, and the vault field plus the Fly secrets below must be updated within
+the 48-hour rotation grace window. Destructive administration outside the program uses a short-lived
+token minted in the UI with the needed scopes and revoked when the work is done.
+
+Point the fleet at the datasets:
 
 ```sh
-ADMIN="$(op read 'op://vers/axiom/admin-token')"
-for ds in vers-traces vers-logs; do
-  curl -sS --fail -X POST https://api.axiom.co/v1/datasets \
-    -H "Authorization: Bearer $ADMIN" -H "Content-Type: application/json" \
-    -d "{\"name\":\"$ds\"}"
-done
-curl -sS --fail -X POST https://api.axiom.co/v2/datasets \
-  -H "Authorization: Bearer $ADMIN" -H "Content-Type: application/json" \
-  -d '{"name":"vers-metrics","kind":"otel:metrics:v1"}'
-
 INGEST="$(op read 'op://vers/axiom/ingest-token')"
 for app in vers-app-web vers-service-activity vers-service-avatar vers-service-email vers-service-keys vers-service-replay vers-service-session vers-service-user vers-service-verification; do
   fly secrets set -a "$app" --stage \
@@ -426,11 +421,7 @@ for app in vers-app-web vers-service-activity vers-service-avatar vers-service-e
 done
 ```
 
-The `vers services — baseline` dashboard (request rate, 5xx responses, and p95 latency per service,
-plus an error-log stream) and the `vers 5xx responses` and `vers verification lag`
-(`vers.verification.lag` over its threshold — `docs/architecture/observability.md`) threshold
-monitors are created through the same API; the monitors notify the `vers alarms` notifier. Agent
-access goes through the hosted MCP server (`https://mcp.axiom.co/mcp`, OAuth) declared in
+Agent access goes through the hosted MCP server (`https://mcp.axiom.co/mcp`, OAuth) declared in
 `.mcp.json`.
 
 The next push to `main` fills the machines.

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -69,7 +69,8 @@ Alerting is Axiom threshold monitors over these datasets, notifying the `vers al
 full Axiom resource set — the datasets and their retention, the ingest and query API tokens' scopes,
 the monitors, the notifier, and the dashboards — is managed as code in the `infra/` Pulumi program
 (`axiom.ts`); a console edit to any of them is drift, reconciled by the next `pulumi up`. Token
-secret values stay in 1Password, never in code or state.
+secret values stay in 1Password and out of code; the sensitive outputs Pulumi records in stack state
+are encrypted by the stack passphrase.
 
 ## Instrument registry
 

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -66,8 +66,10 @@ lands with the metrics that make it observable. The conventions:
 - Every instrument lands with its row in the registry below, in the same PR.
 
 Alerting is Axiom threshold monitors over these datasets, notifying the `vers alarms` notifier. The
-monitors and the notifier are managed as code in the `infra/` Pulumi program (`axiom.ts`) — a
-console edit to either is drift, reconciled by the next `pulumi up`.
+full Axiom resource set — the datasets and their retention, the ingest and query API tokens' scopes,
+the monitors, the notifier, and the dashboards — is managed as code in the `infra/` Pulumi program
+(`axiom.ts`); a console edit to any of them is drift, reconciled by the next `pulumi up`. Token
+secret values stay in 1Password, never in code or state.
 
 ## Instrument registry
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,13 +1,18 @@
 # infra
 
-Cloudflare DNS for `versidle.com` and Axiom alerting (monitors, notifiers), with Pulumi state held
-in Cloudflare R2. Credentials resolve from 1Password at run time, so nothing sensitive lives on
-disk.
+Cloudflare DNS for `versidle.com` and the Axiom observability backend (datasets, API tokens,
+monitors, notifiers, dashboards), with Pulumi state held in Cloudflare R2. Credentials resolve from
+1Password at run time, so nothing sensitive lives on disk.
 
 - `index.ts` — apex and `www` records pointing `versidle.com` at the Fly web app, DNS-only so Fly
   serves TLS.
-- `axiom.ts` — the Axiom threshold monitors and the Discord alarms notifier; the monitor registry in
-  `docs/architecture/observability.md` describes what each one watches.
+- `axiom.ts` — the Axiom resource set: the `vers-*` datasets, the ingest and query API tokens, the
+  threshold monitors, the Discord alarms notifier, and the dashboards; the registries in
+  `docs/architecture/observability.md` describe what the monitors and instruments watch. Token
+  secret values live only in 1Password — any change to a token's arguments regenerates its secret,
+  so a scope edit means updating the vault item and dependent Fly secrets within the 48-hour
+  rotation grace window. The provider's own credential is console-managed: a token cannot rotate
+  itself without invalidating the session doing the rotating.
 - `sdks/axiom/` — committed TypeScript SDK generated from the bridged Terraform provider
   (`pulumi package add terraform-provider axiomhq/axiom 1.6.2` regenerates it; the version is pinned
   in `Pulumi.yaml`).
@@ -21,9 +26,9 @@ disk.
   Cloudflare assigns. DNS records attach to a zone, so this comes first.
 - An R2 bucket named `vers-pulumi-state` for Pulumi state.
 - An Axiom API token (the `iac-token` field on the `vers-ci` vault's `axiom` item) with org-level
-  monitors/notifiers/dashboards create/read/update/delete and query permission on the `vers-*`
-  datasets — Axiom rejects monitor writes unless the token can query every dataset the monitor's APL
-  references.
+  create/read/update/delete on monitors, notifiers, dashboards, datasets, and API tokens, plus query
+  permission on all datasets — Axiom rejects monitor writes unless the token can query every dataset
+  the monitor's APL references.
 
 ## One-time setup
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -9,10 +9,11 @@ monitors, notifiers, dashboards), with Pulumi state held in Cloudflare R2. Crede
 - `axiom.ts` — the Axiom resource set: the `vers-*` datasets, the ingest and query API tokens, the
   threshold monitors, the Discord alarms notifier, and the dashboards; the registries in
   `docs/architecture/observability.md` describe what the monitors and instruments watch. Token
-  secret values live only in 1Password — any change to a token's arguments regenerates its secret,
-  so a scope edit means updating the vault item and dependent Fly secrets within the 48-hour
-  rotation grace window. The provider's own credential is console-managed: a token cannot rotate
-  itself without invalidating the session doing the rotating.
+  secret values live in 1Password, out of code (stack state holds sensitive outputs encrypted) — any
+  change to a token's arguments regenerates its secret, so a scope edit means updating the vault
+  item and dependent Fly secrets within the 48-hour rotation grace window. The provider's own
+  credential is console-managed: a token cannot rotate itself without invalidating the session doing
+  the rotating.
 - `sdks/axiom/` — committed TypeScript SDK generated from the bridged Terraform provider
   (`pulumi package add terraform-provider axiomhq/axiom 1.6.2` regenerates it; the version is pinned
   in `Pulumi.yaml`).

--- a/infra/axiom.ts
+++ b/infra/axiom.ts
@@ -1,19 +1,21 @@
 import * as axiom from '@pulumi/axiom';
 import * as pulumi from '@pulumi/pulumi';
 
-// The provider authenticates with the Axiom admin token; like the Cloudflare
-// credentials, it enters through the environment resolved by `op run`.
+/**
+ * The provider authenticates with the Axiom admin token; like the Cloudflare
+ * credentials, it enters through the environment resolved by `op run`.
+ */
 const axiomProvider = new axiom.Provider('axiom', {
   apiToken: requireEnv('AXIOM_TOKEN'),
 });
 
-// Retention is the org default (no per-dataset override), expressed as
-// useRetentionPeriod: false with a zero day count. The datasets are protected:
-// deleting one destroys its stored telemetry, so removal demands an explicit
-// unprotect first.
-//
-// kind is immutable — changing it forces a replacement, which destroys the
-// stored events.
+/**
+ * Retention on every dataset is the org default (no per-dataset override),
+ * expressed as useRetentionPeriod: false with a zero day count.
+ * kind is immutable — changing it forces a replacement that destroys the
+ * stored events — and each dataset is protected, since deleting one destroys
+ * its stored telemetry.
+ */
 const tracesDataset = new axiom.Dataset(
   'vers-traces',
   {
@@ -43,8 +45,10 @@ const logsDataset = new axiom.Dataset(
   { provider: axiomProvider, protect: true },
 );
 
-// An events dataset rejects OTLP metrics ingest, so the metrics kind is the
-// one kind declaration that is functionally required.
+/**
+ * An events dataset rejects OTLP metrics ingest, so the metrics kind is the
+ * one kind declaration that is functionally required.
+ */
 const metricsDataset = new axiom.Dataset(
   'vers-metrics',
   {
@@ -57,12 +61,14 @@ const metricsDataset = new axiom.Dataset(
   { provider: axiomProvider, protect: true },
 );
 
-// API tokens declare their scopes here; the secret values stay in the vers
-// 1Password vault and never enter code, config, or stack outputs. Any change
-// to a token's arguments regenerates its secret (the old value stays valid for
-// the rotation grace period, 48h by default) — a scope edit is a deliberate
-// rotation, and the vault item plus the Fly secrets that carry the value must
-// be updated inside that window.
+/**
+ * API tokens declare their scopes here; the secret values stay in the vers
+ * 1Password vault, entering neither code nor stack outputs. Any change to a
+ * token's arguments regenerates its secret (the old value stays valid for the
+ * rotation grace period, 48h by default) — a scope edit is a deliberate
+ * rotation, and the vault item plus the Fly secrets that carry the value must
+ * be updated inside that window.
+ */
 const ingestToken = new axiom.Token(
   'vers-production',
   {
@@ -85,8 +91,10 @@ const mcpToken = new axiom.Token(
   { provider: axiomProvider, protect: true },
 );
 
-// Alert destination: the vers alarms Discord channel. The webhook URL grants
-// post access to the channel, so it stays a secret end to end.
+/**
+ * Alert destination: the vers alarms Discord channel. The webhook URL grants
+ * post access to the channel, so it stays a secret end to end.
+ */
 const alarmsNotifier = new axiom.Notifier(
   'vers-alarms',
   {
@@ -118,9 +126,11 @@ const serverErrorsMonitor = new axiom.Monitor(
   { provider: axiomProvider },
 );
 
-// alertOnNoData is part of the contract: the lag gauge exports from
-// service-replay's always-warm machine, so a silent dataset means the exporter
-// or its process is down — never a healthy quiet system.
+/**
+ * alertOnNoData is part of the contract: the lag gauge exports from
+ * service-replay's always-warm machine, so a silent dataset means the exporter
+ * or its process is down — never a healthy quiet system.
+ */
 const verificationLagMonitor = new axiom.Monitor(
   'vers-verification-lag',
   {
@@ -140,11 +150,13 @@ const verificationLagMonitor = new axiom.Monitor(
   { provider: axiomProvider },
 );
 
-// The dashboard document is the full source of truth: a console edit to any of
-// these fields is drift, reverted by the next `pulumi up`. The provider
-// normalizes state against the configured key set, so fields it manages or
-// defaults (uid, owner, empty overrides, server timestamps) stay out — adding
-// one would show a permanent phantom diff.
+/**
+ * The dashboard document is the full source of truth: a console edit to any of
+ * these fields is drift, reverted by the next `pulumi up`. The provider
+ * normalizes state against the configured key set, so fields it manages or
+ * defaults (uid, owner, empty overrides, server timestamps) stay out — adding
+ * one would show a permanent phantom diff.
+ */
 const baselineDashboardDocument = {
   name: 'vers services — baseline',
   description:
@@ -214,10 +226,12 @@ export const serverErrorsMonitorName = serverErrorsMonitor.name;
 export const verificationLagMonitorName = verificationLagMonitor.name;
 export const baselineDashboardUID = baselineDashboard.uid;
 
-// The provider stores the dashboard document re-marshalled by Go, which sorts
-// object keys alphabetically and HTML-escapes <, >, and & inside strings;
-// serializing the same way keeps the committed document byte-identical to
-// state, so refresh previews stay empty.
+/**
+ * The provider stores the dashboard document re-marshalled by Go, which sorts
+ * object keys alphabetically and HTML-escapes <, >, and & inside strings;
+ * serializing the same way keeps the committed document byte-identical to
+ * state, so refresh previews stay empty.
+ */
 function toSortedJSON(value: unknown): string {
   return JSON.stringify(sortKeysDeep(value))
     .replaceAll('<', String.raw`\u003c`)

--- a/infra/axiom.ts
+++ b/infra/axiom.ts
@@ -7,6 +7,84 @@ const axiomProvider = new axiom.Provider('axiom', {
   apiToken: requireEnv('AXIOM_TOKEN'),
 });
 
+// Retention is the org default (no per-dataset override), expressed as
+// useRetentionPeriod: false with a zero day count. The datasets are protected:
+// deleting one destroys its stored telemetry, so removal demands an explicit
+// unprotect first.
+//
+// kind is immutable — changing it forces a replacement, which destroys the
+// stored events.
+const tracesDataset = new axiom.Dataset(
+  'vers-traces',
+  {
+    name: 'vers-traces',
+    description: 'OTel traces from vers services and app-web',
+
+    // The dataset holds OTel traces but carries the generic events kind: it was
+    // created without a kind, and replacing it now would drop the trace
+    // history. Trace-aware querying works regardless — only OTLP metrics
+    // ingest demands a specific kind.
+    kind: 'axiom:events:v1',
+    useRetentionPeriod: false,
+    retentionDays: 0,
+  },
+  { provider: axiomProvider, protect: true },
+);
+
+const logsDataset = new axiom.Dataset(
+  'vers-logs',
+  {
+    name: 'vers-logs',
+    description: 'pino logs from vers services and app-web (OTLP)',
+    kind: 'axiom:events:v1',
+    useRetentionPeriod: false,
+    retentionDays: 0,
+  },
+  { provider: axiomProvider, protect: true },
+);
+
+// An events dataset rejects OTLP metrics ingest, so the metrics kind is the
+// one kind declaration that is functionally required.
+const metricsDataset = new axiom.Dataset(
+  'vers-metrics',
+  {
+    name: 'vers-metrics',
+    description: 'OTel metrics from vers services (OTLP)',
+    kind: 'otel:metrics:v1',
+    useRetentionPeriod: false,
+    retentionDays: 0,
+  },
+  { provider: axiomProvider, protect: true },
+);
+
+// API tokens declare their scopes here; the secret values stay in the vers
+// 1Password vault and never enter code, config, or stack outputs. Any change
+// to a token's arguments regenerates its secret (the old value stays valid for
+// the rotation grace period, 48h by default) — a scope edit is a deliberate
+// rotation, and the vault item plus the Fly secrets that carry the value must
+// be updated inside that window.
+const ingestToken = new axiom.Token(
+  'vers-production',
+  {
+    name: 'vers-production',
+    datasetCapabilities: {
+      '*': { ingests: ['create'] },
+    },
+  },
+  { provider: axiomProvider, protect: true },
+);
+
+const mcpToken = new axiom.Token(
+  'vers-mcp',
+  {
+    name: 'vers-mcp',
+    datasetCapabilities: {
+      '*': { queries: ['read'] },
+    },
+  },
+  { provider: axiomProvider, protect: true },
+);
+
 // Alert destination: the vers alarms Discord channel. The webhook URL grants
 // post access to the channel, so it stays a secret end to end.
 const alarmsNotifier = new axiom.Notifier(
@@ -62,9 +140,112 @@ const verificationLagMonitor = new axiom.Monitor(
   { provider: axiomProvider },
 );
 
+// The dashboard document is the full source of truth: a console edit to any of
+// these fields is drift, reverted by the next `pulumi up`. The provider
+// normalizes state against the configured key set, so fields it manages or
+// defaults (uid, owner, empty overrides, server timestamps) stay out — adding
+// one would show a permanent phantom diff.
+const baselineDashboardDocument = {
+  name: 'vers services — baseline',
+  description:
+    'Request rate, error rate, p95 latency per service, and error log stream. Baseline from #309.',
+  charts: [
+    {
+      id: 'request-rate',
+      name: 'Request rate by service',
+      query: {
+        apl: "['vers-traces'] | where kind == 'server' | summarize count() by ['service.name'], bin_auto(_time)",
+      },
+      type: 'TimeSeries',
+    },
+    {
+      id: 'error-rate',
+      name: '5xx responses by service',
+      query: {
+        apl: "['vers-traces'] | where kind == 'server' and ['attributes.http.response.status_code'] >= 500 | summarize count() by ['service.name'], bin_auto(_time)",
+      },
+      type: 'TimeSeries',
+    },
+    {
+      id: 'p95-latency',
+      name: 'p95 latency by service',
+      query: {
+        apl: "['vers-traces'] | where kind == 'server' | summarize percentile(duration, 95) by ['service.name'], bin_auto(_time)",
+      },
+      type: 'TimeSeries',
+    },
+    {
+      id: 'error-logs',
+      name: 'Error logs',
+      query: {
+        apl: "['vers-logs'] | where severity_number >= 17 | project _time, ['service.name'], body",
+      },
+      type: 'LogStream',
+    },
+  ],
+  layout: [
+    { h: 8, i: 'request-rate', w: 6, x: 0, y: 0 },
+    { h: 8, i: 'error-rate', w: 6, x: 6, y: 0 },
+    { h: 8, i: 'p95-latency', w: 6, x: 0, y: 8 },
+    { h: 8, i: 'error-logs', w: 6, x: 6, y: 8 },
+  ],
+  refreshTime: 60,
+  schemaVersion: 2,
+  timeWindowStart: 'qr-now-24h',
+  timeWindowEnd: 'qr-now',
+};
+
+const baselineDashboard = new axiom.Dashboard(
+  'vers-services-baseline',
+  {
+    uid: 'bc4755c1-41e7-44d5-9b94-1aa30ec423eb',
+    dashboard: toSortedJSON(baselineDashboardDocument),
+  },
+  { provider: axiomProvider },
+);
+
+export const tracesDatasetName = tracesDataset.name;
+export const logsDatasetName = logsDataset.name;
+export const metricsDatasetName = metricsDataset.name;
+export const ingestTokenName = ingestToken.name;
+export const mcpTokenName = mcpToken.name;
 export const alarmsNotifierName = alarmsNotifier.name;
 export const serverErrorsMonitorName = serverErrorsMonitor.name;
 export const verificationLagMonitorName = verificationLagMonitor.name;
+export const baselineDashboardUID = baselineDashboard.uid;
+
+// The provider stores the dashboard document re-marshalled by Go, which sorts
+// object keys alphabetically and HTML-escapes <, >, and & inside strings;
+// serializing the same way keeps the committed document byte-identical to
+// state, so refresh previews stay empty.
+function toSortedJSON(value: unknown): string {
+  return JSON.stringify(sortKeysDeep(value))
+    .replaceAll('<', String.raw`\u003c`)
+    .replaceAll('>', String.raw`\u003e`)
+    .replaceAll('&', String.raw`\u0026`);
+}
+
+function sortKeysDeep(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => sortKeysDeep(entry));
+  }
+
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .toSorted(([a], [b]) => {
+          if (a < b) {
+            return -1;
+          }
+
+          return a > b ? 1 : 0;
+        })
+        .map(([key, entry]) => [key, sortKeysDeep(entry)]),
+    );
+  }
+
+  return value;
+}
 
 function requireEnv(name: string): string {
   const value = process.env[name];

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -3,7 +3,13 @@ import * as pulumi from '@pulumi/pulumi';
 
 export {
   alarmsNotifierName,
+  baselineDashboardUID,
+  ingestTokenName,
+  logsDatasetName,
+  mcpTokenName,
+  metricsDatasetName,
   serverErrorsMonitorName,
+  tracesDatasetName,
   verificationLagMonitorName,
 } from './axiom.ts';
 

--- a/infra/tsconfig.json
+++ b/infra/tsconfig.json
@@ -1,14 +1,9 @@
 {
+  "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "strict": true,
-    "target": "es2022",
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
-    "esModuleInterop": true,
-    "allowImportingTsExtensions": true,
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "noEmit": true
+    "types": ["node"]
   },
-  "files": ["index.ts"]
+  "files": [],
+  "include": ["index.ts", "axiom.ts"],
+  "exclude": []
 }


### PR DESCRIPTION
## Description

Closes #645

Brings the remaining Axiom resources — the three `vers-*` datasets, the `vers-production` ingest and `vers-mcp` query tokens, and the baseline dashboard — under the `vers-infra` Pulumi program, so the whole observability backend is reviewable and drift-checked.

- All six resources were imported into stack state before this PR; a `--refresh --expect-no-changes` preview passes, so no token rotated and nothing was recreated.
- Datasets and tokens carry `protect: true`; `vers-traces` keeps its live `axiom:events:v1` kind because a kind change forces a data-destroying replacement.
- Token secret values stay in 1Password; the provider regenerates a token's secret on any argument change (48h grace), documented in `infra/README.md`.
- The dashboard document serializes through a sorted-key, HTML-escaping JSON encoder so code stays byte-identical to the provider's Go-normalized state.
- `infra/tsconfig.json` now extends `tsconfig.base.json` — its standalone ES2022 config broke type-aware linting of `toSorted`.
- The provider's own credential (`iac-token`) stays console-managed: a token cannot rotate itself.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality (infrastructure program — coverage is the drift-check preview)