### PR TITLE
fix(#673): make the combat event sorter a deterministic total order

### DIFF
--- a/libs/game/idle-core/src/core/utils/create-event-sorter.test.ts
+++ b/libs/game/idle-core/src/core/utils/create-event-sorter.test.ts
@@ -81,7 +81,7 @@ test('it breaks same-source ties by id, independent of scheduling order', () => 
 
   const enemyB: EnemyAttackEvent = {
     id: 'event-b',
-    source: 'enemy-2',
+    source: 'enemy-1',
     time: 100,
     type: CombatEventType.EnemyAttack,
   };

--- a/libs/game/idle-core/src/core/utils/create-event-sorter.test.ts
+++ b/libs/game/idle-core/src/core/utils/create-event-sorter.test.ts
@@ -66,3 +66,28 @@ test('it prioritizes avatar events when time is equal', () => {
 
   expect(events).toStrictEqual([avatarEvent, enemyEvent2, enemyEvent3]);
 });
+
+test('it breaks same-source ties by id, independent of scheduling order', () => {
+  const ctx = createMockSimulationContext();
+  const data = createMockAvatarData();
+  const avatar = createAvatar(data, ctx);
+
+  const enemyA: EnemyAttackEvent = {
+    id: 'event-a',
+    source: 'enemy-1',
+    time: 100,
+    type: CombatEventType.EnemyAttack,
+  };
+
+  const enemyB: EnemyAttackEvent = {
+    id: 'event-b',
+    source: 'enemy-2',
+    time: 100,
+    type: CombatEventType.EnemyAttack,
+  };
+
+  const sorter = createEventSorter(avatar);
+
+  expect([enemyA, enemyB].toSorted(sorter)).toStrictEqual([enemyA, enemyB]);
+  expect([enemyB, enemyA].toSorted(sorter)).toStrictEqual([enemyA, enemyB]);
+});

--- a/libs/game/idle-core/src/core/utils/create-event-sorter.ts
+++ b/libs/game/idle-core/src/core/utils/create-event-sorter.ts
@@ -1,17 +1,33 @@
 import type { Avatar, CombatEvent } from '../../types';
 
 /**
- * Orders combat events by ascending time, placing the avatar's own events before others' at the
- * same timestamp.
+ * Orders combat events into a deterministic total order: ascending time, then the avatar's own
+ * events before others' at an equal timestamp, then by event id so same-source ties resolve the
+ * same way regardless of the order the events were scheduled in.
  */
 export function createEventSorter(avatar: Avatar) {
   return (a: CombatEvent, b: CombatEvent) => {
     const timeDiff = a.time - b.time;
 
-    if (timeDiff === 0) {
-      return a.source === avatar.id ? -1 : 1;
+    if (timeDiff !== 0) {
+      return timeDiff;
     }
 
-    return timeDiff;
+    const aIsAvatar = a.source === avatar.id;
+    const bIsAvatar = b.source === avatar.id;
+
+    if (aIsAvatar !== bIsAvatar) {
+      return aIsAvatar ? -1 : 1;
+    }
+
+    if (a.id < b.id) {
+      return -1;
+    }
+
+    if (a.id > b.id) {
+      return 1;
+    }
+
+    return 0;
   };
 }


### PR DESCRIPTION
## Description

Closes #673. `createEventSorter` returned the same sign both directions for two same-time, same-source events, so their apply order fell to the JS engine's sort stability and flipped with scheduling order — a determinism hole for a sim that must replay bit-for-bit.

- Add an event-`id` tiebreak after the time and avatar-first rules; `compare` returns `0` only for the same event.
- Add a regression test: a same-source tie resolves identically from either input order.
- No golden snapshot changed — no existing combat scenario relied on the unstable order.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `@vers/idle-core` `bun test` passes (185)
- [x] New test added