### PR TITLE
feat(#658): add a viewer composite to mock-services for MSW-regime tests

### DIFF
--- a/libs/game/idle-client/src/resync/run-resync.test.ts
+++ b/libs/game/idle-client/src/resync/run-resync.test.ts
@@ -5,7 +5,7 @@ import {
   createMockAvatarData,
   createMockEnemyData,
 } from '@vers/idle-core/test-utils';
-import { createAuthedServiceClient } from '@vers/mock-services';
+import { createAuthedServiceClient, createViewer } from '@vers/mock-services';
 import { mockActivityService } from '@vers/mock-services/activity';
 import * as db from '@vers/mock-services/db';
 import { waitFor } from '@vers/test-utils';
@@ -44,12 +44,11 @@ async function setupTest(config: Readonly<SetupTestConfig>) {
 }
 
 test('it resolves to none for an avatar with no activity history', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   const result = await runResync({
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     buildSimulationInput: (started) => ({
       activity: createMockActivityInput({
         encounter: {
@@ -74,19 +73,18 @@ test('it resolves to none for an avatar with no activity history', async () => {
 });
 
 test('it rebases from the stop index without simulating when the activity is capped', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   const activity = await db.activityCollection.create({
     appendedHead: 5,
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     status: 'capped',
     verifiedHead: 3,
   });
 
   const result = await runResync({
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     buildSimulationInput: (started) => ({
       activity: createMockActivityInput({
         encounter: {
@@ -121,20 +119,19 @@ test('it rebases from the stop index without simulating when the activity is cap
 });
 
 test('it attaches live when the gap is negligible, leaving the submitter untouched', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   const activity = await db.activityCollection.create({
     appendedAt: new Date(Date.now() - 2000),
     appendedHead: 0,
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     status: 'active',
     verifiedHead: 0,
   });
 
   const result = await runResync({
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     buildSimulationInput: (started) => ({
       activity: createMockActivityInput({
         encounter: {
@@ -168,20 +165,19 @@ test('it attaches live when the gap is negligible, leaving the submitter untouch
 });
 
 test('it fast-forwards a real offline gap and reports the outcome', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   await db.activityCollection.create({
     appendedAt: new Date(Date.now() - 60_000),
     appendedHead: 0,
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     status: 'active',
     verifiedHead: 0,
   });
 
   const result = await runResync({
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     buildSimulationInput: (started) => ({
       activity: createMockActivityInput({
         encounter: {
@@ -213,14 +209,13 @@ test('it fast-forwards a real offline gap and reports the outcome', async () => 
 });
 
 test('it awaits onProgressFetched with the settled progress before planning a fast-forward', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   const activity = await db.activityCollection.create({
     appendedAt: new Date(Date.now() - 60_000),
     appendedHead: 0,
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     status: 'active',
     verifiedHead: 0,
   });
@@ -237,7 +232,7 @@ test('it awaits onProgressFetched with the settled progress before planning a fa
   });
 
   const resync = runResync({
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     buildSimulationInput: (started) => ({
       activity: createMockActivityInput({
         encounter: {
@@ -276,14 +271,13 @@ test('it awaits onProgressFetched with the settled progress before planning a fa
 });
 
 test('it delivers checkpoints a previous worker left queued and plans against the head they advanced', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   const activity = await db.activityCollection.create({
     appendedAt: new Date(Date.now() - 60_000),
     appendedHead: 5,
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     status: 'active',
     verifiedHead: 0,
   });
@@ -299,7 +293,7 @@ test('it delivers checkpoints a previous worker left queued and plans against th
   );
 
   const result = await runResync({
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     buildSimulationInput: (started) => ({
       activity: createMockActivityInput({
         encounter: {
@@ -333,14 +327,13 @@ test('it delivers checkpoints a previous worker left queued and plans against th
 });
 
 test('it refuses to plan while stranded checkpoints cannot be delivered', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ scheduleRetry: () => {}, userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ scheduleRetry: () => {}, userID: viewer.user.id });
 
   const activity = await db.activityCollection.create({
     appendedAt: new Date(Date.now() - 60_000),
     appendedHead: 5,
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     status: 'active',
     verifiedHead: 0,
   });
@@ -358,7 +351,7 @@ test('it refuses to plan while stranded checkpoints cannot be delivered', async 
 
   expect(
     runResync({
-      avatarID: avatar.id,
+      avatarID: viewer.avatar.id,
       buildSimulationInput: (started) => ({
         activity: createMockActivityInput({
           encounter: {
@@ -382,20 +375,19 @@ test('it refuses to plan while stranded checkpoints cannot be delivered', async 
 });
 
 test('it downgrades a fast-forward to attach-live when the activity is already simulating live', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   const activity = await db.activityCollection.create({
     appendedAt: new Date(Date.now() - 60_000),
     appendedHead: 3,
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     status: 'active',
     verifiedHead: 0,
   });
 
   const result = await runResync({
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     buildSimulationInput: (started) => ({
       activity: createMockActivityInput({
         encounter: {
@@ -422,14 +414,13 @@ test('it downgrades a fast-forward to attach-live when the activity is already s
 });
 
 test('it leaves a live activity queue untouched instead of draining it', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   const activity = await db.activityCollection.create({
     appendedAt: new Date(Date.now() - 2000),
     appendedHead: 5,
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     status: 'active',
     verifiedHead: 0,
   });
@@ -441,7 +432,7 @@ test('it leaves a live activity queue untouched instead of draining it', async (
   );
 
   const result = await runResync({
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     buildSimulationInput: (started) => ({
       activity: createMockActivityInput({
         encounter: {

--- a/libs/game/idle-client/src/worker/create-worker-runtime.test.ts
+++ b/libs/game/idle-client/src/worker/create-worker-runtime.test.ts
@@ -2,7 +2,7 @@ import { expect, onTestFinished, test } from 'bun:test';
 import type { ErrorEvent } from '@sentry/browser';
 import { createMockActivityData } from '@vers/contract-activity/test-utils';
 import { ActivityFailureAction } from '@vers/idle-core';
-import { createAuthedServiceClient, resolveServiceURL } from '@vers/mock-services';
+import { createAuthedServiceClient, createViewer, resolveServiceURL } from '@vers/mock-services';
 import { mockActivityService } from '@vers/mock-services/activity';
 import * as db from '@vers/mock-services/db';
 import { waitFor } from '@vers/test-utils';
@@ -63,31 +63,30 @@ test('it seeds the boot state from the device-local failure-action cache before 
 });
 
 test('it retains the cached dirty flag across boot so the next resync flushes it to the server', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const viewer = await createViewer();
 
   await db.activityCollection.create({
     appendedHead: 0,
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     startedAt: new Date(),
   });
 
   await writeFailureActionCache({
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     dirty: true,
     failureAction: ActivityFailureAction.Retry,
   });
 
-  const client = await createAuthedServiceClient<ActivityServiceClient>('activity', user.id);
+  const client = await createAuthedServiceClient<ActivityServiceClient>('activity', viewer.user.id);
 
   using runtime = createWorkerRuntime({ client });
 
   const connection = createConnection(runtime);
 
-  connection.post({ avatarID: avatar.id, type: ClientMessageType.RequestResync });
+  connection.post({ avatarID: viewer.avatar.id, type: ClientMessageType.RequestResync });
 
   await waitFor(() => {
-    const updatedAvatar = db.avatarCollection.findFirst((q) => q.where({ id: avatar.id }));
+    const updatedAvatar = db.avatarCollection.findFirst((q) => q.where({ id: viewer.avatar.id }));
 
     expect(updatedAvatar?.failureAction).toBe('retry');
   });
@@ -185,14 +184,13 @@ test('it reports a fault to the error backend when a message makes its handler t
 });
 
 test('it resumes into a fresh row once a same-row CONFLICT resync drains a held terminal append', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const client = await createAuthedServiceClient<ActivityServiceClient>('activity', user.id);
+  const viewer = await createViewer();
+  const client = await createAuthedServiceClient<ActivityServiceClient>('activity', viewer.user.id);
 
   // this seed's placeholder encounter completes in exactly 60s of simulated time; the fast clock
   // below collapses that wait into a single tick-loop frame
   const activity = await db.activityCollection.create({
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     encounterNode: { difficulty: 1 },
     seed: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaa6072',
   });
@@ -225,7 +223,7 @@ test('it resumes into a fresh row once a same-row CONFLICT resync drains a held 
       clock.jump(65_000);
 
       const minted = db.activityCollection.findFirst((q) =>
-        q.where({ avatarID: avatar.id, status: 'active' }),
+        q.where({ avatarID: viewer.avatar.id, status: 'active' }),
       );
 
       invariant(minted !== undefined, 'expected the same-row CONFLICT resync to mint a fresh row');
@@ -244,14 +242,13 @@ test('it resumes into a fresh row once a same-row CONFLICT resync drains a held 
 });
 
 test('it resumes into a fresh row once a reconnect drains a held terminal append behind an offline continuation', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const client = await createAuthedServiceClient<ActivityServiceClient>('activity', user.id);
+  const viewer = await createViewer();
+  const client = await createAuthedServiceClient<ActivityServiceClient>('activity', viewer.user.id);
 
   // this seed's placeholder encounter completes in exactly 60s of simulated time; the fast clock
   // below collapses that wait into a single tick-loop frame
   const activity = await db.activityCollection.create({
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     encounterNode: { difficulty: 1 },
     seed: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaa6072',
   });
@@ -265,7 +262,7 @@ test('it resumes into a fresh row once a reconnect drains a held terminal append
     ),
     http.post(
       `${resolveServiceURL('activity')}/rpc/startActivity`,
-      makeFailFirstMatchHandler((input) => input['avatarID'] === avatar.id),
+      makeFailFirstMatchHandler((input) => input['avatarID'] === viewer.avatar.id),
     ),
   );
 
@@ -302,7 +299,7 @@ test('it resumes into a fresh row once a reconnect drains a held terminal append
 
   await waitFor(() => {
     const minted = db.activityCollection.findFirst((q) =>
-      q.where({ avatarID: avatar.id, status: 'active' }),
+      q.where({ avatarID: viewer.avatar.id, status: 'active' }),
     );
 
     invariant(minted !== undefined, 'expected the reconnect resync to mint a fresh row');
@@ -316,10 +313,9 @@ test('it resumes into a fresh row once a reconnect drains a held terminal append
 });
 
 test("it resumes the pending continuation's avatar on reconnect over an earlier avatar it resynced", async () => {
-  const user = await db.userCollection.create({});
-  const earlierAvatar = await db.avatarCollection.create({ userID: user.id });
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const client = await createAuthedServiceClient<ActivityServiceClient>('activity', user.id);
+  const viewer = await createViewer();
+  const avatar = await db.avatarCollection.create({ userID: viewer.user.id });
+  const client = await createAuthedServiceClient<ActivityServiceClient>('activity', viewer.user.id);
 
   // this seed's placeholder encounter completes in exactly 60s of simulated time; the fast clock
   // below collapses that wait into a single tick-loop frame
@@ -354,7 +350,7 @@ test("it resumes the pending continuation's avatar on reconnect over an earlier 
 
   // the worker remembers this history-free avatar as its last resync target; the boundary failure
   // below must outrank that memory on reconnect or the pending continuation strands
-  connection.post({ avatarID: earlierAvatar.id, type: ClientMessageType.RequestResync });
+  connection.post({ avatarID: viewer.avatar.id, type: ClientMessageType.RequestResync });
   connection.post({ activity, type: ClientMessageType.SetActivity });
 
   await waitFor(

--- a/libs/game/idle-client/src/worker/flush-pending-stop.test.ts
+++ b/libs/game/idle-client/src/worker/flush-pending-stop.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'bun:test';
-import { createAuthedServiceClient } from '@vers/mock-services';
+import { createAuthedServiceClient, createViewer } from '@vers/mock-services';
 import { mockActivityService } from '@vers/mock-services/activity';
 import * as db from '@vers/mock-services/db';
 import { HttpResponse } from 'msw';
@@ -23,15 +23,19 @@ test('it reports none when no stop is held', async () => {
 });
 
 test('it flushes the queue, stops the row, and releases the intent', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const activity = await db.activityCollection.create({ avatarID: avatar.id, status: 'active' });
-  const client = await createAuthedServiceClient<ActivityServiceClient>('activity', user.id);
+  const viewer = await createViewer();
+
+  const activity = await db.activityCollection.create({
+    avatarID: viewer.avatar.id,
+    status: 'active',
+  });
+
+  const client = await createAuthedServiceClient<ActivityServiceClient>('activity', viewer.user.id);
 
   const submitter = createStubSubmitter();
   const context = createStubWorkerContext({ client, submitter });
 
-  await writePendingStopIntent({ activityID: activity.id, avatarID: avatar.id });
+  await writePendingStopIntent({ activityID: activity.id, avatarID: viewer.avatar.id });
 
   const outcome = await flushPendingStop(context);
 
@@ -49,13 +53,12 @@ test('it flushes the queue, stops the row, and releases the intent', async () =>
 });
 
 test('it treats a missing row as delivered and releases the intent', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const client = await createAuthedServiceClient<ActivityServiceClient>('activity', user.id);
+  const viewer = await createViewer();
+  const client = await createAuthedServiceClient<ActivityServiceClient>('activity', viewer.user.id);
 
   const context = createStubWorkerContext({ client, submitter: createStubSubmitter() });
 
-  await writePendingStopIntent({ activityID: 'activity_gone', avatarID: avatar.id });
+  await writePendingStopIntent({ activityID: 'activity_gone', avatarID: viewer.avatar.id });
 
   const outcome = await flushPendingStop(context);
 
@@ -67,15 +70,23 @@ test('it treats a missing row as delivered and releases the intent', async () =>
 });
 
 test('it never touches a row other than the targeted one', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ended = await db.activityCollection.create({ avatarID: avatar.id, status: 'stopped' });
-  const newer = await db.activityCollection.create({ avatarID: avatar.id, status: 'active' });
-  const client = await createAuthedServiceClient<ActivityServiceClient>('activity', user.id);
+  const viewer = await createViewer();
+
+  const ended = await db.activityCollection.create({
+    avatarID: viewer.avatar.id,
+    status: 'stopped',
+  });
+
+  const newer = await db.activityCollection.create({
+    avatarID: viewer.avatar.id,
+    status: 'active',
+  });
+
+  const client = await createAuthedServiceClient<ActivityServiceClient>('activity', viewer.user.id);
 
   const context = createStubWorkerContext({ client, submitter: createStubSubmitter() });
 
-  await writePendingStopIntent({ activityID: ended.id, avatarID: avatar.id });
+  await writePendingStopIntent({ activityID: ended.id, avatarID: viewer.avatar.id });
 
   const outcome = await flushPendingStop(context);
 

--- a/libs/game/idle-client/src/worker/handle-client-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-client-message.test.ts
@@ -1,8 +1,7 @@
 import { expect, test } from 'bun:test';
 import { createMockActivityData } from '@vers/contract-activity/test-utils';
 import { ActivityFailureAction, createSimulation } from '@vers/idle-core';
-import { createAuthedServiceClient } from '@vers/mock-services';
-import * as db from '@vers/mock-services/db';
+import { createAuthedServiceClient, createViewer } from '@vers/mock-services';
 import type { ActivityServiceClient } from '../submission/types';
 import { createStubWorkerContext } from '../test-utils/create-stub-worker-context';
 import { createTestConnection } from '../test-utils/create-test-connection';
@@ -80,16 +79,15 @@ test('it applies the sent failure action to the live simulation', async () => {
 });
 
 test('it records the resync request for the requested avatar', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const client = await createAuthedServiceClient<ActivityServiceClient>('activity', user.id);
+  const viewer = await createViewer();
+  const client = await createAuthedServiceClient<ActivityServiceClient>('activity', viewer.user.id);
 
   const context = createStubWorkerContext({ client });
 
   const channel = new MessageChannel();
 
   const message: RequestResyncMessage = {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
@@ -97,7 +95,7 @@ test('it records the resync request for the requested avatar', async () => {
 
   await handleClientMessage(context, channel.port2, event);
 
-  expect(context.getResyncAvatarID()).toBe(avatar.id);
+  expect(context.getResyncAvatarID()).toBe(viewer.avatar.id);
 });
 
 test('it acks a request flush message back to the sending port', async () => {

--- a/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
@@ -9,7 +9,7 @@ import {
   createSimulation,
   runAttempt,
 } from '@vers/idle-core';
-import { createAuthedServiceClient } from '@vers/mock-services';
+import { createAuthedServiceClient, createViewer } from '@vers/mock-services';
 import { mockActivityService } from '@vers/mock-services/activity';
 import * as db from '@vers/mock-services/db';
 import { waitFor } from '@vers/test-utils';
@@ -80,12 +80,11 @@ async function setupTest(config: Readonly<SetupTestConfig>) {
 }
 
 test('it broadcasts nothing for an avatar with no activity history', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   const message: RequestResyncMessage = {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
@@ -105,19 +104,18 @@ test('it broadcasts nothing for an avatar with no activity history', async () =>
 });
 
 test('it broadcasts capped and installs no simulation for a capped activity', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   await db.activityCollection.create({
     appendedHead: 5,
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     status: 'capped',
     verifiedHead: 3,
   });
 
   const message: RequestResyncMessage = {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
@@ -133,13 +131,12 @@ test('it broadcasts capped and installs no simulation for a capped activity', as
 });
 
 test('it delivers a queued row for the resync-determined latest activity rather than sweeping it, while sweeping every other activity', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   const activity = await db.activityCollection.create({
     appendedHead: 0,
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     startedAt: new Date(),
   });
 
@@ -151,7 +148,7 @@ test('it delivers a queued row for the resync-determined latest activity rather 
   );
 
   const message: RequestResyncMessage = {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
@@ -171,9 +168,8 @@ test('it delivers a queued row for the resync-determined latest activity rather 
 });
 
 test('it sweeps every queued checkpoint when the avatar has no activity history', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   await writeQueuedCheckpoint(
     'stray-no-activity-activity',
@@ -181,7 +177,7 @@ test('it sweeps every queued checkpoint when the avatar has no activity history'
   );
 
   const message: RequestResyncMessage = {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
@@ -193,16 +189,15 @@ test('it sweeps every queued checkpoint when the avatar has no activity history'
 });
 
 test('it keeps the queued rows of an activity that went live while the resync was running', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
+  const viewer = await createViewer();
 
   await db.activityCollection.create({
     appendedHead: 0,
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     startedAt: new Date(),
   });
 
-  const client = await createAuthedServiceClient<ActivityServiceClient>('activity', user.id);
+  const client = await createAuthedServiceClient<ActivityServiceClient>('activity', viewer.user.id);
 
   let releaseHeldFlush: (() => void) | undefined;
 
@@ -230,7 +225,7 @@ test('it keeps the queued rows of an activity that went live while the resync wa
   );
 
   const message: RequestResyncMessage = {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
@@ -257,18 +252,17 @@ test('it keeps the queued rows of an activity that went live while the resync wa
 });
 
 test('it flushes a held checkpoint for a previously tracked, no-longer-latest activity before sweeping it', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   const staleActivity = await db.activityCollection.create({
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     startedAt: new Date(Date.now() - 60_000),
   });
 
   await db.activityCollection.create({
     appendedHead: 0,
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     startedAt: new Date(),
   });
 
@@ -303,7 +297,7 @@ test('it flushes a held checkpoint for a previously tracked, no-longer-latest ac
   expect(track).toHaveBeenCalledOnce();
 
   const message: RequestResyncMessage = {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
@@ -319,12 +313,11 @@ test('it flushes a held checkpoint for a previously tracked, no-longer-latest ac
 });
 
 test('it reconstructs and installs a live simulation mid-stream, registering from the recovered cursor', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   const activity = await db.activityCollection.create({
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     startedAt: new Date(Date.now() - 2000),
   });
 
@@ -350,7 +343,7 @@ test('it reconstructs and installs a live simulation mid-stream, registering fro
   });
 
   const message: RequestResyncMessage = {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
@@ -388,12 +381,11 @@ test('it reconstructs and installs a live simulation mid-stream, registering fro
 });
 
 test('it reports a divergence via the checkpoint-stream-error channel and skips registration', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   const activity = await db.activityCollection.create({
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     startedAt: new Date(Date.now() - 2000),
   });
 
@@ -411,7 +403,7 @@ test('it reports a divergence via the checkpoint-stream-error channel and skips 
   });
 
   const message: RequestResyncMessage = {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
@@ -431,9 +423,8 @@ test('it reports a divergence via the checkpoint-stream-error channel and skips 
 });
 
 test('it fast-forwards a short gap, broadcasts progress and final tallies, and installs a registered live sim on the final active row', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   // this seed's placeholder encounter completes in exactly 60s of simulated time; a 63s gap
   // leaves just under 3s of budget for the next continuation, too little for any encounter to
@@ -441,13 +432,13 @@ test('it fast-forwards a short gap, broadcasts progress and final tallies, and i
   // unregistered final row regardless of its own random seed
   const activity = await db.activityCollection.create({
     appendedHead: 0,
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     seed: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaa6072',
     startedAt: new Date(Date.now() - 63_000),
   });
 
   const message: RequestResyncMessage = {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
@@ -470,7 +461,7 @@ test('it fast-forwards a short gap, broadcasts progress and final tallies, and i
   // the completed attempt's terminal batch closed the seeded row, so the backend holds exactly
   // one fresh active continuation for the avatar
   const minted = db.activityCollection.findFirst((q) =>
-    q.where({ avatarID: avatar.id, status: 'active' }),
+    q.where({ avatarID: viewer.avatar.id, status: 'active' }),
   );
 
   invariant(minted !== undefined, 'expected the fast-forward to mint an active continuation');
@@ -501,9 +492,8 @@ test('it fast-forwards a short gap, broadcasts progress and final tallies, and i
 });
 
 test('it reconstructs a fast-forward report left mid-stream and registers from its recovered cursor', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   // this seed's placeholder encounter completes in exactly 60s of simulated time with one
   // confirmed ("started") checkpoint at its head; a 20s gap is enough to pick the fast-forward
@@ -511,13 +501,13 @@ test('it reconstructs a fast-forward report left mid-stream and registers from i
   // attempted, reporting back the very row the resync started from
   const activity = await db.activityCollection.create({
     appendedHead: 1,
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     seed: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaa6072',
     startedAt: new Date(Date.now() - 20_000),
   });
 
   const message: RequestResyncMessage = {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
@@ -562,18 +552,17 @@ test('it reconstructs a fast-forward report left mid-stream and registers from i
 });
 
 test('it attaches a fresh login live without broadcasting any catch-up status', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   const activity = await db.activityCollection.create({
     appendedHead: 0,
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     startedAt: new Date(),
   });
 
   const message: RequestResyncMessage = {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
@@ -596,18 +585,17 @@ test('it attaches a fresh login live without broadcasting any catch-up status', 
 });
 
 test('it adopts a server-persisted retry preference during resync, caching and broadcasting the change', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ failureAction: 'retry', userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer({ avatar: { failureAction: 'retry' } });
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   await db.activityCollection.create({
     appendedHead: 0,
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     startedAt: new Date(),
   });
 
   const message: RequestResyncMessage = {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
@@ -624,35 +612,38 @@ test('it adopts a server-persisted retry preference during resync, caching and b
   const cached = await readFailureActionCache();
 
   expect(cached).toStrictEqual({
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     dirty: false,
     failureAction: ActivityFailureAction.Retry,
   });
 });
 
 test('it flushes a dirty local failure action to the server during resync, clearing dirty on success', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ failureAction: ActivityFailureAction.Retry, userID: user.id });
+  const viewer = await createViewer();
+
+  const ctx = await setupTest({
+    failureAction: ActivityFailureAction.Retry,
+    userID: viewer.user.id,
+  });
 
   ctx.context.setFailureActionDirty(true);
 
   // the dirty value lives in the persisted outbox, scoped to this avatar — the record's avatar is
   // what lets the resync flush it rather than adopt the server's
   await writeFailureActionCache({
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     dirty: true,
     failureAction: ActivityFailureAction.Retry,
   });
 
   await db.activityCollection.create({
     appendedHead: 0,
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     startedAt: new Date(),
   });
 
   const message: RequestResyncMessage = {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
@@ -663,28 +654,31 @@ test('it flushes a dirty local failure action to the server during resync, clear
   const cached = await readFailureActionCache();
 
   expect(cached).toStrictEqual({
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     dirty: false,
     failureAction: ActivityFailureAction.Retry,
   });
 
-  const updatedAvatar = db.avatarCollection.findFirst((q) => q.where({ id: avatar.id }));
+  const updatedAvatar = db.avatarCollection.findFirst((q) => q.where({ id: viewer.avatar.id }));
 
   invariant(updatedAvatar !== undefined, 'expected the seeded avatar to still exist');
   expect(updatedAvatar.failureAction).toBe('retry');
 });
 
 test('it keeps the dirty flag when the resync push to the server fails', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ failureAction: ActivityFailureAction.Retry, userID: user.id });
+  const viewer = await createViewer();
+
+  const ctx = await setupTest({
+    failureAction: ActivityFailureAction.Retry,
+    userID: viewer.user.id,
+  });
 
   ctx.context.setFailureActionDirty(true);
 
   // the dirty value lives in the persisted outbox, scoped to this avatar — a failed push must leave
   // that record intact for the next resync to retry
   await writeFailureActionCache({
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     dirty: true,
     failureAction: ActivityFailureAction.Retry,
   });
@@ -697,12 +691,12 @@ test('it keeps the dirty flag when the resync push to the server fails', async (
 
   await db.activityCollection.create({
     appendedHead: 0,
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     startedAt: new Date(),
   });
 
   const message: RequestResyncMessage = {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
@@ -714,36 +708,39 @@ test('it keeps the dirty flag when the resync push to the server fails', async (
   const cached = await readFailureActionCache();
 
   expect(cached).toStrictEqual({
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     dirty: true,
     failureAction: ActivityFailureAction.Retry,
   });
 });
 
 test("it starts a fresh row, installs a live simulation with the worker's failure action, and clears the pending continuation", async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ failureAction: 'retry', userID: user.id });
-  const stopped = await db.activityCollection.create({ avatarID: avatar.id, status: 'stopped' });
+  const viewer = await createViewer({ avatar: { failureAction: 'retry' } });
+
+  const stopped = await db.activityCollection.create({
+    avatarID: viewer.avatar.id,
+    status: 'stopped',
+  });
 
   const ctx = await setupTest({
     pendingContinuation: {
       activityID: stopped.id,
-      avatarID: avatar.id,
+      avatarID: viewer.avatar.id,
       scopeID: stopped.scopeID,
       scopeType: stopped.scopeType,
     },
-    userID: user.id,
+    userID: viewer.user.id,
   });
 
   const message: RequestResyncMessage = {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
   await handleRequestResyncMessage(ctx.context, message);
 
   const minted = db.activityCollection.findFirst((q) =>
-    q.where({ avatarID: avatar.id, status: 'active' }),
+    q.where({ avatarID: viewer.avatar.id, status: 'active' }),
   );
 
   invariant(minted !== undefined, 'expected the continue plan to mint a fresh row');
@@ -758,9 +755,12 @@ test("it starts a fresh row, installs a live simulation with the worker's failur
 });
 
 test('it adopts a fresh row another session raced in ahead of the continuation and clears the pending continuation', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const stopped = await db.activityCollection.create({ avatarID: avatar.id, status: 'stopped' });
+  const viewer = await createViewer();
+
+  const stopped = await db.activityCollection.create({
+    avatarID: viewer.avatar.id,
+    status: 'stopped',
+  });
 
   // the racing row lands between the resync's progress fetch and its start call, so it must not
   // exist when the plan is computed — the scripted handler mints it at start time and answers
@@ -769,7 +769,7 @@ test('it adopts a fresh row another session raced in ahead of the continuation a
     mockActivityService.startActivity.handler(async (opts) => {
       const racing = await db.activityCollection.create({
         appendedHead: 0,
-        avatarID: avatar.id,
+        avatarID: viewer.avatar.id,
         status: 'active',
       });
 
@@ -780,22 +780,22 @@ test('it adopts a fresh row another session raced in ahead of the continuation a
   const ctx = await setupTest({
     pendingContinuation: {
       activityID: stopped.id,
-      avatarID: avatar.id,
+      avatarID: viewer.avatar.id,
       scopeID: stopped.scopeID,
       scopeType: stopped.scopeType,
     },
-    userID: user.id,
+    userID: viewer.user.id,
   });
 
   const message: RequestResyncMessage = {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
   await handleRequestResyncMessage(ctx.context, message);
 
   const racing = db.activityCollection.findFirst((q) =>
-    q.where({ avatarID: avatar.id, status: 'active' }),
+    q.where({ avatarID: viewer.avatar.id, status: 'active' }),
   );
 
   invariant(racing !== undefined, 'expected the scripted handler to mint the racing row');
@@ -809,13 +809,16 @@ test('it adopts a fresh row another session raced in ahead of the continuation a
 });
 
 test('it halts at the boundary and keeps the pending continuation when the offline budget is spent', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const stopped = await db.activityCollection.create({ avatarID: avatar.id, status: 'stopped' });
+  const viewer = await createViewer();
+
+  const stopped = await db.activityCollection.create({
+    avatarID: viewer.avatar.id,
+    status: 'stopped',
+  });
 
   const pending: PendingContinuation = {
     activityID: stopped.id,
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     scopeID: stopped.scopeID,
     scopeType: stopped.scopeType,
   };
@@ -823,11 +826,11 @@ test('it halts at the boundary and keeps the pending continuation when the offli
   const ctx = await setupTest({
     pendingContinuation: pending,
     remainingBudgetMs: 0,
-    userID: user.id,
+    userID: viewer.user.id,
   });
 
   const message: RequestResyncMessage = {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
@@ -843,30 +846,33 @@ test('it halts at the boundary and keeps the pending continuation when the offli
   expect(ctx.context.getPendingContinuation()).toStrictEqual(pending);
 
   const minted = db.activityCollection.findFirst((q) =>
-    q.where({ avatarID: avatar.id, status: 'active' }),
+    q.where({ avatarID: viewer.avatar.id, status: 'active' }),
   );
 
   expect(minted).toBeUndefined();
 });
 
 test('it keeps the pending continuation and reports offline when starting the continued row fails on transport', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const stopped = await db.activityCollection.create({ avatarID: avatar.id, status: 'stopped' });
+  const viewer = await createViewer();
+
+  const stopped = await db.activityCollection.create({
+    avatarID: viewer.avatar.id,
+    status: 'stopped',
+  });
 
   const pending: PendingContinuation = {
     activityID: stopped.id,
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     scopeID: stopped.scopeID,
     scopeType: stopped.scopeType,
   };
 
   server.use(mockActivityService.startActivity.handler(() => HttpResponse.error()));
 
-  const ctx = await setupTest({ pendingContinuation: pending, userID: user.id });
+  const ctx = await setupTest({ pendingContinuation: pending, userID: viewer.user.id });
 
   const message: RequestResyncMessage = {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
@@ -883,13 +889,16 @@ test('it keeps the pending continuation and reports offline when starting the co
 });
 
 test('it clears the pending continuation and reports the resync failure status on a defined error other than CONFLICT', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const stopped = await db.activityCollection.create({ avatarID: avatar.id, status: 'stopped' });
+  const viewer = await createViewer();
+
+  const stopped = await db.activityCollection.create({
+    avatarID: viewer.avatar.id,
+    status: 'stopped',
+  });
 
   const pending: PendingContinuation = {
     activityID: stopped.id,
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     scopeID: stopped.scopeID,
     scopeType: stopped.scopeType,
   };
@@ -900,10 +909,10 @@ test('it clears the pending continuation and reports the resync failure status o
     }),
   );
 
-  const ctx = await setupTest({ pendingContinuation: pending, userID: user.id });
+  const ctx = await setupTest({ pendingContinuation: pending, userID: viewer.user.id });
 
   const message: RequestResyncMessage = {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
@@ -912,7 +921,10 @@ test('it clears the pending continuation and reports the resync failure status o
   await ctx.connection.waitForMessages(1);
 
   expect(ctx.connection.received).toStrictEqual([
-    { status: { avatarID: avatar.id, kind: 'failed' }, type: WorkerMessageType.ResyncStatus },
+    {
+      status: { avatarID: viewer.avatar.id, kind: 'failed' },
+      type: WorkerMessageType.ResyncStatus,
+    },
   ]);
 
   expect(ctx.context.getPendingContinuation()).toBeNull();
@@ -994,9 +1006,8 @@ test('it broadcasts session-expired without a fault report when the session is n
     disableDefaultIntegrations: true,
   });
 
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   server.use(
     mockActivityService.getLatestActivityProgress.handler((opts) => {
@@ -1005,7 +1016,7 @@ test('it broadcasts session-expired without a fault report when the session is n
   );
 
   const message: RequestResyncMessage = {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
@@ -1015,7 +1026,7 @@ test('it broadcasts session-expired without a fault report when the session is n
 
   expect(ctx.connection.received).toStrictEqual([
     {
-      status: { avatarID: avatar.id, kind: 'session-expired' },
+      status: { avatarID: viewer.avatar.id, kind: 'session-expired' },
       type: WorkerMessageType.ResyncStatus,
     },
   ]);
@@ -1027,16 +1038,15 @@ test('it broadcasts session-expired without a fault report when the session is n
 test('it fails the resync while a raised stop is undelivered', async () => {
   server.use(mockActivityService.stopActivity.handler(() => HttpResponse.error()));
 
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
-  await db.activityCollection.create({ avatarID: avatar.id, status: 'active' });
+  await db.activityCollection.create({ avatarID: viewer.avatar.id, status: 'active' });
 
-  await writePendingStopIntent({ activityID: 'activity_stopped', avatarID: avatar.id });
+  await writePendingStopIntent({ activityID: 'activity_stopped', avatarID: viewer.avatar.id });
 
   const message: RequestResyncMessage = {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
@@ -1045,7 +1055,10 @@ test('it fails the resync while a raised stop is undelivered', async () => {
   await ctx.connection.waitForMessages(1);
 
   expect(ctx.connection.received).toStrictEqual([
-    { status: { avatarID: avatar.id, kind: 'failed' }, type: WorkerMessageType.ResyncStatus },
+    {
+      status: { avatarID: viewer.avatar.id, kind: 'failed' },
+      type: WorkerMessageType.ResyncStatus,
+    },
   ]);
 
   expect(ctx.context.getSimulation()).toBeNull();
@@ -1054,20 +1067,19 @@ test('it fails the resync while a raised stop is undelivered', async () => {
 
   expect(intent).toStrictEqual({
     activityID: 'activity_stopped',
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
   });
 });
 
 test('it delivers the held stop before planning, leaving the stopped run cleared', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
-  const row = await db.activityCollection.create({ avatarID: avatar.id, status: 'active' });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
+  const row = await db.activityCollection.create({ avatarID: viewer.avatar.id, status: 'active' });
 
-  await writePendingStopIntent({ activityID: row.id, avatarID: avatar.id });
+  await writePendingStopIntent({ activityID: row.id, avatarID: viewer.avatar.id });
 
   const message: RequestResyncMessage = {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
@@ -1085,10 +1097,9 @@ test('it delivers the held stop before planning, leaving the stopped run cleared
 });
 
 test('it abandons the install when a stop lands mid-resync', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
-  const row = await db.activityCollection.create({ avatarID: avatar.id, status: 'active' });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
+  const row = await db.activityCollection.create({ avatarID: viewer.avatar.id, status: 'active' });
 
   // the stop lands while the progress fetch is in flight — the deviation answers with the live
   // row exactly as the stateful mock would, then advances the epoch as a concurrent stop does
@@ -1108,7 +1119,7 @@ test('it abandons the install when a stop lands mid-resync', async () => {
   );
 
   const message: RequestResyncMessage = {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     type: ClientMessageType.RequestResync,
   };
 
@@ -1119,10 +1130,14 @@ test('it abandons the install when a stop lands mid-resync', async () => {
 });
 
 test('it stops back a continued row when a stop lands during its registration', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const previous = await db.activityCollection.create({ avatarID: avatar.id, status: 'stopped' });
-  const client = await createAuthedServiceClient<ActivityServiceClient>('activity', user.id);
+  const viewer = await createViewer();
+
+  const previous = await db.activityCollection.create({
+    avatarID: viewer.avatar.id,
+    status: 'stopped',
+  });
+
+  const client = await createAuthedServiceClient<ActivityServiceClient>('activity', viewer.user.id);
 
   // the stop lands while the continued row's registration is in flight — after the continue
   // plan's own epoch checks, in the last await before the install guard
@@ -1141,7 +1156,7 @@ test('it stops back a continued row when a stop lands during its registration', 
     client,
     pendingContinuation: {
       activityID: previous.id,
-      avatarID: avatar.id,
+      avatarID: viewer.avatar.id,
       scopeID: previous.scopeID,
       scopeType: previous.scopeType,
     },
@@ -1151,14 +1166,14 @@ test('it stops back a continued row when a stop lands during its registration', 
   contextHolder.current = context;
 
   await handleRequestResyncMessage(context, {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     type: ClientMessageType.RequestResync,
   });
 
   expect(context.getSimulation()).toBeNull();
 
   const revived = db.activityCollection.findFirst((q) =>
-    q.where({ avatarID: avatar.id, status: 'active' }),
+    q.where({ avatarID: viewer.avatar.id, status: 'active' }),
   );
 
   expect(revived).toBeUndefined();

--- a/libs/game/idle-client/src/worker/handle-set-failure-action-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-set-failure-action-message.test.ts
@@ -1,8 +1,7 @@
 import { expect, test } from 'bun:test';
 import { ActivityFailureAction, createSimulation } from '@vers/idle-core';
-import { createAuthedServiceClient } from '@vers/mock-services';
+import { createAuthedServiceClient, createViewer } from '@vers/mock-services';
 import { mockActivityService } from '@vers/mock-services/activity';
-import * as db from '@vers/mock-services/db';
 import { server } from '../mocks/node';
 import { readFailureActionCache } from '../submission/read-failure-action-cache';
 import type { ActivityServiceClient } from '../submission/types';
@@ -26,9 +25,8 @@ async function setupTest(config: Readonly<SetupTestConfig>) {
 }
 
 test('it forwards the change to a live simulation instead of dropping it', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   const simulation = createSimulation();
   const context = createStubWorkerContext({ client: ctx.client });
@@ -36,7 +34,7 @@ test('it forwards the change to a live simulation instead of dropping it', async
   context.setSimulation(simulation);
 
   const message: SetFailureActionMessage = {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     failureAction: ActivityFailureAction.Retry,
     type: ClientMessageType.SetFailureAction,
   };
@@ -47,14 +45,13 @@ test('it forwards the change to a live simulation instead of dropping it', async
 });
 
 test('it applies the change with no live simulation instead of warning and dropping it', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   const context = createStubWorkerContext({ client: ctx.client });
 
   const message: SetFailureActionMessage = {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     failureAction: ActivityFailureAction.Retry,
     type: ClientMessageType.SetFailureAction,
   };
@@ -65,14 +62,13 @@ test('it applies the change with no live simulation instead of warning and dropp
 });
 
 test('it clears the dirty flag once the server push succeeds', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   const context = createStubWorkerContext({ client: ctx.client });
 
   const message: SetFailureActionMessage = {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     failureAction: ActivityFailureAction.Retry,
     type: ClientMessageType.SetFailureAction,
   };
@@ -84,16 +80,15 @@ test('it clears the dirty flag once the server push succeeds', async () => {
   const cached = await readFailureActionCache();
 
   expect(cached).toStrictEqual({
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     dirty: false,
     failureAction: ActivityFailureAction.Retry,
   });
 });
 
 test('it keeps the dirty flag when the server push fails', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   server.use(
     mockActivityService.updateFailureAction.handler(() => {
@@ -104,7 +99,7 @@ test('it keeps the dirty flag when the server push fails', async () => {
   const context = createStubWorkerContext({ client: ctx.client });
 
   const message: SetFailureActionMessage = {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     failureAction: ActivityFailureAction.Retry,
     type: ClientMessageType.SetFailureAction,
   };
@@ -116,16 +111,15 @@ test('it keeps the dirty flag when the server push fails', async () => {
   const cached = await readFailureActionCache();
 
   expect(cached).toStrictEqual({
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     dirty: true,
     failureAction: ActivityFailureAction.Retry,
   });
 });
 
 test('it broadcasts the effective failure action to every connection', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   const channel = new MessageChannel();
 
@@ -138,7 +132,7 @@ test('it broadcasts the effective failure action to every connection', async () 
   });
 
   const message: SetFailureActionMessage = {
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     failureAction: ActivityFailureAction.Retry,
     type: ClientMessageType.SetFailureAction,
   };

--- a/libs/game/idle-client/src/worker/handle-stop-activity-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-stop-activity-message.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'bun:test';
 import { createMockActivityData } from '@vers/contract-activity/test-utils';
 import { ActivityFailureAction, createSimulation } from '@vers/idle-core';
 import { createMockActivityInput, createMockAvatarData } from '@vers/idle-core/test-utils';
-import { createAuthedServiceClient } from '@vers/mock-services';
+import { createAuthedServiceClient, createViewer } from '@vers/mock-services';
 import { mockActivityService } from '@vers/mock-services/activity';
 import * as db from '@vers/mock-services/db';
 import { HttpResponse } from 'msw';
@@ -133,17 +133,16 @@ test('it advances the stop epoch so in-flight installs abandon', async () => {
 });
 
 test('it delivers the targeted server stop and releases the intent', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const row = await db.activityCollection.create({ avatarID: avatar.id, status: 'active' });
-  const client = await createAuthedServiceClient<ActivityServiceClient>('activity', user.id);
+  const viewer = await createViewer();
+  const row = await db.activityCollection.create({ avatarID: viewer.avatar.id, status: 'active' });
+  const client = await createAuthedServiceClient<ActivityServiceClient>('activity', viewer.user.id);
 
   const submitter = createStubSubmitter();
   const context = createStubWorkerContext({ client, submitter });
 
   await handleStopActivityMessage(context, {
     activityID: row.id,
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     type: ClientMessageType.StopActivity,
   });
 
@@ -187,17 +186,16 @@ test('it keeps the intent held when delivery fails, with the local halt already 
 });
 
 test('it halts nothing but still delivers when no simulation is installed', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const row = await db.activityCollection.create({ avatarID: avatar.id, status: 'active' });
-  const client = await createAuthedServiceClient<ActivityServiceClient>('activity', user.id);
+  const viewer = await createViewer();
+  const row = await db.activityCollection.create({ avatarID: viewer.avatar.id, status: 'active' });
+  const client = await createAuthedServiceClient<ActivityServiceClient>('activity', viewer.user.id);
 
   const context = createStubWorkerContext({ client, submitter: createStubSubmitter() });
   const entryEpoch = context.getStopEpoch();
 
   await handleStopActivityMessage(context, {
     activityID: row.id,
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     type: ClientMessageType.StopActivity,
   });
 

--- a/libs/game/idle-client/src/worker/run-continuation.test.ts
+++ b/libs/game/idle-client/src/worker/run-continuation.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'bun:test';
 import { createMockActivityData } from '@vers/contract-activity/test-utils';
 import { createSimulation } from '@vers/idle-core';
 import { createMockActivityInput, createMockAvatarData } from '@vers/idle-core/test-utils';
-import { createAuthedServiceClient } from '@vers/mock-services';
+import { createAuthedServiceClient, createViewer } from '@vers/mock-services';
 import { mockActivityService } from '@vers/mock-services/activity';
 import * as db from '@vers/mock-services/db';
 import { HttpResponse } from 'msw';
@@ -32,21 +32,20 @@ async function setupTest(config: Readonly<SetupTestConfig>) {
 }
 
 test('it adopts a fresh server-started row for the same scope and registers from a zero cursor', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   const submitter = createStubSubmitter();
   const context = createStubWorkerContext({ client: ctx.client, submitter });
   const simulation = createSimulation();
-  const previousActivity = createMockActivityData({ avatarID: avatar.id });
+  const previousActivity = createMockActivityData({ avatarID: viewer.avatar.id });
 
   simulation.startActivity(createMockAvatarData(), createMockActivityInput());
 
   await runContinuation(context, simulation, previousActivity);
 
   const minted = db.activityCollection.findFirst((q) =>
-    q.where({ avatarID: avatar.id, status: 'active' }),
+    q.where({ avatarID: viewer.avatar.id, status: 'active' }),
   );
 
   invariant(minted !== undefined, 'expected the continuation to mint an active row');
@@ -63,19 +62,18 @@ test('it adopts a fresh server-started row for the same scope and registers from
 });
 
 test('it adopts the CONFLICT payload row when one is already active for the scope', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   const conflictingActivity = await db.activityCollection.create({
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     status: 'active',
   });
 
   const submitter = createStubSubmitter();
   const context = createStubWorkerContext({ client: ctx.client, submitter });
   const simulation = createSimulation();
-  const previousActivity = createMockActivityData({ avatarID: avatar.id });
+  const previousActivity = createMockActivityData({ avatarID: viewer.avatar.id });
 
   simulation.startActivity(createMockAvatarData(), createMockActivityInput());
 
@@ -136,10 +134,13 @@ test('it records a pending continuation on a transport failure', async () => {
 });
 
 test('it stops the simulation and records a pending continuation on a same-row CONFLICT', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
-  const activity = await db.activityCollection.create({ avatarID: avatar.id, status: 'active' });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
+
+  const activity = await db.activityCollection.create({
+    avatarID: viewer.avatar.id,
+    status: 'active',
+  });
 
   const submitter = createStubSubmitter();
   const context = createStubWorkerContext({ client: ctx.client, submitter });
@@ -160,20 +161,19 @@ test('it stops the simulation and records a pending continuation on a same-row C
 });
 
 test('it records no pending continuation when the CONFLICT names a different, already-progressed row', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   await db.activityCollection.create({
     appendedHead: 3,
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     status: 'active',
   });
 
   const submitter = createStubSubmitter();
   const context = createStubWorkerContext({ client: ctx.client, submitter });
   const simulation = createSimulation();
-  const previousActivity = createMockActivityData({ avatarID: avatar.id });
+  const previousActivity = createMockActivityData({ avatarID: viewer.avatar.id });
 
   simulation.startActivity(createMockAvatarData(), createMockActivityInput());
 
@@ -202,20 +202,22 @@ test('it records no pending continuation on a defined error other than CONFLICT'
 });
 
 test('it stops the row it started when a stop lands mid-flight', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   const submitter = createStubSubmitter();
   const context = createStubWorkerContext({ client: ctx.client, submitter });
   const simulation = createSimulation();
-  const previousActivity = createMockActivityData({ avatarID: avatar.id });
+  const previousActivity = createMockActivityData({ avatarID: viewer.avatar.id });
 
   simulation.startActivity(createMockAvatarData(), createMockActivityInput());
 
   // the stop lands while the start call is in flight: the deviation answers with the row the
   // continuation minted, then advances the epoch as a concurrent stop does
-  const started = await db.activityCollection.create({ avatarID: avatar.id, status: 'active' });
+  const started = await db.activityCollection.create({
+    avatarID: viewer.avatar.id,
+    status: 'active',
+  });
 
   server.use(
     mockActivityService.startActivity.handler(() => {

--- a/libs/game/idle-client/src/worker/run-simulation.test.ts
+++ b/libs/game/idle-client/src/worker/run-simulation.test.ts
@@ -6,7 +6,7 @@ import {
   createMockAvatarData,
   createMockEnemyData,
 } from '@vers/idle-core/test-utils';
-import { createAuthedServiceClient } from '@vers/mock-services';
+import { createAuthedServiceClient, createViewer } from '@vers/mock-services';
 import * as db from '@vers/mock-services/db';
 import invariant from 'tiny-invariant';
 import type { CheckpointSubmitter } from '../submission/create-checkpoint-submitter';
@@ -44,13 +44,12 @@ async function runSimulationSteps(
 }
 
 test('it continues into a fresh server-started row if it fails and the failure action is retry', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   // the running row's terminal already landed server-side, so no active row blocks the start
   const sourceRow = await db.activityCollection.create({
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     status: 'stopped',
   });
 
@@ -74,7 +73,7 @@ test('it continues into a fresh server-started row if it fails and the failure a
   await runSimulationSteps(context, simulation, 100, 50);
 
   const minted = db.activityCollection.findFirst((q) =>
-    q.where({ avatarID: avatar.id, status: 'active' }),
+    q.where({ avatarID: viewer.avatar.id, status: 'active' }),
   );
 
   invariant(minted !== undefined, 'the continuation minted an active row');
@@ -108,12 +107,11 @@ test('it does not continue if it fails and the failure action is abort', async (
 test.each([[ActivityFailureAction.Abort], [ActivityFailureAction.Retry]])(
   'it continues into a fresh server-started row if it completes, regardless of the failure action (%s)',
   async (failureAction) => {
-    const user = await db.userCollection.create({});
-    const avatar = await db.avatarCollection.create({ userID: user.id });
-    const ctx = await setupTest({ userID: user.id });
+    const viewer = await createViewer();
+    const ctx = await setupTest({ userID: viewer.user.id });
 
     const sourceRow = await db.activityCollection.create({
-      avatarID: avatar.id,
+      avatarID: viewer.avatar.id,
       status: 'stopped',
     });
 
@@ -146,7 +144,7 @@ test.each([[ActivityFailureAction.Abort], [ActivityFailureAction.Retry]])(
     await runSimulationSteps(context, simulation, 100, 700);
 
     const minted = db.activityCollection.findFirst((q) =>
-      q.where({ avatarID: avatar.id, status: 'active' }),
+      q.where({ avatarID: viewer.avatar.id, status: 'active' }),
     );
 
     invariant(minted !== undefined, 'the continuation minted an active row');
@@ -157,12 +155,11 @@ test.each([[ActivityFailureAction.Abort], [ActivityFailureAction.Retry]])(
 );
 
 test('it adopts a conflict row with no confirmed checkpoints as the continuation', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   const sourceRow = await db.activityCollection.create({
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     startedAt: new Date(Date.now() - 60_000),
     status: 'stopped',
   });
@@ -170,7 +167,7 @@ test('it adopts a conflict row with no confirmed checkpoints as the continuation
   // a live never-appended row already owns the avatar, so the start conflicts with it
   const conflictRow = await db.activityCollection.create({
     appendedHead: 0,
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     status: 'active',
   });
 
@@ -199,12 +196,11 @@ test('it adopts a conflict row with no confirmed checkpoints as the continuation
 });
 
 test('it rebuilds through a resync when the conflict row already has confirmed checkpoints', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   const sourceRow = await db.activityCollection.create({
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     startedAt: new Date(Date.now() - 60_000),
     status: 'stopped',
   });
@@ -213,7 +209,7 @@ test('it rebuilds through a resync when the conflict row already has confirmed c
   const conflictRow = await db.activityCollection.create({
     appendedAt: new Date(Date.now() - 2000),
     appendedHead: 1,
-    avatarID: avatar.id,
+    avatarID: viewer.avatar.id,
     status: 'active',
   });
 
@@ -254,9 +250,8 @@ test('it rebuilds through a resync when the conflict row already has confirmed c
 });
 
 test('it skips the continuation when a fresher activity replaced this row mid-submission', async () => {
-  const user = await db.userCollection.create({});
-  const avatar = await db.avatarCollection.create({ userID: user.id });
-  const ctx = await setupTest({ userID: user.id });
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   const context = createStubWorkerContext({ client: ctx.client });
   const simulation = createSimulation();
@@ -266,7 +261,10 @@ test('it skips the continuation when a fresher activity replaced this row mid-su
   const activity = createMockActivityInput({ failureAction: ActivityFailureAction.Retry });
 
   // a different row is tracked than the one the simulation runs — the fresher-owner signal
-  const trackedRow = await db.activityCollection.create({ avatarID: avatar.id, status: 'stopped' });
+  const trackedRow = await db.activityCollection.create({
+    avatarID: viewer.avatar.id,
+    status: 'stopped',
+  });
 
   context.setActivity(trackedRow);
   context.setSimulation(simulation);
@@ -276,7 +274,7 @@ test('it skips the continuation when a fresher activity replaced this row mid-su
 
   // no continuation start reached the service: nothing was minted for the avatar
   const minted = db.activityCollection.findFirst((q) =>
-    q.where({ avatarID: avatar.id, status: 'active' }),
+    q.where({ avatarID: viewer.avatar.id, status: 'active' }),
   );
 
   expect(minted).toBeUndefined();

--- a/libs/testing/mock-services/src/create-viewer.test.ts
+++ b/libs/testing/mock-services/src/create-viewer.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from 'bun:test';
+import * as jose from 'jose';
+import { createViewer } from './create-viewer';
+import { avatarCollection, userCollection } from './db';
+
+test('it seeds a linked user and avatar and mints a token for that user', async () => {
+  const viewer = await createViewer();
+
+  expect(viewer.avatar.userID).toBe(viewer.user.id);
+  expect(jose.decodeJwt(viewer.token).sub).toBe(viewer.user.id);
+
+  expect(userCollection.findFirst((q) => q.where({ id: viewer.user.id }))).toMatchObject({
+    id: viewer.user.id,
+  });
+
+  expect(avatarCollection.findFirst((q) => q.where({ id: viewer.avatar.id }))).toMatchObject({
+    userID: viewer.user.id,
+  });
+});
+
+test('it applies user and avatar overrides', async () => {
+  const viewer = await createViewer({
+    avatar: { name: 'viewer-override-avatar' },
+    user: { email: 'viewer-override@test.com' },
+  });
+
+  expect(viewer.user.email).toBe('viewer-override@test.com');
+  expect(viewer.avatar.name).toBe('viewer-override-avatar');
+});

--- a/libs/testing/mock-services/src/create-viewer.ts
+++ b/libs/testing/mock-services/src/create-viewer.ts
@@ -1,0 +1,30 @@
+import type * as z from 'zod';
+import { createTestAccessToken } from './create-test-access-token';
+import type { AvatarRowSchema, UserRowSchema } from './db';
+import { avatarCollection, userCollection } from './db';
+
+interface CreateViewerConfig {
+  readonly avatar?: z.input<typeof AvatarRowSchema>;
+  readonly user?: z.input<typeof UserRowSchema>;
+}
+
+interface Viewer {
+  readonly avatar: z.output<typeof AvatarRowSchema>;
+  readonly token: string;
+  readonly user: z.output<typeof UserRowSchema>;
+}
+
+/**
+ * An acting user seeded into the mock store: a user row, an avatar row linked to it, and an access
+ * token minted for the user — the MSW-regime counterpart of the real-database viewer composite.
+ * Overrides pass through to the collections' defaults; the avatar's user linkage comes free, though
+ * an explicit `avatar.userID` override still wins. Returns data only — callers build their own
+ * client for the transport they exercise.
+ */
+export async function createViewer(config: Readonly<CreateViewerConfig> = {}): Promise<Viewer> {
+  const user = await userCollection.create(config.user ?? {});
+  const avatar = await avatarCollection.create({ userID: user.id, ...config.avatar });
+  const token = await createTestAccessToken(user.id);
+
+  return { avatar, token, user };
+}

--- a/libs/testing/mock-services/src/create-viewer.ts
+++ b/libs/testing/mock-services/src/create-viewer.ts
@@ -23,7 +23,12 @@ interface Viewer {
  */
 export async function createViewer(config: Readonly<CreateViewerConfig> = {}): Promise<Viewer> {
   const user = await userCollection.create(config.user ?? {});
-  const avatar = await avatarCollection.create({ userID: user.id, ...config.avatar });
+
+  const avatar = await avatarCollection.create({
+    ...config.avatar,
+    userID: config.avatar?.userID ?? user.id,
+  });
+
   const token = await createTestAccessToken(user.id);
 
   return { avatar, token, user };

--- a/libs/testing/mock-services/src/db/avatar-collection.ts
+++ b/libs/testing/mock-services/src/db/avatar-collection.ts
@@ -11,7 +11,7 @@ import * as z from 'zod';
  * `failureAction` is the activity service's own column on this row, not part of the avatar
  * contract's public shape.
  */
-const AvatarRowSchema = AvatarDataSchema.extend({
+export const AvatarRowSchema = AvatarDataSchema.extend({
   createdAt: z.date().default(() => new Date()),
   failureAction: ActivityFailureActionSchema.default('abort'),
   id: z.string().default(() => createId()),

--- a/libs/testing/mock-services/src/db/index.ts
+++ b/libs/testing/mock-services/src/db/index.ts
@@ -1,5 +1,5 @@
 export { activityCollection } from './activity-collection';
-export { avatarCollection } from './avatar-collection';
+export { avatarCollection, AvatarRowSchema } from './avatar-collection';
 export { avatarItemCollection } from './avatar-item-collection';
 export { checkpointCollection } from './checkpoint-collection';
 export { pendingTransactionCollection } from './pending-transaction-collection';

--- a/libs/testing/mock-services/src/index.ts
+++ b/libs/testing/mock-services/src/index.ts
@@ -1,6 +1,7 @@
 export { createAuthedServiceClient } from './create-authed-service-client';
 export { createDemoSeed } from './create-demo-seed';
 export { createTestAccessToken } from './create-test-access-token';
+export { createViewer } from './create-viewer';
 export { DEMO_ACCOUNTS } from './demo-accounts';
 export type { DemoAccount } from './demo-accounts';
 export { resolveServiceURL } from './resolve-service-url';


### PR DESCRIPTION
## Description

Closes #658

Adds a `createViewer` composite to `@vers/mock-services` — one call seeding a user row, a linked avatar row, and a test access token in the `@msw/data` store — and adopts it across idle-client's worker and resync tests, replacing the inlined user/avatar seed blocks.

- Returns data only (`user`, `avatar`, `token`); tests keep building their own oRPC client, mirroring how the real-database viewer composite leaves client construction in-test
- `user`/`avatar` override bags pass through to the collections' defaults; the avatar's user linkage comes free, and an explicit `avatar.userID` override still wins
- Exports `AvatarRowSchema` from the db subpath so the composite's override types derive from the row schema, matching the user row

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality