### PR TITLE
test: drop dead canvas-render headroom from the e2e specs

### DIFF
--- a/apps/web-e2e/specs/avatar-satellite.spec.ts
+++ b/apps/web-e2e/specs/avatar-satellite.spec.ts
@@ -9,9 +9,6 @@ import { waitForHoneypotWindow } from '../src/wait-for-honeypot-window';
 test('it mounts a second canvas for the avatar satellite and drops it on navigation away', async ({
   page,
 }) => {
-  // two software-GL canvas mounts under CI's shared CPU run well past other specs' budget
-  test.slow();
-
   await page.setExtraHTTPHeaders({ 'x-forwarded-for': '127.0.0.1' });
   await page.goto('/login');
 
@@ -44,9 +41,7 @@ test('it mounts a second canvas for the avatar satellite and drops it on navigat
 
   const canvases = page.locator('canvas');
 
-  // software-GL canvas mounts on a loaded shared runner can far outlast the suite-wide expect
-  // timeout while staying sound — slow init is not a missing satellite
-  await expect(canvases).toHaveCount(2, { timeout: 30_000 });
+  await expect(canvases).toHaveCount(2);
 
   const worldCanvas = canvases.first();
 

--- a/apps/web-e2e/specs/canvas-persistence.spec.ts
+++ b/apps/web-e2e/specs/canvas-persistence.spec.ts
@@ -7,10 +7,6 @@ import { waitForHoneypotWindow } from '../src/wait-for-honeypot-window';
  * carrying whatever GPU state it already uploaded.
  */
 test('it keeps the same canvas element across client-side game navigation', async ({ page }) => {
-  // five client-side game navigations, each holding a mounted Three.js canvas, run well past other
-  // specs' budget under CI's shared dev server and CPU contention
-  test.slow();
-
   await page.setExtraHTTPHeaders({ 'x-forwarded-for': '127.0.0.1' });
   await page.goto('/login');
 
@@ -41,7 +37,7 @@ test('it keeps the same canvas element across client-side game navigation', asyn
   // satellite canvas, so an unscoped locator would break strict mode on that leg of the walk
   const canvas = page.locator('canvas').first();
 
-  await expect(canvas).toBeVisible({ timeout: 30_000 });
+  await expect(canvas).toBeVisible();
 
   await canvas.evaluate((element) => {
     element.dataset['canvasPersistenceTag'] = 'original';

--- a/apps/web-e2e/specs/game-smoke.spec.ts
+++ b/apps/web-e2e/specs/game-smoke.spec.ts
@@ -4,10 +4,6 @@ import { waitForHoneypotWindow } from '../src/wait-for-honeypot-window';
 test('it renders respite, avatar, and explore for a signed-in caller without console errors', async ({
   page,
 }) => {
-  // three client-side game navigations, each holding a mounted canvas, run past other specs'
-  // budget under CI's shared dev server and CPU contention
-  test.slow();
-
   await page.setExtraHTTPHeaders({ 'x-forwarded-for': '127.0.0.1' });
   await page.goto('/login');
 
@@ -37,7 +33,7 @@ test('it renders respite, avatar, and explore for a signed-in caller without con
   // the heading text also appears as the nav rail's 'Respite' link label, so a bare text locator
   // would break strict mode
   await expect(page.getByRole('heading', { name: 'Respite' })).toBeVisible();
-  await expect(page.locator('canvas').first()).toBeVisible({ timeout: 30_000 });
+  await expect(page.locator('canvas').first()).toBeVisible();
 
   // guard against the app shipping without its generated stylesheet: at least one sheet must be
   // linked, preflight must have applied (body margin reset), and the preset's global token
@@ -61,7 +57,7 @@ test('it renders respite, avatar, and explore for a signed-in caller without con
   await page.getByRole('link', { exact: true, name: 'Explore' }).click();
 
   await expect(page).toHaveURL(/\/explore$/);
-  await expect(page.locator('canvas').first()).toBeVisible({ timeout: 30_000 });
+  await expect(page.locator('canvas').first()).toBeVisible();
 
   expect(consoleErrors).toStrictEqual([]);
 });


### PR DESCRIPTION
## Description

The game-renderer flag (#682) runs CI e2e with `FEATURE_GAME_RENDERER=false`, so the world and satellite canvases mount as inert `<canvas>` placeholders — no three.js, no swiftshader, no GPU context. The `test.slow()` calls, 30s canvas timeouts, and comments blaming software-GL mount cost no longer describe what CI runs, and the headroom now masks real regressions instead of GL init. Follow-up cleanup #682 left behind; obsoletes the research in #634.

- Drop `test.slow()` and the `30_000` canvas-visibility overrides from canvas-persistence, avatar-satellite, and game-smoke.
- Remove the software-GL / CPU-contention comments that justified them.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] `bun run test` passes (e2e runs in CI)