### PR TITLE
docs: align code comments with the comment style rules

### DIFF
--- a/apps/web-e2e/playwright.config.ts
+++ b/apps/web-e2e/playwright.config.ts
@@ -3,9 +3,10 @@ import { defineConfig, devices } from '@playwright/test';
 
 const baseURL = process.env['BASE_URL'] ?? 'http://localhost:3000';
 
-// having a million issues trying to use __dirname to establish a reliable path
-// so it's easier to do this to handle the case when this file gets parsed for
-// building our task graph
+/**
+ * Resolves the project root without relying on `__dirname`, which is unreliable when this file is
+ * parsed for the task graph rather than run from its own directory.
+ */
 const projectRoot = process.cwd().includes('web-e2e')
   ? process.cwd()
   : `${process.cwd()}/apps/web-e2e`;

--- a/apps/web/src/lib/auth/create-step-up-transaction-token.ts
+++ b/apps/web/src/lib/auth/create-step-up-transaction-token.ts
@@ -116,7 +116,7 @@ let keyPairPromise: Promise<{ privateKey: jose.CryptoKey; publicKey: jose.Crypto
 /**
  * Lazily generates this process's step-up signing keypair. Minting and verifying always happen in
  * the same edge process a token was issued from, so a fresh in-memory keypair per process is
- * enough — no durable key storage needed.
+ * enough.
  */
 function getStepUpTransactionKeyPair(): Promise<{
   privateKey: jose.CryptoKey;

--- a/apps/web/src/lib/rpc/create-edge-service-token.ts
+++ b/apps/web/src/lib/rpc/create-edge-service-token.ts
@@ -2,7 +2,9 @@ import type { ServiceName } from '@vers/service-auth';
 import { createServiceToken, parseServicePrivateKey } from '@vers/service-auth';
 import { env } from '../../server/env';
 
-// imported once at module scope, not per call: every mint reuses this same resolved key
+/**
+ * Resolved once at module scope so every mint reuses this same key rather than re-parsing per call.
+ */
 const privateKey = parseServicePrivateKey(env.SERVICE_AUTH_PRIVATE_KEY);
 
 interface CreateEdgeServiceTokenOptions {

--- a/apps/web/src/lib/rpc/service-urls.ts
+++ b/apps/web/src/lib/rpc/service-urls.ts
@@ -2,8 +2,7 @@ import type { ServiceName } from '@vers/service-auth';
 
 /**
  * Each service's origin for the SSR direct-to-service path, defaulting to the real services' dev
- * ports. Every call is currently intercepted by the mock backend regardless of which origin it
- * names.
+ * ports.
  */
 export const SERVICE_URLS: Readonly<Record<ServiceName, string>> = {
   activity: process.env['ACTIVITY_SERVICE_URL'] ?? 'http://localhost:3006',

--- a/apps/web/src/routes/-account-2fa-verify/verify-two-factor-setup-handler.ts
+++ b/apps/web/src/routes/-account-2fa-verify/verify-two-factor-setup-handler.ts
@@ -9,7 +9,7 @@ import { VerifyTwoFactorSetupFormSchema } from './verify-two-factor-setup-form-s
 /**
  * Runs the 2FA-setup verify form's submission: a code check against the pending `2fa-setup`
  * verification, then flipping that same row's type to `2fa` on success — enabling it for the
- * account without ever deleting and recreating the row.
+ * account.
  */
 export async function verifyTwoFactorSetupHandler(
   formData: FormData,

--- a/apps/web/src/routes/-account-change-email/change-email-form.tsx
+++ b/apps/web/src/routes/-account-change-email/change-email-form.tsx
@@ -31,7 +31,7 @@ export function ChangeEmailForm() {
 
     try {
       // a cleared step-up gate ends in a redirect to verify-otp that useServerFn already
-      // navigated to, resolving this call with no value — there's no further UI to show
+      // navigated to, resolving this call with no value
       const result: ChangeEmailResult | undefined = await changeEmailFn({ data: formData });
 
       if (result === undefined) {

--- a/apps/web/src/routes/-activity/activity-panel.tsx
+++ b/apps/web/src/routes/-activity/activity-panel.tsx
@@ -41,7 +41,7 @@ const characterFrame = css({
 /**
  * The activity screen: an ambient notice while the activity's appended progress is still ahead of
  * its verified head — the stretch whose rewards are not yet settled — and placeholder
- * character-frame blocks until party state is wired up. Reward items themselves — batches,
+ * character-frame blocks standing in for party state. Reward items themselves — batches,
  * per-item cards — are a different screen's concern.
  */
 export function ActivityPanel() {

--- a/apps/web/src/routes/-avatar-create/avatar-create-form.tsx
+++ b/apps/web/src/routes/-avatar-create/avatar-create-form.tsx
@@ -56,7 +56,7 @@ export function AvatarCreateForm() {
 
     try {
       // a successful create ends in a redirect that useServerFn already navigated to, resolving
-      // this call with no value — there's no further UI to show
+      // this call with no value
       const result: AvatarCreateResult | undefined = await avatarCreateFn({ data: formData });
 
       if (result === undefined) {

--- a/apps/web/src/routes/-avatar/avatar-panel.tsx
+++ b/apps/web/src/routes/-avatar/avatar-panel.tsx
@@ -11,8 +11,8 @@ interface AvatarPanelProps {
 const container = css({ display: 'flex', flexDirection: 'column', gap: '4', padding: '6' });
 
 /**
- * Registers the avatar satellite viewer for the panel's lifetime: `useSatellite` defaults to
- * `keepAlive: false`, so the viewer's canvas dies with the route on navigation away.
+ * Registers the avatar satellite viewer for the panel's lifetime. The viewer is not kept alive, so
+ * its canvas dies with the route on navigation away.
  */
 export function AvatarPanel(props: Readonly<AvatarPanelProps>) {
   useSatellite('avatar-viewer', <AvatarViewer />);

--- a/apps/web/src/routes/-forgot-password/forgot-password-form.tsx
+++ b/apps/web/src/routes/-forgot-password/forgot-password-form.tsx
@@ -19,9 +19,6 @@ interface ForgotPasswordFormProps {
 const pageInfo = css({ marginBottom: '8', textAlign: 'center' });
 const formStyles = css({ marginBottom: '6', width: '96' });
 
-/**
- * The forgot-password page's client-interactive form: submits to the forgot-password server function.
- */
 export function ForgotPasswordForm(props: ForgotPasswordFormProps) {
   const forgotPasswordFn = useServerFn(forgotPassword);
   const submission = useFormSubmit(props.action ?? forgotPasswordFn, props.lastResult);

--- a/apps/web/src/routes/-game/game-simulation-mount.tsx
+++ b/apps/web/src/routes/-game/game-simulation-mount.tsx
@@ -17,8 +17,7 @@ let hasSentSessionStart = false;
 let lastEmittedCompletionID: string | undefined;
 
 /**
- * Renders nothing: a side-effect-only sibling to the game layout's outlet, so it returns null by
- * design.
+ * A side-effect-only sibling to the game layout's outlet; renders nothing.
  */
 export function GameSimulationMount() {
   const idleWorkerHandle = useIdleWorkerHandle();

--- a/apps/web/src/routes/-game/respite-scene.tsx
+++ b/apps/web/src/routes/-game/respite-scene.tsx
@@ -24,7 +24,7 @@ const dummy = new Object3D();
 
 /**
  * The home city's placeholder scene: a ground plane and a handful of instanced blocks standing in
- * for buildings, until respite grows real content.
+ * for buildings.
  */
 export function RespiteScene() {
   const blocksRef = useRef<InstancedMesh | null>(null);

--- a/apps/web/src/routes/-market-listing/market-listing-panel.tsx
+++ b/apps/web/src/routes/-market-listing/market-listing-panel.tsx
@@ -18,7 +18,7 @@ const panel = css({
 });
 
 /**
- * Placeholder listing detail: stands in until the market has real listing data to load.
+ * Renders a static placeholder for a market listing's detail view.
  */
 export function MarketListingPanel(props: MarketListingPanelProps) {
   return (

--- a/apps/web/src/routes/-market/market-panel.tsx
+++ b/apps/web/src/routes/-market/market-panel.tsx
@@ -37,8 +37,7 @@ const listing = css({
 });
 
 /**
- * Placeholder market screen: a static listing list stands in until the market has real listings
- * to load.
+ * Renders a static placeholder market screen with a fixed listing list.
  */
 export function MarketPanel() {
   return (

--- a/apps/web/src/routes/-stash/stash-panel.tsx
+++ b/apps/web/src/routes/-stash/stash-panel.tsx
@@ -33,7 +33,7 @@ const item = css({
 });
 
 /**
- * Placeholder stash screen: a static item grid stands in until real inventory data is wired up.
+ * Placeholder stash screen rendering a fixed item grid.
  */
 export function StashPanel() {
   return (

--- a/apps/web/src/routes/-verify-otp/run-change-email.ts
+++ b/apps/web/src/routes/-verify-otp/run-change-email.ts
@@ -5,7 +5,7 @@ import type { RunVerificationContext } from './types';
 /**
  * Confirms ownership of a new email address and applies it to the caller's own account, then
  * notifies the old address of the change. Captures the old address before applying the mutation,
- * since `getCurrentUser` would otherwise see the new one. Returns instead of throwing a redirect,
+ * since reading the current user after the update would return the new address. Returns instead of throwing a redirect,
  * leaving navigation to the caller.
  */
 export async function runChangeEmail(ctx: Readonly<RunVerificationContext>): Promise<void> {

--- a/apps/web/src/routes/-verify-otp/run-unsupported.ts
+++ b/apps/web/src/routes/-verify-otp/run-unsupported.ts
@@ -1,6 +1,6 @@
 /**
  * `2fa-setup` verification isn't confirmed through this shared hub — enabling 2FA has its own
- * bespoke UI (account settings, not yet built) that verifies inline.
+ * bespoke UI (account settings) that verifies inline.
  */
 export function runUnsupported(): Promise<never> {
   return Promise.reject(

--- a/apps/web/src/routes/reset-password-started.tsx
+++ b/apps/web/src/routes/reset-password-started.tsx
@@ -15,7 +15,7 @@ export const Route = createFileRoute('/reset-password-started')({
 const pageInfo = css({ marginBottom: '8', textAlign: 'center' });
 
 /**
- * A pure server component: a confirmation page with no client-interactive parts.
+ * A pure server component with no client-interactive parts.
  */
 function ResetPasswordStarted() {
   return (

--- a/apps/web/src/server/make-request-logger.ts
+++ b/apps/web/src/server/make-request-logger.ts
@@ -14,13 +14,11 @@ interface RequestLoggerSink {
 /**
  * Builds the request-lifecycle logging middleware: one structured line per request on completion,
  * carrying method, path, status, and duration as queryable fields — data never rides in the
- * message text, and presentation is the transport's job. The query string never reaches the line:
- * query params carry emailed tokens and auth codes, and a log stream is no place for either.
- * Severity follows
- * outcome: 5xx at error, 4xx at warn, everything else at info — except a served static asset
- * (a pathname with a file extension), which logs at debug to keep asset traffic out of the
- * shipped stream. A handler that throws still logs, at error with the thrown value, before the
- * throw continues to the runtime.
+ * message text. The query string never reaches the line: query params carry emailed tokens and
+ * auth codes, and a log stream is no place for either. Severity follows outcome: 5xx at error, 4xx
+ * at warn, everything else at info — except a served static asset (a pathname with a file
+ * extension), which logs at debug to keep asset traffic out of the shipped stream. A handler that
+ * throws still logs, at error with the thrown value, before the throw continues to the runtime.
  */
 export function makeRequestLogger(logger: RequestLoggerSink): Middleware {
   return async (request, next) => {

--- a/apps/web/src/server/with-request-trace.ts
+++ b/apps/web/src/server/with-request-trace.ts
@@ -6,7 +6,7 @@ const ASSET_PATH_PATTERN = /\.[a-z0-9]+$/i;
 
 /**
  * Runs the request inside its W3C trace-context scope. A served static asset (a pathname with a
- * file extension) or the `/health` probe — mirroring `makeRequestLogger`'s debug-path list — skips
+ * file extension) or the `/health` probe — the same paths logged only at debug level — skips
  * opening a span; every other request opens a SERVER span extracted from the inbound headers, a
  * no-op without a registered tracer provider. The stored `TraceContext` derives from that span when
  * it continued or started a real trace; otherwise (no span, or no tracer provider registered) it

--- a/apps/web/src/test-utils/register-world-map-node-codex-slot-mock.tsx
+++ b/apps/web/src/test-utils/register-world-map-node-codex-slot-mock.tsx
@@ -1,8 +1,8 @@
 import { mock } from 'bun:test';
 
 /**
- * Stubs the codex slot — the UI mount — so tests can assert the activity-readiness wiring
- * around it rather than the fragment payload it renders.
+ * Stubs the codex slot so tests can assert the activity-readiness wiring around it rather than the
+ * fragment payload it renders.
  */
 export function registerWorldMapNodeCodexSlotMock(): void {
   void mock.module('../components/world-map-node-codex-slot', () => ({

--- a/apps/web/src/test-utils/render.tsx
+++ b/apps/web/src/test-utils/render.tsx
@@ -15,7 +15,7 @@ type RenderResult = ReturnType<typeof renderRTL> & {
 /**
  * The project render util for component tests: wraps the tree in the app's providers (a fresh
  * `buildQueryClient` per render) and returns RTL's queries bound to it. Trees that need
- * router-aware primitives render through `renderWithRouter` instead.
+ * router-aware primitives use the router-aware render util instead.
  */
 export function render(ui: Readonly<ReactElement>): RenderResult {
   const queryClient = buildQueryClient();

--- a/contracts/activity/src/activity-status-schema.ts
+++ b/contracts/activity/src/activity-status-schema.ts
@@ -1,11 +1,10 @@
 import * as z from 'zod';
 
 /**
- * An activity's lifecycle state. Only `active`, `stopped`, and `capped` are reachable today; the
- * terminal verification outcomes are declared now because adding an enum value later costs a
- * migration. `parked` is an operational hold — a replay job whose stamped sim version the registry
- * doesn't know — never a cheat signal. It does not block new activity starts; that check applies
- * only to `quarantined`.
+ * An activity's lifecycle state. The terminal verification outcomes are declared alongside the
+ * operational statuses because adding an enum value later costs a migration. `parked` is an
+ * operational hold — a replay job whose stamped sim version the registry doesn't know — never a
+ * cheat signal. It does not block new activity starts; that check applies only to `quarantined`.
  */
 export const ActivityStatusSchema = z.enum([
   'active',

--- a/contracts/avatar/src/avatar-contract.ts
+++ b/contracts/avatar/src/avatar-contract.ts
@@ -44,7 +44,7 @@ export const avatarContract = {
 
   /**
    * `name` is the only user-editable field by design: `level`/`xp` are server-owned progression.
-   * The input shape is frozen with #255 — do not widen it.
+   * The input shape is intentionally minimal — do not widen it.
    */
   updateAvatar: authedRoute
     .route({

--- a/contracts/base/src/standard-errors.ts
+++ b/contracts/base/src/standard-errors.ts
@@ -16,7 +16,7 @@ export const STANDARD_ERRORS = defineErrors({
   FORBIDDEN: {
     message: 'Insufficient permissions',
 
-    // Deliberately empty: no permission model exists yet; fields are added additively when it lands.
+    // Deliberately empty: there is no permission model to describe; permission fields would extend this shape additively.
     data: z.object({}),
   },
   UNAUTHORIZED: {

--- a/infra/axiom.ts
+++ b/infra/axiom.ts
@@ -2,8 +2,8 @@ import * as axiom from '@pulumi/axiom';
 import * as pulumi from '@pulumi/pulumi';
 
 /**
- * The provider authenticates with the Axiom admin token; like the Cloudflare
- * credentials, it enters through the environment resolved by `op run`.
+ * The provider authenticates with the Axiom admin token; it enters through the
+ * environment resolved by `op run`.
  */
 const axiomProvider = new axiom.Provider('axiom', {
   apiToken: requireEnv('AXIOM_TOKEN'),

--- a/libs/core/email/src/previews.ts
+++ b/libs/core/email/src/previews.ts
@@ -13,9 +13,9 @@ interface Preview {
 
 /**
  * Sample-data render entries for every template renderer, consumed by the
- * email-preview workflow (`yarn email:preview`). Entry names are the
- * renderer export names kebab-cased with the `render` prefix and `Email`
- * suffix stripped; a co-located test enforces one entry per renderer export.
+ * email-preview workflow. Entry names are the renderer export names kebab-cased
+ * with the `render` prefix and `Email` suffix stripped; a co-located test
+ * enforces one entry per renderer export.
  */
 export const previews: ReadonlyArray<Preview> = [
   {

--- a/libs/core/flags/src/env-flag-provider.ts
+++ b/libs/core/flags/src/env-flag-provider.ts
@@ -4,10 +4,10 @@ import { isFlagKey } from './is-flag-key';
 import { toFlagEnvVar } from './to-flag-env-var';
 
 /**
- * OpenFeature provider serving flag values from `process.env`, read fresh on every evaluation —
- * never captured at module load — so a long-lived process picks up a changed env without a
- * restart and tests can override env per-test. Boolean-only by design: the string/number/object
- * resolvers always return the default, since the flag registry declares no non-boolean flags.
+ * OpenFeature provider serving flag values from `process.env`, read fresh on every evaluation, so
+ * a long-lived process picks up a changed env without a restart and tests can override env
+ * per-test. Boolean-only by design: the string/number/object resolvers always return the default,
+ * since the flag registry declares no non-boolean flags.
  */
 export const envFlagProvider: Provider = {
   metadata: { name: 'env-flag-provider' },

--- a/libs/core/utils/src/is-non-nullable.ts
+++ b/libs/core/utils/src/is-non-nullable.ts
@@ -1,9 +1,3 @@
-/**
- * Checks if a value is non-nullable.
- *
- * @param value - The value to check.
- * @returns `true` if the value is non-nullable, `false` otherwise.
- */
 export function isNonNullable<T>(value: T): value is NonNullable<T> {
   return value !== null && value !== undefined;
 }

--- a/libs/core/utils/src/unreachable-code-error.ts
+++ b/libs/core/utils/src/unreachable-code-error.ts
@@ -1,11 +1,8 @@
 /**
- * An error that should never be thrown.
+ * An error thrown to mark a code path as unreachable.
  *
- * This error is used to indicate a piece of code should never be reached.
- * For example, there's an awkward pattern we use in our React Router code
- * where we throw a redirect inside our `logout` method as returning a redirect
- * is far more complicated and ugly, so we use this to make sure TypeScript knows
- * any following code should never be reached.
+ * Use it after a statement that always diverts control flow (for example a
+ * thrown redirect) so the type checker treats any following code as dead.
  */
 export class UnreachableCodeError extends Error {
   constructor(message?: string) {

--- a/libs/data/db/migrations/1783000000006_sessions_user_id_index.ts
+++ b/libs/data/db/migrations/1783000000006_sessions_user_id_index.ts
@@ -1,8 +1,8 @@
 import type { Kysely } from 'kysely';
 
 /**
- * Indexes `sessions.user_id` — both the verify-time eviction delete and
- * `getSessions` filter on it and would otherwise seq-scan.
+ * Indexes `sessions.user_id` — both the verify-time eviction delete and the
+ * per-user session listing filter on it and would otherwise seq-scan.
  */
 export async function up(db: Kysely<unknown>): Promise<void> {
   await db.schema.createIndex('sessions_user_id_index').on('sessions').column('user_id').execute();

--- a/libs/data/db/migrations/1783774951592_activities.ts
+++ b/libs/data/db/migrations/1783774951592_activities.ts
@@ -4,8 +4,7 @@ import { sql } from 'kysely';
 /**
  * Creates the `activity_status` enum, the `activities` head-row table (one row per activity
  * stream, carrying both the appended and verified cursors), and the append-only
- * `activity_checkpoints` table. `activity_checkpoints` is a plain table by design — time
- * partitioning is a later, separate change.
+ * `activity_checkpoints` table.
  */
 export async function up(db: Kysely<unknown>): Promise<void> {
   await db.schema

--- a/libs/data/db/src/test-support/create-test-db.ts
+++ b/libs/data/db/src/test-support/create-test-db.ts
@@ -8,8 +8,6 @@ import { resolveTestDBTarget } from './resolve-test-db-target';
  * database and returns a `@vers/db` client bound to it.
  *
  * Implements `Symbol.asyncDispose` to close the client's connection.
- *
- * @returns - The test database client.
  */
 export async function createTestDB() {
   const target = resolveTestDBTarget();

--- a/libs/data/db/src/test-support/require-safe-db-identifier.ts
+++ b/libs/data/db/src/test-support/require-safe-db-identifier.ts
@@ -2,7 +2,7 @@
  * Guards a `CREATE DATABASE`/`DROP DATABASE` statement, which can't
  * parameterize an identifier: `name` may come straight from an env override
  * or caller-supplied config, so this rejects anything that isn't already a
- * safe identifier rather than trusting the caller.
+ * safe identifier.
  */
 export function requireSafeDBIdentifier(name: string): void {
   if (!/^[a-z0-9_]+$/.test(name)) {

--- a/libs/design/design-system/src/components/status-button/status-button.stories.tsx
+++ b/libs/design/design-system/src/components/status-button/status-button.stories.tsx
@@ -30,8 +30,9 @@ interface EmulateSubmitConfig {
   readonly success: boolean;
 }
 
-// hacky hook to give us a simulatedish submit flow that cycles the
-// status button states from idle -> pending -> success.
+/**
+ * Drives a simulated submit flow that cycles the status button through idle -> pending -> success or error.
+ */
 function useEmulateSubmit(config: EmulateSubmitConfig) {
   const [submitting, setSubmitting] = useState(false);
   const [status, setStatus] = useState(StatusButton.Status.Idle);

--- a/libs/game/game-rendering/src/resolve-scene-state.ts
+++ b/libs/game/game-rendering/src/resolve-scene-state.ts
@@ -3,11 +3,8 @@ import type { SceneContribution, SceneState } from './types';
 /**
  * Folds a matched route branch's `staticData` contributions into the next scene state.
  * `contributions` is root-first (index 0 is the outermost matched route, the last element the
- * leaf); both axes resolve independently and are sticky:
- * - `scene` takes the deepest contribution that declares it; a branch with no declared scene
- *   keeps `previous.scene`.
- * - `presentation` takes the deepest contribution that declares it; a branch with no declared
- *   presentation keeps `previous.presentation`.
+ * leaf). The `scene` and `presentation` axes resolve independently: each takes the deepest
+ * contribution that declares it, otherwise keeping its value from `previous`.
  */
 export function resolveSceneState(
   contributions: ReadonlyArray<SceneContribution | undefined>,

--- a/libs/game/game-utils/src/content/encounter-content-v1.ts
+++ b/libs/game/game-utils/src/content/encounter-content-v1.ts
@@ -1,9 +1,8 @@
 import type { EncounterContent } from '../types';
 
 /**
- * Machinery-exercising placeholder content: two archetypes in one pool, 3-6 waves of 3-6 enemies
- * each, and a 1x content multiplier so stats scale by node difficulty alone. Frozen — a content
- * change is a new version module, never an edit here.
+ * Machinery-exercising placeholder content whose multiplier is 1x so stats scale by node difficulty
+ * alone. Frozen — a content change is a new version module, never an edit here.
  */
 export const encounterContentV1: EncounterContent = {
   contentVersion: '1',

--- a/libs/game/game-utils/src/create-rng.ts
+++ b/libs/game/game-utils/src/create-rng.ts
@@ -9,7 +9,6 @@ import type { RNG } from './types';
  * most of it
  *
  * @param state - the 128-bit xoroshiro128+ state to rehydrate, as a 32-character hex string
- * @returns a thin wrapper around pure-rand
  */
 export function createRNG(state: string): RNG {
   const gen = xoroshiro128plusFromState(decodeState(state));

--- a/libs/game/game-utils/src/merge-seeds.ts
+++ b/libs/game/game-utils/src/merge-seeds.ts
@@ -1,6 +1,7 @@
-// 1. combine seeds using a bitwise XOR (^)
-// 2. multiply by novel large magic number
-// 3. ensure result is 32-bit unsigned integer via >>>0
+/**
+ * Combines two seeds by XORing them and multiplying by a fixed large constant,
+ * truncating the fractional part of the product.
+ */
 export function mergeSeeds(a: number, b: number): number {
   return Math.trunc((a ^ b) * 0xdeadbeef);
 }

--- a/libs/game/idle-client/src/resync/run-fast-forward.ts
+++ b/libs/game/idle-client/src/resync/run-fast-forward.ts
@@ -12,7 +12,7 @@ interface RunFastForwardOptions {
   /**
    * Derives the engine's simulation input and avatar from a server-authored activity row, called
    * fresh for every continuation — the verifier derives the same way from each row's own
-   * `buildSnapshot`, so a stream must never carry one avatar across continuations.
+   * snapshot, so a stream must never carry one avatar across continuations.
    */
   readonly buildSimulationInput: (activity: ActivityData) => {
     activity: ActivityInput;

--- a/libs/game/idle-client/src/resync/run-resync.ts
+++ b/libs/game/idle-client/src/resync/run-resync.ts
@@ -47,8 +47,8 @@ interface RunResyncOptions {
   readonly onProgressFetched?: (progress: LatestActivityProgress) => Promise<void>;
 
   /**
-   * A continuation `runContinuation` couldn't complete, honored as a `continue` plan once its
-   * target row reads closed.
+   * A continuation a previous worker started but couldn't complete, honored as a `continue` plan
+   * once its target row reads closed.
    */
   readonly pendingContinuation?: PendingContinuation | null;
 

--- a/libs/game/idle-client/src/worker/create-worker-runtime.ts
+++ b/libs/game/idle-client/src/worker/create-worker-runtime.ts
@@ -182,7 +182,7 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
     },
   };
 
-  // standard shared worker setup - cache our listeners so we can message them later
+  // cache our listeners so we can message them later
   const handleConnect = (event: MessageEvent) => {
     const [port] = event.ports;
 
@@ -217,8 +217,7 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
     }
   };
 
-  // our main loop function uses a fixed timestep to ensure consistent updates as
-  // we're not directly tied to UI updates nor do we have access to requestAnimationFrame
+  // a fixed timestep keeps updates consistent: the worker isn't tied to UI updates and has no requestAnimationFrame
   const runTickLoop = async () => {
     if (stopped) {
       return;

--- a/libs/game/idle-client/src/worker/sentry-handle.ts
+++ b/libs/game/idle-client/src/worker/sentry-handle.ts
@@ -4,8 +4,8 @@ type SentryModule = typeof Sentry;
 
 /**
  * Worker-wide holder for the lazily-imported Sentry SDK handle: `current` stays undefined until
- * `startErrorReporting` runs with a defined DSN, so a DSN-less worker never loads the SDK.
- * `reportWorkerFault` reads it directly; `startErrorReporting` is its only production writer, and
- * tests swap it in place.
+ * the error-reporting bootstrap runs with a defined DSN, so a DSN-less worker never loads the SDK.
+ * The fault reporter reads it directly; the error-reporting bootstrap is its only production
+ * writer, and tests swap it in place.
  */
 export const sentryHandle: { current: SentryModule | undefined } = { current: undefined };

--- a/libs/game/idle-client/src/worker/types.ts
+++ b/libs/game/idle-client/src/worker/types.ts
@@ -5,9 +5,9 @@ import type { ActivityServiceClient } from '../submission/types';
 import type { RewardSlotLedgerEntry, RewardSlotLedgerSnapshot } from '../types';
 
 /**
- * A continuation `runContinuation` wanted to start but couldn't complete — a same-row `CONFLICT`
+ * A continuation the worker wanted to start but couldn't complete — a same-row `CONFLICT`
  * (the terminal append that closes the row is still unacknowledged) or a transport failure on its
- * own `startActivity` call. `activityID` names the row the pending intent was raised against, so a
+ * own start-activity call. `activityID` names the row the pending intent was raised against, so a
  * resync plans `continue` only once that exact row reads closed, never a different one. The row
  * it eventually starts takes the worker's current failure action, not a snapshot from raise time,
  * so a preference changed while the intent waited still applies.

--- a/libs/game/idle-core/src/behaviours/avatar-weapon-attack/has-main-hand-weapon.ts
+++ b/libs/game/idle-core/src/behaviours/avatar-weapon-attack/has-main-hand-weapon.ts
@@ -1,6 +1,5 @@
 import type { Avatar } from '../../types';
 
 export function hasMainHandWeapon(entity: Avatar): boolean {
-  // TODO: verify main hand is actually a weapon
   return entity.mainHandEquipment !== null;
 }

--- a/libs/game/idle-core/src/core/handle-avatar-attack.ts
+++ b/libs/game/idle-core/src/core/handle-avatar-attack.ts
@@ -4,8 +4,6 @@ import { logger } from '../utils/logger';
 
 export function handleAvatarAttack(_event: AvatarAttackEvent, avatar: Avatar, activity: Activity) {
   const label = createLogLabel('avatar', avatar.id);
-
-  // find the first enemy that is alive
   const enemy = activity.currentWave?.nextLivingEnemy;
 
   if (enemy) {

--- a/libs/game/idle-core/src/core/run-simulation.ts
+++ b/libs/game/idle-core/src/core/run-simulation.ts
@@ -24,7 +24,7 @@ interface SimulationOutput {
 /**
  * Runs one activity from `Started` to `config.duration` in a single call, stopping the underlying
  * simulation once any tick crosses `duration` — the one-shot path's own termination, never shared
- * with a caller advancing the same simulation across several calls (`createSimulationDriver`).
+ * with a caller that advances the same simulation across several calls.
  */
 export async function runSimulation(
   activity: ActivityInput,

--- a/libs/game/idle-core/src/core/run-simulation.ts
+++ b/libs/game/idle-core/src/core/run-simulation.ts
@@ -2,7 +2,7 @@ import type { ActivityCheckpoint, ActivityInput, AvatarData } from '../types';
 import { createSimulationDriver } from './create-simulation-driver';
 
 /**
- * @property duration - how long to run the simulation for. derive from the checkpoint data submitted by the
+ * @property duration - derive from the checkpoint data submitted by the
  * cient, or if simulating offline progress the duration since the last checkpoint (if any)
  * @property expectedCheckpointCount - when the caller knows exactly how many checkpoints the run should
  * produce (a replay), the primary halt condition; `duration` is only the safety cap behind it.

--- a/libs/game/idle-core/src/core/utils/build-wave-clear-reward-slots.ts
+++ b/libs/game/idle-core/src/core/utils/build-wave-clear-reward-slots.ts
@@ -3,9 +3,9 @@ import type { RewardSlotContext, Wave } from '../../types';
 
 /**
  * One reward-slot context per enemy in a cleared wave, in the wave's own enemy order — the same
- * canonical order `buildWaveClearRewards` sums xp over, so the two stay aligned on replay. Ordinals
- * are not assigned here: checkpoint creation numbers the contexts earned since the last checkpoint,
- * keeping them 0-contiguous per checkpoint.
+ * canonical enemy order the wave's xp is summed over, so slots and rewards stay aligned on replay.
+ * Ordinals are not assigned here: checkpoint creation numbers the contexts earned since the last
+ * checkpoint, keeping them 0-contiguous per checkpoint.
  */
 export function buildWaveClearRewardSlots(
   wave: Wave,

--- a/libs/game/idle-core/src/core/utils/create-event-sorter.ts
+++ b/libs/game/idle-core/src/core/utils/create-event-sorter.ts
@@ -1,8 +1,8 @@
 import type { Avatar, CombatEvent } from '../../types';
 
 /**
- * Orders combat events by time, breaking ties in favour of the avatar's events so ties resolve
- * deterministically.
+ * Orders combat events by ascending time, placing the avatar's own events before others' at the
+ * same timestamp.
  */
 export function createEventSorter(avatar: Avatar) {
   return (a: CombatEvent, b: CombatEvent) => {

--- a/libs/game/idle-core/src/core/utils/create-event-sorter.ts
+++ b/libs/game/idle-core/src/core/utils/create-event-sorter.ts
@@ -1,7 +1,9 @@
 import type { Avatar, CombatEvent } from '../../types';
 
-// returns a fn that sorts events by time then by event source,
-// preferring the avatar's events first
+/**
+ * Orders combat events by time, breaking ties in favour of the avatar's events so ties resolve
+ * deterministically.
+ */
 export function createEventSorter(avatar: Avatar) {
   return (a: CombatEvent, b: CombatEvent) => {
     const timeDiff = a.time - b.time;

--- a/libs/game/idle-core/src/entities/create-avatar.ts
+++ b/libs/game/idle-core/src/entities/create-avatar.ts
@@ -29,7 +29,6 @@ export function createAvatar(data: AvatarData, ctx: SimulationContext): Avatar {
   let state = getInitialState(data);
   let currentLevel = data.level;
 
-  // TODO: pull this out into a util
   const getSnapshot = (): AvatarSnapshot => {
     const behaviourState: AvatarBehaviourSnapshot = {};
 
@@ -157,7 +156,10 @@ function getInitialState(data: AvatarData): AvatarState {
   };
 }
 
-// type safe util for adding our behaviour state to our serializable state
+/**
+ * Writes a behaviour's state into the serializable snapshot under its id, keeping the id and value
+ * types aligned.
+ */
 function updateBehaviourSnapshot<K extends BehaviourID>(
   state: AvatarBehaviourSnapshot,
   id: K,

--- a/libs/game/idle-core/src/entities/create-enemy.ts
+++ b/libs/game/idle-core/src/entities/create-enemy.ts
@@ -126,7 +126,10 @@ function getInitialState(data: EnemyData): EnemyState {
   };
 }
 
-// type safe util for adding our behaviour state to our serializable state
+/**
+ * Writes a behaviour's state into the serializable snapshot under its id, keeping the id and value
+ * types aligned.
+ */
 function updateBehaviourSnapshot<K extends BehaviourID>(
   state: EnemyBehaviourSnapshot,
   id: K,

--- a/libs/game/idle-core/src/types/entities.ts
+++ b/libs/game/idle-core/src/types/entities.ts
@@ -11,11 +11,8 @@ export interface AvatarData {
   name: string;
   xp: number;
 
-  // TODO: implement this as a map? type? where we use a record to enforce equipment type e.g. 1h/2h weapons = weapons, etc
   paperdoll: {
     [EquipmentSlot.MainHand]: EquipmentWeapon | null;
-
-    // [EquipmentSlot.OffHand]: EquipmentWeapon;
   };
 }
 

--- a/libs/game/idle-core/src/utils/logger.ts
+++ b/libs/game/idle-core/src/utils/logger.ts
@@ -1,4 +1,3 @@
-// TODO(#109): resolve this travesty
 const isDebugEnabled = false;
 
 export const logger = {

--- a/libs/game/roll-crypto/src/derive-avatar-key.ts
+++ b/libs/game/roll-crypto/src/derive-avatar-key.ts
@@ -11,8 +11,8 @@ export interface DeriveAvatarKeyInput {
 }
 
 /**
- * Derives a 32-byte avatar roll key via HKDF-SHA256 from a population root secret. Pure and
- * bit-for-bit reproducible: identical input always yields an identical key.
+ * Derives a 32-byte avatar roll key via HKDF-SHA256 from a population root secret. Pure:
+ * identical input always yields an identical key.
  *
  * The info-string layout (`vers/avatar-key/v1|${population}|${avatarID}|${keyVersion}`) is frozen.
  * Its `v1` segment is scheme versioning — it changes only when the derivation algorithm or field

--- a/libs/game/worldmap-client/src/components-three/isometric-camera.tsx
+++ b/libs/game/worldmap-client/src/components-three/isometric-camera.tsx
@@ -21,9 +21,8 @@ const ISOMETRIC_CAMERA_ROTATION = new Euler(CAMERA_ROTATION_X, CAMERA_ROTATION_Y
 const AnimatedGroup = animated['group'];
 
 /**
- * this component is a lie. it used to be an orthographic camera configured
- * for an isometric view, but now it's just a perspective camera with the same fixed
- * height and rotation. with out current World layout, isometric looks awful.
+ * A perspective camera fixed at an isometric height and rotation; a true orthographic isometric
+ * projection reads poorly against the current world layout.
  */
 export function IsometricCamera() {
   const cameraRigRef = useRef<Group | null>(null);
@@ -81,24 +80,6 @@ export function IsometricCamera() {
   );
 }
 
-// keeping this for a rainy day
-// <orthographicCamera
-//   ref={cameraRef}
-//   args={[
-//     -CAMERA_DISTANCE * aspect,
-//     CAMERA_DISTANCE * aspect,
-//     CAMERA_DISTANCE,
-//     -CAMERA_DISTANCE,
-//     1,
-//     1000,
-//   ]}
-// />
-
-/**
- * get the camera position we want to animate to for a given node
- * @param node - the node to get the camera position for
- * @returns the camera position
- */
 function getNodeCameraPosition(node: null | Object3D): [number, number, number] {
   if (!node) {
     return [0, CAMERA_DISTANCE, 0];

--- a/libs/game/worldmap-client/src/components-three/world-map-nodes.tsx
+++ b/libs/game/worldmap-client/src/components-three/world-map-nodes.tsx
@@ -112,7 +112,6 @@ export function WorldMapNodes(props: Readonly<WorldMapNodesProps>) {
       return;
     }
 
-    // TODO(#119): limit node navigation to nodes connected to any completed node
     setSelectedNode(node);
   };
 

--- a/libs/game/worldmap-client/src/components-ui/node-tooltip.tsx
+++ b/libs/game/worldmap-client/src/components-ui/node-tooltip.tsx
@@ -49,7 +49,10 @@ export function NodeTooltip(props: Readonly<NodeTooltipProps>) {
   );
 }
 
-// util to prevent us from having SSR issues with document not being defined
+/**
+ * Defers reading `document` until after mount so server rendering, where `document` is
+ * undefined, does not throw.
+ */
 function useDocument() {
   const [myDocument, setMyDocument] = useState<Document | null>(null);
 

--- a/libs/game/worldmap-client/src/consts.ts
+++ b/libs/game/worldmap-client/src/consts.ts
@@ -1,14 +1,17 @@
-// standard isometric camera rotation
+/**
+ * Standard isometric camera rotation about Y.
+ */
 export const CAMERA_ROTATION_Y = Math.atan(1 / Math.sqrt(2));
 export const CAMERA_ROTATION_X = -Math.PI / 4;
-
-// fixed camera distance
 export const CAMERA_DISTANCE = 40;
 
-// precalculate our X/Z offset for the camera at our origin
+/**
+ * Camera X/Z offset from the origin, precomputed from the fixed distance and isometric angle.
+ */
 export const ISOMETRIC_OFFSET_X = CAMERA_DISTANCE * Math.sin(CAMERA_ROTATION_Y);
 export const ISOMETRIC_OFFSET_Z = CAMERA_DISTANCE * Math.cos(CAMERA_ROTATION_Y);
 
-// we scale up our positions because it feels weird to be woring with
-// distances of <1 between nodes
+/**
+ * Positions are scaled up so inter-node distances aren't sub-1, which looked wrong.
+ */
 export const NODE_POSITION_SCALING_FACTOR = 10;

--- a/libs/game/worldmap-client/src/consts.ts
+++ b/libs/game/worldmap-client/src/consts.ts
@@ -12,6 +12,7 @@ export const ISOMETRIC_OFFSET_X = CAMERA_DISTANCE * Math.sin(CAMERA_ROTATION_Y);
 export const ISOMETRIC_OFFSET_Z = CAMERA_DISTANCE * Math.cos(CAMERA_ROTATION_Y);
 
 /**
- * Positions are scaled up so inter-node distances aren't sub-1, which looked wrong.
+ * Graph node coordinates are multiplied into scene units so adjacent nodes sit more than one unit
+ * apart.
  */
 export const NODE_POSITION_SCALING_FACTOR = 10;

--- a/libs/game/worldmap-client/src/state/use-selected-node.ts
+++ b/libs/game/worldmap-client/src/state/use-selected-node.ts
@@ -4,11 +4,10 @@ import { getScenePosition } from '../utils/get-scene-position';
 import { useWorldmapStore } from './use-worldmap-store';
 
 /**
- * Reads the selected node alongside its scene `Object3D`. A node selected without one — the
- * URL-driven path has no rendered mesh to store with the selection — resolves a synthetic `Object3D`
- * positioned at the node's own scene position instead, so every consumer of `object3D` (camera
- * targeting, distance-based graph filtering) sees a real position instead of recentering to the
- * origin.
+ * Reads the selected node alongside its scene `Object3D`. When the selection was made through the
+ * URL, no rendered mesh was stored with it, so the hook builds a synthetic `Object3D` at the node's
+ * own scene position instead, giving every consumer of `object3D` (camera targeting, distance-based
+ * graph filtering) a real position rather than recentering to the origin.
  */
 export function useSelectedNode() {
   const node = useWorldmapStore((state) => state.selectedNode);

--- a/libs/game/worldmap-client/src/state/use-selected-node.ts
+++ b/libs/game/worldmap-client/src/state/use-selected-node.ts
@@ -5,7 +5,7 @@ import { useWorldmapStore } from './use-worldmap-store';
 
 /**
  * Reads the selected node alongside its scene `Object3D`. A node selected without one — the
- * URL-driven path has no rendered mesh to hand `setSelectedNode` — resolves a synthetic `Object3D`
+ * URL-driven path has no rendered mesh to store with the selection — resolves a synthetic `Object3D`
  * positioned at the node's own scene position instead, so every consumer of `object3D` (camera
  * targeting, distance-based graph filtering) sees a real position instead of recentering to the
  * origin.

--- a/libs/game/worldmap-client/src/utils/build-nearby-graph.ts
+++ b/libs/game/worldmap-client/src/utils/build-nearby-graph.ts
@@ -3,7 +3,9 @@ import type { Object3D } from 'three';
 import { Vector3 } from 'three';
 import { getScenePosition } from './get-scene-position';
 
-// i dialed this in until it looked acceptable on 1080 with the fog
+/**
+ * Cull radius, tuned empirically against 1080p rendering with the scene fog.
+ */
 const MAX_DISTANCE = 160;
 
 /**

--- a/libs/game/worldmap-client/src/utils/get-scene-position.ts
+++ b/libs/game/worldmap-client/src/utils/get-scene-position.ts
@@ -1,9 +1,6 @@
 import { NODE_POSITION_SCALING_FACTOR } from '../consts';
 import type { VectorTuple } from '../types';
 
-/**
- * convert a given x,y position to an x,y,z
- */
 export function getScenePosition(position: readonly [number, number]): VectorTuple {
   const x = position[0] * NODE_POSITION_SCALING_FACTOR;
   const y = position[1] * NODE_POSITION_SCALING_FACTOR;

--- a/libs/game/worldmap-core/src/build-graph-nodes.ts
+++ b/libs/game/worldmap-core/src/build-graph-nodes.ts
@@ -14,12 +14,6 @@ function toDraftNode(node: WorldMapNode): WorldMapNodeDraft {
   return { ...node, connections: [...node.connections] };
 }
 
-/**
- * Generates a graph of WorldMapNodes and returns them as an array.
- *
- * @param maxDifficulty - The maximum difficulty of the graph
- * @returns A graph of WorldMapNodes
- */
 export function buildGraphNodes(maxDifficulty: number): Array<WorldMapNode> {
   const graph: Array<WorldMapNodeDraft> = [];
   const centralNode = toDraftNode(createWorldMapNode(0, 0));

--- a/libs/game/worldmap-core/src/compress-world-map-nodes.ts
+++ b/libs/game/worldmap-core/src/compress-world-map-nodes.ts
@@ -1,11 +1,5 @@
 import type { CompressedWorldMapNode, WorldMapNode } from './types';
 
-/**
- * converts an array of WorldMapNodes into an array of CompressedWorldMapNodes
- *
- * @param nodes - The WorldMapNodes to serialize.
- * @returns An array of CompressedWorldMapNodes.
- */
 export function compressWorldMapNodes(
   nodes: ReadonlyArray<WorldMapNode>,
 ): Array<CompressedWorldMapNode> {

--- a/libs/game/worldmap-core/src/get-node-position.ts
+++ b/libs/game/worldmap-core/src/get-node-position.ts
@@ -13,7 +13,7 @@ export function getNodePosition(i: number, difficulty: number): [number, number]
   const segments = difficulty * 4;
   const segmentRadians = (2 * Math.PI) / segments;
 
-  // add 0 to ensure -0 becomes 0. probably doesn't matter but apparently this is a thing.
+  // add 0 to ensure -0 becomes 0.
   const x = Number((difficulty * Math.cos(segmentRadians * i)).toFixed(3)) + 0;
   const y = Number((difficulty * Math.sin(segmentRadians * i)).toFixed(3)) + 0;
 

--- a/libs/service/service-runtime/src/create-service.ts
+++ b/libs/service/service-runtime/src/create-service.ts
@@ -206,8 +206,8 @@ interface RegisterORPCHandlerDeps {
 
 /**
  * Registers an oRPC fetch handler behind the s2s trust boundary: an invalid service token short-
- * circuits with a plain 401 before the handler ever runs, per the auth/trust-boundary split in
- * docs/architecture/services/service-contracts.md. Every response — including that 401 — carries the request's trace id
+ * circuits with a plain 401 before the handler ever runs, per the service auth/trust-boundary
+ * split. Every response — including that 401 — carries the request's trace id
  * in `x-trace-id`, and the whole request runs inside its trace-context scope so logs correlate.
  * Every request logs one structured line on completion (method, path, status, duration), severity
  * following the response status; a trust-boundary rejection's line carries the rejection reason.

--- a/libs/service/service-utils/src/otel/build-telemetry-resource.ts
+++ b/libs/service/service-utils/src/otel/build-telemetry-resource.ts
@@ -8,9 +8,8 @@ interface BuildTelemetryResourceOptions {
 /**
  * Builds the OpenTelemetry resource shared by every exporter a process registers: the service
  * name, its version (the deployed Fly image reference when `FLY_IMAGE_REF` is set, absent
- * otherwise), and the deployment environment name from `NODE_ENV`. Passed as `resource` into
- * `startTraceExport`, `startMetricsExport`, `createOTLPLogStream`, and the Elysia OTel plugin's
- * `NodeSDK` options, so every signal a process exports tags the same identity.
+ * otherwise), and the deployment environment name from `NODE_ENV`. Passed into every exporter a
+ * process registers, so every signal it exports tags the same identity.
  */
 export function buildTelemetryResource(options: BuildTelemetryResourceOptions): Resource {
   const flyImageRef = process.env['FLY_IMAGE_REF'];

--- a/libs/service/service-utils/src/otel/build-telemetry-resource.ts
+++ b/libs/service/service-utils/src/otel/build-telemetry-resource.ts
@@ -6,10 +6,10 @@ interface BuildTelemetryResourceOptions {
 }
 
 /**
- * Builds the OpenTelemetry resource shared by every exporter a process registers: the service
- * name, its version (the deployed Fly image reference when `FLY_IMAGE_REF` is set, absent
- * otherwise), and the deployment environment name from `NODE_ENV`. Passed into every exporter a
- * process registers, so every signal it exports tags the same identity.
+ * Builds the OpenTelemetry resource every exporter a process registers shares: the service name,
+ * its version (the deployed Fly image reference when `FLY_IMAGE_REF` is set, absent otherwise), and
+ * the deployment environment name from `NODE_ENV` — so every signal the process exports tags the
+ * same identity.
  */
 export function buildTelemetryResource(options: BuildTelemetryResourceOptions): Resource {
   const flyImageRef = process.env['FLY_IMAGE_REF'];

--- a/libs/service/service-utils/src/schemas/logging-schema.ts
+++ b/libs/service/service-utils/src/schemas/logging-schema.ts
@@ -1,7 +1,3 @@
 import { z } from 'zod';
 
-/**
- * Reusable schema for LOGGING environment variable.
- * Enforces our standard logging levels across all services.
- */
 export const LoggingSchema = z.enum(['debug', 'info', 'warn', 'error']).optional().default('info');

--- a/libs/service/service-utils/src/schemas/node-env-schema.ts
+++ b/libs/service/service-utils/src/schemas/node-env-schema.ts
@@ -1,7 +1,3 @@
 import { z } from 'zod';
 
-/**
- * Reusable schema for NODE_ENV environment variable.
- * Enforces our standard environment types across all services.
- */
 export const NodeEnvSchema = z.enum(['development', 'e2e', 'test', 'production']);

--- a/libs/testing/client-test-utils/src/orpc/rpc-prefix.ts
+++ b/libs/testing/client-test-utils/src/orpc/rpc-prefix.ts
@@ -1,4 +1,4 @@
 /**
- * The RPC mount point every service exposes its contract under; see docs/architecture/services/service-contracts.md.
+ * The RPC mount point every service exposes its contract under.
  */
 export const RPC_PREFIX = '/rpc';

--- a/libs/testing/mock-services/src/session/step-up/record-failed-attempt.ts
+++ b/libs/testing/mock-services/src/session/step-up/record-failed-attempt.ts
@@ -9,8 +9,8 @@ const MAX_STEP_UP_ATTEMPTS = 5;
 
 /**
  * Records one failed step-up code check. A pending transaction that runs out of attempts is
- * deleted outright, matching `consumePendingTransaction`'s `NOT_FOUND` once a caller can no longer
- * finish it — the caller must restart the step-up flow instead of retrying the same transaction.
+ * deleted outright, so a caller who can no longer finish it hits NOT_FOUND on a further consume —
+ * the caller must restart the step-up flow instead of retrying the same transaction.
  */
 export const recordFailedAttempt = os.stepUp.recordFailedAttempt.handler(async (opts) => {
   const row = findLivePendingTransaction(opts.input.id);

--- a/libs/testing/service-test-utils/src/bun/get-test-service-key-pair.ts
+++ b/libs/testing/service-test-utils/src/bun/get-test-service-key-pair.ts
@@ -8,8 +8,7 @@ interface TestServiceKeyPair {
 
 /**
  * One s2s keypair per test process: a package's preload publishes the public key as env, and
- * viewer composites mint tokens from the private key. Bridges preload and test setup through
- * shared module state so both sides agree on the same keypair.
+ * viewer composites mint tokens from the private key.
  */
 export function getTestServiceKeyPair(): Promise<TestServiceKeyPair> {
   cached ??= createServiceKeyPair();

--- a/libs/testing/service-test-utils/src/create-postgres-container.ts
+++ b/libs/testing/service-test-utils/src/create-postgres-container.ts
@@ -2,11 +2,6 @@ import { PostgreSqlContainer } from '@testcontainers/postgresql';
 import type { StartedPostgreSqlContainer } from '@testcontainers/postgresql';
 import { Wait } from 'testcontainers';
 
-/**
- * Creates a postgres container for testing.
- *
- * @returns - The started postgres container.
- */
 export function createPostgresContainer(): Promise<StartedPostgreSqlContainer> {
   return (
     new PostgreSqlContainer('postgres:16.2-alpine3.19')

--- a/libs/testing/test-utils/src/collect-conformance-cases.ts
+++ b/libs/testing/test-utils/src/collect-conformance-cases.ts
@@ -26,9 +26,13 @@ export interface ConformanceCaseApp {
  */
 export interface ConformanceCase {
   /**
-   * Behavioural title, e.g. "it rejects malformed input on users.getCurrentUser".
+   * Runs the case against a real app via its `handle` function.
    */
   run: (app: ConformanceCaseApp) => Promise<void>;
+
+  /**
+   * Behavioural title, e.g. "it rejects malformed input on users.getCurrentUser".
+   */
   title: string;
 }
 

--- a/scripts/src/deploy/plan-scheduled-machine-actions.ts
+++ b/scripts/src/deploy/plan-scheduled-machine-actions.ts
@@ -2,9 +2,7 @@ import type { ScheduledMachine, ScheduledMachineAction, ScheduledMachineState } 
 
 /**
  * Diffs a target's declared scheduled machines against its existing ones,
- * matched by name. A declaration absent from `existing` needs creating; one
- * present on a different image needs its image updated; a current match
- * needs nothing.
+ * matched by name.
  */
 export function planScheduledMachineActions(
   declarations: ReadonlyArray<ScheduledMachine>,

--- a/scripts/src/issue-hygiene/check-issue.ts
+++ b/scripts/src/issue-hygiene/check-issue.ts
@@ -21,9 +21,10 @@ const TYPE_LABELS = new Set([
 ]);
 
 /**
- * Evaluates an issue against the repository's issue-shape rules — required area, type, and priority
- * labels, a delivery milestone, and the type-specific body sections. Returns one human-readable
- * finding per violated rule, empty when the issue is clean.
+ * Evaluates an issue against the repository's issue-shape rules, returning one human-readable
+ * finding per violation and an empty array when the issue is clean. Requirements vary by type — an
+ * upkeep issue carries a trigger line and no milestone, where other types require area, type, and
+ * priority labels, a delivery milestone, and their template's body sections.
  */
 export function checkIssue(issue: IssueShape): Array<string> {
   if (issue.labels.some((label) => EXEMPT_LABELS.has(label))) {

--- a/scripts/src/issue-hygiene/check-issue.ts
+++ b/scripts/src/issue-hygiene/check-issue.ts
@@ -21,9 +21,9 @@ const TYPE_LABELS = new Set([
 ]);
 
 /**
- * Evaluates an issue against the shape rules in the Issue hygiene section of AGENTS.md and the
- * `.github/ISSUE_TEMPLATE` bodies. Returns one human-readable finding per violated rule, empty
- * when the issue is clean.
+ * Evaluates an issue against the repository's issue-shape rules — required area, type, and priority
+ * labels, a delivery milestone, and the type-specific body sections. Returns one human-readable
+ * finding per violated rule, empty when the issue is clean.
  */
 export function checkIssue(issue: IssueShape): Array<string> {
   if (issue.labels.some((label) => EXEMPT_LABELS.has(label))) {

--- a/services/activity/src/handlers/get-activity-rewards.ts
+++ b/services/activity/src/handlers/get-activity-rewards.ts
@@ -40,7 +40,7 @@ interface GetActivityRewardsResult {
  * ordinal. Mint and anchor-advance commit in the same transaction, so every coordinate this range
  * covers is already minted — an unverified tail simply isn't in range yet, never a partial read.
  * `afterChainIndex` is a keyset cursor: a client that already holds rows through some chain index
- * passes it to read only what advanced since, never refetching the full history.
+ * passes it to read only what advanced since.
  */
 export async function getActivityRewards(
   db: Kysely<DB>,

--- a/services/activity/src/handlers/track-activity-progress.ts
+++ b/services/activity/src/handlers/track-activity-progress.ts
@@ -346,7 +346,7 @@ interface SettledTailRow {
 /**
  * Reports whether a checkpoint batch, replayed from scratch, recomputes onto a settled activity's
  * recorded tail: the last entry's version lands on `settled.appendedHead`, and every entry's hash —
- * rebuilt via `buildCheckpointHash`, never trusted from the submitted `hash` field — chains onto
+ * recomputed from each payload, never trusted from the submitted `hash` field — chains onto
  * the previous entry's rebuilt hash and the final one reproduces `settled.lastHash`. A match proves
  * the recorded tail is this exact batch: the original submit landed and only the ack was lost.
  */
@@ -409,7 +409,7 @@ const RewardSlotsSchema = z.array(RewardSlotSchema);
 
 /**
  * A checkpoint's `rewardSlots` field rides outside the hashed subset like `rewards`, so it's
- * validated here rather than by `CheckpointPayloadSchema`. Absent is valid — an older client or a
+ * validated here rather than by the payload schema. Absent is valid — an older client or a
  * checkpoint that dropped nothing carries no key at all. Present, it must parse and its ordinals
  * must run contiguous from 0 in list order.
  */

--- a/services/activity/src/test-utils/factories/create-mock-activity.ts
+++ b/services/activity/src/test-utils/factories/create-mock-activity.ts
@@ -7,8 +7,8 @@ import type { Insertable } from 'kysely';
 /**
  * A plain, unpersisted activity row with faker-generated defaults. Never requires a parent —
  * `avatarId` defaults to a random id, not a real avatar's. `lastHash`/`startHash` default to the
- * real `buildStartHash` of the row's own `id`/`seed`/version fields, so a factory-built row chains
- * correctly with `createMockCheckpointBatch`.
+ * real start hash of the row's own `id`/`seed`/version fields, so a factory-built row chains
+ * correctly with a mock checkpoint batch.
  */
 export function createMockActivity(
   overrides: Readonly<Partial<Insertable<Activities>>> = {},

--- a/services/activity/src/test-utils/factories/create-mock-activity.ts
+++ b/services/activity/src/test-utils/factories/create-mock-activity.ts
@@ -7,8 +7,8 @@ import type { Insertable } from 'kysely';
 /**
  * A plain, unpersisted activity row with faker-generated defaults. Never requires a parent —
  * `avatarId` defaults to a random id, not a real avatar's. `lastHash`/`startHash` default to the
- * real start hash of the row's own `id`/`seed`/version fields, so a factory-built row chains
- * correctly with a mock checkpoint batch.
+ * real start hash of the row's own hash inputs, so a factory-built row chains correctly with a mock
+ * checkpoint batch.
  */
 export function createMockActivity(
   overrides: Readonly<Partial<Insertable<Activities>>> = {},

--- a/services/activity/src/test-utils/factories/create-mock-checkpoint-batch.ts
+++ b/services/activity/src/test-utils/factories/create-mock-checkpoint-batch.ts
@@ -10,7 +10,7 @@ interface CreateMockCheckpointBatchConfig {
 
   /**
    * Extra fields merged into the last entry's payload — `type`/`rewards` for a batch ending in a
-   * terminal checkpoint. Excluded from the hashed subset, so the chain stays valid.
+   * terminal checkpoint. Merged before that entry's hash is computed, so the chain stays valid.
    */
   readonly finalPayloadOverrides?: Readonly<Record<string, unknown>>;
 

--- a/services/activity/src/test-utils/factories/create-mock-checkpoint-batch.ts
+++ b/services/activity/src/test-utils/factories/create-mock-checkpoint-batch.ts
@@ -10,7 +10,7 @@ interface CreateMockCheckpointBatchConfig {
 
   /**
    * Extra fields merged into the last entry's payload — `type`/`rewards` for a batch ending in a
-   * terminal checkpoint. Ignored by `buildCheckpointHash`, so the chain stays valid.
+   * terminal checkpoint. Excluded from the hashed subset, so the chain stays valid.
    */
   readonly finalPayloadOverrides?: Readonly<Record<string, unknown>>;
 
@@ -39,8 +39,8 @@ interface CreateMockCheckpointBatchConfig {
 }
 
 /**
- * Builds a chain-valid checkpoint batch: real hashes computed via `buildCheckpointHash`, each
- * entry linking onto the previous one, starting from a given version and previous hash.
+ * Builds a chain-valid checkpoint batch: real hashes computed the same way the service validates
+ * them, each entry linking onto the previous one, starting from a given version and previous hash.
  */
 export function createMockCheckpointBatch(
   config: Readonly<CreateMockCheckpointBatchConfig>,

--- a/services/avatar/src/test-utils/create-avatar-row.ts
+++ b/services/avatar/src/test-utils/create-avatar-row.ts
@@ -7,8 +7,8 @@ interface CreateAvatarRowData extends Partial<Insertable<Avatars>> {
 }
 
 /**
- * Inserts an avatar row for a given owner via kysely — needed to seed avatars owned by *another*
- * user for cross-tenant ownership tests, which can't go through the owner-scoped RPC client.
+ * Seeds an avatar owned by *another* user for cross-tenant ownership tests, which can't go through
+ * the owner-scoped RPC client.
  */
 export function createAvatarRow(
   db: Kysely<DB>,

--- a/services/replay/src/replay/compare-replay-segment.ts
+++ b/services/replay/src/replay/compare-replay-segment.ts
@@ -5,8 +5,8 @@ import { TERMINAL_CHECKPOINT_TYPES } from './types';
 import type { CompareVerdict, ReplayedCheckpoint, RewardFact, StoredCheckpoint } from './types';
 
 /**
- * The sole legal entropy-source tag until #467/#470 land mode-aware validation and self-found
- * verification.
+ * The sole legal entropy-source tag: the checkpoint chain is derived only from server-held key
+ * material.
  */
 const SERVER_KEY_ENTROPY_SOURCE: EntropySource = 'server-key';
 

--- a/services/replay/src/replay/types.ts
+++ b/services/replay/src/replay/types.ts
@@ -97,7 +97,7 @@ type DivergenceReason =
 /**
  * The outcome of comparing a segment's stored checkpoints against a fresh replay. `match` carries
  * the segment's verified xp delta (the terminal checkpoint's reward, when the segment ends on one,
- * else zero) for the caller to fold into its `applyVerifiedSegment` call.
+ * else zero) for the caller to fold into its verified-segment apply.
  */
 export type CompareVerdict =
   | {

--- a/services/replay/src/worker/start-replay-worker.ts
+++ b/services/replay/src/worker/start-replay-worker.ts
@@ -72,9 +72,8 @@ function pickBackoffMs(idleStreak: number): number {
 
 /**
  * Resolves after `ms`, or immediately once `signal` aborts — an idle worker's sleep never
- * outlives a requested stop. The loser of the race leaves no timer or listener behind: both are
- * explicitly cleared once the race settles either way, so a pending timeout never holds up an
- * otherwise-finished shutdown.
+ * outlives a requested stop. Both the timer and the listener are cleared once the race settles
+ * either way, so a pending timeout never holds up an otherwise-finished shutdown.
  */
 function wait(ms: number, signal: AbortSignal): Promise<void> {
   let onAbort: (() => void) | undefined;

--- a/services/session/src/create-session-service.ts
+++ b/services/session/src/create-session-service.ts
@@ -23,7 +23,7 @@ const envShape = {
 };
 
 /**
- * Boots the session service; the production entrypoint and tests both call this as the one shared config.
+ * The production entrypoint and tests both boot through this one shared config.
  */
 export function createSessionService(
   config: CreateSessionServiceConfig = {},

--- a/services/session/src/handlers/consume-pending-transaction.ts
+++ b/services/session/src/handlers/consume-pending-transaction.ts
@@ -31,7 +31,7 @@ interface ConsumePendingTransactionOpts {
 /**
  * Atomically consumes a pending step-up transaction: the DELETE...RETURNING is the single
  * statement that both claims and reads the row, so a second consume of the same id always finds
- * it already gone (#148). The consuming request's fields are matched against the deleted row only
+ * it already gone. The consuming request's fields are matched against the deleted row only
  * after the delete — a mismatch still burns the transaction, by design, rather than leaving a
  * transaction alive for a second, better-matched attempt.
  */

--- a/services/session/src/handlers/consume-transaction-token.ts
+++ b/services/session/src/handlers/consume-transaction-token.ts
@@ -9,7 +9,7 @@ interface ConsumeTransactionTokenOpts {
 }
 
 /**
- * Marks a step-up transaction token's jti as used in a durable blocklist (#148): the row's own
+ * Marks a step-up transaction token's jti as used in a durable blocklist: the row's own
  * `expiresAt` — not a TTL cache's lifetime — is what a replay is checked against, so the blocklist
  * outlives any mismatch between the token's validity window and a cache's eviction policy. The
  * insert's `ON CONFLICT DO NOTHING` is the single statement that both claims and detects a replay;

--- a/services/session/src/handlers/refresh-tokens.ts
+++ b/services/session/src/handlers/refresh-tokens.ts
@@ -18,7 +18,7 @@ interface RefreshTokensOpts {
 
 /**
  * Rotates a session's refresh token, or skips rotation inside the grace window. Reuse detection
- * (#154) keeps a one-deep history: `previousRefreshToken` is the last rotated-away token, so a
+ * keeps a one-deep history: `previousRefreshToken` is the last rotated-away token, so a
  * client that replays it (its own request having lost the race, or an attacker replaying a
  * stolen token) revokes the whole session rather than being silently ignored. Rotation itself is
  * one conditional UPDATE keyed on the refresh token it expects to replace — a concurrent

--- a/services/session/src/handlers/remove-session.ts
+++ b/services/session/src/handlers/remove-session.ts
@@ -15,7 +15,7 @@ interface RemoveSessionOpts {
 
 /**
  * Removes a session owned by the acting user. A foreign or already-missing id is a silent
- * no-op (#147) — the contract declares no NOT_FOUND, so ownership can't be probed by inspecting
+ * no-op — the contract declares no NOT_FOUND, so ownership can't be probed by inspecting
  * the response.
  */
 export async function removeSession(

--- a/services/session/src/handlers/to-pending-transaction-data.ts
+++ b/services/session/src/handlers/to-pending-transaction-data.ts
@@ -4,8 +4,7 @@ import type { Selectable } from 'kysely';
 
 /**
  * Maps a kysely `pending_transactions` row onto the contract's `PendingTransactionData` shape,
- * stripping the row's own timestamps. `action` is cast to `SecureAction`: the column is untyped
- * text, but every write goes through `SecureActionSchema`-validated contract input.
+ * stripping the row's own timestamps.
  */
 export function toPendingTransactionData(
   row: Readonly<Selectable<PendingTransactions>>,

--- a/services/user/src/handlers/create-password-reset-token.ts
+++ b/services/user/src/handlers/create-password-reset-token.ts
@@ -17,7 +17,7 @@ interface CreatePasswordResetTokenOpts {
 }
 
 /**
- * Mints a password-reset token, storing only its sha256 hash (#152) and returning the plaintext to
+ * Mints a password-reset token, storing only its sha256 hash and returning the plaintext to
  * present to the reset flow.
  */
 export async function createPasswordResetToken(

--- a/services/user/src/handlers/reset-password.ts
+++ b/services/user/src/handlers/reset-password.ts
@@ -17,7 +17,7 @@ interface ResetPasswordOpts {
 
 /**
  * Resets a user's password given a plaintext reset token whose sha256 hash matches the stored
- * value (#152); atomically rehashes the password and signs the user out of every session (#149).
+ * value; atomically rehashes the password and signs the user out of every session.
  */
 export async function resetPassword(
   db: Kysely<DB>,

--- a/services/user/src/handlers/update-email.ts
+++ b/services/user/src/handlers/update-email.ts
@@ -19,9 +19,9 @@ interface UpdateEmailOpts {
  * Changes the acting user's email, repointing any in-progress 2FA verification at the old email
  * to the new one in the same statement; throws CONFLICT when the email is taken. The users update
  * only applies while the row still holds the old email read just before it, and the verifications
- * repoint targets that same old email — pinning both edits to the row this call observed. In the
- * exotic case of a concurrent email change racing this one, the guarded update matches zero rows
- * and the call retries once against the row's current email before giving up.
+ * repoint targets that same old email. In the exotic case of a concurrent email change racing this
+ * one, the guarded update matches zero rows and the call retries once against the row's current
+ * email before giving up.
  */
 export async function updateEmail(
   db: Kysely<DB>,

--- a/services/user/src/handlers/verify-password.ts
+++ b/services/user/src/handlers/verify-password.ts
@@ -2,7 +2,7 @@ import type { DB } from '@vers/db';
 import type { Kysely } from 'kysely';
 
 // a fixed, valid argon2id hash verified against on every miss so a missing user or unset
-// password takes the same time as a real check — never revealing which case occurred (#155)
+// password takes the same time as a real check — never revealing which case occurred
 const DUMMY_HASH =
   '$argon2id$v=19$m=65536,t=2,p=1$HcnWDKgn0Ge+fMLfUNLxdQyZQP62cm11r4tp2hS9GwE$jcksXM4djDmS+FjzQVmKOHr/5+J1lvSh1lPjUesXBco';
 
@@ -15,7 +15,7 @@ interface VerifyPasswordOpts {
 
 /**
  * Checks a password against a user's stored hash; never throws for wrong credentials or an
- * unknown email, and rehashes a successfully verified legacy bcrypt hash to argon2id (#150).
+ * unknown email, and rehashes a successfully verified legacy bcrypt hash to argon2id.
  */
 export async function verifyPassword(
   db: Kysely<DB>,

--- a/services/user/src/handlers/verify-password.ts
+++ b/services/user/src/handlers/verify-password.ts
@@ -1,8 +1,10 @@
 import type { DB } from '@vers/db';
 import type { Kysely } from 'kysely';
 
-// a fixed, valid argon2id hash verified against on every miss so a missing user or unset
-// password takes the same time as a real check — never revealing which case occurred
+/**
+ * A fixed, valid argon2id hash verified against on every miss so a missing user or unset password
+ * takes the same time as a real check, never revealing which case occurred.
+ */
 const DUMMY_HASH =
   '$argon2id$v=19$m=65536,t=2,p=1$HcnWDKgn0Ge+fMLfUNLxdQyZQP62cm11r4tp2hS9GwE$jcksXM4djDmS+FjzQVmKOHr/5+J1lvSh1lPjUesXBco';
 

--- a/services/verification/src/handlers/create-verification.ts
+++ b/services/verification/src/handlers/create-verification.ts
@@ -5,10 +5,14 @@ import type { DB } from '@vers/db';
 import type { Kysely } from 'kysely';
 import { toVerificationData } from './to-verification-data';
 
-// alphanumeric excluding 0, O, and I on purpose to avoid confusing users
+/**
+ * Alphanumeric excluding 0, O, and I to avoid confusing users.
+ */
 const TOTP_CHARSET = 'ABCDEFGHJKLMNPQRSTUVWXYZ123456789';
 
-// standard charset used by 2FA apps
+/**
+ * The digit charset standard 2FA apps expect.
+ */
 const TWO_FACTOR_CHARSET = '0123456789';
 
 const VERIFICATION_TYPE_TO_CHARSET: Record<VerificationType, string> = {


### PR DESCRIPTION
## Description

Audit every commented source file against the AGENTS.md comment rules, then trim the survivors for brevity. Comment-only — zero code lines change.

- Drop history, TODOs, "until X is wired up" placeholders, and issue numbers from prose comments — rationale lives in the commit, not the code.
- Replace references to sibling declarations, doc paths, and commands with the contract they describe, so a rename can't strand them.
- Promote `//` on declarations to JSDoc blocks; delete comments that only restated a name or signature.
- Correct stale comments, including `merge-seeds`' step list claiming a `>>>0` coercion the body never performs and `previews.ts`' nonexistent `yarn email:preview` command.
- Brevity pass: cut clauses that restate a neighbour, an obvious mechanic, or a rationale already stated once — losing no fact.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] `bun run test` passes
- [ ] New tests added for new functionality