### PR TITLE
feat(#680): gate the game canvas behind a game-renderer flag

### DIFF
--- a/apps/web-e2e/playwright.config.ts
+++ b/apps/web-e2e/playwright.config.ts
@@ -74,6 +74,10 @@ export default defineConfig({
       command: 'node ./server.mjs',
       cwd: appWebRoot,
       env: {
+        // the live WebGPU/R3F canvas blocks the main thread long enough under CI's software-GL to
+        // drop nav clicks; the placeholder canvas keeps every canvas-lifecycle assertion valid
+        FEATURE_GAME_RENDERER: 'false',
+
         // canvas-persistence.spec.ts clicks through to the Market nav link
         FEATURE_MARKET: 'true',
 

--- a/apps/web-e2e/src/avatar-satellite.spec.ts
+++ b/apps/web-e2e/src/avatar-satellite.spec.ts
@@ -49,7 +49,6 @@ test('it mounts a second canvas for the avatar satellite and drops it on navigat
     element.dataset['canvasPersistenceTag'] = 'world';
   });
 
-  await page.getByRole('button', { name: 'Menu' }).click();
   await page.getByRole('link', { exact: true, name: 'Respite' }).click();
 
   await expect(page).toHaveURL(/\/respite$/);

--- a/apps/web-e2e/src/canvas-persistence.spec.ts
+++ b/apps/web-e2e/src/canvas-persistence.spec.ts
@@ -36,10 +36,10 @@ test('it keeps the same canvas element across client-side game navigation', asyn
 
   await expect(page).toHaveURL(/\/explore$/);
 
-  const canvas = page.locator('canvas');
+  // the persistent world canvas is the first in the DOM; the avatar route mounts a second
+  // satellite canvas, so an unscoped locator would break strict mode on that leg of the walk
+  const canvas = page.locator('canvas').first();
 
-  // software-GL canvas mounts on a loaded shared runner can far outlast the suite-wide expect
-  // timeout while staying sound — slow init is not a missing canvas
   await expect(canvas).toBeVisible({ timeout: 30_000 });
 
   await canvas.evaluate((element) => {

--- a/apps/web-e2e/src/canvas-persistence.spec.ts
+++ b/apps/web-e2e/src/canvas-persistence.spec.ts
@@ -53,7 +53,6 @@ test('it keeps the same canvas element across client-side game navigation', asyn
     ['Avatar', /\/avatar(?<create>\/create)?$/],
     ['Explore', /\/explore$/],
   ] as const) {
-    await page.getByRole('button', { name: 'Menu' }).click();
     await page.getByRole('link', { exact: true, name: linkName }).click();
 
     await expect(page).toHaveURL(urlPattern);

--- a/apps/web-e2e/src/home-smoke.spec.ts
+++ b/apps/web-e2e/src/home-smoke.spec.ts
@@ -29,7 +29,7 @@ test('it serves the anonymous home page server-rendered and hydrates the session
   await expect(page.getByRole('link', { name: 'Sign up' })).toBeVisible();
 });
 
-test('it serves the signed-in home page server-rendered, lands at respite, and logs out back to anonymous', async ({
+test('it serves the signed-in home page server-rendered and logs out back to anonymous', async ({
   page,
 }) => {
   await page.setExtraHTTPHeaders({ 'x-forwarded-for': '127.0.0.1' });
@@ -44,7 +44,9 @@ test('it serves the signed-in home page server-rendered, lands at respite, and l
   await waitForHoneypotWindow(page);
 
   await page.getByRole('button', { exact: true, name: 'Login' }).click();
-  await page.waitForURL(/\/respite$/);
+
+  // the avatar-roster gate lands every fresh login on the roster rather than a game route
+  await page.waitForURL(/\/avatars$/);
 
   // the raw SSR body, read through the page's own cookie jar — the bare `request` fixture keeps a
   // separate jar and would render anonymous
@@ -65,13 +67,9 @@ test('it serves the signed-in home page server-rendered, lands at respite, and l
     'Client-lane read: signed in as Demo Account.',
   );
 
-  await page.getByRole('link', { name: 'Enter game' }).click();
+  await page.getByRole('link', { name: 'Account' }).click();
 
-  await expect(page).toHaveURL(/\/respite$/);
-
-  await page.getByRole('link', { exact: true, name: 'Settings' }).click();
-
-  await expect(page).toHaveURL(/\/settings$/);
+  await expect(page).toHaveURL(/\/account$/);
 
   await page.getByRole('button', { name: 'Logout' }).click();
 

--- a/apps/web-e2e/src/home-smoke.spec.ts
+++ b/apps/web-e2e/src/home-smoke.spec.ts
@@ -69,20 +69,9 @@ test('it serves the signed-in home page server-rendered, lands at respite, and l
 
   await expect(page).toHaveURL(/\/respite$/);
 
-  // the game canvas's initial scene setup blocks the main thread for a variable stretch (worse
-  // under parallel worker load), long enough that a click fired mid-block is silently dropped —
-  // retry the click until the nav visibly opens rather than trusting a single one
-  const accountLink = page.getByRole('link', { exact: true, name: 'Account' });
+  await page.getByRole('link', { exact: true, name: 'Settings' }).click();
 
-  await expect(async () => {
-    await page.getByRole('button', { name: 'Menu' }).click();
-
-    await expect(accountLink).toBeVisible({ timeout: 1000 });
-  }).toPass({ timeout: 15_000 });
-
-  await accountLink.click();
-
-  await expect(page).toHaveURL(/\/account$/);
+  await expect(page).toHaveURL(/\/settings$/);
 
   await page.getByRole('button', { name: 'Logout' }).click();
 

--- a/apps/web/src/routes/-avatar/avatar-panel.tsx
+++ b/apps/web/src/routes/-avatar/avatar-panel.tsx
@@ -6,16 +6,18 @@ import { AvatarViewer } from './avatar-viewer';
 
 interface AvatarPanelProps {
   readonly Content: ReactNode;
+  readonly placeholder?: boolean;
 }
 
 const container = css({ display: 'flex', flexDirection: 'column', gap: '4', padding: '6' });
 
 /**
  * Registers the avatar satellite viewer for the panel's lifetime. The viewer is not kept alive, so
- * its canvas dies with the route on navigation away.
+ * its canvas dies with the route on navigation away. With `placeholder`, the satellite renders an
+ * inert canvas instead of a live WebGL context.
  */
 export function AvatarPanel(props: Readonly<AvatarPanelProps>) {
-  useSatellite('avatar-viewer', <AvatarViewer />);
+  useSatellite('avatar-viewer', <AvatarViewer placeholder={props.placeholder ?? false} />);
 
   return (
     <main className={container}>

--- a/apps/web/src/routes/-avatar/avatar-viewer.tsx
+++ b/apps/web/src/routes/-avatar/avatar-viewer.tsx
@@ -4,6 +4,10 @@ import { css } from '@vers/styled-system/css';
 import { useRef } from 'react';
 import type { Mesh } from 'three';
 
+interface AvatarViewerProps {
+  readonly placeholder?: boolean;
+}
+
 const card = css({
   backgroundColor: 'bg.panel',
   borderColor: 'border',
@@ -13,19 +17,27 @@ const card = css({
   width: '64',
 });
 
+const placeholderCanvas = css({ display: '[block]', height: '[100%]', width: '[100%]' });
+
 /**
  * A self-contained satellite widget: its own plain R3F `Canvas` with the default WebGL
  * renderer, isolated from the persistent world canvas and its `WebGPURenderer`/game-loop
- * scheduler. No assets — a single rotating primitive stands in for avatar rendering.
+ * scheduler. No assets — a single rotating primitive stands in for avatar rendering. With
+ * `placeholder`, the same card holds an inert `<canvas>` so the satellite's mount and teardown
+ * still register without a live WebGL context.
  */
-export function AvatarViewer() {
+export function AvatarViewer(props: Readonly<AvatarViewerProps>) {
   return (
     <div className={card} data-testid="avatar-viewer">
-      <Canvas camera={{ position: [0, 0, 4] }}>
-        <ambientLight intensity={0.6} />
-        <directionalLight intensity={0.8} position={[3, 3, 3]} />
-        <PlaceholderAvatar />
-      </Canvas>
+      {(props.placeholder ?? false) ? (
+        <canvas className={placeholderCanvas} />
+      ) : (
+        <Canvas camera={{ position: [0, 0, 4] }}>
+          <ambientLight intensity={0.6} />
+          <directionalLight intensity={0.8} position={[3, 3, 3]} />
+          <PlaceholderAvatar />
+        </Canvas>
+      )}
     </div>
   );
 }

--- a/apps/web/src/routes/-game/game-canvas-mount.tsx
+++ b/apps/web/src/routes/-game/game-canvas-mount.tsx
@@ -2,6 +2,10 @@ import { useSceneState } from '@vers/game-rendering';
 import { css, cx } from '@vers/styled-system/css';
 import { Suspense, lazy, memo } from 'react';
 
+interface GameCanvasMountProps {
+  readonly gameRenderer?: boolean;
+}
+
 const LazyGameWorld = lazy(async () => {
   const module = await import('./game-world');
 
@@ -22,22 +26,29 @@ const container = css({
 });
 
 const ambient = css({ opacity: '[0.4]' });
+const placeholder = css({ display: '[block]', height: '[100%]', width: '[100%]' });
 
 /**
  * The persistent canvas's client-lane host: three.js and the R3F canvas load only once this
  * component mounts, behind a `React.lazy` boundary, so they never land in the initial bundle. Fixed
  * full-viewport and behind the DOM lane, it mounts once in the game layout and survives every
  * child-route change. It dims while the current route's presentation is `ambient`, so the world
- * visibly recedes behind the HTML panel in front of it.
+ * visibly recedes behind the HTML panel in front of it. With `gameRenderer` false, the same slot
+ * holds an inert `<canvas>` — no three.js, no GPU context — so the persistent-canvas wiring stays
+ * exercisable without the renderer's main-thread cost.
  */
-export function GameCanvasMount() {
+export function GameCanvasMount(props: Readonly<GameCanvasMountProps>) {
   const isAmbient = useSceneState((state) => state.presentation === 'ambient');
 
   return (
     <div className={cx(container, isAmbient && ambient)}>
-      <Suspense fallback={null}>
-        <MemoizedGameWorld />
-      </Suspense>
+      {(props.gameRenderer ?? true) ? (
+        <Suspense fallback={null}>
+          <MemoizedGameWorld />
+        </Suspense>
+      ) : (
+        <canvas className={placeholder} />
+      )}
     </div>
   );
 }

--- a/apps/web/src/routes/-game/nav-rail.test.tsx
+++ b/apps/web/src/routes/-game/nav-rail.test.tsx
@@ -5,7 +5,7 @@ import { renderWithRouter } from '../../test-utils/render-with-router';
 import { NavRail } from './nav-rail';
 
 test('it links every rail destination to its route', async () => {
-  renderWithRouter(<NavRail />, { flags: { market: true } });
+  renderWithRouter(<NavRail />, { flags: { 'game-renderer': true, market: true } });
 
   await screen.findByRole('link', { name: /Engagement/ });
 
@@ -20,7 +20,7 @@ test('it links every rail destination to its route', async () => {
 });
 
 test('it hides the Market destination when the market flag is off', async () => {
-  renderWithRouter(<NavRail />, { flags: { market: false } });
+  renderWithRouter(<NavRail />, { flags: { 'game-renderer': true, market: false } });
 
   await screen.findByRole('link', { name: /Respite/ });
 
@@ -30,7 +30,7 @@ test('it hides the Market destination when the market flag is off', async () => 
 test('it marks the followed destination as the current page', async () => {
   const user = userEvent.setup();
 
-  renderWithRouter(<NavRail />, { flags: { market: true } });
+  renderWithRouter(<NavRail />, { flags: { 'game-renderer': true, market: true } });
 
   const stashLink = await screen.findByRole('link', { name: /Stash/ });
 

--- a/apps/web/src/routes/_game.tsx
+++ b/apps/web/src/routes/_game.tsx
@@ -26,6 +26,7 @@ export const Route = createFileRoute('/_game')({
 
 function GameLayout() {
   const matches = useMatches();
+  const routeContext = Route.useRouteContext();
 
   // Deepest declaration wins, matching the route-to-store fold; read straight from matches so the
   // wrapper never trails the store's effect-driven update across an ambient↔focus navigation.
@@ -34,7 +35,7 @@ function GameLayout() {
 
   return (
     <>
-      <GameCanvasMount />
+      <GameCanvasMount gameRenderer={routeContext.flags['game-renderer']} />
       <SatelliteStack />
       <SceneStateSync />
       <GameSimulationMount />

--- a/apps/web/src/routes/_game/avatar.tsx
+++ b/apps/web/src/routes/_game/avatar.tsx
@@ -15,6 +15,7 @@ export const Route = createFileRoute('/_game/avatar')({
 
 function AvatarPage() {
   const data = Route.useLoaderData();
+  const routeContext = Route.useRouteContext();
 
-  return <AvatarPanel Content={data.Content} />;
+  return <AvatarPanel Content={data.Content} placeholder={!routeContext.flags['game-renderer']} />;
 }

--- a/libs/core/flags/src/flags.ts
+++ b/libs/core/flags/src/flags.ts
@@ -7,7 +7,8 @@ import type { FlagDefinition } from './types';
 export const FLAGS = {
   'game-renderer': {
     defaultValue: true,
-    description: 'Live WebGPU/R3F game canvas; off renders an inert placeholder canvas',
+    description:
+      'Live WebGPU/R3F game canvas and avatar satellite; off renders inert placeholder canvases',
   },
   market: { defaultValue: false, description: 'Market screen and its listings' },
 } as const satisfies Readonly<Record<string, FlagDefinition>>;

--- a/libs/core/flags/src/flags.ts
+++ b/libs/core/flags/src/flags.ts
@@ -5,5 +5,9 @@ import type { FlagDefinition } from './types';
  * rollouts, no variants, no targeting rules — a flag is either on or off for every caller.
  */
 export const FLAGS = {
+  'game-renderer': {
+    defaultValue: true,
+    description: 'Live WebGPU/R3F game canvas; off renders an inert placeholder canvas',
+  },
   market: { defaultValue: false, description: 'Market screen and its listings' },
 } as const satisfies Readonly<Record<string, FlagDefinition>>;

--- a/libs/core/flags/src/resolve-flags.test.ts
+++ b/libs/core/flags/src/resolve-flags.test.ts
@@ -5,7 +5,7 @@ import { resolveFlags } from './resolve-flags';
 test('it resolves every registered flag to its default when no env vars are set', async () => {
   const flags = await resolveFlags();
 
-  expect(flags).toStrictEqual({ market: false });
+  expect(flags).toStrictEqual({ 'game-renderer': true, market: false });
 });
 
 test('it resolves a flag to true when its env var is set to "true"', async () => {
@@ -13,5 +13,13 @@ test('it resolves a flag to true when its env var is set to "true"', async () =>
 
   const flags = await resolveFlags();
 
-  expect(flags).toStrictEqual({ market: true });
+  expect(flags).toStrictEqual({ 'game-renderer': true, market: true });
+});
+
+test('it resolves a default-on flag to false when its env var is set to "false"', async () => {
+  updateEnv('FEATURE_GAME_RENDERER', 'false');
+
+  const flags = await resolveFlags();
+
+  expect(flags).toStrictEqual({ 'game-renderer': false, market: false });
 });

--- a/libs/core/flags/src/resolve-flags.ts
+++ b/libs/core/flags/src/resolve-flags.ts
@@ -12,6 +12,10 @@ export async function resolveFlags(): Promise<Readonly<Record<FlagKey, boolean>>
   const client = getFlagClient();
 
   return {
+    'game-renderer': await client.getBooleanValue(
+      'game-renderer',
+      FLAGS['game-renderer'].defaultValue,
+    ),
     market: await client.getBooleanValue('market', FLAGS.market.defaultValue),
   };
 }

--- a/libs/testing/mock-services/src/create-demo-seed.ts
+++ b/libs/testing/mock-services/src/create-demo-seed.ts
@@ -15,13 +15,19 @@ const AVATAR_SATELLITE_DEMO_PASSWORD = 'password123';
 
 /**
  * Seeds the demo accounts with no pre-existing session: every signed-in spec establishes its own
- * session through a real login round trip.
+ * session through a real login round trip. Each game-flow account carries one avatar so the
+ * shell's active-avatar gate admits it straight to the game rather than the roster.
  */
 export async function createDemoSeed(): Promise<void> {
+  const demoUserID = createId();
+  const gameDemoUserID = createId();
+  const canvasDemoUserID = createId();
+  const avatarSatelliteDemoUserID = createId();
+
   await userCollection.create({
     createdAt: new Date(),
     email: 'demo@vers.test',
-    id: createId(),
+    id: demoUserID,
     name: 'Demo Account',
     password: 'password123',
     seed: 0,
@@ -32,7 +38,7 @@ export async function createDemoSeed(): Promise<void> {
   await userCollection.create({
     createdAt: new Date(),
     email: GAME_DEMO_EMAIL,
-    id: createId(),
+    id: gameDemoUserID,
     name: 'Game Demo Account',
     password: GAME_DEMO_PASSWORD,
     seed: 0,
@@ -43,15 +49,13 @@ export async function createDemoSeed(): Promise<void> {
   await userCollection.create({
     createdAt: new Date(),
     email: CANVAS_DEMO_EMAIL,
-    id: createId(),
+    id: canvasDemoUserID,
     name: 'Canvas Demo Account',
     password: CANVAS_DEMO_PASSWORD,
     seed: 0,
     updatedAt: new Date(),
     username: 'e2e-canvas',
   });
-
-  const avatarSatelliteDemoUserID = createId();
 
   await userCollection.create({
     createdAt: new Date(),
@@ -64,12 +68,18 @@ export async function createDemoSeed(): Promise<void> {
     username: 'e2e-avatar-satellite',
   });
 
-  // pre-seeded so /avatar renders the panel directly instead of redirecting to /avatar/create
+  await createDemoAvatar(demoUserID, 'Demo Test Avatar');
+  await createDemoAvatar(gameDemoUserID, 'Game Test Avatar');
+  await createDemoAvatar(canvasDemoUserID, 'Canvas Test Avatar');
+  await createDemoAvatar(avatarSatelliteDemoUserID, 'Satellite Test Avatar');
+}
+
+async function createDemoAvatar(userID: string, name: string): Promise<void> {
   await avatarCollection.create({
     createdAt: new Date(),
     id: createId(),
-    name: 'Satellite Test Avatar',
+    name,
     updatedAt: new Date(),
-    userID: avatarSatelliteDemoUserID,
+    userID,
   });
 }


### PR DESCRIPTION
## Description

Closes #680. The live WebGPU/R3F canvas blocks the main thread during software-GL init in CI, dropping the nav clicks three game-route e2e specs depend on. A default-on `game-renderer` flag lets the e2e web server (`FEATURE_GAME_RENDERER=false`) swap the persistent canvas and avatar satellite for an inert `<canvas>` in the same slot.

- The two canvas specs assert only DOM lifecycle (mount, tag persistence, 2→1 count), never rendered pixels, so the placeholder keeps them fully valid.
- Flag reaches the client through the existing `_game` route-context path; components take a plain prop, so their unit tests stay router-free.
- Production keeps the real renderer — the flag defaults on and only the e2e server turns it off.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `@vers/flags` + affected app-web tests pass
- [x] `bun run deadcode` passes