### PR TITLE
feat(#675): gate the game shell behind an avatar roster

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -420,6 +420,7 @@
         "**/apps/web/src/routes/**/*.ts",
         "**/apps/web/src/routes/**/*.tsx",
         "**/apps/web/src/lib/auth/**/*.ts",
+        "**/apps/web/src/lib/avatar/**/*.ts",
         "**/apps/web/src/lib/avatar/**/*.tsx"
       ],
       "rules": {

--- a/apps/web/src/lib/auth/run-session-sign-in.ts
+++ b/apps/web/src/lib/auth/run-session-sign-in.ts
@@ -47,5 +47,5 @@ export async function runSessionSignIn(opts: Readonly<RunSessionSignInOptions>):
     { expiresAt: opts.session.expiresAt },
   );
 
-  throw redirect({ href: toSafeRedirectPath(opts.redirectTo, '/respite') });
+  throw redirect({ href: toSafeRedirectPath(opts.redirectTo, '/avatars') });
 }

--- a/apps/web/src/lib/avatar/get-avatar-content.test.ts
+++ b/apps/web/src/lib/avatar/get-avatar-content.test.ts
@@ -9,8 +9,8 @@ test('it throws when a shell route loads without an active avatar', async () => 
   const outcome = await withRequestContext({ cookies: signedIn.cookies }, () =>
     getAvatarContent()
       .then(() => null)
-      .catch((error: unknown) => error),
+      .catch((error: unknown) => (error instanceof Error ? error.message : null)),
   );
 
-  expect(outcome.value).toBeInstanceOf(Error);
+  expect(outcome.value).toContain('active avatar');
 });

--- a/apps/web/src/lib/avatar/get-avatar-content.test.ts
+++ b/apps/web/src/lib/avatar/get-avatar-content.test.ts
@@ -1,17 +1,16 @@
 import { expect, test } from 'bun:test';
-import { isRedirect } from '@tanstack/react-router';
 import { createSignedInUser } from '../../test-utils/create-signed-in-user';
 import { withRequestContext } from '../../test-utils/with-request-context';
 import { getAvatarContent } from './get-avatar-content';
 
-test('it redirects to avatar creation when the caller has no avatar yet', async () => {
+test('it throws when a shell route loads without an active avatar', async () => {
   const signedIn = await createSignedInUser();
 
   const outcome = await withRequestContext({ cookies: signedIn.cookies }, () =>
     getAvatarContent()
       .then(() => null)
-      .catch((error: unknown) => (isRedirect(error) ? error.options.href : null)),
+      .catch((error: unknown) => error),
   );
 
-  expect(outcome.value).toBe('/avatar/create');
+  expect(outcome.value).toBeInstanceOf(Error);
 });

--- a/apps/web/src/lib/avatar/get-avatar-content.tsx
+++ b/apps/web/src/lib/avatar/get-avatar-content.tsx
@@ -1,21 +1,20 @@
-import { redirect } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
 import { renderServerComponent } from '@tanstack/react-start/rsc';
+import invariant from 'tiny-invariant';
 import { AvatarContent } from '../../routes/-avatar/avatar-content';
 import { avatarClient } from '../rpc/clients/avatar-client';
 import { findActiveAvatar } from './find-active-avatar';
 
 /**
- * Runs fresh on every loader pass (no client-side cache layer of its own).
+ * Runs fresh on every loader pass (no client-side cache layer of its own). The shell gate redirects
+ * an avatarless caller to the roster before any shell route loads, so an active avatar is present.
  */
 export const getAvatarContent = createServerFn({ method: 'GET' }).handler(async () => {
   const avatars = await avatarClient.getAvatars({});
 
   const avatar = findActiveAvatar(avatars);
 
-  if (avatar === null) {
-    throw redirect({ href: '/avatar/create' });
-  }
+  invariant(avatar, 'a shell route loaded without an active avatar');
 
   const Renderable = await renderServerComponent(<AvatarContent avatar={avatar} />);
 

--- a/apps/web/src/lib/avatar/read-avatars.ts
+++ b/apps/web/src/lib/avatar/read-avatars.ts
@@ -1,0 +1,13 @@
+import { createServerFn } from '@tanstack/react-start';
+import { requireAuth } from '../auth/require-auth';
+import { avatarClient } from '../rpc/clients/avatar-client';
+
+/**
+ * Reads the caller's avatars for the roster; the standalone route guards its own auth since it sits
+ * outside the shell.
+ */
+export const readAvatars = createServerFn({ method: 'GET' }).handler(async () => {
+  await requireAuth();
+
+  return avatarClient.getAvatars({});
+});

--- a/apps/web/src/lib/avatar/require-active-avatar.test.ts
+++ b/apps/web/src/lib/avatar/require-active-avatar.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from 'bun:test';
+import { isRedirect } from '@tanstack/react-router';
+import * as db from '@vers/mock-services/db';
+import { createSignedInUser } from '../../test-utils/create-signed-in-user';
+import { withRequestContext } from '../../test-utils/with-request-context';
+import { requireActiveAvatar } from './require-active-avatar';
+
+test('it redirects to the roster when the caller has no avatar', async () => {
+  const signedIn = await createSignedInUser();
+
+  const outcome = await withRequestContext({ cookies: signedIn.cookies }, () =>
+    requireActiveAvatar()
+      .then(() => null)
+      .catch((error: unknown) => (isRedirect(error) ? error.options.href : null)),
+  );
+
+  expect(outcome.value).toBe('/avatars');
+});
+
+test('it does not redirect when the caller has an avatar', async () => {
+  const signedIn = await createSignedInUser();
+
+  await db.avatarCollection.create({ name: 'Karnak', userID: signedIn.userID });
+
+  const outcome = await withRequestContext({ cookies: signedIn.cookies }, () =>
+    requireActiveAvatar()
+      .then(() => 'passed')
+      .catch((error: unknown) => (isRedirect(error) ? error.options.href : 'other-error')),
+  );
+
+  expect(outcome.value).toBe('passed');
+});

--- a/apps/web/src/lib/avatar/require-active-avatar.ts
+++ b/apps/web/src/lib/avatar/require-active-avatar.ts
@@ -1,0 +1,20 @@
+import { redirect } from '@tanstack/react-router';
+import { createServerFn } from '@tanstack/react-start';
+import { avatarClient } from '../rpc/clients/avatar-client';
+import { findActiveAvatar } from './find-active-avatar';
+
+/**
+ * The game shell's gate: redirects to the avatar roster when the caller has no avatar to play, so
+ * every shell route can assume an active avatar exists.
+ */
+export const requireActiveAvatar = createServerFn({ method: 'GET' }).handler(async () => {
+  const avatars = await avatarClient.getAvatars({});
+
+  const avatar = findActiveAvatar(avatars);
+
+  if (avatar === null) {
+    throw redirect({ href: '/avatars' });
+  }
+
+  return { avatar };
+});

--- a/apps/web/src/routes/-avatar-create/run-avatar-create.test.ts
+++ b/apps/web/src/routes/-avatar-create/run-avatar-create.test.ts
@@ -34,7 +34,7 @@ test('it reports a field error for a name that is already taken', async () => {
   });
 });
 
-test('it creates the avatar and redirects to the avatar page', async () => {
+test('it creates the avatar and enters the game', async () => {
   const signedIn = await createSignedInUser();
 
   const outcome = await withRequestContext({ cookies: signedIn.cookies }, async () => {
@@ -45,7 +45,7 @@ test('it creates the avatar and redirects to the avatar page', async () => {
     return redirectHref;
   });
 
-  expect(outcome.value).toBe('/avatar');
+  expect(outcome.value).toBe('/explore');
 
   const created = db.avatarCollection.findFirst((q) =>
     q.where({ name: 'Karnak', userID: signedIn.userID }),
@@ -63,7 +63,7 @@ test('it creates a Self-Found avatar when that mode is requested', async () => {
       .catch((error: unknown) => (isRedirect(error) ? error.options.href : null)),
   );
 
-  expect(outcome.value).toBe('/avatar');
+  expect(outcome.value).toBe('/explore');
 
   const created = db.avatarCollection.findFirst((q) =>
     q.where({ name: 'Vagrant', userID: signedIn.userID }),

--- a/apps/web/src/routes/-avatar-create/run-avatar-create.ts
+++ b/apps/web/src/routes/-avatar-create/run-avatar-create.ts
@@ -39,7 +39,7 @@ export async function runAvatarCreate(formData: FormData): Promise<AvatarCreateR
     };
   }
 
-  throw redirect({ href: '/avatar' });
+  throw redirect({ href: '/explore' });
 }
 
 function toFieldErrors(error: z.ZodError): AvatarCreateResult['fieldErrors'] {

--- a/apps/web/src/routes/-avatars/avatar-roster.test.tsx
+++ b/apps/web/src/routes/-avatars/avatar-roster.test.tsx
@@ -1,0 +1,29 @@
+import { expect, test } from 'bun:test';
+import { screen } from '@testing-library/react';
+import { createMockAvatar } from '../../test-utils/factories/create-mock-avatar';
+import { renderWithRouter } from '../../test-utils/render-with-router';
+import { AvatarRoster } from './avatar-roster';
+
+test('it links each avatar into the game and offers a create slot', async () => {
+  const avatar = createMockAvatar({ name: 'Karnak' });
+
+  renderWithRouter(<AvatarRoster avatars={[avatar]} />);
+
+  const card = await screen.findByRole('link', { name: /Karnak/ });
+
+  expect(card).toHaveAttribute('href', '/explore');
+
+  expect(screen.getByRole('link', { name: /Create avatar/ })).toHaveAttribute(
+    'href',
+    '/avatars/create',
+  );
+});
+
+test('it shows only the create slot when the account has no avatars', async () => {
+  renderWithRouter(<AvatarRoster avatars={[]} />);
+
+  const createLink = await screen.findByRole('link', { name: /Create avatar/ });
+
+  expect(createLink).toHaveAttribute('href', '/avatars/create');
+  expect(screen.queryByText(/Level/)).not.toBeInTheDocument();
+});

--- a/apps/web/src/routes/-avatars/avatar-roster.tsx
+++ b/apps/web/src/routes/-avatars/avatar-roster.tsx
@@ -1,0 +1,81 @@
+import { Link } from '@tanstack/react-router';
+import type { AvatarData } from '@vers/contract-avatar';
+import { Heading, Text } from '@vers/design-system';
+import { css } from '@vers/styled-system/css';
+
+const screen = css({
+  alignItems: 'center',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '6',
+  padding: '8',
+});
+
+const grid = css({
+  display: 'grid',
+  gap: '4',
+  gridTemplateColumns: 'repeat(auto-fill, minmax(12rem, 1fr))',
+  width: 'full',
+});
+
+const card = css({
+  alignItems: 'flex-start',
+  backgroundColor: 'bg.panel',
+  borderColor: 'border',
+  borderRadius: 'lg',
+  borderWidth: '[1px]',
+  color: 'text.primary',
+  cursor: '[pointer]',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '2',
+  minHeight: '[9rem]',
+  padding: '5',
+  transitionDuration: 'fast',
+  transitionProperty: '[border-color]',
+  _hover: { borderColor: 'border.strong' },
+});
+
+const createSlot = css({
+  alignItems: 'center',
+  borderColor: 'border.strong',
+  borderRadius: 'lg',
+  borderStyle: '[dashed]',
+  borderWidth: '[1px]',
+  color: 'text.muted',
+  cursor: '[pointer]',
+  display: 'flex',
+  justifyContent: 'center',
+  minHeight: '[9rem]',
+  padding: '5',
+  transitionDuration: 'fast',
+  transitionProperty: '[color, border-color]',
+  _hover: { borderColor: 'border.strong', color: 'text.primary' },
+});
+
+const cardName = css({ fontSize: 'lg', fontWeight: 'semibold' });
+const cardMeta = css({ color: 'text.muted', fontSize: 'sm' });
+
+/**
+ * The pre-shell roster: pick an avatar to enter the game as, or take the empty slot to create one.
+ */
+export function AvatarRoster(props: Readonly<{ avatars: ReadonlyArray<AvatarData> }>) {
+  return (
+    <main className={screen}>
+      <Heading level={1}>Choose your avatar</Heading>
+      <div className={grid}>
+        {props.avatars.map((avatar) => (
+          <Link key={avatar.id} className={card} to="/explore">
+            <span className={cardName}>{avatar.name}</span>
+            <span className={cardMeta}>
+              Level {avatar.level} · {avatar.mode === 'self_found' ? 'Self-Found' : 'Trade'}
+            </span>
+          </Link>
+        ))}
+        <Link className={createSlot} to="/avatars/create">
+          <Text>+ Create avatar</Text>
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/routes/-avatars/avatar-roster.tsx
+++ b/apps/web/src/routes/-avatars/avatar-roster.tsx
@@ -14,7 +14,7 @@ const screen = css({
 const grid = css({
   display: 'grid',
   gap: '4',
-  gridTemplateColumns: 'repeat(auto-fill, minmax(12rem, 1fr))',
+  gridTemplateColumns: '[repeat(auto-fill,minmax(12rem,1fr))]',
   width: 'full',
 });
 

--- a/apps/web/src/routes/-home/home-hero.test.tsx
+++ b/apps/web/src/routes/-home/home-hero.test.tsx
@@ -26,7 +26,7 @@ test('it welcomes a signed-in visitor with links into the game and account', asy
     const welcome = await screen.findByText('Welcome back, Demo Account.');
 
     expect(welcome).toBeVisible();
-    expect(screen.getByText('Enter game').closest('a')).toHaveAttribute('href', '/respite');
+    expect(screen.getByText('Enter game').closest('a')).toHaveAttribute('href', '/avatars');
     expect(screen.getByText('Account').closest('a')).toHaveAttribute('href', '/account');
   });
 });

--- a/apps/web/src/routes/-home/home-hero.tsx
+++ b/apps/web/src/routes/-home/home-hero.tsx
@@ -31,7 +31,7 @@ export function HomeHero(props: HomeHeroProps) {
           <>
             <Heading level={2}>Welcome back, {query.data.name}.</Heading>
             <nav className={linkRowStyles}>
-              <Link to="/respite">Enter game</Link>
+              <Link to="/avatars">Enter game</Link>
               <Link to="/account">Account</Link>
             </nav>
           </>

--- a/apps/web/src/routes/-login-force-logout/run-force-logout.test.ts
+++ b/apps/web/src/routes/-login-force-logout/run-force-logout.test.ts
@@ -68,7 +68,7 @@ test('it signs out every other live session and completes sign-in on confirm', a
     },
   );
 
-  expect(outcome.value).toBe('/respite');
+  expect(outcome.value).toBe('/avatars');
   expect(outcome.cookies['en_verification']).toStrictEqual({});
   expect(outcome.cookies['en_session']).toContainKeys(['accessToken', 'refreshToken', 'sessionID']);
   expect(db.sessionCollection.findFirst((q) => q.where({ id: otherSessionID }))).toBeUndefined();

--- a/apps/web/src/routes/-login-force-logout/run-force-logout.ts
+++ b/apps/web/src/routes/-login-force-logout/run-force-logout.ts
@@ -58,5 +58,5 @@ export async function runForceLogout(formData: FormData): Promise<never> {
     updateOptions,
   );
 
-  throw redirect({ href: toSafeRedirectPath(redirectTo, '/respite') });
+  throw redirect({ href: toSafeRedirectPath(redirectTo, '/avatars') });
 }

--- a/apps/web/src/routes/-login/run-login.test.ts
+++ b/apps/web/src/routes/-login/run-login.test.ts
@@ -166,7 +166,7 @@ test('it signs a first-time caller in directly and clears their redirect target'
   expect(outcome.cookies['en_session']).toContainKeys(['accessToken', 'refreshToken', 'sessionID']);
 });
 
-test('it lands a caller with no redirect target at respite', async () => {
+test('it lands a caller with no redirect target on the avatar roster', async () => {
   await db.userCollection.create({ email: 'default-landing@vers.test', password: 'password123' });
 
   const outcome = await withRequestContext({}, async () => {

--- a/apps/web/src/routes/-login/run-login.test.ts
+++ b/apps/web/src/routes/-login/run-login.test.ts
@@ -179,5 +179,5 @@ test('it lands a caller with no redirect target at respite', async () => {
     return redirectHref;
   });
 
-  expect(outcome.value).toBe('/respite');
+  expect(outcome.value).toBe('/avatars');
 });

--- a/apps/web/src/routes/-onboarding/run-onboarding.test.ts
+++ b/apps/web/src/routes/-onboarding/run-onboarding.test.ts
@@ -151,7 +151,7 @@ test('it creates the account, signs the caller in, and clears the onboarding ses
     },
   );
 
-  expect(outcome.value).toBe('/respite');
+  expect(outcome.value).toBe('/avatars');
   expect(outcome.cookies['en_session']).toContainKeys(['accessToken', 'refreshToken', 'sessionID']);
   expect(outcome.cookies['en_verification']).toStrictEqual({});
 

--- a/apps/web/src/routes/-respite/respite-panel.test.tsx
+++ b/apps/web/src/routes/-respite/respite-panel.test.tsx
@@ -16,7 +16,7 @@ test('it shows a call to action for a caller with no avatar', async () => {
     const callToAction = await screen.findByText('Awaken your Avatar');
 
     expect(callToAction).toBeVisible();
-    expect(callToAction.closest('a')).toHaveAttribute('href', '/avatar/create');
+    expect(callToAction.closest('a')).toHaveAttribute('href', '/avatars/create');
   });
 });
 

--- a/apps/web/src/routes/-respite/respite-panel.tsx
+++ b/apps/web/src/routes/-respite/respite-panel.tsx
@@ -29,7 +29,7 @@ export function RespitePanel(props: RespitePanelProps) {
         <Heading level={1}>Destiny Awaits a Vessel</Heading>
         <Text>What is an Arbiter without a champion?</Text>
         <Text>Call forth your Avatar and guide their path across the World.</Text>
-        <Link to="/avatar/create">Awaken your Avatar</Link>
+        <Link to="/avatars/create">Awaken your Avatar</Link>
       </>
     );
   }

--- a/apps/web/src/routes/_game.tsx
+++ b/apps/web/src/routes/_game.tsx
@@ -2,6 +2,7 @@ import { Outlet, createFileRoute, useMatches } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
 import { resolveFlags } from '@vers/flags';
 import { requireAuth } from '../lib/auth/require-auth';
+import { requireActiveAvatar } from '../lib/avatar/require-active-avatar';
 import { ActivityProgressNotice } from './-game/activity-progress-notice';
 import { AmbientSheet } from './-game/ambient-sheet';
 import { GameCanvasMount } from './-game/game-canvas-mount';
@@ -17,7 +18,10 @@ const resolveFlagsFn = createServerFn({ method: 'GET' }).handler(() => resolveFl
 export const Route = createFileRoute('/_game')({
   beforeLoad: async () => ({ flags: await resolveFlagsFn() }),
   component: GameLayout,
-  loader: () => requireAuthFn(),
+  loader: async () => {
+    await requireAuthFn();
+    await requireActiveAvatar();
+  },
 });
 
 function GameLayout() {

--- a/apps/web/src/routes/_game/avatar_.create.tsx
+++ b/apps/web/src/routes/_game/avatar_.create.tsx
@@ -1,8 +1,0 @@
-import { createFileRoute } from '@tanstack/react-router';
-import { AvatarCreateForm } from '../-avatar-create/avatar-create-form';
-
-export const Route = createFileRoute('/_game/avatar_/create')({
-  component: AvatarCreateForm,
-  head: () => ({ meta: [{ title: 'vers | Create an Avatar' }] }),
-  staticData: { presentation: 'focus' },
-});

--- a/apps/web/src/routes/avatars.tsx
+++ b/apps/web/src/routes/avatars.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { readAvatars } from '../lib/avatar/read-avatars';
+import { AvatarRoster } from './-avatars/avatar-roster';
+
+export const Route = createFileRoute('/avatars')({
+  component: AvatarsPage,
+  head: () => ({ meta: [{ title: 'vers | Avatars' }] }),
+  loader: async () => ({ avatars: await readAvatars() }),
+});
+
+function AvatarsPage() {
+  const data = Route.useLoaderData();
+
+  return <AvatarRoster avatars={data.avatars} />;
+}

--- a/apps/web/src/routes/avatars_.create.tsx
+++ b/apps/web/src/routes/avatars_.create.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { createServerFn } from '@tanstack/react-start';
+import { requireAuth } from '../lib/auth/require-auth';
+import { AvatarCreateForm } from './-avatar-create/avatar-create-form';
+
+const requireAuthFn = createServerFn({ method: 'GET' }).handler(() => requireAuth());
+
+export const Route = createFileRoute('/avatars_/create')({
+  component: AvatarCreateForm,
+  head: () => ({ meta: [{ title: 'vers | Create an Avatar' }] }),
+  loader: () => requireAuthFn(),
+});

--- a/apps/web/src/test-utils/factories/create-mock-avatar.test.ts
+++ b/apps/web/src/test-utils/factories/create-mock-avatar.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from 'bun:test';
+import { createMockAvatar } from './create-mock-avatar';
+
+test('it builds an avatar with every field defaulted', () => {
+  const avatar = createMockAvatar();
+
+  expect(avatar).toContainAllKeys([
+    'createdAt',
+    'id',
+    'level',
+    'mode',
+    'name',
+    'updatedAt',
+    'userID',
+    'xp',
+  ]);
+});
+
+test('it applies overrides over the defaults', () => {
+  const avatar = createMockAvatar({ level: 5, name: 'Karnak' });
+
+  expect(avatar).toMatchObject({ level: 5, name: 'Karnak' });
+});

--- a/apps/web/src/test-utils/factories/create-mock-avatar.ts
+++ b/apps/web/src/test-utils/factories/create-mock-avatar.ts
@@ -1,0 +1,16 @@
+import { faker } from '@faker-js/faker';
+import type { AvatarData } from '@vers/contract-avatar';
+
+export function createMockAvatar(overrides: Readonly<Partial<AvatarData>> = {}): AvatarData {
+  return {
+    createdAt: faker.date.past(),
+    id: faker.string.uuid(),
+    level: faker.number.int({ max: 99, min: 1 }),
+    mode: 'trade',
+    name: faker.person.firstName(),
+    updatedAt: faker.date.recent(),
+    userID: faker.string.uuid(),
+    xp: faker.number.int({ max: 100_000, min: 0 }),
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Description

Closes #675. Adds a pre-shell avatar roster: after signing in you land on your avatars and pick one before the game opens, and every shell route now requires an active avatar.

- New `/avatars` roster (pick a card to enter) and `/avatars/create` reusing the existing create form; the in-shell create route is removed.
- `_game` gains an active-avatar gate — avatarless callers redirect to the roster; deep-links still honor their target.
- Default post-auth landing (login, verify, onboarding, force-logout, home) is now the roster.
- Create redirects into the game; `get-avatar-content`'s avatarless case becomes an invariant the gate guarantees.
- Single-avatar backend unchanged; server-side active-avatar and multiple avatars are #676.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality

## Context

Part of the incremental low-fidelity design migration; a hi-fi pass on the roster screen comes later. Selection is trivial at single-avatar (enter as the one you have) — #676 makes it real and persistent.