### PR TITLE
feat(#717): consolidate the worker into a single lifecycle owner

### DIFF
--- a/docs/architecture/game/game-simulation.md
+++ b/docs/architecture/game/game-simulation.md
@@ -188,9 +188,11 @@ there. A larger gap fast-forwards through one or more attempts first, then attac
 whichever continuation is still active when the budget runs out.
 
 A continuation the worker couldn't complete — a same-row race just after a terminal checkpoint, or a
-transport failure starting the next row — leaves a pending record that the next resync consults. A
-non-active row matching that record starts fresh once its terminal append is acknowledged. A player
-stop leaves no such record, so a stopped activity is never resumed.
+transport failure starting the next row — is held as a durable start intent. Intents deliver before
+a resync fetches its snapshot, so the row an intent mints is already in the snapshot and attaches
+like any other active row; delivery is idempotent through the intent's start key, and a claim
+another device raced in moots the intent. A player stop clears any held intent, so a stopped
+activity is never resumed.
 
 ### The offline budget
 

--- a/libs/game/idle-client/src/resync/plan-resync.test.ts
+++ b/libs/game/idle-client/src/resync/plan-resync.test.ts
@@ -27,25 +27,6 @@ test('it plans nothing for a stopped activity', () => {
   });
 });
 
-test('it rebases a capped activity', () => {
-  const activity = createMockActivityData({ appendedHead: 7, status: 'capped' });
-  const progress = createMockLatestActivityProgress({ activity, appendedHead: 7 });
-
-  const plan = planResync({
-    progress,
-  });
-
-  expect(plan).toStrictEqual({
-    context: {
-      activityID: activity.id,
-      appendedHead: 7,
-      lastHash: activity.lastHash,
-      startChainIndex: activity.startChainIndex,
-    },
-    kind: 'rebase',
-  });
-});
-
 test('it attaches live when the gap is not worth simulating', () => {
   const serverTime = new Date('2026-07-14T12:00:00Z');
 

--- a/libs/game/idle-client/src/resync/plan-resync.test.ts
+++ b/libs/game/idle-client/src/resync/plan-resync.test.ts
@@ -27,49 +27,11 @@ test('it plans nothing for a stopped activity', () => {
   });
 });
 
-test('it plans nothing for a stopped activity when the pending continuation names a different row', () => {
-  const activity = createMockActivityData({ status: 'stopped' });
-
-  const plan = planResync({
-    pendingContinuation: {
-      activityID: 'a-different-activity',
-      avatarID: activity.avatarID,
-      scopeID: activity.scopeID,
-      scopeType: activity.scopeType,
-    },
-    progress: createMockLatestActivityProgress({ activity }),
-  });
-
-  expect(plan).toStrictEqual({ kind: 'none' });
-});
-
-test('it continues a stopped activity matching the pending continuation', () => {
-  const activity = createMockActivityData({ status: 'stopped' });
-
-  const plan = planResync({
-    pendingContinuation: {
-      activityID: activity.id,
-      avatarID: activity.avatarID,
-      scopeID: activity.scopeID,
-      scopeType: activity.scopeType,
-    },
-    progress: createMockLatestActivityProgress({ activity }),
-  });
-
-  expect(plan).toStrictEqual({ activity, kind: 'continue' });
-});
-
-test('it rebases a capped activity over a matching pending continuation', () => {
+test('it rebases a capped activity', () => {
   const activity = createMockActivityData({ appendedHead: 7, status: 'capped' });
   const progress = createMockLatestActivityProgress({ activity, appendedHead: 7 });
 
   const plan = planResync({
-    pendingContinuation: {
-      activityID: activity.id,
-      avatarID: activity.avatarID,
-      scopeID: activity.scopeID,
-      scopeType: activity.scopeType,
-    },
     progress,
   });
 

--- a/libs/game/idle-client/src/resync/plan-resync.ts
+++ b/libs/game/idle-client/src/resync/plan-resync.ts
@@ -1,12 +1,10 @@
 import { OFFLINE_PROGRESS_CAP_MS } from '@vers/contract-activity';
 import { PROGRESS_FLUSH_INTERVAL_MS } from '../submission/constants';
 import type { ActivitySubmissionContext } from '../submission/types';
-import type { PendingContinuation } from '../worker/types';
 import type { LatestActivityProgress, ResyncPlan } from './types';
 
 interface PlanResyncInput {
   readonly capMs?: number;
-  readonly pendingContinuation?: PendingContinuation | null;
   readonly progress: LatestActivityProgress;
 }
 
@@ -15,10 +13,8 @@ interface PlanResyncInput {
  * entirely from server data — the server clock minus the last append (or the start, for a stream
  * that never appended) — so a skewed local clock can neither inflate nor starve the budget, and
  * the budget never exceeds the cap. A capped activity resolves to a rebase from its exact stop
- * index rather than trusting any locally derived cursor, taking priority over a pending
- * continuation. A non-active row matching a pending continuation's target plans `continue`
- * instead of `none` — the pending intent is stale, and ignored, when it names a different row than
- * the one fetched.
+ * index rather than trusting any locally derived cursor. A non-active row plans nothing: pending
+ * intents deliver before the snapshot is fetched, so whatever they mint is already in it.
  */
 export function planResync(input: Readonly<PlanResyncInput>): ResyncPlan {
   const capMs = input.capMs ?? OFFLINE_PROGRESS_CAP_MS;
@@ -36,10 +32,6 @@ export function planResync(input: Readonly<PlanResyncInput>): ResyncPlan {
   }
 
   if (activity.status !== 'active') {
-    if (input.pendingContinuation?.activityID === activity.id) {
-      return { activity, kind: 'continue' };
-    }
-
     return { kind: 'none' };
   }
 

--- a/libs/game/idle-client/src/resync/run-resync.ts
+++ b/libs/game/idle-client/src/resync/run-resync.ts
@@ -4,7 +4,6 @@ import type { ActivityInput, AvatarData } from '@vers/idle-core';
 import type { CheckpointSubmitter } from '../submission/create-checkpoint-submitter';
 import { readQueuedCheckpoints } from '../submission/read-queued-checkpoints';
 import type { ActivityServiceClient } from '../submission/types';
-import type { PendingContinuation } from '../worker/types';
 import { planResync } from './plan-resync';
 import { runFastForward } from './run-fast-forward';
 import type { FastForwardProgress, LatestActivityProgress, ResyncResult } from './types';
@@ -45,12 +44,6 @@ interface RunResyncOptions {
    * fast-forward reads it.
    */
   readonly onProgressFetched?: (progress: LatestActivityProgress) => Promise<void>;
-
-  /**
-   * A continuation a previous worker started but couldn't complete, honored as a `continue` plan
-   * once its target row reads closed.
-   */
-  readonly pendingContinuation?: PendingContinuation | null;
 
   readonly submitter: CheckpointSubmitter;
 }
@@ -95,9 +88,6 @@ export async function runResync(
   const plan = planResync({
     progress,
     ...(options.capMs !== undefined && { capMs: options.capMs }),
-    ...(options.pendingContinuation !== undefined && {
-      pendingContinuation: options.pendingContinuation,
-    }),
   });
 
   if (plan.kind !== 'fast-forward') {

--- a/libs/game/idle-client/src/resync/types.ts
+++ b/libs/game/idle-client/src/resync/types.ts
@@ -9,7 +9,6 @@ export type LatestActivityProgress = Awaited<
  * The action a resync snapshot resolves to, decided before any simulation runs: `fast-forward`
  * re-simulates the offline gap up to its budget, `attach-live` resumes live submission with no
  * catch-up worth simulating, `rebase` restarts bookkeeping from a capped activity's stop index,
- * `continue` starts the next row a pending continuation wanted once its target row reads closed,
  * and `none` means no resumable activity exists.
  */
 export type ResyncPlan =
@@ -20,7 +19,6 @@ export type ResyncPlan =
     }
   | { readonly context: ActivitySubmissionContext; readonly kind: 'attach-live' }
   | { readonly context: ActivitySubmissionContext; readonly kind: 'rebase' }
-  | { readonly activity: ActivityData; readonly kind: 'continue' }
   | { readonly kind: 'none' };
 
 export interface FastForwardProgress {

--- a/libs/game/idle-client/src/submission/constants.ts
+++ b/libs/game/idle-client/src/submission/constants.ts
@@ -40,4 +40,11 @@ export const FAILURE_ACTION_PREFERENCE_KEY = 'failure-action';
  * target row the newer run's own start flow has already closed server-side.
  */
 export const PENDING_STOP_INTENT_KEY = 'pending-stop';
+
+/**
+ * The `preferences` record holding the one undelivered start intent — a continuation raised
+ * against a closing row, delivered once that row reads closed. A newer intent overwrites an
+ * older one; the worker drives one avatar at a time.
+ */
+export const PENDING_START_INTENT_KEY = 'pending-start';
 export const PREFERENCES_STORE_NAME = 'preferences';

--- a/libs/game/idle-client/src/submission/read-pending-start-intent.test.ts
+++ b/libs/game/idle-client/src/submission/read-pending-start-intent.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from 'bun:test';
+import { readPendingStartIntent } from './read-pending-start-intent';
+import { writePendingStartIntent } from './write-pending-start-intent';
+import { writePendingStopIntent } from './write-pending-stop-intent';
+
+test('it returns undefined when no start is held', async () => {
+  const intent = await readPendingStartIntent();
+
+  expect(intent).toBeUndefined();
+});
+
+test('it returns the held intent', async () => {
+  await writePendingStartIntent({
+    avatarID: 'avatar_1',
+    scopeID: 'scope_1',
+    scopeType: 'world_map_node',
+    startKey: 'continue_activity_1',
+  });
+
+  const intent = await readPendingStartIntent();
+
+  expect(intent).toStrictEqual({
+    avatarID: 'avatar_1',
+    scopeID: 'scope_1',
+    scopeType: 'world_map_node',
+    startKey: 'continue_activity_1',
+  });
+});
+
+test('it never reads the stop intent sharing the preferences store', async () => {
+  await writePendingStopIntent({ activityID: 'activity_1', avatarID: 'avatar_1' });
+
+  const intent = await readPendingStartIntent();
+
+  expect(intent).toBeUndefined();
+});

--- a/libs/game/idle-client/src/submission/read-pending-start-intent.ts
+++ b/libs/game/idle-client/src/submission/read-pending-start-intent.ts
@@ -1,0 +1,13 @@
+import { PENDING_START_INTENT_KEY, PREFERENCES_STORE_NAME } from './constants';
+import { resolveCheckpointQueueDB } from './resolve-checkpoint-queue-db';
+import type { PendingStartIntent } from './types';
+
+/**
+ * Reads the undelivered start intent, `undefined` when every raised start has been delivered.
+ */
+export async function readPendingStartIntent(): Promise<PendingStartIntent | undefined> {
+  const db = await resolveCheckpointQueueDB();
+  const record = await db.get(PREFERENCES_STORE_NAME, PENDING_START_INTENT_KEY);
+
+  return record !== undefined && 'startKey' in record ? record : undefined;
+}

--- a/libs/game/idle-client/src/submission/remove-pending-start-intent.test.ts
+++ b/libs/game/idle-client/src/submission/remove-pending-start-intent.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from 'bun:test';
+import { readPendingStartIntent } from './read-pending-start-intent';
+import { removePendingStartIntent } from './remove-pending-start-intent';
+import { writePendingStartIntent } from './write-pending-start-intent';
+
+test('it removes the held intent for the delivered key', async () => {
+  await writePendingStartIntent({
+    avatarID: 'avatar_1',
+    scopeID: 'scope_1',
+    scopeType: 'world_map_node',
+    startKey: 'continue_activity_1',
+  });
+
+  await removePendingStartIntent('continue_activity_1');
+
+  const intent = await readPendingStartIntent();
+
+  expect(intent).toBeUndefined();
+});
+
+test('it keeps a fresher intent held under a different key', async () => {
+  await writePendingStartIntent({
+    avatarID: 'avatar_1',
+    scopeID: 'scope_2',
+    scopeType: 'world_map_node',
+    startKey: 'continue_activity_2',
+  });
+
+  await removePendingStartIntent('continue_activity_1');
+
+  const intent = await readPendingStartIntent();
+
+  expect(intent).toStrictEqual({
+    avatarID: 'avatar_1',
+    scopeID: 'scope_2',
+    scopeType: 'world_map_node',
+    startKey: 'continue_activity_2',
+  });
+});
+
+test('it tolerates no intent being held', async () => {
+  await removePendingStartIntent('continue_activity_1');
+
+  const intent = await readPendingStartIntent();
+
+  expect(intent).toBeUndefined();
+});

--- a/libs/game/idle-client/src/submission/remove-pending-start-intent.ts
+++ b/libs/game/idle-client/src/submission/remove-pending-start-intent.ts
@@ -1,0 +1,21 @@
+import { PENDING_START_INTENT_KEY, PREFERENCES_STORE_NAME } from './constants';
+import { resolveCheckpointQueueDB } from './resolve-checkpoint-queue-db';
+
+/**
+ * Removes the held start intent, but only while it still carries the delivered key — a fresher
+ * intent written while this delivery was in flight stays held. The read and delete share one
+ * transaction, so the check and the removal are atomic.
+ */
+export async function removePendingStartIntent(startKey: string): Promise<void> {
+  const db = await resolveCheckpointQueueDB();
+
+  const transaction = db.transaction(PREFERENCES_STORE_NAME, 'readwrite');
+
+  const record = await transaction.store.get(PENDING_START_INTENT_KEY);
+
+  if (record !== undefined && 'startKey' in record && record.startKey === startKey) {
+    await transaction.store.delete(PENDING_START_INTENT_KEY);
+  }
+
+  await transaction.done;
+}

--- a/libs/game/idle-client/src/submission/types.ts
+++ b/libs/game/idle-client/src/submission/types.ts
@@ -34,6 +34,18 @@ export interface PendingStopIntent {
   readonly avatarID: string;
 }
 
+/**
+ * A continuation the server hasn't confirmed yet, held durably so it survives worker restarts
+ * and offline gaps. `startKey` makes delivery idempotent: a retry converges on whatever row an
+ * earlier attempt already minted.
+ */
+export interface PendingStartIntent {
+  readonly avatarID: string;
+  readonly scopeID: string;
+  readonly scopeType: string;
+  readonly startKey: string;
+}
+
 export interface CheckpointQueueSchema extends DBSchema {
   'pending-checkpoints': {
     key: [string, number];
@@ -41,7 +53,7 @@ export interface CheckpointQueueSchema extends DBSchema {
   };
   preferences: {
     key: string;
-    value: FailureActionPreference | PendingStopIntent;
+    value: FailureActionPreference | PendingStartIntent | PendingStopIntent;
   };
 }
 

--- a/libs/game/idle-client/src/submission/write-pending-start-intent.test.ts
+++ b/libs/game/idle-client/src/submission/write-pending-start-intent.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from 'bun:test';
+import { readPendingStartIntent } from './read-pending-start-intent';
+import { writePendingStartIntent } from './write-pending-start-intent';
+
+test('it overwrites the previously held intent', async () => {
+  await writePendingStartIntent({
+    avatarID: 'avatar_1',
+    scopeID: 'scope_1',
+    scopeType: 'world_map_node',
+    startKey: 'continue_activity_1',
+  });
+
+  await writePendingStartIntent({
+    avatarID: 'avatar_1',
+    scopeID: 'scope_2',
+    scopeType: 'world_map_node',
+    startKey: 'continue_activity_2',
+  });
+
+  const intent = await readPendingStartIntent();
+
+  expect(intent).toStrictEqual({
+    avatarID: 'avatar_1',
+    scopeID: 'scope_2',
+    scopeType: 'world_map_node',
+    startKey: 'continue_activity_2',
+  });
+});

--- a/libs/game/idle-client/src/submission/write-pending-start-intent.ts
+++ b/libs/game/idle-client/src/submission/write-pending-start-intent.ts
@@ -1,0 +1,12 @@
+import { PENDING_START_INTENT_KEY, PREFERENCES_STORE_NAME } from './constants';
+import { resolveCheckpointQueueDB } from './resolve-checkpoint-queue-db';
+import type { PendingStartIntent } from './types';
+
+/**
+ * Persists a start intent, overwriting whatever undelivered intent was held before.
+ */
+export async function writePendingStartIntent(intent: Readonly<PendingStartIntent>): Promise<void> {
+  const db = await resolveCheckpointQueueDB();
+
+  await db.put(PREFERENCES_STORE_NAME, intent, PENDING_START_INTENT_KEY);
+}

--- a/libs/game/idle-client/src/test-utils/create-stub-worker-context.test.ts
+++ b/libs/game/idle-client/src/test-utils/create-stub-worker-context.test.ts
@@ -7,7 +7,7 @@ test('it creates a context with no connections and no simulation by default', ()
   const context = createStubWorkerContext();
 
   expect(context.connections.size).toBe(0);
-  expect(context.getSimulation()).toBeNull();
+  expect(context.getSimulation().activity).toBeNull();
 });
 
 test('it seeds the connections set from the given ports', () => {

--- a/libs/game/idle-client/src/test-utils/create-stub-worker-context.ts
+++ b/libs/game/idle-client/src/test-utils/create-stub-worker-context.ts
@@ -2,19 +2,18 @@ import { createORPCClient } from '@orpc/client';
 import { RPCLink } from '@orpc/client/fetch';
 import type { ActivityData } from '@vers/contract-activity';
 import type { Simulation } from '@vers/idle-core';
-import { ActivityFailureAction } from '@vers/idle-core';
+import { ActivityFailureAction, createSimulation } from '@vers/idle-core';
 import { resolveServiceURL } from '@vers/mock-services';
 import type { CheckpointSubmitter } from '../submission/create-checkpoint-submitter';
 import type { ActivityServiceClient } from '../submission/types';
 import type { RewardSlotLedgerEntry } from '../types';
-import type { PendingContinuation, WorkerContext } from '../worker/types';
+import type { WorkerContext } from '../worker/types';
 import { createStubSubmitter } from './create-stub-submitter';
 
 interface CreateStubWorkerContextOptions {
   readonly client?: ActivityServiceClient;
   readonly connections?: ReadonlyArray<MessagePort>;
   readonly failureAction?: ActivityFailureAction;
-  readonly pendingContinuation?: PendingContinuation | null;
   readonly remainingBudgetMs?: number;
   readonly submitter?: Readonly<CheckpointSubmitter>;
 }
@@ -29,9 +28,8 @@ export function createStubWorkerContext(
     createORPCClient(new RPCLink({ url: `${resolveServiceURL('activity')}/rpc` }));
 
   const submitter: CheckpointSubmitter = options.submitter ?? createStubSubmitter();
-  let simulation: null | Simulation = null;
+  let simulation: Simulation = createSimulation();
   let activity: ActivityData | null = null;
-  let pendingContinuation: PendingContinuation | null = options.pendingContinuation ?? null;
   let resyncAvatarID: string | null = null;
   let resyncInFlight = false;
   let rewardSlotLedgerActivityID: null | string = null;
@@ -41,7 +39,7 @@ export function createStubWorkerContext(
   let failureActionPushInFlight = false;
   let stopEpoch = 0;
   let startRequestID: null | string = null;
-  let startFlow: Readonly<Promise<void>> = Promise.resolve();
+  let lifecycleFlow: Readonly<Promise<void>> = Promise.resolve();
 
   return {
     advanceStopEpoch: () => {
@@ -51,7 +49,6 @@ export function createStubWorkerContext(
     getActivity: () => activity,
     getClient: () => client,
     getFailureAction: () => failureAction,
-    getPendingContinuation: () => pendingContinuation,
     getRemainingBudgetMs: () => options.remainingBudgetMs ?? Number.MAX_SAFE_INTEGER,
     getResyncAvatarID: () => resyncAvatarID,
     getRewardSlotLedger: () => ({
@@ -59,7 +56,7 @@ export function createStubWorkerContext(
       entries: rewardSlotLedger,
     }),
     getSimulation: () => simulation,
-    getStartFlow: () => startFlow,
+    getLifecycleFlow: () => lifecycleFlow,
     getStartRequestID: () => startRequestID,
     getStopEpoch: () => stopEpoch,
     getSubmitter: () => submitter,
@@ -95,17 +92,14 @@ export function createStubWorkerContext(
     setFailureActionPushInFlight: (inFlight) => {
       failureActionPushInFlight = inFlight;
     },
-    setPendingContinuation: (pending) => {
-      pendingContinuation = pending;
-    },
     setResyncAvatarID: (avatarID) => {
       resyncAvatarID = avatarID;
     },
     setResyncInFlight: (inFlight) => {
       resyncInFlight = inFlight;
     },
-    setStartFlow: (flow) => {
-      startFlow = flow;
+    setLifecycleFlow: (flow) => {
+      lifecycleFlow = flow;
     },
     setStartRequestID: (requestID) => {
       startRequestID = requestID;

--- a/libs/game/idle-client/src/worker/create-worker-runtime.ts
+++ b/libs/game/idle-client/src/worker/create-worker-runtime.ts
@@ -1,11 +1,12 @@
 import type { ActivityData } from '@vers/contract-activity';
 import { OFFLINE_PROGRESS_CAP_MS } from '@vers/contract-activity';
 import type { Simulation } from '@vers/idle-core';
-import { ActivityFailureAction, SIMULATION_TIMESTEP_MS } from '@vers/idle-core';
+import { ActivityFailureAction, SIMULATION_TIMESTEP_MS, createSimulation } from '@vers/idle-core';
 import invariant from 'tiny-invariant';
 import { createActivityServiceClient } from '../submission/create-activity-service-client';
 import { createCheckpointSubmitter } from '../submission/create-checkpoint-submitter';
 import { readFailureActionCache } from '../submission/read-failure-action-cache';
+import { readPendingStartIntent } from '../submission/read-pending-start-intent';
 import type { ActivityServiceClient } from '../submission/types';
 import type { ClientMessage, RewardSlotLedgerEntry, WorkerMessage } from '../types';
 import { createCheckpointFlushStalledMessage } from './create-checkpoint-flush-stalled-message';
@@ -16,9 +17,10 @@ import { createRequestResyncMessage } from './create-request-resync-message';
 import { flushPendingStop } from './flush-pending-stop';
 import { handleClientMessage } from './handle-client-message';
 import { handleRequestResyncMessage } from './handle-request-resync-message';
+import { registerSimulationListeners } from './register-simulation-listeners';
 import { reportWorkerFault } from './report-worker-fault';
 import { runSimulation } from './run-simulation';
-import type { PendingContinuation, WorkerContext } from './types';
+import type { WorkerContext } from './types';
 
 export interface WorkerRuntime {
   readonly connections: ReadonlySet<MessagePort>;
@@ -62,13 +64,13 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
   const connections = new Set<MessagePort>();
 
   const client = options.client ?? createActivityServiceClient();
-  let simulation: null | Simulation = null;
+  const initialSimulation = createSimulation();
+  let simulation: Simulation = initialSimulation;
   let activity: ActivityData | null = null;
   let running = false;
   let stopped = false;
   let lastFrameTime = now();
   let accumulator = 0;
-  let pendingContinuation: PendingContinuation | null = null;
   let resyncAvatarID: string | null = null;
   let resyncInFlight = false;
   let failureAction: ActivityFailureAction = ActivityFailureAction.Abort;
@@ -76,7 +78,7 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
   let failureActionPushInFlight = false;
   let stopEpoch = 0;
   let startRequestID: null | string = null;
-  let startFlow: Readonly<Promise<void>> = Promise.resolve();
+  let lifecycleFlow: Readonly<Promise<void>> = Promise.resolve();
 
   // Every client message and the self-triggered reconnect resync await this before running, so a
   // relaunch-while-offline never plans against the enum's Abort default while the real cached
@@ -138,7 +140,6 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
     getActivity: () => activity,
     getClient: () => client,
     getFailureAction: () => failureAction,
-    getPendingContinuation: () => pendingContinuation,
     getRemainingBudgetMs: () => OFFLINE_PROGRESS_CAP_MS - (Date.now() - lastAckAt),
     getResyncAvatarID: () => resyncAvatarID,
     getRewardSlotLedger: () => ({
@@ -146,7 +147,7 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
       entries: rewardSlotLedger,
     }),
     getSimulation: () => simulation,
-    getStartFlow: () => startFlow,
+    getLifecycleFlow: () => lifecycleFlow,
     getStartRequestID: () => startRequestID,
     getStopEpoch: () => stopEpoch,
     getSubmitter: () => submitter,
@@ -182,17 +183,14 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
     setFailureActionPushInFlight: (inFlight) => {
       failureActionPushInFlight = inFlight;
     },
-    setPendingContinuation: (pending) => {
-      pendingContinuation = pending;
-    },
     setResyncAvatarID: (avatarID) => {
       resyncAvatarID = avatarID;
     },
     setResyncInFlight: (inFlight) => {
       resyncInFlight = inFlight;
     },
-    setStartFlow: (flow) => {
-      startFlow = flow;
+    setLifecycleFlow: (flow) => {
+      lifecycleFlow = flow;
     },
     setStartRequestID: (requestID) => {
       startRequestID = requestID;
@@ -201,6 +199,8 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
       simulation = newSimulation;
     },
   };
+
+  registerSimulationListeners(context, initialSimulation);
 
   // cache our listeners so we can message them later
   const handleConnect = (event: MessageEvent) => {
@@ -251,11 +251,7 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
     while (accumulator >= timestep) {
       accumulator -= timestep;
 
-      const currentSimulation = context.getSimulation();
-
-      if (currentSimulation) {
-        await runSimulation(context, currentSimulation, timestep);
-      }
+      await runSimulation(context, context.getSimulation(), timestep);
     }
 
     lastFrameTime = frameNow;
@@ -293,11 +289,13 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
         // below is skipped while a simulation is live, and after a stop one always is.
         await flushPendingStop(context);
 
-        // the pending continuation is always the fresher signal: it was recorded at the most
-        // recent boundary failure, while the remembered resync avatar can predate it
-        const avatarID = pendingContinuation?.avatarID ?? resyncAvatarID ?? null;
+        // the held continuation is the fresher signal: it was raised at the most recent boundary
+        // failure, while the remembered resync avatar can predate it
+        const startIntent = await readPendingStartIntent();
 
-        if (context.getSimulation() === null && avatarID !== null) {
+        const avatarID = startIntent?.avatarID ?? resyncAvatarID ?? null;
+
+        if (context.getActivity() === null && avatarID !== null) {
           await handleRequestResyncMessage(context, createRequestResyncMessage(avatarID));
         }
       } catch (error) {

--- a/libs/game/idle-client/src/worker/create-worker-runtime.ts
+++ b/libs/game/idle-client/src/worker/create-worker-runtime.ts
@@ -285,8 +285,8 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
 
         await submitter.flushHeld();
 
-        // A stop raised offline delivers here even when no resync will follow — the self-resync
-        // below is skipped while a simulation is live, and after a stop one always is.
+        // A stop raised offline delivers here even when no resync follows; a stopped runtime has
+        // no activity, so the self-resync below also fires and resolves to a no-op plan.
         await flushPendingStop(context);
 
         // the held continuation is the fresher signal: it was raised at the most recent boundary

--- a/libs/game/idle-client/src/worker/flush-pending-start.test.ts
+++ b/libs/game/idle-client/src/worker/flush-pending-start.test.ts
@@ -1,0 +1,190 @@
+import { expect, test } from 'bun:test';
+import { createAuthedServiceClient, createViewer } from '@vers/mock-services';
+import { mockActivityService } from '@vers/mock-services/activity';
+import * as db from '@vers/mock-services/db';
+import { HttpResponse } from 'msw';
+import invariant from 'tiny-invariant';
+import { server } from '../mocks/node';
+import { readPendingStartIntent } from '../submission/read-pending-start-intent';
+import type { ActivityServiceClient } from '../submission/types';
+import { writePendingStartIntent } from '../submission/write-pending-start-intent';
+import { createStubWorkerContext } from '../test-utils/create-stub-worker-context';
+import { createTestConnection } from '../test-utils/create-test-connection';
+import { WorkerMessageType } from '../types';
+import { flushPendingStart } from './flush-pending-start';
+
+test('it reports none when no start is held', async () => {
+  const context = createStubWorkerContext();
+
+  const outcome = await flushPendingStart(context);
+
+  expect(outcome).toBe('none');
+});
+
+test('it mints the row and releases the intent', async () => {
+  const viewer = await createViewer();
+  const client = await createAuthedServiceClient<ActivityServiceClient>('activity', viewer.user.id);
+
+  const context = createStubWorkerContext({ client });
+
+  await writePendingStartIntent({
+    avatarID: viewer.avatar.id,
+    scopeID: 'a9lp75',
+    scopeType: 'world_map_node',
+    startKey: 'continue_activity_1',
+  });
+
+  const outcome = await flushPendingStart(context);
+
+  expect(outcome).toBe('delivered');
+
+  const minted = db.activityCollection.findFirst((q) =>
+    q.where({ avatarID: viewer.avatar.id, status: 'active' }),
+  );
+
+  invariant(minted !== undefined, 'expected the delivery to mint a row');
+  expect(minted.startKey).toBe('continue_activity_1');
+
+  const intent = await readPendingStartIntent();
+
+  expect(intent).toBeUndefined();
+});
+
+test('it holds the intent and broadcasts the cap while the offline budget is spent', async () => {
+  const connection = createTestConnection();
+
+  const context = createStubWorkerContext({
+    connections: [connection.port],
+    remainingBudgetMs: 0,
+  });
+
+  await writePendingStartIntent({
+    avatarID: 'avatar_1',
+    scopeID: 'a9lp75',
+    scopeType: 'world_map_node',
+    startKey: 'continue_activity_1',
+  });
+
+  const outcome = await flushPendingStart(context);
+
+  expect(outcome).toBe('held');
+
+  await connection.waitForMessages(1);
+
+  expect(connection.received).toStrictEqual([
+    { halted: true, remainingMs: 0, type: WorkerMessageType.OfflineCapStatus },
+  ]);
+
+  const intent = await readPendingStartIntent();
+
+  expect(intent).toBeDefined();
+});
+
+test('it holds the intent while its own target row is still closing', async () => {
+  const viewer = await createViewer();
+  const client = await createAuthedServiceClient<ActivityServiceClient>('activity', viewer.user.id);
+
+  const context = createStubWorkerContext({ client });
+
+  // the target's terminal append hasn't drained: the row still reads active and conflicts
+  const closing = await db.activityCollection.create({
+    avatarID: viewer.avatar.id,
+    status: 'active',
+  });
+
+  await writePendingStartIntent({
+    avatarID: viewer.avatar.id,
+    scopeID: closing.scopeID,
+    scopeType: closing.scopeType,
+    startKey: `continue_${closing.id}`,
+  });
+
+  const outcome = await flushPendingStart(context);
+
+  expect(outcome).toBe('held');
+
+  const intent = await readPendingStartIntent();
+
+  expect(intent).toBeDefined();
+});
+
+test('it drops the intent when a foreign claim conflicts', async () => {
+  const viewer = await createViewer();
+  const client = await createAuthedServiceClient<ActivityServiceClient>('activity', viewer.user.id);
+
+  const context = createStubWorkerContext({ client });
+
+  await db.activityCollection.create({
+    avatarID: viewer.avatar.id,
+    startKey: 'someone-elses-start',
+    status: 'active',
+  });
+
+  await writePendingStartIntent({
+    avatarID: viewer.avatar.id,
+    scopeID: 'a9lp75',
+    scopeType: 'world_map_node',
+    startKey: 'continue_activity_gone',
+  });
+
+  const outcome = await flushPendingStart(context);
+
+  expect(outcome).toBe('none');
+
+  const intent = await readPendingStartIntent();
+
+  expect(intent).toBeUndefined();
+});
+
+test('it drops an intent the service refuses', async () => {
+  server.use(
+    mockActivityService.startActivity.handler((opts) => {
+      throw opts.errors.CHAIN_QUARANTINED({ data: {} });
+    }),
+  );
+
+  const context = createStubWorkerContext();
+
+  await writePendingStartIntent({
+    avatarID: 'avatar_1',
+    scopeID: 'a9lp75',
+    scopeType: 'world_map_node',
+    startKey: 'continue_activity_1',
+  });
+
+  const outcome = await flushPendingStart(context);
+
+  expect(outcome).toBe('none');
+
+  const intent = await readPendingStartIntent();
+
+  expect(intent).toBeUndefined();
+});
+
+test('it holds the intent and reports offline on a transport failure', async () => {
+  server.use(mockActivityService.startActivity.handler(() => HttpResponse.error()));
+
+  const connection = createTestConnection();
+  const context = createStubWorkerContext({ connections: [connection.port] });
+
+  await writePendingStartIntent({
+    avatarID: 'avatar_1',
+    scopeID: 'a9lp75',
+    scopeType: 'world_map_node',
+    startKey: 'continue_activity_1',
+  });
+
+  const outcome = await flushPendingStart(context);
+
+  expect(outcome).toBe('held');
+
+  await connection.waitForMessages(1);
+
+  expect(connection.received).toStrictEqual([
+    { online: false, type: WorkerMessageType.ConnectionStatus },
+  ]);
+
+  const intent = await readPendingStartIntent();
+
+  expect(intent).toBeDefined();
+});

--- a/libs/game/idle-client/src/worker/flush-pending-start.ts
+++ b/libs/game/idle-client/src/worker/flush-pending-start.ts
@@ -55,6 +55,12 @@ export async function flushPendingStart(context: WorkerContext): Promise<Pending
     return 'none';
   }
 
+  // an expired or insufficient session is expected behavior with one remedy — a fresh sign-in —
+  // so the intent survives it, exactly as it survives a transport failure
+  if (isDefinedError(error) && (error.code === 'UNAUTHORIZED' || error.code === 'FORBIDDEN')) {
+    return 'held';
+  }
+
   if (isDefinedError(error)) {
     reportWorkerFault('start', error);
 

--- a/libs/game/idle-client/src/worker/flush-pending-start.ts
+++ b/libs/game/idle-client/src/worker/flush-pending-start.ts
@@ -1,0 +1,85 @@
+import { isDefinedError, safe } from '@orpc/client';
+import { readPendingStartIntent } from '../submission/read-pending-start-intent';
+import { removePendingStartIntent } from '../submission/remove-pending-start-intent';
+import { createConnectionStatusMessage } from './create-connection-status-message';
+import { createOfflineCapStatusMessage } from './create-offline-cap-status-message';
+import { reportWorkerFault } from './report-worker-fault';
+import type { WorkerContext } from './types';
+
+export type PendingStartFlushOutcome = 'delivered' | 'held' | 'none';
+
+/**
+ * Attempts delivery of the held start intent — a continuation raised against a closing row,
+ * idempotent through its start key. A spent offline budget holds the intent and broadcasts the
+ * cap. A `CONFLICT` naming the intent's own target means the terminal append hasn't drained yet,
+ * so the intent stays held; a `CONFLICT` naming any other claim moots it — the resync that
+ * follows reconciles onto that claim. Any other defined rejection drops the intent as
+ * undeliverable and reports the fault; a transport failure holds it and reports the worker
+ * offline. Delivery only mints the server row: the resync that runs next attaches it.
+ */
+export async function flushPendingStart(context: WorkerContext): Promise<PendingStartFlushOutcome> {
+  const intent = await readPendingStartIntent();
+
+  if (intent === undefined) {
+    return 'none';
+  }
+
+  if (context.getRemainingBudgetMs() <= 0) {
+    emitCapStatus(context);
+
+    return 'held';
+  }
+
+  const [error] = await safe(
+    context.getClient().startActivity({
+      avatarID: intent.avatarID,
+      scopeID: intent.scopeID,
+      scopeType: intent.scopeType,
+      startKey: intent.startKey,
+    }),
+  );
+
+  if (error === null) {
+    await removePendingStartIntent(intent.startKey);
+
+    return 'delivered';
+  }
+
+  if (isDefinedError(error) && error.code === 'CONFLICT') {
+    if (`continue_${error.data.activity.id}` === intent.startKey) {
+      return 'held';
+    }
+
+    await removePendingStartIntent(intent.startKey);
+
+    return 'none';
+  }
+
+  if (isDefinedError(error)) {
+    reportWorkerFault('start', error);
+
+    await removePendingStartIntent(intent.startKey);
+
+    return 'none';
+  }
+
+  emitConnectionStatus(context, false);
+
+  return 'held';
+}
+
+function emitCapStatus(context: WorkerContext): void {
+  const message = createOfflineCapStatusMessage(0, true);
+
+  for (const connection of context.connections) {
+    connection.postMessage(message);
+  }
+}
+
+function emitConnectionStatus(context: WorkerContext, online: boolean): void {
+  const message = createConnectionStatusMessage(online);
+
+  for (const connection of context.connections) {
+    connection.postMessage(message);
+  }
+}

--- a/libs/game/idle-client/src/worker/handle-client-message.ts
+++ b/libs/game/idle-client/src/worker/handle-client-message.ts
@@ -13,6 +13,7 @@ import { isSetActivityMessage } from './is-set-activity-message';
 import { isSetFailureActionMessage } from './is-set-failure-action-message';
 import { isStartActivityMessage } from './is-start-activity-message';
 import { isStopActivityMessage } from './is-stop-activity-message';
+import { runOnLifecycleChain } from './run-on-lifecycle-chain';
 import type { WorkerContext } from './types';
 
 export async function handleClientMessage(
@@ -25,7 +26,13 @@ export async function handleClientMessage(
   }
 
   if (isSetActivityMessage(event.data)) {
-    await handleSetActivityMessage(context, event.data);
+    const message = event.data;
+
+    // installs mutate the runtime, so an externally raised install takes a chain slot like every
+    // other lifecycle flow
+    await runOnLifecycleChain(context, 'message-routing', () =>
+      handleSetActivityMessage(context, message),
+    );
   }
 
   if (isSetFailureActionMessage(event.data)) {

--- a/libs/game/idle-client/src/worker/handle-initialize-message.ts
+++ b/libs/game/idle-client/src/worker/handle-initialize-message.ts
@@ -1,20 +1,16 @@
-import type { Simulation } from '@vers/idle-core';
-import { createSimulation } from '@vers/idle-core';
 import type { InitializeMessage } from '../types';
 import { createFailureActionStatusMessage } from './create-failure-action-status-message';
 import { createInitialStateMessage } from './create-initial-state-message';
-import { registerSimulationListeners } from './register-simulation-listeners';
 import type { WorkerContext } from './types';
 
 /**
- * Answers an initialize with the worker's current state: it creates the one simulation on the
- * first initialize and reuses it afterward, then broadcasts the snapshot and the retained
- * reward-slot ledger to every connection — so a tab connecting mid-run catches up rather than
- * starting empty. Also broadcasts the effective failure-action preference, so a connecting tab
- * reflects it even before any simulation snapshot carries one.
+ * Answers an initialize by broadcasting the worker's current snapshot and retained reward-slot
+ * ledger to every connection — so a tab connecting mid-run catches up rather than starting empty.
+ * Also broadcasts the effective failure-action preference, so a connecting tab reflects it even
+ * before any simulation snapshot carries one.
  */
 export function handleInitializeMessage(context: WorkerContext, _message: InitializeMessage) {
-  const simulation = context.getSimulation() ?? createSimulationForContext(context);
+  const simulation = context.getSimulation();
 
   const initialStateMessage = createInitialStateMessage(
     simulation.getSnapshot(),
@@ -27,14 +23,4 @@ export function handleInitializeMessage(context: WorkerContext, _message: Initia
     connection.postMessage(initialStateMessage);
     connection.postMessage(failureActionStatusMessage);
   }
-}
-
-function createSimulationForContext(context: WorkerContext): Simulation {
-  const simulation = createSimulation();
-
-  context.setSimulation(simulation);
-
-  registerSimulationListeners(context, simulation);
-
-  return simulation;
 }

--- a/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-request-resync-message.test.ts
@@ -19,10 +19,12 @@ import { server } from '../mocks/node';
 import type { CheckpointSubmitter } from '../submission/create-checkpoint-submitter';
 import { createCheckpointSubmitter } from '../submission/create-checkpoint-submitter';
 import { readFailureActionCache } from '../submission/read-failure-action-cache';
+import { readPendingStartIntent } from '../submission/read-pending-start-intent';
 import { readPendingStopIntent } from '../submission/read-pending-stop-intent';
 import { readQueuedCheckpoints } from '../submission/read-queued-checkpoints';
 import type { ActivityServiceClient } from '../submission/types';
 import { writeFailureActionCache } from '../submission/write-failure-action-cache';
+import { writePendingStartIntent } from '../submission/write-pending-start-intent';
 import { writePendingStopIntent } from '../submission/write-pending-stop-intent';
 import { writeQueuedCheckpoint } from '../submission/write-queued-checkpoint';
 import { createStubSubmitter } from '../test-utils/create-stub-submitter';
@@ -35,11 +37,10 @@ import { ClientMessageType, WorkerMessageType } from '../types';
 import { handleRequestResyncMessage } from './handle-request-resync-message';
 import { sentryHandle } from './sentry-handle';
 import { startErrorReporting } from './start-error-reporting';
-import type { PendingContinuation, WorkerContext } from './types';
+import type { WorkerContext } from './types';
 
 interface SetupTestConfig {
   readonly failureAction?: ActivityFailureAction;
-  readonly pendingContinuation?: PendingContinuation | null;
   readonly remainingBudgetMs?: number;
   readonly userID: string;
 }
@@ -70,9 +71,6 @@ async function setupTest(config: Readonly<SetupTestConfig>) {
     connections: [connection.port],
     submitter,
     ...(config.failureAction === undefined ? {} : { failureAction: config.failureAction }),
-    ...(config.pendingContinuation !== undefined && {
-      pendingContinuation: config.pendingContinuation,
-    }),
     ...(config.remainingBudgetMs !== undefined && { remainingBudgetMs: config.remainingBudgetMs }),
   });
 
@@ -100,7 +98,7 @@ test('it broadcasts nothing for an avatar with no activity history', async () =>
     { online: true, type: WorkerMessageType.ConnectionStatus },
   ]);
 
-  expect(ctx.context.getSimulation()).toBeNull();
+  expect(ctx.context.getSimulation().activity).toBeNull();
 });
 
 test('it broadcasts capped and installs no simulation for a capped activity', async () => {
@@ -127,7 +125,7 @@ test('it broadcasts capped and installs no simulation for a capped activity', as
     { status: { kind: 'capped' }, type: WorkerMessageType.ResyncStatus },
   ]);
 
-  expect(ctx.context.getSimulation()).toBeNull();
+  expect(ctx.context.getSimulation().activity).toBeNull();
 });
 
 test('it delivers a queued row for the resync-determined latest activity rather than sweeping it, while sweeping every other activity', async () => {
@@ -419,7 +417,7 @@ test('it reports a divergence via the checkpoint-stream-error channel and skips 
     },
   ]);
 
-  expect(ctx.context.getSimulation()).toBeNull();
+  expect(ctx.context.getSimulation().activity).toBeNull();
 });
 
 test('it fast-forwards a short gap, broadcasts progress and final tallies, and installs a registered live sim on the final active row', async () => {
@@ -714,7 +712,7 @@ test('it keeps the dirty flag when the resync push to the server fails', async (
   });
 });
 
-test("it starts a fresh row, installs a live simulation with the worker's failure action, and clears the pending continuation", async () => {
+test("it delivers a held continuation, attaches the minted row with the worker's failure action, and releases the intent", async () => {
   const viewer = await createViewer({ avatar: { failureAction: 'retry' } });
 
   const stopped = await db.activityCollection.create({
@@ -722,15 +720,14 @@ test("it starts a fresh row, installs a live simulation with the worker's failur
     status: 'stopped',
   });
 
-  const ctx = await setupTest({
-    pendingContinuation: {
-      activityID: stopped.id,
-      avatarID: viewer.avatar.id,
-      scopeID: stopped.scopeID,
-      scopeType: stopped.scopeType,
-    },
-    userID: viewer.user.id,
+  await writePendingStartIntent({
+    avatarID: viewer.avatar.id,
+    scopeID: stopped.scopeID,
+    scopeType: stopped.scopeType,
+    startKey: `continue_${stopped.id}`,
   });
+
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   const message: RequestResyncMessage = {
     avatarID: viewer.avatar.id,
@@ -743,49 +740,46 @@ test("it starts a fresh row, installs a live simulation with the worker's failur
     q.where({ avatarID: viewer.avatar.id, status: 'active' }),
   );
 
-  invariant(minted !== undefined, 'expected the continue plan to mint a fresh row');
+  invariant(minted !== undefined, 'expected the delivered intent to mint a fresh row');
   expect(minted.scopeID).toBe(stopped.scopeID);
+  expect(minted.startKey).toBe(`continue_${stopped.id}`);
 
   const simulation = ctx.context.getSimulation();
 
-  invariant(simulation !== null, 'expected the continue plan to install a live simulation');
   expect(simulation.activity?.id).toBe(minted.id);
   expect(simulation.failureAction).toBe(ActivityFailureAction.Retry);
-  expect(ctx.context.getPendingContinuation()).toBeNull();
+
+  const intent = await readPendingStartIntent();
+
+  expect(intent).toBeUndefined();
 });
 
-test('it fails the resync when a foreign row races in ahead of the continuation', async () => {
+test('it drops a held continuation a foreign row raced and attaches that row instead', async () => {
   const viewer = await createViewer();
 
   const stopped = await db.activityCollection.create({
     avatarID: viewer.avatar.id,
+    startedAt: new Date(Date.now() - 60_000),
     status: 'stopped',
   });
 
-  // the racing row lands between the resync's progress fetch and its start call, so it must not
-  // exist when the plan is computed — the scripted handler mints it at start time and answers
-  // CONFLICT with it, exactly as the real service would
-  server.use(
-    mockActivityService.startActivity.handler(async (opts) => {
-      const racing = await db.activityCollection.create({
-        appendedHead: 0,
-        avatarID: viewer.avatar.id,
-        status: 'active',
-      });
-
-      throw opts.errors.CONFLICT({ data: { activity: racing } });
-    }),
-  );
-
-  const ctx = await setupTest({
-    pendingContinuation: {
-      activityID: stopped.id,
-      avatarID: viewer.avatar.id,
-      scopeID: stopped.scopeID,
-      scopeType: stopped.scopeType,
-    },
-    userID: viewer.user.id,
+  // a foreign claim raced the held continuation in: its delivery conflicts on a different key,
+  // the intent is moot, and the snapshot the resync fetches already carries the foreign row
+  const racing = await db.activityCollection.create({
+    appendedHead: 0,
+    avatarID: viewer.avatar.id,
+    startKey: 'someone-elses-start',
+    status: 'active',
   });
+
+  await writePendingStartIntent({
+    avatarID: viewer.avatar.id,
+    scopeID: stopped.scopeID,
+    scopeType: stopped.scopeType,
+    startKey: `continue_${stopped.id}`,
+  });
+
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   const message: RequestResyncMessage = {
     avatarID: viewer.avatar.id,
@@ -794,18 +788,14 @@ test('it fails the resync when a foreign row races in ahead of the continuation'
 
   await handleRequestResyncMessage(ctx.context, message);
 
-  expect(ctx.context.getSimulation()).toBeNull();
-  expect(ctx.context.getPendingContinuation()).toBeNull();
+  expect(ctx.context.getSimulation().activity?.id).toBe(racing.id);
 
-  await ctx.connection.waitForMessages(1);
+  const intent = await readPendingStartIntent();
 
-  expect(ctx.connection.received).toContainEqual({
-    status: { avatarID: viewer.avatar.id, kind: 'failed' },
-    type: WorkerMessageType.ResyncStatus,
-  });
+  expect(intent).toBeUndefined();
 });
 
-test('it halts at the boundary and keeps the pending continuation when the offline budget is spent', async () => {
+test('it holds a continuation intent at the boundary when the offline budget is spent', async () => {
   const viewer = await createViewer();
 
   const stopped = await db.activityCollection.create({
@@ -813,18 +803,14 @@ test('it halts at the boundary and keeps the pending continuation when the offli
     status: 'stopped',
   });
 
-  const pending: PendingContinuation = {
-    activityID: stopped.id,
+  await writePendingStartIntent({
     avatarID: viewer.avatar.id,
     scopeID: stopped.scopeID,
     scopeType: stopped.scopeType,
-  };
-
-  const ctx = await setupTest({
-    pendingContinuation: pending,
-    remainingBudgetMs: 0,
-    userID: viewer.user.id,
+    startKey: `continue_${stopped.id}`,
   });
+
+  const ctx = await setupTest({ remainingBudgetMs: 0, userID: viewer.user.id });
 
   const message: RequestResyncMessage = {
     avatarID: viewer.avatar.id,
@@ -839,8 +825,16 @@ test('it halts at the boundary and keeps the pending continuation when the offli
     { halted: true, remainingMs: 0, type: WorkerMessageType.OfflineCapStatus },
   ]);
 
-  expect(ctx.context.getSimulation()).toBeNull();
-  expect(ctx.context.getPendingContinuation()).toStrictEqual(pending);
+  expect(ctx.context.getSimulation().activity).toBeNull();
+
+  const intent = await readPendingStartIntent();
+
+  expect(intent).toStrictEqual({
+    avatarID: viewer.avatar.id,
+    scopeID: stopped.scopeID,
+    scopeType: stopped.scopeType,
+    startKey: `continue_${stopped.id}`,
+  });
 
   const minted = db.activityCollection.findFirst((q) =>
     q.where({ avatarID: viewer.avatar.id, status: 'active' }),
@@ -849,7 +843,7 @@ test('it halts at the boundary and keeps the pending continuation when the offli
   expect(minted).toBeUndefined();
 });
 
-test('it keeps the pending continuation and reports offline when starting the continued row fails on transport', async () => {
+test('it holds a continuation intent and reports offline when its delivery fails on transport', async () => {
   const viewer = await createViewer();
 
   const stopped = await db.activityCollection.create({
@@ -857,16 +851,16 @@ test('it keeps the pending continuation and reports offline when starting the co
     status: 'stopped',
   });
 
-  const pending: PendingContinuation = {
-    activityID: stopped.id,
+  await writePendingStartIntent({
     avatarID: viewer.avatar.id,
     scopeID: stopped.scopeID,
     scopeType: stopped.scopeType,
-  };
+    startKey: `continue_${stopped.id}`,
+  });
 
   server.use(mockActivityService.startActivity.handler(() => HttpResponse.error()));
 
-  const ctx = await setupTest({ pendingContinuation: pending, userID: viewer.user.id });
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   const message: RequestResyncMessage = {
     avatarID: viewer.avatar.id,
@@ -877,15 +871,24 @@ test('it keeps the pending continuation and reports offline when starting the co
 
   await ctx.connection.waitForMessages(1);
 
-  expect(ctx.connection.received).toStrictEqual([
-    { online: false, type: WorkerMessageType.ConnectionStatus },
-  ]);
+  expect(ctx.connection.received).toContainEqual({
+    online: false,
+    type: WorkerMessageType.ConnectionStatus,
+  });
 
-  expect(ctx.context.getSimulation()).toBeNull();
-  expect(ctx.context.getPendingContinuation()).toStrictEqual(pending);
+  expect(ctx.context.getSimulation().activity).toBeNull();
+
+  const intent = await readPendingStartIntent();
+
+  expect(intent).toStrictEqual({
+    avatarID: viewer.avatar.id,
+    scopeID: stopped.scopeID,
+    scopeType: stopped.scopeType,
+    startKey: `continue_${stopped.id}`,
+  });
 });
 
-test('it clears the pending continuation and reports the resync failure status on a defined error other than CONFLICT', async () => {
+test('it drops a continuation intent the service refuses and resyncs on regardless', async () => {
   const viewer = await createViewer();
 
   const stopped = await db.activityCollection.create({
@@ -893,12 +896,12 @@ test('it clears the pending continuation and reports the resync failure status o
     status: 'stopped',
   });
 
-  const pending: PendingContinuation = {
-    activityID: stopped.id,
+  await writePendingStartIntent({
     avatarID: viewer.avatar.id,
     scopeID: stopped.scopeID,
     scopeType: stopped.scopeType,
-  };
+    startKey: `continue_${stopped.id}`,
+  });
 
   server.use(
     mockActivityService.startActivity.handler((opts) => {
@@ -906,7 +909,7 @@ test('it clears the pending continuation and reports the resync failure status o
     }),
   );
 
-  const ctx = await setupTest({ pendingContinuation: pending, userID: viewer.user.id });
+  const ctx = await setupTest({ userID: viewer.user.id });
 
   const message: RequestResyncMessage = {
     avatarID: viewer.avatar.id,
@@ -915,16 +918,11 @@ test('it clears the pending continuation and reports the resync failure status o
 
   await handleRequestResyncMessage(ctx.context, message);
 
-  await ctx.connection.waitForMessages(1);
+  expect(ctx.context.getSimulation().activity).toBeNull();
 
-  expect(ctx.connection.received).toStrictEqual([
-    {
-      status: { avatarID: viewer.avatar.id, kind: 'failed' },
-      type: WorkerMessageType.ResyncStatus,
-    },
-  ]);
+  const intent = await readPendingStartIntent();
 
-  expect(ctx.context.getPendingContinuation()).toBeNull();
+  expect(intent).toBeUndefined();
 });
 
 test('it reports a fault to the error backend and broadcasts a failed status when the resync fails outright', async () => {
@@ -1058,7 +1056,7 @@ test('it fails the resync while a raised stop is undelivered', async () => {
     },
   ]);
 
-  expect(ctx.context.getSimulation()).toBeNull();
+  expect(ctx.context.getSimulation().activity).toBeNull();
 
   const intent = await readPendingStopIntent();
 
@@ -1090,7 +1088,7 @@ test('it delivers the held stop before planning, leaving the stopped run cleared
   const intent = await readPendingStopIntent();
 
   expect(intent).toBeUndefined();
-  expect(ctx.context.getSimulation()).toBeNull();
+  expect(ctx.context.getSimulation().activity).toBeNull();
 });
 
 test('it abandons the install when a stop lands mid-resync', async () => {
@@ -1122,7 +1120,7 @@ test('it abandons the install when a stop lands mid-resync', async () => {
 
   await handleRequestResyncMessage(ctx.context, message);
 
-  expect(ctx.context.getSimulation()).toBeNull();
+  expect(ctx.context.getSimulation().activity).toBeNull();
   expect(ctx.context.getActivity()).toBeNull();
 });
 
@@ -1149,16 +1147,14 @@ test('it stops back a continued row when a stop lands during its registration', 
     }),
   };
 
-  const context = createStubWorkerContext({
-    client,
-    pendingContinuation: {
-      activityID: previous.id,
-      avatarID: viewer.avatar.id,
-      scopeID: previous.scopeID,
-      scopeType: previous.scopeType,
-    },
-    submitter,
+  await writePendingStartIntent({
+    avatarID: viewer.avatar.id,
+    scopeID: previous.scopeID,
+    scopeType: previous.scopeType,
+    startKey: `continue_${previous.id}`,
   });
+
+  const context = createStubWorkerContext({ client, submitter });
 
   contextHolder.current = context;
 
@@ -1167,7 +1163,7 @@ test('it stops back a continued row when a stop lands during its registration', 
     type: ClientMessageType.RequestResync,
   });
 
-  expect(context.getSimulation()).toBeNull();
+  expect(context.getSimulation().activity).toBeNull();
 
   const revived = db.activityCollection.findFirst((q) =>
     q.where({ avatarID: viewer.avatar.id, status: 'active' }),

--- a/libs/game/idle-client/src/worker/handle-request-resync-message.ts
+++ b/libs/game/idle-client/src/worker/handle-request-resync-message.ts
@@ -1,4 +1,4 @@
-import { ORPCError, isDefinedError, safe } from '@orpc/client';
+import { ORPCError, safe } from '@orpc/client';
 import type {
   ActivityData,
   ActivityFailureAction as ContractFailureAction,
@@ -19,14 +19,14 @@ import { sweepStaleCheckpoints } from '../submission/sweep-stale-checkpoints';
 import { writeFailureActionCache } from '../submission/write-failure-action-cache';
 import type { RequestResyncMessage, ResyncStatus } from '../types';
 import { createCheckpointStreamInvalidMessage } from './create-checkpoint-stream-invalid-message';
-import { createConnectionStatusMessage } from './create-connection-status-message';
 import { createFailureActionStatusMessage } from './create-failure-action-status-message';
-import { createOfflineCapStatusMessage } from './create-offline-cap-status-message';
 import { createResyncStatusMessage } from './create-resync-status-message';
+import { flushPendingStart } from './flush-pending-start';
 import { flushPendingStop } from './flush-pending-stop';
 import { hasStopIntervened } from './has-stop-intervened';
 import { registerSimulationListeners } from './register-simulation-listeners';
 import { reportWorkerFault } from './report-worker-fault';
+import { runOnLifecycleChain } from './run-on-lifecycle-chain';
 import { submitStopIntent } from './submit-stop-intent';
 import type { WorkerContext } from './types';
 
@@ -53,11 +53,31 @@ export async function handleRequestResyncMessage(
   context: WorkerContext,
   message: RequestResyncMessage,
 ): Promise<void> {
+  // single-flight across arrival and queueing: a request that lands while one is in flight or
+  // queued is dropped rather than stacked — a tab's retry re-requests it
   if (context.isResyncInFlight()) {
     return;
   }
 
   context.setResyncInFlight(true);
+
+  await runOnLifecycleChain(context, 'resync', async () => {
+    try {
+      await runResyncFlow(context, message);
+    } finally {
+      context.setResyncInFlight(false);
+    }
+  });
+}
+
+/**
+ * One resync request end to end, run inside an already-claimed lifecycle-chain slot — a running
+ * lifecycle flow resyncs by calling this directly, never by re-entering the chain.
+ */
+export async function runResyncFlow(
+  context: WorkerContext,
+  message: RequestResyncMessage,
+): Promise<void> {
   context.setResyncAvatarID(message.avatarID);
 
   // Captured before any await: every simulation install below re-checks it, so a stop the player
@@ -77,12 +97,16 @@ export async function handleRequestResyncMessage(
       return;
     }
 
+    // A held continuation delivers before the snapshot is fetched, so the row it mints is already
+    // in the snapshot and attaches like any other active row.
+    await flushPendingStart(context);
+
     const result = await runResync({
       avatarID: message.avatarID,
       buildSimulationInput: (activity) =>
         buildSimulationInput(activity, { failureAction: context.getFailureAction() }),
       client: context.getClient(),
-      isActivityLive: (activityID) => context.getSimulation()?.activity?.id === activityID,
+      isActivityLive: (activityID) => context.getSimulation().activity?.id === activityID,
       onProgress: (progress) => {
         emitResyncStatus(context, { ...progress, kind: 'fast-forwarding' });
       },
@@ -105,7 +129,6 @@ export async function handleRequestResyncMessage(
           toActivityFailureAction(progress.failureAction),
         );
       },
-      pendingContinuation: context.getPendingContinuation(),
       submitter: context.getSubmitter(),
     });
 
@@ -118,8 +141,6 @@ export async function handleRequestResyncMessage(
       reportWorkerFault('resync', error);
       emitResyncStatus(context, { avatarID: message.avatarID, kind: 'failed' });
     }
-  } finally {
-    context.setResyncInFlight(false);
   }
 }
 
@@ -205,10 +226,6 @@ function pickLatestActivityID(result: Readonly<ResyncResult>): string | undefine
     return undefined;
   }
 
-  if (result.plan.kind === 'continue') {
-    return result.plan.activity.id;
-  }
-
   return result.plan.context.activityID;
 }
 
@@ -231,12 +248,6 @@ async function applyResyncResult(
 
   if (result.plan.kind === 'attach-live') {
     await applyAttachLive(context, result.plan, result.progress, entryEpoch);
-
-    return;
-  }
-
-  if (result.plan.kind === 'continue') {
-    await applyContinue(context, result.plan, entryEpoch);
   }
 }
 
@@ -246,7 +257,7 @@ async function applyAttachLive(
   progress: ResyncResult['progress'],
   entryEpoch: number,
 ): Promise<void> {
-  if (context.getSimulation()?.activity?.id === plan.context.activityID) {
+  if (context.getSimulation().activity?.id === plan.context.activityID) {
     return;
   }
 
@@ -266,7 +277,7 @@ async function applyAttachLive(
 
     simulation.startActivity(input.avatar, input.activity);
 
-    setLiveSimulation(context, progress.activity, simulation, entryEpoch);
+    await setLiveSimulationOrStopBack(context, progress.activity, simulation, entryEpoch);
 
     return;
   }
@@ -288,100 +299,12 @@ async function applyAttachLive(
     previousNextSeed: reconstruction.lastCheckpoint.nextSeed,
   });
 
-  setLiveSimulation(context, progress.activity, reconstruction.simulation, entryEpoch);
-}
-
-/**
- * Starts the row a pending continuation wanted, now that its target reads closed. A spent budget
- * halts at the boundary, keeping the record. Duplicate deliveries dedupe server-side via the
- * start key, so a defined error is a genuinely different claim: the record clears and the error
- * rethrows into the caller's resync-failure handling. A transport failure keeps the record and
- * reports the worker offline for the next reconnect to retry.
- */
-async function applyContinue(
-  context: WorkerContext,
-  plan: Extract<ResyncPlan, { kind: 'continue' }>,
-  entryEpoch: number,
-): Promise<void> {
-  // A stop that landed while the plan was computed also cleared the pending continuation the plan
-  // was built from — the continuation intent died with the run the player ended.
-  if (hasStopIntervened(context, entryEpoch)) {
-    return;
-  }
-
-  invariant(
-    context.getPendingContinuation() !== null,
-    'a continue plan is only reached with a pending continuation',
+  await setLiveSimulationOrStopBack(
+    context,
+    progress.activity,
+    reconstruction.simulation,
+    entryEpoch,
   );
-
-  if (context.getRemainingBudgetMs() <= 0) {
-    emitCapStatus(context, 0, true);
-
-    return;
-  }
-
-  // the same key the live continuation carried, so this retry dedupes onto anything it minted
-  const [error, started] = await safe(
-    context.getClient().startActivity({
-      avatarID: plan.activity.avatarID,
-      scopeID: plan.activity.scopeID,
-      scopeType: plan.activity.scopeType,
-      startKey: `continue_${plan.activity.id}`,
-    }),
-  );
-
-  if (error === null) {
-    // The player ended the run while the start was in flight: the fresh row was raised on behalf
-    // of a run that no longer exists, so it is stopped the same durable way any player stop is.
-    if (hasStopIntervened(context, entryEpoch)) {
-      await submitStopIntent(context, started);
-
-      return;
-    }
-
-    await startContinuedActivity(context, started, entryEpoch);
-
-    context.setPendingContinuation(null);
-
-    return;
-  }
-
-  if (!isDefinedError(error)) {
-    emitConnectionStatus(context, false);
-
-    return;
-  }
-
-  context.setPendingContinuation(null);
-  throw error;
-}
-
-async function startContinuedActivity(
-  context: WorkerContext,
-  row: Readonly<ActivityData>,
-  entryEpoch: number,
-): Promise<void> {
-  const input = buildSimulationInput(row, { failureAction: context.getFailureAction() });
-
-  await context.getSubmitter().registerActivity({
-    activityID: row.id,
-    appendedHead: 0,
-    lastHash: row.startHash,
-    startChainIndex: row.startChainIndex,
-  });
-
-  const simulation = createSimulation();
-
-  simulation.startActivity(input.avatar, input.activity);
-
-  const installed = setLiveSimulation(context, row, simulation, entryEpoch);
-
-  // A stop that landed during the registration await left this freshly started row active on the
-  // server with nothing local driving it — the next resync would revive it — so it is stopped
-  // back durably, the same way any player stop delivers.
-  if (!installed && hasStopIntervened(context, entryEpoch)) {
-    await submitStopIntent(context, row);
-  }
 }
 
 async function applyFastForward(
@@ -431,7 +354,7 @@ async function applyFastForwardAttach(
 
     simulation.startActivity(input.avatar, input.activity);
 
-    setLiveSimulation(context, report.activity, simulation, entryEpoch);
+    await setLiveSimulationOrStopBack(context, report.activity, simulation, entryEpoch);
 
     return;
   }
@@ -460,7 +383,12 @@ async function applyFastForwardAttach(
     startChainIndex: report.activity.startChainIndex,
   });
 
-  setLiveSimulation(context, report.activity, reconstruction.simulation, entryEpoch);
+  await setLiveSimulationOrStopBack(
+    context,
+    report.activity,
+    reconstruction.simulation,
+    entryEpoch,
+  );
 }
 
 function isTerminalCheckpoint(checkpoint: ActivityCheckpoint): boolean {
@@ -468,6 +396,24 @@ function isTerminalCheckpoint(checkpoint: ActivityCheckpoint): boolean {
     checkpoint.type === ActivityCheckpointType.Completed ||
     checkpoint.type === ActivityCheckpointType.Failed
   );
+}
+
+/**
+ * Installs a resync's simulation, stopping the row back durably when a landed stop refused the
+ * install — the row would otherwise sit active on the server with nothing local driving it. A
+ * refusal to a fresher claim leaves the row to its owner.
+ */
+async function setLiveSimulationOrStopBack(
+  context: WorkerContext,
+  activity: Readonly<ActivityData>,
+  simulation: Simulation,
+  entryEpoch: number,
+): Promise<void> {
+  const installed = setLiveSimulation(context, activity, simulation, entryEpoch);
+
+  if (!installed && hasStopIntervened(context, entryEpoch)) {
+    await submitStopIntent(context, activity);
+  }
 }
 
 /**
@@ -486,7 +432,7 @@ function setLiveSimulation(
     return false;
   }
 
-  const currentID = context.getSimulation()?.activity?.id;
+  const currentID = context.getSimulation().activity?.id;
 
   if (currentID !== undefined && currentID !== activity.id) {
     return false;
@@ -521,22 +467,6 @@ function emitFailureActionStatus(
   failureAction: ActivityFailureAction,
 ): void {
   const message = createFailureActionStatusMessage(failureAction);
-
-  for (const connection of context.connections) {
-    connection.postMessage(message);
-  }
-}
-
-function emitCapStatus(context: WorkerContext, remainingMs: number, halted: boolean): void {
-  const message = createOfflineCapStatusMessage(remainingMs, halted);
-
-  for (const connection of context.connections) {
-    connection.postMessage(message);
-  }
-}
-
-function emitConnectionStatus(context: WorkerContext, online: boolean): void {
-  const message = createConnectionStatusMessage(online);
 
   for (const connection of context.connections) {
     connection.postMessage(message);

--- a/libs/game/idle-client/src/worker/handle-set-activity-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-set-activity-message.test.ts
@@ -59,17 +59,3 @@ test('it remembers the row as the live simulation source', async () => {
 
   expect(context.getActivity()).toStrictEqual(activity);
 });
-
-test('it does nothing when no simulation is initialized', async () => {
-  const submitter = createStubSubmitter();
-  const context = createStubWorkerContext({ submitter });
-
-  const message: SetActivityMessage = {
-    activity: createMockActivityData(),
-    type: ClientMessageType.SetActivity,
-  };
-
-  await handleSetActivityMessage(context, message);
-
-  expect(submitter.registerActivity).not.toHaveBeenCalled();
-});

--- a/libs/game/idle-client/src/worker/handle-set-activity-message.ts
+++ b/libs/game/idle-client/src/worker/handle-set-activity-message.ts
@@ -8,12 +8,6 @@ export async function handleSetActivityMessage(
 ): Promise<void> {
   const simulation = context.getSimulation();
 
-  if (!simulation) {
-    console.warn('-- tried setting activity but no simulation');
-
-    return;
-  }
-
   const input = buildSimulationInput(message.activity, {
     failureAction: context.getFailureAction(),
   });
@@ -29,7 +23,6 @@ export async function handleSetActivityMessage(
   });
 
   context.setActivity(message.activity);
-  context.setPendingContinuation(null);
   simulation.startActivity(input.avatar, input.activity);
 
   await registration;

--- a/libs/game/idle-client/src/worker/handle-simulation-update.ts
+++ b/libs/game/idle-client/src/worker/handle-simulation-update.ts
@@ -1,11 +1,8 @@
-import invariant from 'tiny-invariant';
 import { createSimulationUpdateMessage } from './create-simulation-update-message';
 import type { WorkerContext } from './types';
 
 export function handleSimulationUpdate(context: WorkerContext) {
   const simulation = context.getSimulation();
-
-  invariant(simulation, 'simulation is required');
 
   for (const connection of context.connections) {
     const message = createSimulationUpdateMessage(simulation.getSnapshot());

--- a/libs/game/idle-client/src/worker/handle-start-activity-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-start-activity-message.test.ts
@@ -388,9 +388,9 @@ test('it fails an attach the resync could not install', async () => {
     submitter: createStubSubmitter(),
   });
 
-  // a resync already in flight makes the nested attach resync a no-op — the status must not
-  // promise a row the runtime never installed
-  context.setResyncInFlight(true);
+  // the nested attach resync dies on its progress fetch — the status must not promise a row the
+  // runtime never installed
+  server.use(mockActivityService.getLatestActivityProgress.handler(() => HttpResponse.error()));
 
   const message: StartActivityMessage = {
     avatarID: viewer.avatar.id,
@@ -402,17 +402,15 @@ test('it fails an attach the resync could not install', async () => {
 
   await handleStartActivityMessage(context, message);
 
-  expect(context.getSimulation()).toBeNull();
+  expect(context.getSimulation().activity).toBeNull();
 
   await connection.waitForMessages(1);
 
-  expect(connection.received).toStrictEqual([
-    {
-      requestID: message.requestID,
-      status: { kind: 'failed' },
-      type: WorkerMessageType.StartStatus,
-    },
-  ]);
+  expect(connection.received).toContainEqual({
+    requestID: message.requestID,
+    status: { kind: 'failed' },
+    type: WorkerMessageType.StartStatus,
+  });
 });
 
 test('it runs interleaved starts one at a time, the fresher claim winning', async () => {

--- a/libs/game/idle-client/src/worker/handle-start-activity-message.ts
+++ b/libs/game/idle-client/src/worker/handle-start-activity-message.ts
@@ -1,15 +1,16 @@
 import { isDefinedError, safe } from '@orpc/client';
 import type { ActivityData } from '@vers/contract-activity';
-import { createSimulation } from '@vers/idle-core';
+import { readPendingStartIntent } from '../submission/read-pending-start-intent';
+import { removePendingStartIntent } from '../submission/remove-pending-start-intent';
 import type { StartActivityMessage, StartStatus } from '../types';
 import { ClientMessageType } from '../types';
 import { createRequestResyncMessage } from './create-request-resync-message';
 import { createStartStatusMessage } from './create-start-status-message';
-import { handleRequestResyncMessage } from './handle-request-resync-message';
+import { runResyncFlow } from './handle-request-resync-message';
 import { handleSetActivityMessage } from './handle-set-activity-message';
 import { hasStopIntervened } from './has-stop-intervened';
-import { registerSimulationListeners } from './register-simulation-listeners';
 import { reportWorkerFault } from './report-worker-fault';
+import { runOnLifecycleChain } from './run-on-lifecycle-chain';
 import { submitStopIntent } from './submit-stop-intent';
 import type { WorkerContext } from './types';
 
@@ -28,12 +29,8 @@ export async function handleStartActivityMessage(
 ): Promise<void> {
   context.setStartRequestID(message.requestID);
 
-  const previous = context.getStartFlow();
-
-  // the flow settles without rejecting — a throw would strand every queued start behind it
-  const flow = (async () => {
-    await previous;
-
+  await runOnLifecycleChain(context, 'start', async () => {
+    // a throw still answers the tab — an unreported outcome would leave it spinning
     try {
       const status = await runStart(context, message);
 
@@ -42,11 +39,7 @@ export async function handleStartActivityMessage(
       reportWorkerFault('start', error);
       emitStartStatus(context, message.requestID, { kind: 'failed' });
     }
-  })();
-
-  context.setStartFlow(flow);
-
-  await flow;
+  });
 }
 
 async function runStart(
@@ -86,11 +79,11 @@ async function runStart(
 
   // the requested scope is already running — a resync attaches its confirmed stream
   if (row.scopeType === message.scopeType && row.scopeID === message.scopeID) {
-    await handleRequestResyncMessage(context, createRequestResyncMessage(message.avatarID));
+    await runResyncFlow(context, createRequestResyncMessage(message.avatarID));
 
     // a resync can be skipped, gated, or abandoned without installing; reporting attached anyway
     // would leave the tab waiting forever on a run that never arrives
-    if (context.getSimulation()?.activity?.id !== row.id) {
+    if (context.getSimulation().activity?.id !== row.id) {
       return { kind: 'failed' };
     }
 
@@ -158,17 +151,14 @@ async function setLiveStartedRow(
     return { kind: 'failed' };
   }
 
-  // a worker that never saw an initialize has no simulation; a silently skipped install would
-  // leave the tab spinning on a started run
-  if (context.getSimulation() === null) {
-    const simulation = createSimulation();
-
-    registerSimulationListeners(context, simulation);
-
-    context.setSimulation(simulation);
-  }
-
   await handleSetActivityMessage(context, { activity: row, type: ClientMessageType.SetActivity });
+
+  // a held continuation is moot once the player starts a run of their own choosing
+  const startIntent = await readPendingStartIntent();
+
+  if (startIntent !== undefined && startIntent.startKey !== message.requestID) {
+    await removePendingStartIntent(startIntent.startKey);
+  }
 
   // the install's registration await is this flow's last yield; a request that arrived during it
   // owns the claim, and its queued flow will replace this install

--- a/libs/game/idle-client/src/worker/handle-stop-activity-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-stop-activity-message.test.ts
@@ -8,8 +8,10 @@ import * as db from '@vers/mock-services/db';
 import { HttpResponse } from 'msw';
 import invariant from 'tiny-invariant';
 import { server } from '../mocks/node';
+import { readPendingStartIntent } from '../submission/read-pending-start-intent';
 import { readPendingStopIntent } from '../submission/read-pending-stop-intent';
 import type { ActivityServiceClient } from '../submission/types';
+import { writePendingStartIntent } from '../submission/write-pending-start-intent';
 import { createStubSubmitter } from '../test-utils/create-stub-submitter';
 import { createStubWorkerContext } from '../test-utils/create-stub-worker-context';
 import { createTestConnection } from '../test-utils/create-test-connection';
@@ -25,11 +27,11 @@ test('it halts the live simulation and clears the runtime', async () => {
   context.setSimulation(simulation);
   context.setActivity(activity);
 
-  context.setPendingContinuation({
-    activityID: activity.id,
+  await writePendingStartIntent({
     avatarID: activity.avatarID,
     scopeID: activity.scopeID,
     scopeType: activity.scopeType,
+    startKey: `continue_${activity.id}`,
   });
 
   simulation.startActivity(createMockAvatarData(), createMockActivityInput());
@@ -42,7 +44,10 @@ test('it halts the live simulation and clears the runtime', async () => {
 
   expect(simulation.activity).toBeNull();
   expect(context.getActivity()).toBeNull();
-  expect(context.getPendingContinuation()).toBeNull();
+
+  const startIntent = await readPendingStartIntent();
+
+  expect(startIntent).toBeUndefined();
 });
 
 test('it replaces the stopped simulation with a fresh empty one', async () => {

--- a/libs/game/idle-client/src/worker/handle-stop-activity-message.ts
+++ b/libs/game/idle-client/src/worker/handle-stop-activity-message.ts
@@ -1,4 +1,6 @@
 import { createSimulation } from '@vers/idle-core';
+import { readPendingStartIntent } from '../submission/read-pending-start-intent';
+import { removePendingStartIntent } from '../submission/remove-pending-start-intent';
 import type { StopActivityMessage } from '../types';
 import { createSimulationUpdateMessage } from './create-simulation-update-message';
 import { registerSimulationListeners } from './register-simulation-listeners';
@@ -27,11 +29,7 @@ export async function handleStopActivityMessage(
 
   context.advanceStopEpoch();
 
-  const simulation = context.getSimulation();
-
-  if (simulation !== null) {
-    await simulation.stopActivity();
-  }
+  await context.getSimulation().stopActivity();
 
   const replacement = createSimulation();
 
@@ -39,10 +37,16 @@ export async function handleStopActivityMessage(
 
   context.setSimulation(replacement);
   context.setActivity(null);
-  context.setPendingContinuation(null);
   context.resetRewardSlotLedger();
 
   emitClearedSnapshot(context);
+
+  // a held continuation dies with the run the player ended
+  const startIntent = await readPendingStartIntent();
+
+  if (startIntent !== undefined) {
+    await removePendingStartIntent(startIntent.startKey);
+  }
 
   await submitStopIntent(context, { avatarID: message.avatarID, id: message.activityID });
 }

--- a/libs/game/idle-client/src/worker/report-worker-fault.ts
+++ b/libs/game/idle-client/src/worker/report-worker-fault.ts
@@ -1,6 +1,7 @@
 import { sentryHandle } from './sentry-handle';
 
 export type WorkerFaultSite =
+  | 'continuation'
   | 'message-routing'
   | 'preference-seed'
   | 'reconnect'

--- a/libs/game/idle-client/src/worker/run-continuation.test.ts
+++ b/libs/game/idle-client/src/worker/run-continuation.test.ts
@@ -8,6 +8,7 @@ import * as db from '@vers/mock-services/db';
 import { HttpResponse } from 'msw';
 import invariant from 'tiny-invariant';
 import { server } from '../mocks/node';
+import { readPendingStartIntent } from '../submission/read-pending-start-intent';
 import { readPendingStopIntent } from '../submission/read-pending-stop-intent';
 import type { ActivityServiceClient } from '../submission/types';
 import { createStubSubmitter } from '../test-utils/create-stub-submitter';
@@ -41,6 +42,8 @@ test('it adopts a fresh server-started row for the same scope and registers from
   const previousActivity = createMockActivityData({ avatarID: viewer.avatar.id });
 
   simulation.startActivity(createMockAvatarData(), createMockActivityInput());
+  context.setSimulation(simulation);
+  context.setActivity(previousActivity);
 
   await runContinuation(context, simulation, previousActivity);
 
@@ -76,6 +79,8 @@ test('it hands a foreign-claim CONFLICT to a resync that attaches the conflictin
   const previousActivity = createMockActivityData({ avatarID: viewer.avatar.id });
 
   simulation.startActivity(createMockAvatarData(), createMockActivityInput());
+  context.setSimulation(simulation);
+  context.setActivity(previousActivity);
 
   await runContinuation(context, simulation, previousActivity);
 
@@ -87,7 +92,10 @@ test('it hands a foreign-claim CONFLICT to a resync that attaches the conflictin
   expect(installed).not.toBe(simulation);
   expect(installed.activity?.id).toBe(conflictingActivity.id);
   expect(context.getActivity()).toStrictEqual(conflictingActivity);
-  expect(context.getPendingContinuation()).toBeNull();
+
+  const intent = await readPendingStartIntent();
+
+  expect(intent).toBeUndefined();
 
   expect(submitter.registerActivity).toHaveBeenCalledExactlyOnceWith({
     activityID: conflictingActivity.id,
@@ -107,6 +115,8 @@ test('it stops the simulation and broadcasts offline on a transport failure', as
   const previousActivity = createMockActivityData();
 
   simulation.startActivity(createMockAvatarData(), createMockActivityInput());
+  context.setSimulation(simulation);
+  context.setActivity(previousActivity);
 
   await runContinuation(context, simulation, previousActivity);
 
@@ -129,14 +139,18 @@ test('it records a pending continuation on a transport failure', async () => {
   const previousActivity = createMockActivityData();
 
   simulation.startActivity(createMockAvatarData(), createMockActivityInput());
+  context.setSimulation(simulation);
+  context.setActivity(previousActivity);
 
   await runContinuation(context, simulation, previousActivity);
 
-  expect(context.getPendingContinuation()).toStrictEqual({
-    activityID: previousActivity.id,
+  const intent = await readPendingStartIntent();
+
+  expect(intent).toStrictEqual({
     avatarID: previousActivity.avatarID,
     scopeID: previousActivity.scopeID,
     scopeType: previousActivity.scopeType,
+    startKey: `continue_${previousActivity.id}`,
   });
 });
 
@@ -154,16 +168,20 @@ test('it stops the simulation and records a pending continuation on a same-row C
   const simulation = createSimulation();
 
   simulation.startActivity(createMockAvatarData(), createMockActivityInput());
+  context.setSimulation(simulation);
+  context.setActivity(activity);
 
   await runContinuation(context, simulation, activity);
 
   expect(simulation.activity).toBeNull();
 
-  expect(context.getPendingContinuation()).toStrictEqual({
-    activityID: activity.id,
+  const intent = await readPendingStartIntent();
+
+  expect(intent).toStrictEqual({
     avatarID: activity.avatarID,
     scopeID: activity.scopeID,
     scopeType: activity.scopeType,
+    startKey: `continue_${activity.id}`,
   });
 });
 
@@ -183,10 +201,14 @@ test('it records no pending continuation when the CONFLICT names a different, al
   const previousActivity = createMockActivityData({ avatarID: viewer.avatar.id });
 
   simulation.startActivity(createMockAvatarData(), createMockActivityInput());
+  context.setSimulation(simulation);
+  context.setActivity(previousActivity);
 
   await runContinuation(context, simulation, previousActivity);
 
-  expect(context.getPendingContinuation()).toBeNull();
+  const intent = await readPendingStartIntent();
+
+  expect(intent).toBeUndefined();
 });
 
 test('it records no pending continuation on a defined error other than CONFLICT', async () => {
@@ -202,10 +224,14 @@ test('it records no pending continuation on a defined error other than CONFLICT'
   const previousActivity = createMockActivityData();
 
   simulation.startActivity(createMockAvatarData(), createMockActivityInput());
+  context.setSimulation(simulation);
+  context.setActivity(previousActivity);
 
   await runContinuation(context, simulation, previousActivity);
 
-  expect(context.getPendingContinuation()).toBeNull();
+  const intent = await readPendingStartIntent();
+
+  expect(intent).toBeUndefined();
 });
 
 test('it stops the row it started when a stop lands mid-flight', async () => {
@@ -233,6 +259,9 @@ test('it stops the row it started when a stop lands mid-flight', async () => {
       return started;
     }),
   );
+
+  context.setSimulation(simulation);
+  context.setActivity(previousActivity);
 
   await runContinuation(context, simulation, previousActivity);
 
@@ -265,7 +294,9 @@ test('it records no pending continuation for a same-row CONFLICT after a stop la
 
   await runContinuation(context, simulation, previousActivity);
 
-  expect(context.getPendingContinuation()).toBeNull();
+  const intent = await readPendingStartIntent();
+
+  expect(intent).toBeUndefined();
 });
 
 test('it leaves a replacement simulation installed when uninstalling after a stop', async () => {
@@ -286,8 +317,14 @@ test('it leaves a replacement simulation installed when uninstalling after a sto
     }),
   );
 
+  context.setSimulation(simulation);
+  context.setActivity(previousActivity);
+
   await runContinuation(context, simulation, previousActivity);
 
   expect(context.getSimulation()).toBe(replacement);
-  expect(context.getPendingContinuation()).toBeNull();
+
+  const intent = await readPendingStartIntent();
+
+  expect(intent).toBeUndefined();
 });

--- a/libs/game/idle-client/src/worker/run-continuation.ts
+++ b/libs/game/idle-client/src/worker/run-continuation.ts
@@ -2,6 +2,7 @@ import { isDefinedError, safe } from '@orpc/client';
 import type { ActivityData } from '@vers/contract-activity';
 import type { Simulation } from '@vers/idle-core';
 import { buildSimulationInput, createSimulation } from '@vers/idle-core';
+import { removePendingStartIntent } from '../submission/remove-pending-start-intent';
 import { writePendingStartIntent } from '../submission/write-pending-start-intent';
 import { createConnectionStatusMessage } from './create-connection-status-message';
 import { createRequestResyncMessage } from './create-request-resync-message';
@@ -87,6 +88,7 @@ async function runContinuationFlow(
 
     if (row.id === activity.id && !hasStopIntervened(context, entryEpoch)) {
       await parkContinuation(activity);
+      await removeParkIfStopped(context, entryEpoch, activity);
     }
 
     await stopAndClear(context, simulation);
@@ -100,6 +102,7 @@ async function runContinuationFlow(
   if (!isDefinedError(error)) {
     if (!hasStopIntervened(context, entryEpoch)) {
       await parkContinuation(activity);
+      await removeParkIfStopped(context, entryEpoch, activity);
     }
 
     emitConnectionStatus(context, false);
@@ -139,6 +142,21 @@ async function stopAndClear(context: WorkerContext, simulation: Simulation): Pro
 
     context.setSimulation(replacement);
     context.setActivity(null);
+  }
+}
+
+/**
+ * Removes a just-parked intent when a stop landed while the park's durable write was in flight —
+ * the stop's own clear can read the store before the write commits, and a surviving intent would
+ * resume the run the player ended.
+ */
+async function removeParkIfStopped(
+  context: WorkerContext,
+  entryEpoch: number,
+  activity: Readonly<ActivityData>,
+): Promise<void> {
+  if (hasStopIntervened(context, entryEpoch)) {
+    await removePendingStartIntent(`continue_${activity.id}`);
   }
 }
 

--- a/libs/game/idle-client/src/worker/run-continuation.ts
+++ b/libs/game/idle-client/src/worker/run-continuation.ts
@@ -1,11 +1,14 @@
 import { isDefinedError, safe } from '@orpc/client';
 import type { ActivityData } from '@vers/contract-activity';
 import type { Simulation } from '@vers/idle-core';
-import { buildSimulationInput } from '@vers/idle-core';
+import { buildSimulationInput, createSimulation } from '@vers/idle-core';
+import { writePendingStartIntent } from '../submission/write-pending-start-intent';
 import { createConnectionStatusMessage } from './create-connection-status-message';
 import { createRequestResyncMessage } from './create-request-resync-message';
-import { handleRequestResyncMessage } from './handle-request-resync-message';
+import { runResyncFlow } from './handle-request-resync-message';
 import { hasStopIntervened } from './has-stop-intervened';
+import { registerSimulationListeners } from './register-simulation-listeners';
+import { runOnLifecycleChain } from './run-on-lifecycle-chain';
 import { submitStopIntent } from './submit-stop-intent';
 import type { WorkerContext } from './types';
 
@@ -38,12 +41,23 @@ export async function runContinuation(
   simulation: Simulation,
   activity: Readonly<ActivityData>,
 ): Promise<void> {
-  const entryEpoch = context.getStopEpoch();
-  const entrySimulation = context.getSimulation();
-  const entryActivityID = context.getActivity()?.id;
+  await runOnLifecycleChain(context, 'continuation', () =>
+    runContinuationFlow(context, simulation, activity),
+  );
+}
 
-  const hasLostOwnership = () =>
-    context.getSimulation() !== entrySimulation || context.getActivity()?.id !== entryActivityID;
+async function runContinuationFlow(
+  context: WorkerContext,
+  simulation: Simulation,
+  activity: Readonly<ActivityData>,
+): Promise<void> {
+  const entryEpoch = context.getStopEpoch();
+
+  // the chain serialized any queued lifecycle work behind this flow, but the runtime may already
+  // have moved past the terminal row before this flow got its turn
+  if (context.getSimulation() !== simulation || context.getActivity()?.id !== activity.id) {
+    return;
+  }
 
   // keyed by the terminal row it succeeds: a retried delivery dedupes onto the first attempt's
   // row, while the next continuation carries a new key and conflicts as a distinct intent
@@ -63,10 +77,6 @@ export async function runContinuation(
       return;
     }
 
-    if (hasLostOwnership()) {
-      return;
-    }
-
     await startContinuationFrom(context, simulation, started);
 
     return;
@@ -76,20 +86,20 @@ export async function runContinuation(
     const row = error.data.activity;
 
     if (row.id === activity.id && !hasStopIntervened(context, entryEpoch)) {
-      setPendingContinuation(context, activity);
+      await parkContinuation(activity);
     }
 
-    await stopAndUninstall(context, simulation);
-    await handleRequestResyncMessage(context, createRequestResyncMessage(row.avatarID));
+    await stopAndClear(context, simulation);
+    await runResyncFlow(context, createRequestResyncMessage(row.avatarID));
 
     return;
   }
 
-  await stopAndUninstall(context, simulation);
+  await stopAndClear(context, simulation);
 
   if (!isDefinedError(error)) {
     if (!hasStopIntervened(context, entryEpoch)) {
-      setPendingContinuation(context, activity);
+      await parkContinuation(activity);
     }
 
     emitConnectionStatus(context, false);
@@ -115,23 +125,33 @@ async function startContinuationFrom(
 }
 
 /**
- * Stops this continuation's own simulation and uninstalls it — but only while it still owns the
- * runtime; a stop or a fresher selection may have installed a replacement this must not evict.
+ * Stops this continuation's own simulation and clears the runtime to an empty replacement — but
+ * only while it still owns the runtime; a stop may have installed a replacement this must not
+ * evict. The stopped instance retains avatar and combat state, so it never stays installed.
  */
-async function stopAndUninstall(context: WorkerContext, simulation: Simulation): Promise<void> {
+async function stopAndClear(context: WorkerContext, simulation: Simulation): Promise<void> {
   await simulation.stopActivity();
 
   if (context.getSimulation() === simulation) {
-    context.setSimulation(null);
+    const replacement = createSimulation();
+
+    registerSimulationListeners(context, replacement);
+
+    context.setSimulation(replacement);
+    context.setActivity(null);
   }
 }
 
-function setPendingContinuation(context: WorkerContext, activity: Readonly<ActivityData>): void {
-  context.setPendingContinuation({
-    activityID: activity.id,
+/**
+ * Sets this continuation aside as a durable start intent for a later reconnect or resync entry
+ * to deliver.
+ */
+async function parkContinuation(activity: Readonly<ActivityData>): Promise<void> {
+  await writePendingStartIntent({
     avatarID: activity.avatarID,
     scopeID: activity.scopeID,
     scopeType: activity.scopeType,
+    startKey: `continue_${activity.id}`,
   });
 }
 

--- a/libs/game/idle-client/src/worker/run-on-lifecycle-chain.test.ts
+++ b/libs/game/idle-client/src/worker/run-on-lifecycle-chain.test.ts
@@ -53,3 +53,35 @@ test('it settles a throwing flow without stranding the next', async () => {
 
   expect(order).toStrictEqual(['second-ran']);
 });
+
+test('it serializes flows of different kinds on the one chain', async () => {
+  const context = createStubWorkerContext();
+  const order: Array<string> = [];
+  const gate = Promise.withResolvers<void>();
+
+  const start = runOnLifecycleChain(context, 'start', async () => {
+    order.push('start-entered');
+
+    await gate.promise;
+
+    order.push('start-settled');
+  });
+
+  const resync = runOnLifecycleChain(context, 'resync', () => {
+    order.push('resync-entered');
+
+    return Promise.resolve();
+  });
+
+  await waitFor(() => {
+    expect(order).toContain('start-entered');
+  });
+
+  expect(order).toStrictEqual(['start-entered']);
+
+  gate.resolve();
+
+  await Promise.all([start, resync]);
+
+  expect(order).toStrictEqual(['start-entered', 'start-settled', 'resync-entered']);
+});

--- a/libs/game/idle-client/src/worker/run-on-lifecycle-chain.test.ts
+++ b/libs/game/idle-client/src/worker/run-on-lifecycle-chain.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from 'bun:test';
+import { waitFor } from '@vers/test-utils';
+import { createStubWorkerContext } from '../test-utils/create-stub-worker-context';
+import { runOnLifecycleChain } from './run-on-lifecycle-chain';
+
+test('it runs queued flows strictly one at a time, in arrival order', async () => {
+  const context = createStubWorkerContext();
+  const order: Array<string> = [];
+  const gate = Promise.withResolvers<void>();
+
+  const first = runOnLifecycleChain(context, 'start', async () => {
+    order.push('first-entered');
+
+    await gate.promise;
+
+    order.push('first-settled');
+  });
+
+  const second = runOnLifecycleChain(context, 'start', () => {
+    order.push('second-entered');
+
+    return Promise.resolve();
+  });
+
+  await waitFor(() => {
+    expect(order).toContain('first-entered');
+  });
+
+  expect(order).toStrictEqual(['first-entered']);
+
+  gate.resolve();
+
+  await Promise.all([first, second]);
+
+  expect(order).toStrictEqual(['first-entered', 'first-settled', 'second-entered']);
+});
+
+test('it settles a throwing flow without stranding the next', async () => {
+  const context = createStubWorkerContext();
+  const order: Array<string> = [];
+
+  await runOnLifecycleChain(context, 'start', async () => {
+    await Promise.resolve();
+
+    throw new Error('first flow dies');
+  });
+
+  await runOnLifecycleChain(context, 'start', () => {
+    order.push('second-ran');
+
+    return Promise.resolve();
+  });
+
+  expect(order).toStrictEqual(['second-ran']);
+});

--- a/libs/game/idle-client/src/worker/run-on-lifecycle-chain.ts
+++ b/libs/game/idle-client/src/worker/run-on-lifecycle-chain.ts
@@ -1,0 +1,34 @@
+import type { WorkerFaultSite } from './report-worker-fault';
+import { reportWorkerFault } from './report-worker-fault';
+import type { WorkerContext } from './types';
+
+/**
+ * Runs a lifecycle flow on the worker's one chain: the flow waits for its predecessor to settle,
+ * so start, resync, and continuation work never interleave — a stale flow can never install over
+ * or stop out a fresher one's work. Stops stay off the chain; their local halt is immediate and
+ * their epoch bump is what queued flows re-check. A flow that throws is reported against the
+ * given site and settles the chain cleanly — a rejection would strand every queued flow behind
+ * it. Nested lifecycle work inside a running flow calls its target directly; chaining it again
+ * would deadlock the chain on itself.
+ */
+export async function runOnLifecycleChain(
+  context: WorkerContext,
+  site: WorkerFaultSite,
+  flow: () => Promise<void>,
+): Promise<void> {
+  const previous = context.getLifecycleFlow();
+
+  const chained = (async () => {
+    await previous;
+
+    try {
+      await flow();
+    } catch (error) {
+      reportWorkerFault(site, error);
+    }
+  })();
+
+  context.setLifecycleFlow(chained);
+
+  await chained;
+}

--- a/libs/game/idle-client/src/worker/types.ts
+++ b/libs/game/idle-client/src/worker/types.ts
@@ -5,21 +5,6 @@ import type { ActivityServiceClient } from '../submission/types';
 import type { RewardSlotLedgerEntry, RewardSlotLedgerSnapshot } from '../types';
 
 /**
- * A continuation the worker wanted to start but couldn't complete — a same-row `CONFLICT`
- * (the terminal append that closes the row is still unacknowledged) or a transport failure on its
- * own start-activity call. `activityID` names the row the pending intent was raised against, so a
- * resync plans `continue` only once that exact row reads closed, never a different one. The row
- * it eventually starts takes the worker's current failure action, not a snapshot from raise time,
- * so a preference changed while the intent waited still applies.
- */
-export interface PendingContinuation {
-  readonly activityID: string;
-  readonly avatarID: string;
-  readonly scopeID: string;
-  readonly scopeType: string;
-}
-
-/**
  * Accessors over the runtime's closure state, threaded to every message and simulation event
  * handler. `connections` is exposed read-only — `removeConnection` is the one mutation a handler
  * needs. `getSubmitter` and `getClient` always return the same instance: both exist for the
@@ -53,12 +38,6 @@ export interface WorkerContext {
   readonly getFailureAction: () => ActivityFailureAction;
 
   /**
-   * The continuation intent a resync should honor once its target row reads closed — `null` when
-   * no continuation is outstanding.
-   */
-  readonly getPendingContinuation: () => PendingContinuation | null;
-
-  /**
    * The worker's conservative view of the avatar's offline-progress budget: the cap minus the
    * wall clock elapsed since the last acknowledged submission. It can only under-estimate the
    * server's meter, never over-run it.
@@ -76,14 +55,14 @@ export interface WorkerContext {
    * its initial state.
    */
   readonly getRewardSlotLedger: () => RewardSlotLedgerSnapshot;
-  readonly getSimulation: () => null | Simulation;
+  readonly getSimulation: () => Simulation;
 
   /**
-   * The start-flow chain's tail. Start flows run one at a time — interleaved, a stale flow could
-   * stop a row the fresher one just attached. Stops stay concurrent; they bump the epoch queued
-   * flows re-check.
+   * The lifecycle chain's tail. Start, resync, and continuation flows run one at a time —
+   * interleaved, a stale flow could install over or stop out a fresher one's work. Stops stay
+   * concurrent; they bump the epoch queued flows re-check.
    */
-  readonly getStartFlow: () => Readonly<Promise<void>>;
+  readonly getLifecycleFlow: () => Readonly<Promise<void>>;
 
   /**
    * The most recent start request's id. A flow that finds a fresher claim after an await abandons
@@ -125,10 +104,9 @@ export interface WorkerContext {
   readonly setFailureAction: (action: ActivityFailureAction) => void;
   readonly setFailureActionDirty: (dirty: boolean) => void;
   readonly setFailureActionPushInFlight: (inFlight: boolean) => void;
-  readonly setPendingContinuation: (pending: PendingContinuation | null) => void;
   readonly setResyncAvatarID: (avatarID: string) => void;
   readonly setResyncInFlight: (inFlight: boolean) => void;
-  readonly setStartFlow: (flow: Readonly<Promise<void>>) => void;
+  readonly setLifecycleFlow: (flow: Readonly<Promise<void>>) => void;
   readonly setStartRequestID: (requestID: string) => void;
-  readonly setSimulation: (simulation: null | Simulation) => void;
+  readonly setSimulation: (simulation: Simulation) => void;
 }


### PR DESCRIPTION
## Description

Closes #717

Three deletions of accidental complexity in the idle worker: continuations become durable start intents, lifecycle flows share one serialized chain, and the simulation handle is never null. Each pays for itself — net code shrinks while a held continuation now survives worker restarts.

- Durable start intent replaces the in-memory pending continuation: held in the preferences store, delivered idempotently (start key) at resync entry before the snapshot fetch, cleared by a player stop or a fresh player-chosen start. `planResync` loses its continue kind; the continue apply path is deleted.
- Lifecycle mailbox: start, resync, and continuation flows run one at a time on a shared chain; stops stay concurrent via the epoch. The per-await ownership captures and the per-flow chain plumbing collapse into one utility, with the stop-back at a single install boundary.
- Never-null simulation deletes the lazy creations, null guards, and null-uninstalls.
- Adversarially pre-reviewed; fixes landed for session-expiry intent durability and the park/stop write race.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality