### PR TITLE
docs: prefer established third-party packages over hand-rolling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,6 +247,13 @@ Express a true invariant — a condition only a bug can break — with `tiny-inv
 (`invariant(value, 'message')`) rather than a hand-rolled `if`/`throw`. A condition real input can
 trigger is ordinary control flow, not an invariant.
 
+## Third-party packages
+
+Prefer an established, narrowly scoped third-party package over hand-rolling the same logic —
+recommend one whenever it covers the need. Hand-roll only when no candidate is both proven and
+focused on the problem, when a Bun or Node builtin already covers it, or when the logic is small
+enough that a dependency costs more than it saves.
+
 ## Error handling
 
 Read `docs/architecture/services/error-handling.md` before adding or changing a failure path — it

--- a/agents/project.md
+++ b/agents/project.md
@@ -92,6 +92,13 @@ Express a true invariant — a condition only a bug can break — with `tiny-inv
 (`invariant(value, 'message')`) rather than a hand-rolled `if`/`throw`. A condition real input can
 trigger is ordinary control flow, not an invariant.
 
+## Third-party packages
+
+Prefer an established, narrowly scoped third-party package over hand-rolling the same logic —
+recommend one whenever it covers the need. Hand-roll only when no candidate is both proven and
+focused on the problem, when a Bun or Node builtin already covers it, or when the logic is small
+enough that a dependency costs more than it saves.
+
 ## Error handling
 
 Read `docs/architecture/services/error-handling.md` before adding or changing a failure path — it


### PR DESCRIPTION
## Summary

Adds a Third-party packages rule to the agent guidelines: prefer an established, narrowly scoped package over hand-rolling, with the three cases where hand-rolling stays right (no proven focused candidate, a builtin covers it, logic too small to earn a dependency).

- New `## Third-party packages` section in `agents/project.md`; `AGENTS.md` regenerated.

## Testing

- `bash scripts/build-agents-md.sh` regenerates cleanly; `bun run format` idempotent.