### PR TITLE
feat(#621): make issue-hygiene comments actionable and self-resolving

### DIFF
--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -2,7 +2,7 @@ name: Issue Hygiene
 
 on:
   issues:
-    types: [opened]
+    types: [opened, edited, labeled, unlabeled, milestoned, demilestoned]
   workflow_dispatch:
     inputs:
       issue:

--- a/scripts/src/bin/issue-hygiene.ts
+++ b/scripts/src/bin/issue-hygiene.ts
@@ -1,6 +1,9 @@
 import { $ } from 'bun';
 import { z } from 'zod';
 import { checkIssue } from '../issue-hygiene/check-issue';
+import { findSectionStub } from '../issue-hygiene/find-section-stub';
+import { HYGIENE_MARKER, renderHygieneComment } from '../issue-hygiene/render-hygiene-comment';
+import type { Finding, ResolvedFinding } from '../issue-hygiene/types';
 
 const issueNumber = Number(process.argv[2]);
 
@@ -27,23 +30,77 @@ const findings = checkIssue({
   milestone: issue.milestone?.title ?? null,
 });
 
-if (findings.length === 0) {
+const resolved = await Promise.all(findings.map((finding) => resolveFinding(finding)));
+
+const body = renderHygieneComment(resolved);
+
+const repoResult = await $`gh repo view --json nameWithOwner -q .nameWithOwner`.text();
+
+const repo = process.env['GITHUB_REPOSITORY'] ?? repoResult.trim();
+
+const existingCommentID = await findStickyCommentID(repo, issueNumber);
+
+/**
+ * A clean issue that never earned a sticky comment needs none — only issues the bot has already
+ * commented on get their comment flipped to the all-clear rendering.
+ */
+if (findings.length === 0 && existingCommentID === null) {
   console.log(`#${issueNumber} is clean`);
   process.exit(0);
 }
 
-const comment = [
-  'Issue hygiene check found defects:',
-  '',
-  ...findings.map((finding) => `- ${finding}`),
-  '',
-  'Templates live in `.github/ISSUE_TEMPLATE`; the rules are the Issue hygiene section of AGENTS.md.',
-].join('\n');
-
-await $`gh issue comment ${issueNumber} --body ${comment}`;
+await upsertStickyComment(repo, issueNumber, existingCommentID, body);
 
 for (const finding of findings) {
-  console.log(`#${issueNumber}: ${finding}`);
+  console.log(`#${issueNumber}: ${finding.task}`);
 }
 
-process.exit(1);
+/**
+ * Resolves a finding's stub descriptor to paste-ready markdown: a section stub is read from its
+ * template file, a literal stub is passed through, and a finding without a stub stays without one.
+ */
+async function resolveFinding(finding: Finding): Promise<ResolvedFinding> {
+  if (finding.stub === undefined) {
+    return { rule: finding.rule, task: finding.task };
+  }
+
+  if (finding.stub.kind === 'literal') {
+    return { rule: finding.rule, stub: finding.stub.markdown, task: finding.task };
+  }
+
+  const template = await Bun.file(finding.stub.templatePath).text();
+
+  const stub = findSectionStub(template, finding.stub.title);
+
+  return stub === null
+    ? { rule: finding.rule, task: finding.task }
+    : { rule: finding.rule, stub, task: finding.task };
+}
+
+const commentSchema = z.array(z.object({ body: z.string(), id: z.number() }));
+
+async function findStickyCommentID(repository: string, issueNum: number): Promise<number | null> {
+  const raw: unknown =
+    await $`gh api repos/${repository}/issues/${issueNum}/comments --paginate`.json();
+
+  const sticky = commentSchema
+    .parse(raw)
+    .find((comment) => comment.body.startsWith(HYGIENE_MARKER));
+
+  return sticky?.id ?? null;
+}
+
+async function upsertStickyComment(
+  repository: string,
+  issueNum: number,
+  commentID: number | null,
+  commentBody: string,
+): Promise<void> {
+  if (commentID === null) {
+    await $`gh api --method POST repos/${repository}/issues/${issueNum}/comments -f body=${commentBody}`.quiet();
+
+    return;
+  }
+
+  await $`gh api --method PATCH repos/${repository}/issues/comments/${commentID} -f body=${commentBody}`.quiet();
+}

--- a/scripts/src/bin/issue-hygiene.ts
+++ b/scripts/src/bin/issue-hygiene.ts
@@ -77,9 +77,9 @@ async function resolveFinding(finding: Finding): Promise<ResolvedFinding> {
     : { rule: finding.rule, stub, task: finding.task };
 }
 
-const commentSchema = z.array(z.object({ body: z.string(), id: z.number() }));
-
 async function findStickyCommentID(repository: string, issueNum: number): Promise<number | null> {
+  const commentSchema = z.array(z.object({ body: z.string(), id: z.number() }));
+
   const raw: unknown =
     await $`gh api repos/${repository}/issues/${issueNum}/comments --paginate`.json();
 

--- a/scripts/src/issue-hygiene/check-issue.test.ts
+++ b/scripts/src/issue-hygiene/check-issue.test.ts
@@ -18,7 +18,13 @@ test('it flags a feature issue without a Scope section', () => {
     milestone: 'P2 · Game backend spine',
   });
 
-  expect(findings).toStrictEqual(['missing a `## Scope` section']);
+  expect(findings).toStrictEqual([
+    {
+      rule: 'a feature issue follows its template',
+      stub: { kind: 'section', templatePath: '.github/ISSUE_TEMPLATE/feature.md', title: 'Scope' },
+      task: 'Add a `## Scope` section listing the behaviors this delivers',
+    },
+  ]);
 });
 
 test('it requires a player story on an area/game feature', () => {
@@ -28,8 +34,8 @@ test('it requires a player story on an area/game feature', () => {
     milestone: 'P3 · World map',
   });
 
-  expect(findings).toStrictEqual([
-    'missing a `## Player story` section (required for area/game features)',
+  expect(findings.map((finding) => finding.task)).toStrictEqual([
+    'Add a `## Player story` section describing what the player perceives once this ships',
   ]);
 });
 
@@ -56,11 +62,11 @@ test('it does not require a player story on a non-game feature', () => {
 test('it flags an untriaged issue once per missing triage field', () => {
   const findings = checkIssue({ body: 'prose', labels: [], milestone: null });
 
-  expect(findings).toIncludeSameMembers([
-    'missing an `area/*` label',
-    'missing a type label (feature, bug, chore, …)',
-    'missing a priority label (`p0-critical`, `p1-high`, `p2-medium`)',
-    'missing the delivery-phase milestone',
+  expect(findings.map((finding) => finding.task)).toIncludeSameMembers([
+    'Add an `area/*` label for the subsystem it touches (e.g. `area/platform`, `area/game`)',
+    'Add a type label (`feature`, `bug`, `chore`, …)',
+    'Add a priority label (`p0-critical`, `p1-high`, `p2-medium`)',
+    'Assign the delivery-phase milestone',
   ]);
 });
 
@@ -71,8 +77,8 @@ test('it rejects a priority label outside the supported set', () => {
     milestone: 'P0 · Tooling',
   });
 
-  expect(findings).toStrictEqual([
-    'missing a priority label (`p0-critical`, `p1-high`, `p2-medium`)',
+  expect(findings.map((finding) => finding.task)).toStrictEqual([
+    'Add a priority label (`p0-critical`, `p1-high`, `p2-medium`)',
   ]);
 });
 
@@ -83,9 +89,9 @@ test('it requires observed, expected, and repro sections on a bug', () => {
     milestone: 'P3 · World map',
   });
 
-  expect(findings).toStrictEqual([
-    'missing a `## Expected` section',
-    'missing a `## Repro` section',
+  expect(findings.map((finding) => finding.task)).toStrictEqual([
+    'Add a `## Expected` section',
+    'Add a `## Repro` section',
   ]);
 });
 
@@ -116,10 +122,10 @@ test('it flags an upkeep issue with a milestone', () => {
     milestone: 'P0 · Tooling',
   });
 
-  expect(findings).toStrictEqual(['upkeep issues carry no milestone — remove it']);
+  expect(findings.map((finding) => finding.task)).toStrictEqual(['Remove the milestone']);
 });
 
-test('it flags an upkeep issue without a parseable trigger line', () => {
+test('it flags an upkeep issue without a parseable trigger line, offering a stub', () => {
   const findings = checkIssue({
     body: 'no trigger here',
     labels: ['upkeep', 'area/platform'],
@@ -127,7 +133,11 @@ test('it flags an upkeep issue without a parseable trigger line', () => {
   });
 
   expect(findings).toStrictEqual([
-    'body carries no parseable trigger line (`trigger: date <YYYY-MM-DD>` or `trigger: release <pkg> ><version>`)',
+    {
+      rule: 'an upkeep issue opens with a machine-readable trigger line the dep-health sweep evaluates',
+      stub: { kind: 'literal', markdown: '```\ntrigger: date <YYYY-MM-DD>\n```' },
+      task: 'Add a trigger line (`trigger: date <YYYY-MM-DD>` or `trigger: release <pkg> ><version>`)',
+    },
   ]);
 });
 

--- a/scripts/src/issue-hygiene/check-issue.ts
+++ b/scripts/src/issue-hygiene/check-issue.ts
@@ -1,5 +1,5 @@
 import { parseTrigger } from '../upkeep/parse-trigger';
-import type { IssueShape } from './types';
+import type { Finding, IssueShape } from './types';
 
 /**
  * Labels for issues the dep-health sweep creates and manages itself; their bodies are generated
@@ -20,63 +20,99 @@ const TYPE_LABELS = new Set([
   'spike',
 ]);
 
+const TEMPLATE_DIR = '.github/ISSUE_TEMPLATE';
+const BUG_TEMPLATE = `${TEMPLATE_DIR}/bug.md`;
+const FEATURE_TEMPLATE = `${TEMPLATE_DIR}/feature.md`;
+
 /**
- * Evaluates an issue against the repository's issue-shape rules, returning one human-readable
- * finding per violation and an empty array when the issue is clean. Requirements vary by type — an
- * upkeep issue carries a trigger line and no milestone, where other types require area, type, and
- * priority labels, a delivery milestone, and their template's body sections.
+ * Evaluates an issue against the repository's issue-shape rules, returning one actionable finding
+ * per violation and an empty array when the issue is clean. Requirements vary by type — an upkeep
+ * issue carries a trigger line and no milestone, where other types require area, type, and priority
+ * labels, a delivery milestone, and their template's body sections.
  */
-export function checkIssue(issue: IssueShape): Array<string> {
+export function checkIssue(issue: IssueShape): Array<Finding> {
   if (issue.labels.some((label) => EXEMPT_LABELS.has(label))) {
     return [];
   }
 
-  const findings: Array<string> = [];
+  const findings: Array<Finding> = [];
 
   if (!issue.labels.some((label) => label.startsWith('area/'))) {
-    findings.push('missing an `area/*` label');
+    findings.push({
+      rule: 'every issue carries an `area/*` label',
+      task: 'Add an `area/*` label for the subsystem it touches (e.g. `area/platform`, `area/game`)',
+    });
   }
 
   if (issue.labels.includes('upkeep')) {
     if (issue.milestone !== null) {
-      findings.push('upkeep issues carry no milestone — remove it');
+      findings.push({
+        rule: 'upkeep issues carry no milestone and stay off the delivery board',
+        task: 'Remove the milestone',
+      });
     }
 
     if (parseTrigger(issue.body) === null) {
-      findings.push(
-        'body carries no parseable trigger line (`trigger: date <YYYY-MM-DD>` or `trigger: release <pkg> ><version>`)',
-      );
+      findings.push({
+        rule: 'an upkeep issue opens with a machine-readable trigger line the dep-health sweep evaluates',
+        stub: {
+          kind: 'literal',
+          markdown: '```\ntrigger: date <YYYY-MM-DD>\n```',
+        },
+        task: 'Add a trigger line (`trigger: date <YYYY-MM-DD>` or `trigger: release <pkg> ><version>`)',
+      });
     }
 
     return findings;
   }
 
   if (!issue.labels.some((label) => TYPE_LABELS.has(label))) {
-    findings.push('missing a type label (feature, bug, chore, …)');
+    findings.push({
+      rule: 'every issue carries a type label',
+      task: 'Add a type label (`feature`, `bug`, `chore`, …)',
+    });
   }
 
   if (!issue.labels.some((label) => PRIORITY_LABELS.has(label))) {
-    findings.push('missing a priority label (`p0-critical`, `p1-high`, `p2-medium`)');
+    findings.push({
+      rule: 'every issue carries a priority label',
+      task: 'Add a priority label (`p0-critical`, `p1-high`, `p2-medium`)',
+    });
   }
 
   if (issue.milestone === null) {
-    findings.push('missing the delivery-phase milestone');
+    findings.push({
+      rule: 'every issue has a delivery-phase milestone',
+      task: 'Assign the delivery-phase milestone',
+    });
   }
 
   if (issue.labels.includes('feature')) {
     if (!hasSection(issue.body, 'Scope')) {
-      findings.push('missing a `## Scope` section');
+      findings.push({
+        rule: 'a feature issue follows its template',
+        stub: { kind: 'section', templatePath: FEATURE_TEMPLATE, title: 'Scope' },
+        task: 'Add a `## Scope` section listing the behaviors this delivers',
+      });
     }
 
     if (issue.labels.includes('area/game') && !hasSection(issue.body, 'Player story')) {
-      findings.push('missing a `## Player story` section (required for area/game features)');
+      findings.push({
+        rule: 'every area/game feature carries a `## Player story` section',
+        stub: { kind: 'section', templatePath: FEATURE_TEMPLATE, title: 'Player story' },
+        task: 'Add a `## Player story` section describing what the player perceives once this ships',
+      });
     }
   }
 
   if (issue.labels.includes('bug')) {
-    for (const section of ['Observed', 'Expected', 'Repro']) {
-      if (!hasSection(issue.body, section)) {
-        findings.push(`missing a \`## ${section}\` section`);
+    for (const title of ['Observed', 'Expected', 'Repro']) {
+      if (!hasSection(issue.body, title)) {
+        findings.push({
+          rule: 'a bug issue follows its template',
+          stub: { kind: 'section', templatePath: BUG_TEMPLATE, title },
+          task: `Add a \`## ${title}\` section`,
+        });
       }
     }
   }

--- a/scripts/src/issue-hygiene/find-section-stub.test.ts
+++ b/scripts/src/issue-hygiene/find-section-stub.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from 'bun:test';
+import { findSectionStub } from './find-section-stub';
+
+const TEMPLATE = [
+  '---',
+  'name: Bug',
+  '---',
+  '',
+  '## Observed',
+  '',
+  '<!-- what actually happens -->',
+  '',
+  '## Repro',
+  '',
+  '<!-- numbered steps -->',
+  '',
+].join('\n');
+
+test('it extracts a section up to the next heading, trimming trailing blank lines', () => {
+  expect(findSectionStub(TEMPLATE, 'Observed')).toBe(
+    '## Observed\n\n<!-- what actually happens -->',
+  );
+});
+
+test('it extracts the final section through end of file', () => {
+  expect(findSectionStub(TEMPLATE, 'Repro')).toBe('## Repro\n\n<!-- numbered steps -->');
+});
+
+test('it returns null when the template has no such heading', () => {
+  expect(findSectionStub(TEMPLATE, 'Expected')).toBeNull();
+});

--- a/scripts/src/issue-hygiene/find-section-stub.ts
+++ b/scripts/src/issue-hygiene/find-section-stub.ts
@@ -1,0 +1,24 @@
+/**
+ * Returns the named `##` section of an issue template — its heading through the line before the next
+ * `##` heading (or end of file), trailing blank lines trimmed — as a paste-ready block, or null when
+ * the template has no such heading.
+ */
+export function findSectionStub(template: string, title: string): string | null {
+  const lines = template.split('\n');
+
+  const headingPattern = new RegExp(`^##\\s+${title}\\s*$`);
+
+  const start = lines.findIndex((line) => headingPattern.test(line));
+
+  if (start === -1) {
+    return null;
+  }
+
+  let end = start + 1;
+
+  while (end < lines.length && !/^##\s/.test(lines[end] ?? '')) {
+    end += 1;
+  }
+
+  return lines.slice(start, end).join('\n').trimEnd();
+}

--- a/scripts/src/issue-hygiene/render-hygiene-comment.test.ts
+++ b/scripts/src/issue-hygiene/render-hygiene-comment.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from 'bun:test';
+import { renderHygieneComment } from './render-hygiene-comment';
+
+test('it renders an all-clear acknowledgement when there are no findings', () => {
+  expect(renderHygieneComment([])).toBe(
+    '<!-- issue-hygiene -->\n✅ **Issue hygiene: all clear.** Thanks for keeping this one tidy.',
+  );
+});
+
+test('it renders a stubless finding as a single checklist line tied to its rule', () => {
+  const comment = renderHygieneComment([
+    { rule: 'every issue carries a type label', task: 'Add a type label' },
+  ]);
+
+  expect(comment).toBe(
+    [
+      '<!-- issue-hygiene -->',
+      "Thanks for opening this! A few tweaks will help it move through triage — here's the checklist:",
+      '',
+      '- [ ] Add a type label — _every issue carries a type label_',
+      '',
+      "Edit the issue or adjust its labels once you've worked through these, and I'll re-check and update this comment.",
+    ].join('\n'),
+  );
+});
+
+test('it nests a section stub in a collapsible block under its checklist item', () => {
+  const comment = renderHygieneComment([
+    {
+      rule: 'a bug issue follows its template',
+      stub: '## Repro\n\n<!-- numbered steps -->',
+      task: 'Add a `## Repro` section',
+    },
+  ]);
+
+  expect(comment).toInclude(
+    [
+      '- [ ] Add a `## Repro` section — _a bug issue follows its template_',
+      '',
+      '  <details>',
+      '  <summary>Paste-ready stub</summary>',
+      '',
+      '  ````markdown',
+      '  ## Repro',
+      '',
+      '  <!-- numbered steps -->',
+      '  ````',
+      '',
+      '  </details>',
+    ].join('\n'),
+  );
+});
+
+test('it nests a fenced literal stub without colliding with the outer fence', () => {
+  const comment = renderHygieneComment([
+    {
+      rule: 'an upkeep issue opens with a trigger line',
+      stub: '```\ntrigger: date <YYYY-MM-DD>\n```',
+      task: 'Add a trigger line',
+    },
+  ]);
+
+  expect(comment).toInclude(
+    ['  ````markdown', '  ```', '  trigger: date <YYYY-MM-DD>', '  ```', '  ````'].join('\n'),
+  );
+});

--- a/scripts/src/issue-hygiene/render-hygiene-comment.ts
+++ b/scripts/src/issue-hygiene/render-hygiene-comment.ts
@@ -1,0 +1,57 @@
+import type { ResolvedFinding } from './types';
+
+/**
+ * Hidden marker on the comment's first line. The bin finds its prior sticky comment by this string,
+ * so it must stay identical across the clean and unclean renderings.
+ */
+export const HYGIENE_MARKER = '<!-- issue-hygiene -->';
+
+/**
+ * Renders the sticky hygiene comment: a conversational checklist of the findings, each tied to the
+ * rule it enforces and carrying a collapsible paste-ready stub where one applies, or an all-clear
+ * acknowledgement when there are no findings. The leading marker lets the bin recognise and update
+ * its own comment in place.
+ */
+export function renderHygieneComment(findings: ReadonlyArray<ResolvedFinding>): string {
+  if (findings.length === 0) {
+    return `${HYGIENE_MARKER}\n✅ **Issue hygiene: all clear.** Thanks for keeping this one tidy.`;
+  }
+
+  return [
+    HYGIENE_MARKER,
+    "Thanks for opening this! A few tweaks will help it move through triage — here's the checklist:",
+    '',
+    findings.map((finding) => renderFinding(finding)).join('\n'),
+    '',
+    "Edit the issue or adjust its labels once you've worked through these, and I'll re-check and update this comment.",
+  ].join('\n');
+}
+
+function renderFinding(finding: ResolvedFinding): string {
+  const line = `- [ ] ${finding.task} — _${finding.rule}_`;
+
+  if (finding.stub === undefined) {
+    return line;
+  }
+
+  return [line, '', ...renderStub(finding.stub)].join('\n');
+}
+
+/**
+ * Wraps the stub in a collapsible block indented under its checklist item. The outer fence uses four
+ * backticks so a stub that is itself a fenced block (the upkeep trigger line) nests cleanly.
+ */
+function renderStub(stub: string): Array<string> {
+  const indented = stub.split('\n').map((line) => (line === '' ? '' : `  ${line}`));
+
+  return [
+    '  <details>',
+    '  <summary>Paste-ready stub</summary>',
+    '',
+    '  ````markdown',
+    ...indented,
+    '  ````',
+    '',
+    '  </details>',
+  ];
+}

--- a/scripts/src/issue-hygiene/types.ts
+++ b/scripts/src/issue-hygiene/types.ts
@@ -3,3 +3,42 @@ export interface IssueShape {
   readonly labels: ReadonlyArray<string>;
   readonly milestone: string | null;
 }
+
+/**
+ * A stub whose text is the named `##` section of the issue type's template, extracted from the
+ * template at render time so it never drifts from the template itself.
+ */
+interface SectionStub {
+  readonly kind: 'section';
+  readonly title: string;
+  readonly templatePath: string;
+}
+
+/**
+ * A stub whose text is fixed rather than drawn from a template section — the upkeep trigger line,
+ * which lives in a fenced block, not under a heading.
+ */
+interface LiteralStub {
+  readonly kind: 'literal';
+  readonly markdown: string;
+}
+
+/**
+ * A single hygiene violation, phrased so the issue author can act on it: `task` is the imperative
+ * fix, `rule` names the AGENTS.md requirement it enforces, and `stub` — present when the fix is
+ * pasted body content — describes the paste-ready block to offer.
+ */
+export interface Finding {
+  readonly task: string;
+  readonly rule: string;
+  readonly stub?: SectionStub | LiteralStub;
+}
+
+/**
+ * A finding whose stub has been resolved to paste-ready markdown, ready for the comment renderer.
+ */
+export interface ResolvedFinding {
+  readonly task: string;
+  readonly rule: string;
+  readonly stub?: string;
+}


### PR DESCRIPTION
## Description

Closes #621

Turns the hygiene bot's bare rule citations into a conversational, self-resolving checklist.

- Findings are now structured: each carries the AGENTS.md rule it enforces and, where the fix is body content, a paste-ready stub.
- Section stubs are extracted from the issue type's template at runtime, so they can't drift from the template.
- The bin maintains one sticky comment (found by a hidden marker), updating it in place and flipping it to all-clear when the issue comes clean; a clean issue that never had a comment gets none.
- The check re-runs on `edited`/`labeled`/`unlabeled`/`milestoned`/`demilestoned`, not just `opened`, and always exits 0 — the comment is the signal, not a red check.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes (`@vers/scripts`)
- [x] `bun run lint` passes
- [x] New tests added for new functionality