### PR TITLE
feat(#646): manage github repo configuration in the pulumi program

### DIFF
--- a/.github/workflows/infra-drift.yml
+++ b/.github/workflows/infra-drift.yml
@@ -61,6 +61,7 @@ jobs:
           R2_STATE_BUCKET: op://vers-ci/vers-infra/r2-state-bucket
           PULUMI_CONFIG_PASSPHRASE: op://vers-ci/vers-infra/pulumi-passphrase
           AXIOM_TOKEN: op://vers-ci/axiom/iac-token
+          GITHUB_TOKEN: op://vers-ci/vers-infra/github-token
           DISCORD_ALARMS_WEBHOOK: op://vers-ci/discord-alarms-webhook/credential
 
       - name: Preview

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,6 +227,9 @@ Triage a GitHub issue the moment it's opened, not in a later pass:
 
 An open issue that isn't on the board with a milestone and status is a defect.
 
+The label registry is the vers-infra Pulumi program (`infra/github.ts`): a label change is a PR
+there, never a console edit. Milestones stay console-managed — they are delivery state, not schema.
+
 A new issue's body follows its type's template in `.github/ISSUE_TEMPLATE` (feature, bug, upkeep). A
 feature issue whose outcome a player can perceive — every `area/game` feature — carries a
 `## Player story` section: second person, present tense, what the player concretely sees or feels

--- a/agents/project.md
+++ b/agents/project.md
@@ -65,6 +65,9 @@ Triage a GitHub issue the moment it's opened, not in a later pass:
 
 An open issue that isn't on the board with a milestone and status is a defect.
 
+The label registry is the vers-infra Pulumi program (`infra/github.ts`): a label change is a PR
+there, never a console edit. Milestones stay console-managed — they are delivery state, not schema.
+
 A new issue's body follows its type's template in `.github/ISSUE_TEMPLATE` (feature, bug, upkeep). A
 feature issue whose outcome a player can perceive — every `area/game` feature — carries a
 `## Player story` section: second person, present tense, what the player concretely sees or feels

--- a/bun.lock
+++ b/bun.lock
@@ -303,6 +303,7 @@
       "dependencies": {
         "@pulumi/axiom": "file:sdks/axiom",
         "@pulumi/cloudflare": "catalog:",
+        "@pulumi/github": "catalog:",
         "@pulumi/pulumi": "catalog:",
       },
       "devDependencies": {
@@ -1199,6 +1200,7 @@
     "@paralleldrive/cuid2": "3.3.0",
     "@playwright/test": "1.61.1",
     "@pulumi/cloudflare": "6.17.0",
+    "@pulumi/github": "6.14.0",
     "@pulumi/pulumi": "3.250.0",
     "@react-email/components": "1.0.12",
     "@react-hookz/web": "25.2.0",
@@ -2052,6 +2054,8 @@
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.1", "", {}, "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="],
 
     "@pulumi/cloudflare": ["@pulumi/cloudflare@6.17.0", "", { "dependencies": { "@pulumi/pulumi": "^3.142.0" } }, "sha512-sIL1rfjNavy+yZQ/OjyFHD4owe2E/TpHLFCVsogQJOC+Y6Bj7JxrhoTfsJdxVEXEFBGlNCu68T+g9im8iEZM9A=="],
+
+    "@pulumi/github": ["@pulumi/github@6.14.0", "", { "dependencies": { "@pulumi/pulumi": "^3.142.0" } }, "sha512-qrgH5ot2Wh9xLMPnBq9hpBjEYTIfgDpJRS/rmROgt5NIEAhwDfaTJ8dgpdjV8CQwfpuaRY7mrs8mKWlSANEeYQ=="],
 
     "@pulumi/pulumi": ["@pulumi/pulumi@3.250.0", "", { "dependencies": { "@grpc/grpc-js": "^1.10.1", "@logdna/tail-file": "^2.0.6", "@npmcli/arborist": "^9.0.0", "@opentelemetry/api": "^1.9", "@opentelemetry/exporter-trace-otlp-grpc": "^0.57", "@opentelemetry/exporter-zipkin": "^1.30", "@opentelemetry/instrumentation": "^0.57", "@opentelemetry/instrumentation-grpc": "^0.57", "@opentelemetry/resources": "^1.30", "@opentelemetry/sdk-trace-base": "^1.30", "@opentelemetry/sdk-trace-node": "^1.30", "@types/google-protobuf": "^3.15.5", "@types/semver": "^7.5.6", "execa": "^5.1.0", "google-protobuf": "^3.21.4", "ini": "^2.0.0", "js-yaml": "^4.0.0", "minimist": "^1.2.6", "normalize-package-data": "^6.0.0", "require-from-string": "^2.0.1", "semver": "^7.5.2", "source-map-support": "^0.5.6", "upath": "^1.1.0" }, "peerDependencies": { "ts-node": ">= 7.0.1 < 12", "typescript": ">= 3.8.3 < 7" }, "optionalPeers": ["ts-node", "typescript"] }, "sha512-/CaE4gWlOGNFt9eWxip2SscL1Nh1i9ZzzFSkjbrNQol5u9dOjGWNzWlOCerA6riH0603MkT9xNlRnJ4TGstXrw=="],
 
@@ -4767,6 +4771,8 @@
 
     "@pulumi/cloudflare/@pulumi/pulumi": ["@pulumi/pulumi@3.251.0", "", { "dependencies": { "@grpc/grpc-js": "^1.10.1", "@logdna/tail-file": "^2.0.6", "@npmcli/arborist": "^9.0.0", "@opentelemetry/api": "^1.9", "@opentelemetry/exporter-trace-otlp-grpc": "^0.57", "@opentelemetry/exporter-zipkin": "^1.30", "@opentelemetry/instrumentation": "^0.57", "@opentelemetry/instrumentation-grpc": "^0.57", "@opentelemetry/resources": "^1.30", "@opentelemetry/sdk-trace-base": "^1.30", "@opentelemetry/sdk-trace-node": "^1.30", "@types/google-protobuf": "^3.15.5", "@types/semver": "^7.5.6", "execa": "^5.1.0", "google-protobuf": "^3.21.4", "ini": "^2.0.0", "js-yaml": "^4.0.0", "minimist": "^1.2.6", "normalize-package-data": "^6.0.0", "require-from-string": "^2.0.1", "semver": "^7.5.2", "source-map-support": "^0.5.6", "upath": "^1.1.0" }, "peerDependencies": { "ts-node": ">= 7.0.1 < 12", "typescript": ">= 3.8.3 < 7" }, "optionalPeers": ["ts-node", "typescript"] }, "sha512-gtpkmQRPsEv8ll0fPHDqIDqSa8mapFqeV06QWYOMLDHj28/wNE13pNZ6jYcteYDdNCgsf4qesw8toOlWqEDQig=="],
 
+    "@pulumi/github/@pulumi/pulumi": ["@pulumi/pulumi@3.251.0", "", { "dependencies": { "@grpc/grpc-js": "^1.10.1", "@logdna/tail-file": "^2.0.6", "@npmcli/arborist": "^9.0.0", "@opentelemetry/api": "^1.9", "@opentelemetry/exporter-trace-otlp-grpc": "^0.57", "@opentelemetry/exporter-zipkin": "^1.30", "@opentelemetry/instrumentation": "^0.57", "@opentelemetry/instrumentation-grpc": "^0.57", "@opentelemetry/resources": "^1.30", "@opentelemetry/sdk-trace-base": "^1.30", "@opentelemetry/sdk-trace-node": "^1.30", "@types/google-protobuf": "^3.15.5", "@types/semver": "^7.5.6", "execa": "^5.1.0", "google-protobuf": "^3.21.4", "ini": "^2.0.0", "js-yaml": "^4.0.0", "minimist": "^1.2.6", "normalize-package-data": "^6.0.0", "require-from-string": "^2.0.1", "semver": "^7.5.2", "source-map-support": "^0.5.6", "upath": "^1.1.0" }, "peerDependencies": { "ts-node": ">= 7.0.1 < 12", "typescript": ">= 3.8.3 < 7" }, "optionalPeers": ["ts-node", "typescript"] }, "sha512-gtpkmQRPsEv8ll0fPHDqIDqSa8mapFqeV06QWYOMLDHj28/wNE13pNZ6jYcteYDdNCgsf4qesw8toOlWqEDQig=="],
+
     "@pulumi/pulumi/@opentelemetry/resources": ["@opentelemetry/resources@1.30.1", "", { "dependencies": { "@opentelemetry/core": "1.30.1", "@opentelemetry/semantic-conventions": "1.28.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA=="],
 
     "@pulumi/pulumi/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@1.30.1", "", { "dependencies": { "@opentelemetry/core": "1.30.1", "@opentelemetry/resources": "1.30.1", "@opentelemetry/semantic-conventions": "1.28.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg=="],
@@ -5231,6 +5237,14 @@
 
     "@pulumi/cloudflare/@pulumi/pulumi/execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
 
+    "@pulumi/github/@pulumi/pulumi/@opentelemetry/resources": ["@opentelemetry/resources@1.30.1", "", { "dependencies": { "@opentelemetry/core": "1.30.1", "@opentelemetry/semantic-conventions": "1.28.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA=="],
+
+    "@pulumi/github/@pulumi/pulumi/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@1.30.1", "", { "dependencies": { "@opentelemetry/core": "1.30.1", "@opentelemetry/resources": "1.30.1", "@opentelemetry/semantic-conventions": "1.28.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg=="],
+
+    "@pulumi/github/@pulumi/pulumi/@opentelemetry/sdk-trace-node": ["@opentelemetry/sdk-trace-node@1.30.1", "", { "dependencies": { "@opentelemetry/context-async-hooks": "1.30.1", "@opentelemetry/core": "1.30.1", "@opentelemetry/propagator-b3": "1.30.1", "@opentelemetry/propagator-jaeger": "1.30.1", "@opentelemetry/sdk-trace-base": "1.30.1", "semver": "^7.5.2" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ=="],
+
+    "@pulumi/github/@pulumi/pulumi/execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
+
     "@pulumi/pulumi/@opentelemetry/resources/@opentelemetry/core": ["@opentelemetry/core@1.30.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "1.28.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ=="],
 
     "@pulumi/pulumi/@opentelemetry/resources/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
@@ -5483,6 +5497,30 @@
 
     "@pulumi/cloudflare/@pulumi/pulumi/execa/strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
 
+    "@pulumi/github/@pulumi/pulumi/@opentelemetry/resources/@opentelemetry/core": ["@opentelemetry/core@1.30.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "1.28.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ=="],
+
+    "@pulumi/github/@pulumi/pulumi/@opentelemetry/resources/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
+
+    "@pulumi/github/@pulumi/pulumi/@opentelemetry/sdk-trace-base/@opentelemetry/core": ["@opentelemetry/core@1.30.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "1.28.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ=="],
+
+    "@pulumi/github/@pulumi/pulumi/@opentelemetry/sdk-trace-base/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
+
+    "@pulumi/github/@pulumi/pulumi/@opentelemetry/sdk-trace-node/@opentelemetry/context-async-hooks": ["@opentelemetry/context-async-hooks@1.30.1", "", { "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA=="],
+
+    "@pulumi/github/@pulumi/pulumi/@opentelemetry/sdk-trace-node/@opentelemetry/core": ["@opentelemetry/core@1.30.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "1.28.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ=="],
+
+    "@pulumi/github/@pulumi/pulumi/execa/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
+
+    "@pulumi/github/@pulumi/pulumi/execa/human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
+
+    "@pulumi/github/@pulumi/pulumi/execa/is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
+    "@pulumi/github/@pulumi/pulumi/execa/npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
+
+    "@pulumi/github/@pulumi/pulumi/execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "@pulumi/github/@pulumi/pulumi/execa/strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
+
     "@pulumi/pulumi/@opentelemetry/sdk-trace-node/@opentelemetry/core/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
 
     "@sentry/bundler-plugin-core/@babel/core/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
@@ -5578,6 +5616,8 @@
     "@pandacss/config/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
     "@pulumi/cloudflare/@pulumi/pulumi/@opentelemetry/sdk-trace-node/@opentelemetry/core/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
+
+    "@pulumi/github/@pulumi/pulumi/@opentelemetry/sdk-trace-node/@opentelemetry/core/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
 
     "@vers/infra/@pulumi/axiom/@pulumi/pulumi/@opentelemetry/resources/@opentelemetry/core": ["@opentelemetry/core@1.30.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "1.28.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ=="],
 

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -15,5 +15,8 @@ PULUMI_CONFIG_PASSPHRASE=op://vers-ci/vers-infra/pulumi-passphrase
 # axiom monitors/notifiers management token
 AXIOM_TOKEN=op://vers-ci/axiom/iac-token
 
+# fine-grained PAT managing the zgeoff/vers repo configuration
+GITHUB_TOKEN=op://vers-ci/vers-infra/github-token
+
 # discord webhook the axiom alarms notifier posts to
 DISCORD_ALARMS_WEBHOOK=op://vers-ci/discord-alarms-webhook/credential

--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -1,5 +1,8 @@
 config:
+  github:owner: zgeoff
   vers-infra:zoneName: versidle.com
   vers-infra:appHostname: vers-app-web.fly.dev
   vers-infra:zoneId: fc9e4cdc2fff4aee760c7fd1e71ffe27
+  vers-infra:serviceAuthPublicKey:
+    secure: v1:9fX6e9Du2R3qZ/WM:XjVN+MrRFi0sVtI0dvWG0N8ZtFL9HkoYyu53yLBqe+MXTmNgxBH9ietOJUaSlsLtdw+ANl87btRSkTxRvUx9LhYzW/y8qAoB8L9n5hyPo9aPzaYZmGzSs4e8RqSQO1tnN6uPsGoj0CymhGTEHdsS/DKtcN9piL20mtEnjrVLdpQ=
 encryptionsalt: v1:X3B5c2FRqiA=:v1:6xmc+OObdCNfxT/j:hcfedYdoJcanVVXYfwNGrBvsmAtmLQ==

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,8 +1,9 @@
 # infra
 
-Cloudflare DNS for `versidle.com` and the Axiom observability backend (datasets, API tokens,
-monitors, notifiers, dashboards), with Pulumi state held in Cloudflare R2. Credentials resolve from
-1Password at run time, so nothing sensitive lives on disk.
+Cloudflare DNS for `versidle.com`, the Axiom observability backend (datasets, API tokens, monitors,
+notifiers, dashboards), and the zgeoff/vers GitHub repo configuration (labels, rulesets, the
+production environment, Actions variables), with Pulumi state held in Cloudflare R2. Credentials
+resolve from 1Password at run time, so nothing sensitive lives on disk.
 
 - `index.ts` — apex and `www` records pointing `versidle.com` at the Fly web app, DNS-only so Fly
   serves TLS.
@@ -14,6 +15,14 @@ monitors, notifiers, dashboards), with Pulumi state held in Cloudflare R2. Crede
   vault item and dependent Fly secrets within the 48-hour rotation grace window. The provider's own
   credential is console-managed: a token cannot rotate itself without invalidating the session doing
   the rotating.
+- `github.ts` — the zgeoff/vers repo configuration: the authoritative label set (the registry the
+  issue-hygiene rules point at), the `main protection` branch ruleset, the `production` environment,
+  and the Actions variables (repo- and environment-scoped; the service-auth public key value comes
+  from encrypted stack config, the rest sit in code). Console-managed and therefore not drift:
+  milestones and the delivery board (delivery state, not schema — and Projects v2 lacks mature
+  provider support), Actions secrets (values live only in the 1Password vault and the console), and
+  the provider's own PAT, for the same reason the Axiom token is — a token cannot rotate itself
+  without invalidating the session doing the rotating.
 - `sdks/axiom/` — committed TypeScript SDK generated from the bridged Terraform provider
   (`pulumi package add terraform-provider axiomhq/axiom 1.6.2` regenerates it; the version is pinned
   in `Pulumi.yaml`).
@@ -30,6 +39,9 @@ monitors, notifiers, dashboards), with Pulumi state held in Cloudflare R2. Crede
   create/read/update/delete on monitors, notifiers, dashboards, datasets, and API tokens, plus query
   permission on all datasets — Axiom rejects monitor writes unless the token can query every dataset
   the monitor's APL references.
+- A GitHub fine-grained PAT (the `github-token` field on the `vers-ci` vault's `vers-infra` item)
+  scoped to the zgeoff/vers repository with read/write on Administration, Environments, Issues,
+  Secrets, Variables, and Webhooks.
 
 ## One-time setup
 

--- a/infra/github.ts
+++ b/infra/github.ts
@@ -1,0 +1,161 @@
+import * as github from '@pulumi/github';
+import * as pulumi from '@pulumi/pulumi';
+
+/**
+ * The default provider authenticates with a fine-grained PAT scoped to
+ * zgeoff/vers (Administration, Environments, Issues, Secrets, Variables,
+ * Webhooks — all read/write), read from GITHUB_TOKEN in the environment
+ * resolved by `op run`; the owner comes from the stack's github:owner config.
+ * The PAT itself is console-managed: a token cannot rotate itself without
+ * invalidating the session doing the rotating.
+ */
+
+const repository = 'vers';
+
+/**
+ * The authoritative label set — the registry the issue-hygiene rules assume.
+ * The resource owns the repo's labels wholesale: a label added in the console
+ * is drift, removed by the next `pulumi up`, and deleting an entry here
+ * detaches the label from every issue carrying it. protect guards against
+ * whole-set deletion, not per-entry edits.
+ */
+const labels = new github.IssueLabels(
+  'vers',
+  {
+    repository,
+    labels: [
+      { name: 'area/auth', color: '1D76DB', description: 'area: authentication & authorization' },
+      { name: 'area/game', color: '33AA3F', description: 'area: simulation, aether, game systems' },
+      {
+        name: 'area/platform',
+        color: 'C5DEF5',
+        description: 'area: deploy, db hosting, monorepo, CI',
+      },
+      { name: 'area/services', color: 'B392F0', description: 'area: backend services & contracts' },
+      { name: 'area/web', color: '5DADE2', description: 'area: web app shell & UI' },
+      { name: 'bug', color: 'd73a4a', description: 'bzzzz' },
+      { name: 'build', color: 'C2E0C6' },
+      { name: 'chore', color: 'FEF2C0', description: 'maintenance / housekeeping' },
+      { name: 'dep-audit', color: 'B60205', description: 'bun audit found advisories' },
+      { name: 'dep-outdated', color: 'FBCA04', description: 'weekly outdated-dependency report' },
+      { name: 'do-not-merge', color: '000000', description: 'reference PR — never merge' },
+      { name: 'documentation', color: 'C2E0C6', description: 'docs' },
+      { name: 'duplicate', color: 'cfd3d7', description: 'already exists' },
+      { name: 'easy win', color: '7057ff', description: 'small task, high value' },
+      { name: 'epic', color: '5319E7', description: 'capturing related work' },
+      { name: 'feature', color: '0052CC', description: 'new feature' },
+      {
+        name: 'game-design',
+        color: '8b5cf6',
+        description: 'game-design lane: discovery → design note → iteration resources',
+      },
+      {
+        name: 'needs-refinement',
+        color: 'E4E669',
+        description: 'scope/decision gap — not ready to pick up until refined',
+      },
+      { name: 'p0-critical', color: 'B60205', description: 'priority: critical' },
+      { name: 'p1-high', color: 'D93F0B', description: 'priority: high' },
+      { name: 'p2-medium', color: 'FBCA04', description: 'priority: medium' },
+      { name: 'rebuild', color: 'E99695', description: 'greenfield rebuild workstream (#143)' },
+      { name: 'refactor', color: 'BFDADC' },
+      { name: 'research', color: 'd876e3', description: 'engage llm' },
+      { name: 'security', color: 'cf222e', description: 'security-sensitive work' },
+      { name: 'spike', color: '8250DF', description: 'time-boxed prototype to de-risk a decision' },
+      { name: 'tech-debt', color: 'D4C5F9', description: 'accumulated shortcut to revisit' },
+      {
+        name: 'upkeep',
+        color: '0E8A16',
+        description:
+          'event- or date-triggered maintenance; body carries a trigger line the weekly sweep evaluates',
+      },
+      {
+        name: 'upkeep-ready',
+        color: 'D93F0B',
+        description: 'upkeep trigger has fired; cleanup is actionable now',
+      },
+      { name: 'ux', color: '0E8A16', description: 'polish' },
+    ],
+  },
+  { protect: true },
+);
+
+/**
+ * Branch protection for main: squash-only PRs gated on the aggregate `checks`
+ * status, no deletions, no force pushes, no bypass actors.
+ */
+const mainProtectionRuleset = new github.RepositoryRuleset('main-protection', {
+  name: 'main protection',
+  repository,
+  target: 'branch',
+  enforcement: 'active',
+  conditions: {
+    refName: {
+      includes: ['~DEFAULT_BRANCH'],
+      excludes: [],
+    },
+  },
+  rules: {
+    deletion: true,
+    nonFastForward: true,
+    pullRequest: {
+      allowedMergeMethods: ['squash'],
+      requiredApprovingReviewCount: 0,
+    },
+    requiredStatusChecks: {
+      requiredChecks: [{ context: 'checks' }],
+      strictRequiredStatusChecksPolicy: false,
+    },
+  },
+});
+
+/**
+ * The deploy-phase jobs target this environment. Deleting it destroys the
+ * environment-scoped secrets with it, so it is protected. No protection rules:
+ * deploys gate on green checks, not human approval.
+ */
+const productionEnvironment = new github.RepositoryEnvironment(
+  'production',
+  {
+    repository,
+    environment: 'production',
+  },
+  { protect: true },
+);
+
+/**
+ * Actions variables carry the deploy configuration. Plainly public values sit
+ * in code; the service-auth public key enters through encrypted stack config,
+ * keeping key material of any kind out of the committed source. Actions
+ * secrets are console-managed: their values cannot be read back through the
+ * API, so a declaration here could only overwrite them, never adopt them.
+ */
+const umamiWebsiteIDVariable = new github.ActionsVariable('vite-umami-website-id', {
+  repository,
+  variableName: 'VITE_UMAMI_WEBSITE_ID',
+  value: 'b72918cb-3763-411c-b471-ac694e31d8f4',
+});
+
+const serviceAuthPublicKeyVariable = new github.ActionsEnvironmentVariable(
+  'service-auth-public-key',
+  {
+    repository,
+    environment: productionEnvironment.environment,
+    variableName: 'SERVICE_AUTH_PUBLIC_KEY',
+    value: new pulumi.Config('vers-infra').requireSecret('serviceAuthPublicKey'),
+  },
+);
+
+const sentryDSNVariable = new github.ActionsEnvironmentVariable('vite-sentry-dsn', {
+  repository,
+  environment: productionEnvironment.environment,
+  variableName: 'VITE_SENTRY_DSN',
+  value: 'https://929f735fcaf5436db8d0910fd1c0d71d@vers-bugsink.fly.dev/1',
+});
+
+export const labelCount = labels.labels.apply((entries) => entries?.length ?? 0);
+export const mainProtectionRulesetName = mainProtectionRuleset.name;
+export const productionEnvironmentName = productionEnvironment.environment;
+export const umamiWebsiteIDVariableName = umamiWebsiteIDVariable.variableName;
+export const serviceAuthPublicKeyVariableName = serviceAuthPublicKeyVariable.variableName;
+export const sentryDSNVariableName = sentryDSNVariable.variableName;

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -13,6 +13,15 @@ export {
   tracesDatasetName,
 } from './axiom.ts';
 
+export {
+  labelCount,
+  mainProtectionRulesetName,
+  productionEnvironmentName,
+  sentryDSNVariableName,
+  serviceAuthPublicKeyVariableName,
+  umamiWebsiteIDVariableName,
+} from './github.ts';
+
 const config = new pulumi.Config();
 
 const zoneId = config.require('zoneId');

--- a/infra/package.json
+++ b/infra/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "index.ts",
   "scripts": {
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "preview": "op run --env-file=.env -- pulumi preview",
     "up": "op run --env-file=.env -- pulumi up",
     "destroy": "op run --env-file=.env -- pulumi destroy"
@@ -12,6 +13,7 @@
   "dependencies": {
     "@pulumi/axiom": "file:sdks/axiom",
     "@pulumi/cloudflare": "catalog:",
+    "@pulumi/github": "catalog:",
     "@pulumi/pulumi": "catalog:"
   },
   "devDependencies": {

--- a/infra/tsconfig.json
+++ b/infra/tsconfig.json
@@ -4,6 +4,6 @@
     "types": ["node"]
   },
   "files": [],
-  "include": ["index.ts", "axiom.ts"],
+  "include": ["index.ts", "axiom.ts", "github.ts"],
   "exclude": []
 }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
       "@paralleldrive/cuid2": "3.3.0",
       "@playwright/test": "1.61.1",
       "@pulumi/cloudflare": "6.17.0",
+      "@pulumi/github": "6.14.0",
       "@pulumi/pulumi": "3.250.0",
       "@react-email/components": "1.0.12",
       "@react-hookz/web": "25.2.0",


### PR DESCRIPTION
## Description

Closes #646

Manages the zgeoff/vers repo configuration — labels, the `main protection` ruleset, the `production` environment, and Actions variables — declaratively in the vers-infra Pulumi program, so the schema the issue-hygiene rules assume is reviewed and drift-checked instead of living as console state.

- Labels use the authoritative `IssueLabels` resource: console-added labels read as drift.
- Existing resources were imported into stack state; `pulumi up` confirms zero resource changes.
- Default provider reads `GITHUB_TOKEN` (fine-grained PAT, `vers-ci` vault) resolved by `op run`; owner comes from `github:owner` stack config.
- The service-auth public key value lives in encrypted stack config, not source.
- Console-managed by design: milestones (delivery state, not schema), Actions secrets (values unreadable via API; #705 backfills the vault and adopts them), and the delivery board (Projects v2 provider support immature).
- No repo webhooks exist, so none are declared.
- Issue-hygiene guidelines now name the program as the label registry.

## Testing

- [x] `bun run typecheck` passes
- [ ] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality

## Context

Infra changes are covered by the infra-drift preview (`expect-no-changes` against prod state) rather than unit tests.
