### PR TITLE
docs: trim three redundant comment tails

### DIFF
--- a/apps/web/src/lib/forms/types.ts
+++ b/apps/web/src/lib/forms/types.ts
@@ -17,7 +17,7 @@ export type FormAction = (
 
 /**
  * The subset of Conform's submit context the shared submit handler reads — the assembled
- * `FormData`. Conform passes a wider object; only this field is consumed.
+ * `FormData`.
  */
 export interface FormSubmitContext {
   readonly formData: FormData;

--- a/contracts/email/src/email-contract.ts
+++ b/contracts/email/src/email-contract.ts
@@ -59,7 +59,7 @@ export const emailContract = {
 
   /**
    * Despite the name, this template carries the signup onboarding OTP: `verificationCode` and
-   * `verificationURL` are the props it renders, not a distinct "welcome" payload.
+   * `verificationURL` are the props it renders.
    */
   sendWelcome: publicRoute
     .route({

--- a/libs/game/idle-client/src/state/set-checkpoint-stream-error.ts
+++ b/libs/game/idle-client/src/state/set-checkpoint-stream-error.ts
@@ -3,8 +3,7 @@ import { useIdleStore } from './use-idle-store';
 
 /**
  * Records a fatal checkpoint-stream rejection and empties the reward-slot ledger in the same
- * update: once the stream is invalid its pending rewards will never verify, so the same event that
- * reports the failure also drops the counts that were catching up.
+ * update: once the stream is invalid its pending rewards will never verify.
  */
 export function setCheckpointStreamError(checkpointStreamError: CheckpointStreamError) {
   useIdleStore.setState(() => ({ checkpointStreamError, rewardSlotLedger: [] }));


### PR DESCRIPTION
## Description

Three brevity trims the comment audit (#672) produced but that never landed — an apply step wrote them to the wrong checkout. Each drops a trailing clause restating what its comment already says. Comment-only, no fact lost.

- `forms/types.ts` — the "subset" lead already says only `formData` is read.
- `email-contract.ts` — "Despite the name … carries the signup onboarding OTP" already rules out a welcome payload.
- `set-checkpoint-stream-error.ts` — "in the same update" already states the single-write coupling.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] `bun run test` passes