### PR TITLE
feat(#669): prefill and auto-submit the verify-otp code from the link

### DIFF
--- a/apps/web/src/routes/-verify-otp/verify-otp-form.test.tsx
+++ b/apps/web/src/routes/-verify-otp/verify-otp-form.test.tsx
@@ -102,11 +102,13 @@ test('it pre-fills the OTP field from the code prop', async () => {
   await withRequestContext({}, async () => {
     const action = mock<FormAction>(() => Promise.resolve(undefined));
 
-    renderWithRouter(<VerifyOTPForm action={action} code="TMMPD7" target="user_1" type="2fa" />);
+    renderWithRouter(
+      <VerifyOTPForm action={action} code="TMMPD7" target="new-user@vers.test" type="onboarding" />,
+    );
 
     await screen.findByTestId('otp-input');
 
-    expect(document.querySelector('input[name="code"]')).toHaveValue('TMMPD7');
+    expect(screen.getByDisplayValue('TMMPD7')).toBeInTheDocument();
   });
 });
 
@@ -114,7 +116,9 @@ test('it auto-submits once when a valid code arrives with the emailed link', asy
   await withRequestContext({}, async () => {
     const action = mock<FormAction>(() => Promise.resolve(undefined));
 
-    renderWithRouter(<VerifyOTPForm action={action} code="TMMPD7" target="user_1" type="2fa" />);
+    renderWithRouter(
+      <VerifyOTPForm action={action} code="TMMPD7" target="new-user@vers.test" type="onboarding" />,
+    );
 
     await waitFor(() => {
       expect(action).toHaveBeenCalledOnce();
@@ -124,6 +128,22 @@ test('it auto-submits once when a valid code arrives with the emailed link', asy
 
     invariant(call !== undefined, 'expected the auto-submit to dispatch the action');
     expect(call.data.get('code')).toBe('TMMPD7');
+  });
+});
+
+test('it auto-submits a rejected code only once instead of looping', async () => {
+  await withRequestContext({}, async () => {
+    const action = mock<FormAction>(() => Promise.resolve(new Response(null, { status: 400 })));
+
+    renderWithRouter(
+      <VerifyOTPForm action={action} code="TMMPD7" target="new-user@vers.test" type="onboarding" />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Something went wrong. Please try again.')).toBeVisible();
+    });
+
+    expect(action).toHaveBeenCalledOnce();
   });
 });
 
@@ -143,11 +163,13 @@ test('it pre-fills without auto-submitting when the code is the wrong length', a
   await withRequestContext({}, async () => {
     const action = mock<FormAction>(() => Promise.resolve(undefined));
 
-    renderWithRouter(<VerifyOTPForm action={action} code="ABC" target="user_1" type="2fa" />);
+    renderWithRouter(
+      <VerifyOTPForm action={action} code="ABC" target="new-user@vers.test" type="onboarding" />,
+    );
 
     await screen.findByTestId('otp-input');
 
-    expect(document.querySelector('input[name="code"]')).toHaveValue('ABC');
+    expect(screen.getByDisplayValue('ABC')).toBeInTheDocument();
     expect(action).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/routes/-verify-otp/verify-otp-form.test.tsx
+++ b/apps/web/src/routes/-verify-otp/verify-otp-form.test.tsx
@@ -1,6 +1,8 @@
 import { expect, mock, test } from 'bun:test';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import invariant from 'tiny-invariant';
+import type { FormAction } from '../../lib/forms/types';
 import { buildDeferred } from '../../test-utils/build-deferred';
 import { renderWithRouter } from '../../test-utils/render-with-router';
 import { withRequestContext } from '../../test-utils/with-request-context';
@@ -93,5 +95,59 @@ test('it disables the submit button while the verify request is pending', async 
     await deferred.release(undefined);
 
     expect(screen.getByRole('button', { name: 'Verify' })).not.toBeDisabled();
+  });
+});
+
+test('it pre-fills the OTP field from the code prop', async () => {
+  await withRequestContext({}, async () => {
+    const action = mock<FormAction>(() => Promise.resolve(undefined));
+
+    renderWithRouter(<VerifyOTPForm action={action} code="TMMPD7" target="user_1" type="2fa" />);
+
+    await screen.findByTestId('otp-input');
+
+    expect(document.querySelector('input[name="code"]')).toHaveValue('TMMPD7');
+  });
+});
+
+test('it auto-submits once when a valid code arrives with the emailed link', async () => {
+  await withRequestContext({}, async () => {
+    const action = mock<FormAction>(() => Promise.resolve(undefined));
+
+    renderWithRouter(<VerifyOTPForm action={action} code="TMMPD7" target="user_1" type="2fa" />);
+
+    await waitFor(() => {
+      expect(action).toHaveBeenCalledOnce();
+    });
+
+    const call = action.mock.calls[0]?.[0];
+
+    invariant(call !== undefined, 'expected the auto-submit to dispatch the action');
+    expect(call.data.get('code')).toBe('TMMPD7');
+  });
+});
+
+test('it does not auto-submit when the link carries no code', async () => {
+  await withRequestContext({}, async () => {
+    const action = mock<FormAction>(() => Promise.resolve(undefined));
+
+    renderWithRouter(<VerifyOTPForm action={action} target="user_1" type="2fa" />);
+
+    await screen.findByTestId('otp-input');
+
+    expect(action).not.toHaveBeenCalled();
+  });
+});
+
+test('it pre-fills without auto-submitting when the code is the wrong length', async () => {
+  await withRequestContext({}, async () => {
+    const action = mock<FormAction>(() => Promise.resolve(undefined));
+
+    renderWithRouter(<VerifyOTPForm action={action} code="ABC" target="user_1" type="2fa" />);
+
+    await screen.findByTestId('otp-input');
+
+    expect(document.querySelector('input[name="code"]')).toHaveValue('ABC');
+    expect(action).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/routes/-verify-otp/verify-otp-form.tsx
+++ b/apps/web/src/routes/-verify-otp/verify-otp-form.tsx
@@ -6,7 +6,7 @@ import { useServerFn } from '@tanstack/react-start';
 import type { VerificationType } from '@vers/contract-verification';
 import { Brand, Heading, OTPField, StatusButton, Text } from '@vers/design-system';
 import { css } from '@vers/styled-system/css';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { HoneypotInputs } from '../../lib/auth/honeypot-inputs';
 import type { FormAction } from '../../lib/forms/types';
 import { useFormSubmit } from '../../lib/forms/use-form-submit';
@@ -15,6 +15,7 @@ import { VerifyOTPFormSchema } from './verify-otp-form-schema';
 
 interface VerifyOTPFormProps {
   readonly action?: FormAction;
+  readonly code?: string | undefined;
   readonly lastResult?: SubmissionResult;
   readonly redirectTo?: string | undefined;
   readonly target: string;
@@ -63,9 +64,12 @@ export function VerifyOTPForm(props: VerifyOTPFormProps) {
   const router = useRouter();
   const verifyOTPFn = useServerFn(verifyOTP);
   const submission = useFormSubmit(props.action ?? verifyOTPFn, props.lastResult);
+  const formRef = useRef<HTMLFormElement>(null);
+  const hasAutoSubmitted = useRef(false);
 
   const [form, fields] = useForm({
     constraint: getZodConstraint(VerifyOTPFormSchema),
+    defaultValue: { code: props.code },
     id: 'verify-otp-form',
     lastResult: submission.lastResult,
     onSubmit: submission.onSubmit,
@@ -89,6 +93,20 @@ export function VerifyOTPForm(props: VerifyOTPFormProps) {
     void runAccountNavigation();
   }, [props.type, router, submission.lastResult]);
 
+  useEffect(() => {
+    // a code carried by the emailed link submits at most once — a rejected code must land on the
+    // error state and wait for the user to retype rather than resubmit itself in a loop
+    if (hasAutoSubmitted.current || props.code === undefined || props.code.length !== 6) {
+      return;
+    }
+
+    hasAutoSubmitted.current = true;
+
+    const submitButton = formRef.current?.querySelector<HTMLButtonElement>('button[type="submit"]');
+
+    formRef.current?.requestSubmit(submitButton);
+  }, [props.code]);
+
   const { key: _codeKey, ...codeProps } = getInputProps(fields.code, { type: 'text' });
   const codeErrors = [...(fields.code.errors ?? []), ...(form.errors ?? [])];
 
@@ -101,7 +119,7 @@ export function VerifyOTPForm(props: VerifyOTPFormProps) {
         <Heading level={2}>{HEADING_BY_TYPE[props.type]}</Heading>
         <Text>{INSTRUCTION_BY_TYPE[props.type]}</Text>
       </section>
-      <form {...getFormProps(form)} className={formStyles} method="post">
+      <form {...getFormProps(form)} className={formStyles} method="post" ref={formRef}>
         <HoneypotInputs />
         <OTPField
           className={otpField}

--- a/apps/web/src/routes/verify-otp.tsx
+++ b/apps/web/src/routes/verify-otp.tsx
@@ -20,5 +20,12 @@ function VerifyOTPPage() {
   const search = Route.useSearch();
   const type = VerificationTypeSchema.parse(search.type);
 
-  return <VerifyOTPForm redirectTo={search.redirect} target={search.target ?? ''} type={type} />;
+  return (
+    <VerifyOTPForm
+      code={search.code}
+      redirectTo={search.redirect}
+      target={search.target ?? ''}
+      type={type}
+    />
+  );
 }


### PR DESCRIPTION
## Description

Closes #669

Pre-fills the verify-OTP field from the code carried in the emailed link and auto-submits it once, so a user tapping the link doesn't have to retype the code.

- `verify-otp.tsx` forwards `search.code` into `VerifyOTPForm`
- `VerifyOTPForm` seeds Conform's `defaultValue` with the code prop
- a mount-time effect auto-submits via `requestSubmit()` exactly once, only when the code is exactly 6 characters, guarded by a ref so a rejected/expired code lands on the error state instead of looping
- `requestSubmit()` passes the form's own submit button explicitly, which is spec-correct and also avoids a happy-dom quirk where the no-arg call throws
- 4 new tests cover pre-fill, auto-submit dispatch, no-code, and wrong-length-code paths

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
