### PR TITLE
derive sim life from level and show the real avatar name

### DIFF
--- a/apps/web/src/routes/-activity/activity-panel.tsx
+++ b/apps/web/src/routes/-activity/activity-panel.tsx
@@ -25,6 +25,7 @@ export function ActivityPanel() {
   const navigate = useNavigate();
   const avatarQuery = useQuery(buildActiveAvatarQueryOptions());
   const avatarID = avatarQuery.data?.id;
+  const avatarName = avatarQuery.data?.name;
 
   const currentActivityQuery = useQuery({
     ...buildCurrentActivityQueryOptions(avatarID ?? ''),
@@ -56,7 +57,10 @@ export function ActivityPanel() {
 
   return (
     <ScreenLayout title="Engagement">
-      <EngagementView {...(endRun !== undefined && { onEndRun: endRun })} />
+      <EngagementView
+        {...(avatarName !== undefined && { avatarName })}
+        {...(endRun !== undefined && { onEndRun: endRun })}
+      />
       {pendingCount > 0 ? (
         <output
           className={settlingIndicator}

--- a/libs/game/idle-client/src/components/avatar-unit-plate.test.tsx
+++ b/libs/game/idle-client/src/components/avatar-unit-plate.test.tsx
@@ -18,3 +18,11 @@ test('it renders the avatar identity, life, and swing timer', () => {
   expect(screen.getByText(makeNodeTextMatcher('80 / 100'))).toBeInTheDocument();
   expect(screen.getByText('STRIKE')).toBeInTheDocument();
 });
+
+test('it prefers the display name over the sim-reported name', () => {
+  const avatar = createMockAvatarSnapshot({ name: 'avatar_1' });
+
+  render(<AvatarUnitPlate avatar={avatar} displayName="Aria" />);
+  expect(screen.getByText('Aria')).toBeInTheDocument();
+  expect(screen.queryByText('avatar_1')).not.toBeInTheDocument();
+});

--- a/libs/game/idle-client/src/components/avatar-unit-plate.tsx
+++ b/libs/game/idle-client/src/components/avatar-unit-plate.tsx
@@ -86,9 +86,9 @@ interface AvatarUnitPlateProps {
 
 /**
  * The player's frame: identity, the life/barrier/aether stack, the weapon swing timer, active
- * effects, and the ability bar. Life and the swing timer read real combat state; the rest stand in
- * until their state exists. The simulation knows the avatar only by id, so `displayName` carries
- * the player-facing name; the sim-reported name is the fallback.
+ * effects, and the ability bar. Life and the swing timer read real combat state; the rest render
+ * fixed stubs. The simulation knows the avatar only by id, so `displayName` carries the
+ * player-facing name; the sim-reported name is the fallback.
  */
 export function AvatarUnitPlate(props: Readonly<AvatarUnitPlateProps>) {
   const lastAttackTime = props.avatar.behaviours.avatar_weapon_attack?.lastAttackTime ?? 0;

--- a/libs/game/idle-client/src/components/avatar-unit-plate.tsx
+++ b/libs/game/idle-client/src/components/avatar-unit-plate.tsx
@@ -81,12 +81,14 @@ const abilitySlot = css({
 
 interface AvatarUnitPlateProps {
   readonly avatar: AvatarSnapshot;
+  readonly displayName?: string;
 }
 
 /**
  * The player's frame: identity, the life/barrier/aether stack, the weapon swing timer, active
  * effects, and the ability bar. Life and the swing timer read real combat state; the rest stand in
- * until their state exists.
+ * until their state exists. The simulation knows the avatar only by id, so `displayName` carries
+ * the player-facing name; the sim-reported name is the fallback.
  */
 export function AvatarUnitPlate(props: Readonly<AvatarUnitPlateProps>) {
   const lastAttackTime = props.avatar.behaviours.avatar_weapon_attack?.lastAttackTime ?? 0;
@@ -96,7 +98,7 @@ export function AvatarUnitPlate(props: Readonly<AvatarUnitPlateProps>) {
       <div className={identity}>
         <Sigil size={48} tint="self" />
         <div>
-          <div className={nameText}>{props.avatar.name}</div>
+          <div className={nameText}>{props.displayName ?? props.avatar.name}</div>
           <div className={disciplineText}>{STUB_DISCIPLINE}</div>
         </div>
         <span className={levelBadge}>LV {props.avatar.level}</span>

--- a/libs/game/idle-client/src/engagement-view.tsx
+++ b/libs/game/idle-client/src/engagement-view.tsx
@@ -31,6 +31,7 @@ const avatarArea = css({
 });
 
 interface EngagementViewProps {
+  readonly avatarName?: string;
   readonly onEndRun?: () => void;
 }
 
@@ -58,7 +59,10 @@ export function EngagementView(props: Readonly<EngagementViewProps>) {
         ))}
       </div>
       <div className={avatarArea}>
-        <AvatarUnitPlate avatar={avatar} />
+        <AvatarUnitPlate
+          avatar={avatar}
+          {...(props.avatarName !== undefined && { displayName: props.avatarName })}
+        />
       </div>
     </div>
   );

--- a/libs/game/idle-core/src/core/build-simulation-input.test.ts
+++ b/libs/game/idle-core/src/core/build-simulation-input.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'bun:test';
 import { CURRENT_CONTENT_VERSION } from '@vers/game-utils';
 import invariant from 'tiny-invariant';
 import { buildLifeFromLevel } from '../progression';
+import { createMockSimulationInputSource } from '../test-utils';
 import { ActivityFailureAction, EquipmentSlot } from '../types';
 import { buildSimulationInput } from './build-simulation-input';
 
@@ -24,16 +25,13 @@ test('it derives the activity id, avatar id, seed, and build snapshot from the s
 });
 
 test('it derives the avatar life from the build snapshot level', () => {
-  const source = {
-    avatarID: 'avatar_1',
-    contentVersion: CURRENT_CONTENT_VERSION,
-    encounterNode: { difficulty: 1 },
-    id: 'act_1',
-    seed: 'aa'.repeat(16),
-  };
+  const levelOne = buildSimulationInput(
+    createMockSimulationInputSource({ buildSnapshot: { level: 1, xp: 0 } }),
+  );
 
-  const levelOne = buildSimulationInput({ ...source, buildSnapshot: { level: 1, xp: 0 } });
-  const levelled = buildSimulationInput({ ...source, buildSnapshot: { level: 27, xp: 0 } });
+  const levelled = buildSimulationInput(
+    createMockSimulationInputSource({ buildSnapshot: { level: 27, xp: 0 } }),
+  );
 
   expect(levelOne.avatar.life).toBe(buildLifeFromLevel(1));
   expect(levelled.avatar.life).toBe(buildLifeFromLevel(27));

--- a/libs/game/idle-core/src/core/build-simulation-input.test.ts
+++ b/libs/game/idle-core/src/core/build-simulation-input.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'bun:test';
 import { CURRENT_CONTENT_VERSION } from '@vers/game-utils';
 import invariant from 'tiny-invariant';
+import { buildLifeFromLevel } from '../progression';
 import { ActivityFailureAction, EquipmentSlot } from '../types';
 import { buildSimulationInput } from './build-simulation-input';
 
@@ -20,6 +21,23 @@ test('it derives the activity id, avatar id, seed, and build snapshot from the s
   expect(result.avatar.id).toBe('avatar_1');
   expect(result.avatar.level).toBe(3);
   expect(result.avatar.xp).toBe(450);
+});
+
+test('it derives the avatar life from the build snapshot level', () => {
+  const source = {
+    avatarID: 'avatar_1',
+    contentVersion: CURRENT_CONTENT_VERSION,
+    encounterNode: { difficulty: 1 },
+    id: 'act_1',
+    seed: 'aa'.repeat(16),
+  };
+
+  const levelOne = buildSimulationInput({ ...source, buildSnapshot: { level: 1, xp: 0 } });
+  const levelled = buildSimulationInput({ ...source, buildSnapshot: { level: 27, xp: 0 } });
+
+  expect(levelOne.avatar.life).toBe(buildLifeFromLevel(1));
+  expect(levelled.avatar.life).toBe(buildLifeFromLevel(27));
+  expect(levelled.avatar.life).toBeGreaterThan(levelOne.avatar.life);
 });
 
 test('it builds the same input for the same source row', () => {

--- a/libs/game/idle-core/src/core/build-simulation-input.ts
+++ b/libs/game/idle-core/src/core/build-simulation-input.ts
@@ -1,4 +1,5 @@
 import { MIN_DIFFICULTY, buildEncounter, getEncounterContent } from '@vers/game-utils';
+import { buildLifeFromLevel } from '../progression';
 import type { ActivityInput, AvatarData } from '../types';
 import { ActivityFailureAction, ActivityType, EquipmentSlot } from '../types';
 
@@ -59,7 +60,7 @@ export function buildSimulationInput(
     avatar: {
       id: source.avatarID,
       level: source.buildSnapshot.level,
-      life: 200,
+      life: buildLifeFromLevel(source.buildSnapshot.level),
       name: source.avatarID,
       paperdoll: { [EquipmentSlot.MainHand]: buildPlaceholderWeapon() },
       xp: source.buildSnapshot.xp,

--- a/libs/game/idle-core/src/progression/build-life-from-level.test.ts
+++ b/libs/game/idle-core/src/progression/build-life-from-level.test.ts
@@ -8,6 +8,8 @@ test('it returns the base life at level one', () => {
 test('it grows life by a fixed amount per level', () => {
   const perLevel = buildLifeFromLevel(2) - buildLifeFromLevel(1);
 
+  expect(perLevel).toBe(20);
+
   for (let level = 2; level <= 50; level++) {
     expect(buildLifeFromLevel(level) - buildLifeFromLevel(level - 1)).toBe(perLevel);
   }

--- a/libs/game/idle-core/src/progression/build-life-from-level.test.ts
+++ b/libs/game/idle-core/src/progression/build-life-from-level.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from 'bun:test';
+import { buildLifeFromLevel } from './build-life-from-level';
+
+test('it returns the base life at level one', () => {
+  expect(buildLifeFromLevel(1)).toBe(200);
+});
+
+test('it grows life by a fixed amount per level', () => {
+  const perLevel = buildLifeFromLevel(2) - buildLifeFromLevel(1);
+
+  for (let level = 2; level <= 50; level++) {
+    expect(buildLifeFromLevel(level) - buildLifeFromLevel(level - 1)).toBe(perLevel);
+  }
+});

--- a/libs/game/idle-core/src/progression/build-life-from-level.ts
+++ b/libs/game/idle-core/src/progression/build-life-from-level.ts
@@ -1,0 +1,9 @@
+import { LIFE_BASE, LIFE_PER_LEVEL } from './constants';
+
+/**
+ * Maximum life for an avatar at a level — a placeholder linear curve standing in for a designed
+ * one, until life derives from the avatar's build.
+ */
+export function buildLifeFromLevel(level: number): number {
+  return LIFE_BASE + LIFE_PER_LEVEL * (level - 1);
+}

--- a/libs/game/idle-core/src/progression/build-life-from-level.ts
+++ b/libs/game/idle-core/src/progression/build-life-from-level.ts
@@ -2,7 +2,7 @@ import { LIFE_BASE, LIFE_PER_LEVEL } from './constants';
 
 /**
  * Maximum life for an avatar at a level — a placeholder linear curve standing in for a designed
- * one, until life derives from the avatar's build.
+ * one.
  */
 export function buildLifeFromLevel(level: number): number {
   return LIFE_BASE + LIFE_PER_LEVEL * (level - 1);

--- a/libs/game/idle-core/src/progression/constants.ts
+++ b/libs/game/idle-core/src/progression/constants.ts
@@ -14,3 +14,13 @@ export const COMPLETION_BASE_XP = 25;
  * Fraction of an avatar's progress into its current level lost on activity failure.
  */
 export const FAILURE_XP_LOSS_FRACTION = 0.1;
+
+/**
+ * Life at level 1, before per-level growth.
+ */
+export const LIFE_BASE = 200;
+
+/**
+ * Life gained per level past the first.
+ */
+export const LIFE_PER_LEVEL = 20;

--- a/libs/game/idle-core/src/progression/index.ts
+++ b/libs/game/idle-core/src/progression/index.ts
@@ -1,4 +1,5 @@
 export { buildCompletionXP } from './build-completion-xp';
 export { buildFailureXPLoss } from './build-failure-xp-loss';
 export { buildLevelFromXP } from './build-level-from-xp';
+export { buildLifeFromLevel } from './build-life-from-level';
 export { buildXPThreshold } from './build-xp-threshold';

--- a/libs/game/idle-core/src/test-utils/factories/create-mock-simulation-input-source.test.ts
+++ b/libs/game/idle-core/src/test-utils/factories/create-mock-simulation-input-source.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from 'bun:test';
+import { CURRENT_CONTENT_VERSION } from '@vers/game-utils';
+import { createMockSimulationInputSource } from './create-mock-simulation-input-source';
+
+test('it creates a simulation input source with expected properties', () => {
+  const source = createMockSimulationInputSource();
+
+  expect(source).toStrictEqual({
+    avatarID: expect.toBeString(),
+    buildSnapshot: { level: 1, xp: 0 },
+    contentVersion: CURRENT_CONTENT_VERSION,
+    encounterNode: { difficulty: 1 },
+    id: expect.toStartWith('act_'),
+    seed: 'aa'.repeat(16),
+  });
+});
+
+test('it creates a simulation input source with custom properties', () => {
+  const source = createMockSimulationInputSource({
+    buildSnapshot: { level: 27, xp: 67_600 },
+    encounterNode: { difficulty: 3 },
+  });
+
+  expect(source.buildSnapshot).toStrictEqual({ level: 27, xp: 67_600 });
+  expect(source.encounterNode).toStrictEqual({ difficulty: 3 });
+});

--- a/libs/game/idle-core/src/test-utils/factories/create-mock-simulation-input-source.ts
+++ b/libs/game/idle-core/src/test-utils/factories/create-mock-simulation-input-source.ts
@@ -1,0 +1,17 @@
+import { createId } from '@paralleldrive/cuid2';
+import { CURRENT_CONTENT_VERSION } from '@vers/game-utils';
+import type { SimulationInputSource } from '../../core/build-simulation-input';
+
+export function createMockSimulationInputSource(
+  overrides: Partial<SimulationInputSource> = {},
+): SimulationInputSource {
+  return {
+    avatarID: createId(),
+    buildSnapshot: { level: 1, xp: 0 },
+    contentVersion: CURRENT_CONTENT_VERSION,
+    encounterNode: { difficulty: 1 },
+    id: `act_${createId()}`,
+    seed: 'aa'.repeat(16),
+    ...overrides,
+  };
+}

--- a/libs/game/idle-core/src/test-utils/index.ts
+++ b/libs/game/idle-core/src/test-utils/index.ts
@@ -9,4 +9,5 @@ export { createMockEnemySnapshot } from './factories/create-mock-enemy-snapshot'
 export { createMockFailedCheckpoint } from './factories/create-mock-failed-checkpoint';
 export { createMockProgressCheckpoint } from './factories/create-mock-progress-checkpoint';
 export { createMockSimulationContext } from './factories/create-mock-simulation-context';
+export { createMockSimulationInputSource } from './factories/create-mock-simulation-input-source';
 export { createMockStartedCheckpoint } from './factories/create-mock-started-checkpoint';


### PR DESCRIPTION
## Description

Closes #702

The engagement plate showed a placeholder combat avatar: hardcoded 200 life and the avatar id as the name. Life now derives from the build snapshot's level, and the plate shows the avatar's real name.

- `buildLifeFromLevel` joins the progression curves as a placeholder linear curve (200 at level 1), replacing the hardcoded life in `buildSimulationInput`.
- The avatar's display name is passed from app-web's avatar query through `EngagementView` into the plate — the sim keeps knowing the avatar only by id, so nothing cosmetic enters the deterministic input.
- The build snapshot shape is unchanged; the derivation change rides the engine's sim-version stamp, so in-flight activities replay against their original engine.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality

## Context

Equipment/passive-derived stats (the issue's full Expected) need an equip system that doesn't exist yet — follow-up issue to come.