### PR TITLE
fix: give service-activity a replay service url in both compose stacks

### DIFF
--- a/apps/web-e2e/docker-compose.stack.yml
+++ b/apps/web-e2e/docker-compose.stack.yml
@@ -49,7 +49,9 @@ services:
       retries: 15
   service-activity:
     image: ${IMAGE_VERS_SERVICE_ACTIVITY}
-    environment: *db-env
+    environment:
+      <<: *db-env
+      REPLAY_SERVICE_URL: http://service-replay:3000
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - services/activity/.env.development
     environment:
       - DATABASE_URL=postgresql://admin:password@postgres:5433/vers
+      - REPLAY_SERVICE_URL=http://service-replay:3009
     ports:
       - '3006:3006'
     depends_on:


### PR DESCRIPTION
## What

`service-activity` now validates `REPLAY_SERVICE_URL` at boot (added in #690), but neither compose stack supplied it — the full-stack e2e container exited with `invalid service environment: → at REPLAY_SERVICE_URL`, so the stack never booted and `Deploy` was skipped.

- e2e stack: point activity at `http://service-replay:3000`, matching how replay reaches keys.
- dev stack: override the `localhost:3009` default with `http://service-replay:3009`, which otherwise resolves to the container itself.

Production is unaffected — `services/activity/fly.toml` already sets the flycast URL.

## Why

Unblocks the deploy pipeline on `main`; the wake poke is fire-and-forget, so a wrong URL fails silently rather than loudly.

Follow-up to #689 / #690.
