### PR TITLE
chore(deps): bump format-codemod to 0.0.8 and pad expect runs

### DIFF
--- a/apps/web/src/lib/send-analytics-event.test.ts
+++ b/apps/web/src/lib/send-analytics-event.test.ts
@@ -11,6 +11,7 @@ test('it forwards the event to the tracker on the page', () => {
   });
 
   sendAnalyticsEvent('signup-complete');
+
   expect(track).toHaveBeenCalledExactlyOnceWith('signup-complete');
 });
 

--- a/apps/web/src/routes/-account/account-content.test.tsx
+++ b/apps/web/src/routes/-account/account-content.test.tsx
@@ -10,6 +10,7 @@ test('it shows the caller profile and a not-enabled 2FA status', async () => {
   });
 
   render(<AccountContent has2FA={false} user={user} />);
+
   expect(screen.getByTestId('account-username')).toHaveTextContent('Username: account-content');
   expect(screen.getByTestId('account-email')).toHaveTextContent('Email: account-content@vers.test');
 

--- a/apps/web/src/routes/-explore-current/activity-rewards-panel.test.tsx
+++ b/apps/web/src/routes/-explore-current/activity-rewards-panel.test.tsx
@@ -11,6 +11,7 @@ import { ActivityRewardsPanel } from './activity-rewards-panel';
 test('it renders nothing without an active activity', () => {
   // no activity id means the query never runs, so this needs no session or MSW override
   renderWithRouter(<ActivityRewardsPanel activityID={undefined} orpc={orpc} />);
+
   expect(screen.queryByTestId('activity-rewards-panel')).not.toBeInTheDocument();
 });
 

--- a/apps/web/src/routes/-explore-current/approaching-cap-warning.test.tsx
+++ b/apps/web/src/routes/-explore-current/approaching-cap-warning.test.tsx
@@ -5,17 +5,20 @@ import { ApproachingCapWarning } from './approaching-cap-warning';
 
 test('it renders nothing while no cap status is reported', () => {
   render(<ApproachingCapWarning />);
+
   expect(screen.queryByText(/reconnect/i)).not.toBeInTheDocument();
 });
 
 test('it warns with the remaining time while the budget drains', () => {
   setOfflineCapStatus({ halted: false, remainingMs: 5_400_000 });
   render(<ApproachingCapWarning />);
+
   expect(screen.getByText('Reconnect within 1h 30m to keep progressing.')).toBeInTheDocument();
 });
 
 test('it reports the pause once the worker halts at the boundary', () => {
   setOfflineCapStatus({ halted: true, remainingMs: 0 });
   render(<ApproachingCapWarning />);
+
   expect(screen.getByText('Progress is paused — reconnect to continue.')).toBeInTheDocument();
 });

--- a/apps/web/src/routes/-explore-current/explore-current-panel.test.tsx
+++ b/apps/web/src/routes/-explore-current/explore-current-panel.test.tsx
@@ -76,6 +76,7 @@ test('it re-sends the start intent against a promoted writer', async () => {
     const [, second] = calls.filter((call) => isStartActivityMessage(call));
 
     invariant(second !== undefined, 'expected a re-raised start intent');
+
     expect(second.requestID).not.toBe(first.requestID);
   });
 });
@@ -290,6 +291,7 @@ test('it offers a retry on a failed report and sends a fresh intent on demand', 
     const [, second] = calls.filter((call) => isStartActivityMessage(call));
 
     invariant(second !== undefined, 'expected a second start intent');
+
     expect(second.requestID).not.toBe(first.requestID);
   });
 });

--- a/apps/web/src/routes/-explore/selected-node-info.test.tsx
+++ b/apps/web/src/routes/-explore/selected-node-info.test.tsx
@@ -8,6 +8,7 @@ import { SelectedNodeInfo } from './selected-node-info';
 test('it renders nothing with no node selected', () => {
   setSelectedNode(null);
   renderWithRouter(<SelectedNodeInfo />);
+
   expect(screen.queryByTestId('selected-node-id')).not.toBeInTheDocument();
 });
 

--- a/apps/web/src/routes/-game/game-simulation-mount.test.tsx
+++ b/apps/web/src/routes/-game/game-simulation-mount.test.tsx
@@ -22,6 +22,7 @@ test('it sends the initialize message once a worker connects that has not report
   });
 
   render(<GameSimulationMount />);
+
   expect(calls).toStrictEqual([{ type: ClientMessageType.Initialize }]);
 });
 
@@ -37,6 +38,7 @@ test('it sends nothing once the worker has already reported its state and no ava
   });
 
   render(<GameSimulationMount />);
+
   expect(calls).toStrictEqual([]);
 });
 
@@ -51,6 +53,7 @@ test('it sends nothing before a worker has connected', () => {
   });
 
   render(<GameSimulationMount />);
+
   expect(calls).toStrictEqual([]);
 });
 

--- a/apps/web/src/routes/-game/playing-elsewhere-notice.test.tsx
+++ b/apps/web/src/routes/-game/playing-elsewhere-notice.test.tsx
@@ -13,12 +13,14 @@ import { PlayingElsewhereNotice } from './playing-elsewhere-notice';
 
 test('it renders nothing while no displacement is reported', () => {
   render(<PlayingElsewhereNotice />);
+
   expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 });
 
 test('it tells the player their run picked up on another device', () => {
   setWriterDisplacedActivityID('activity_1');
   render(<PlayingElsewhereNotice />);
+
   expect(screen.getByText('Playing on another device')).toBeInTheDocument();
   expect(screen.getByRole('button', { name: 'Continue here' })).toBeInTheDocument();
 });

--- a/apps/web/src/routes/-game/welcome-back-modal.test.tsx
+++ b/apps/web/src/routes/-game/welcome-back-modal.test.tsx
@@ -9,12 +9,14 @@ import { WelcomeBackModal } from './welcome-back-modal';
 
 test('it renders nothing while no resync is underway', () => {
   render(<WelcomeBackModal />);
+
   expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 });
 
 test('it masks the catch-up from its zero-tally start', () => {
   setResyncStatus({ attempts: 0, kind: 'fast-forwarding', levelUps: 0 });
   render(<WelcomeBackModal />);
+
   expect(screen.getByText('Welcome back')).toBeInTheDocument();
   expect(screen.getByText('Catching up… 0 attempts, 0 level-ups so far.')).toBeInTheDocument();
 });
@@ -22,24 +24,28 @@ test('it masks the catch-up from its zero-tally start', () => {
 test('it reports the running tally while fast-forwarding', () => {
   setResyncStatus({ attempts: 12, kind: 'fast-forwarding', levelUps: 1 });
   render(<WelcomeBackModal />);
+
   expect(screen.getByText('Catching up… 12 attempts, 1 level-ups so far.')).toBeInTheDocument();
 });
 
 test('it reports the final tally when the catch-up is done', () => {
   setResyncStatus({ attempts: 42, kind: 'done', levelUps: 2 });
   render(<WelcomeBackModal />);
+
   expect(screen.getByText('While you were away: 42 attempts, 2 level-ups.')).toBeInTheDocument();
 });
 
 test('it explains a capped catch-up', () => {
   setResyncStatus({ kind: 'capped' });
   render(<WelcomeBackModal />);
+
   expect(screen.getByText(/reached its cap/)).toBeInTheDocument();
 });
 
 test('it offers a retry when the catch-up fails outright', () => {
   setResyncStatus({ avatarID: 'avatar_1', kind: 'failed' });
   render(<WelcomeBackModal />);
+
   expect(screen.getByText('Catching up didn’t finish. Your progress is safe.')).toBeInTheDocument();
   expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument();
 });
@@ -100,5 +106,6 @@ test('it dismisses by clearing the resync status', async () => {
 test('it renders nothing when the catch-up ended on another device taking the run', () => {
   setResyncStatus({ activityID: 'activity_1', kind: 'active-elsewhere' });
   render(<WelcomeBackModal />);
+
   expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 });

--- a/apps/web/src/routes/-market-listing/market-listing-panel.test.tsx
+++ b/apps/web/src/routes/-market-listing/market-listing-panel.test.tsx
@@ -4,6 +4,7 @@ import { MarketListingPanel } from './market-listing-panel';
 
 test('it shows the listing id and placeholder detail text', () => {
   render(<MarketListingPanel listingID="listing-1" />);
+
   expect(screen.getByRole('heading', { name: 'Listing listing-1' })).toBeVisible();
   expect(screen.getByText('Full listing details are coming soon.')).toBeVisible();
 });

--- a/apps/web/src/routes/-stash/stash-panel.test.tsx
+++ b/apps/web/src/routes/-stash/stash-panel.test.tsx
@@ -4,6 +4,7 @@ import { StashPanel } from './stash-panel';
 
 test('it renders the stash title and its tabs', () => {
   render(<StashPanel />);
+
   expect(screen.getByRole('heading', { name: 'Stash' })).toBeVisible();
   expect(screen.getByRole('tab', { name: 'Tab 01' })).toBeVisible();
   expect(screen.getByRole('tab', { name: 'Currency' })).toBeVisible();

--- a/apps/web/src/routes/-verify-otp/verify-otp-form.test.tsx
+++ b/apps/web/src/routes/-verify-otp/verify-otp-form.test.tsx
@@ -127,6 +127,7 @@ test('it auto-submits once when a valid code arrives with the emailed link', asy
     const call = action.mock.calls[0]?.[0];
 
     invariant(call !== undefined, 'expected the auto-submit to dispatch the action');
+
     expect(call.data.get('code')).toBe('TMMPD7');
   });
 });

--- a/apps/web/src/server/make-request-logger.test.ts
+++ b/apps/web/src/server/make-request-logger.test.ts
@@ -26,6 +26,7 @@ test('it logs one structured line at info when a page request completes', async 
 
   expect(response.status).toBe(200);
   expect(lines).toHaveLength(1);
+
   invariant(lines[0], 'one line was logged');
 
   expect(lines[0]).toStrictEqual({
@@ -63,7 +64,9 @@ test('it excludes the query string from the logged path', async () => {
   );
 
   expect(lines).toHaveLength(1);
+
   invariant(lines[0], 'one line was logged');
+
   expect(lines[0].fields).toContainEntry(['path', '/login']);
 });
 
@@ -90,7 +93,9 @@ test('it logs a client error response at warn', async () => {
   );
 
   expect(lines).toHaveLength(1);
+
   invariant(lines[0], 'one line was logged');
+
   expect(lines[0].level).toBe('warn');
   expect(lines[0].fields).toContainEntry(['status', 404]);
 });
@@ -118,7 +123,9 @@ test('it logs a server error response at error', async () => {
   );
 
   expect(lines).toHaveLength(1);
+
   invariant(lines[0], 'one line was logged');
+
   expect(lines[0].level).toBe('error');
   expect(lines[0].fields).toContainEntry(['status', 500]);
 });
@@ -146,7 +153,9 @@ test('it logs a served static asset at debug', async () => {
   );
 
   expect(lines).toHaveLength(1);
+
   invariant(lines[0], 'one line was logged');
+
   expect(lines[0].level).toBe('debug');
 });
 
@@ -173,7 +182,9 @@ test('it logs a missing asset at warn rather than debug', async () => {
   );
 
   expect(lines).toHaveLength(1);
+
   invariant(lines[0], 'one line was logged');
+
   expect(lines[0].level).toBe('warn');
 });
 
@@ -206,6 +217,7 @@ test('it logs at error and rethrows when the handler throws', async () => {
   await expect(pending).toReject();
 
   expect(lines).toHaveLength(1);
+
   invariant(lines[0], 'one line was logged');
 
   expect(lines[0]).toStrictEqual({

--- a/bun.lock
+++ b/bun.lock
@@ -1245,7 +1245,7 @@
     "@vitejs/plugin-rsc": "0.5.27",
     "@zgeoff/bun-test-extended": "0.0.3",
     "@zgeoff/dbhub": "0.23.4",
-    "@zgeoff/format-codemod": "0.0.6",
+    "@zgeoff/format-codemod": "0.0.8",
     "@zgeoff/oxlint-config": "0.0.6",
     "autoprefixer": "10.5.2",
     "babel-plugin-react-compiler": "1.0.0",
@@ -2825,7 +2825,7 @@
 
     "@zgeoff/dbhub": ["@zgeoff/dbhub@0.23.4", "", { "dependencies": { "@iarna/toml": "2.2.5", "@modelcontextprotocol/sdk": "1.29.0", "dotenv": "16.5.0", "express": "5.2.1", "ssh-config": "5.0.3", "ssh2": "1.16.0", "zod": "3.25.64" }, "optionalDependencies": { "@aws-sdk/rds-signer": "3.1079.0", "@azure/identity": "4.13.1", "mariadb": "3.4.2", "mssql": "11.0.1", "mysql2": "3.14.1", "pg": "8.16.0" }, "bin": { "dbhub": "dist/index.js" } }, "sha512-mA/fQOLJRxmph0XidO9KzPvHJfk+vonVibUT06tKxr9zxQdG3TeloRkqtgpilACLjX2ok23mI6VhZGX5DMoW8w=="],
 
-    "@zgeoff/format-codemod": ["@zgeoff/format-codemod@0.0.6", "", { "dependencies": { "oxc-parser": "0.137.0" }, "bin": { "format-codemod": "dist/cli.js" } }, "sha512-7m2Iiydwn2ekBB+t3LUI4sUPSkb5j3zr/JnqGmBg7u21nJlY2spCz+d56jcdAhqs7bLOixZtkY6Jr9UTP9XhgA=="],
+    "@zgeoff/format-codemod": ["@zgeoff/format-codemod@0.0.8", "", { "dependencies": { "oxc-parser": "0.137.0" }, "bin": { "format-codemod": "dist/cli.js" } }, "sha512-McQm4/N+49SqpRdcoTKV8sGkYmB7BGtECvSgbuoPK22lsgaUCwQ+E1bO5Llyo7izO990xXPNkzMqlOdhttO4gg=="],
 
     "@zgeoff/oxlint-config": ["@zgeoff/oxlint-config@0.0.6", "", { "dependencies": { "@stylistic/eslint-plugin": "5.10.0" }, "peerDependencies": { "oxlint": ">=1.71.0" } }, "sha512-svh9vchedZlLgnE1dewvAFLbEoQKYR35aSTKNvnGxkMWdK45XsLOOdSnYxntYOe4RYf9fibNNCuy5MFMCwJqcQ=="],
 

--- a/libs/data/db/src/create-db.test.ts
+++ b/libs/data/db/src/create-db.test.ts
@@ -63,6 +63,7 @@ test('it emits a db.select client span carrying the compiled sql with placeholde
   const [span] = ctx.exporter.getFinishedSpans();
 
   invariant(span, 'expected the query span to be exported');
+
   expect(span.name).toBe('db.select');
   expect(span.kind).toBe(SpanKind.CLIENT);
   expect(span.attributes['db.system']).toBe('postgresql');
@@ -126,6 +127,7 @@ test('it parents the query span to the active context', async () => {
 
   invariant(querySpan, 'expected the query span to be exported');
   invariant(parentSpan, 'expected the parent span to be exported');
+
   expect(querySpan.parentSpanContext?.spanId).toBe(parentSpan.spanContext().spanId);
 });
 

--- a/libs/data/db/src/test-support/create-test-template.test.ts
+++ b/libs/data/db/src/test-support/create-test-template.test.ts
@@ -34,6 +34,7 @@ test('it is a no-op the second time against an already-current template', async 
   const templateDB = `test_template_provision_${createId()}`;
 
   await createTestTemplate({ baseURI, templateDB });
+
   await expect(createTestTemplate({ baseURI, templateDB })).toResolve();
 });
 

--- a/libs/design/design-system/src/components/status-pill/status-pill.test.tsx
+++ b/libs/design/design-system/src/components/status-pill/status-pill.test.tsx
@@ -4,6 +4,7 @@ import { StatusPill } from './status-pill';
 
 test('it abbreviates the effect name to a glyph and carries the full name for hover', () => {
   render(<StatusPill kind="buff" name="Fortified" />);
+
   expect(screen.getByText('FO')).toBeInTheDocument();
   expect(screen.getByTitle('Fortified')).toBeInTheDocument();
 });

--- a/libs/design/design-system/src/components/tabs/tabs.test.tsx
+++ b/libs/design/design-system/src/components/tabs/tabs.test.tsx
@@ -10,6 +10,7 @@ const ITEMS = [
 
 test('it shows the first tab by default', () => {
   render(<Tabs items={ITEMS} />);
+
   expect(screen.getByText('first panel')).toBeVisible();
 });
 
@@ -25,5 +26,6 @@ test('it switches to the selected tab', async () => {
 
 test('it honors a default value', () => {
   render(<Tabs defaultValue="two" items={ITEMS} />);
+
   expect(screen.getByText('second panel')).toBeVisible();
 });

--- a/libs/design/design-system/test-setup.ts
+++ b/libs/design/design-system/test-setup.ts
@@ -3,6 +3,7 @@ import { GlobalRegistrator } from '@happy-dom/global-registrator';
 import * as jestDOMMatchers from '@testing-library/jest-dom/matchers';
 
 GlobalRegistrator.register();
+
 expect.extend(jestDOMMatchers);
 
 // dynamic import: RTL reads `document` at import time, so it must load after registration

--- a/libs/game/game-rendering/src/create-game-loop.test.ts
+++ b/libs/game/game-rendering/src/create-game-loop.test.ts
@@ -74,6 +74,7 @@ test('it tolerates unregistering the same callback twice', () => {
   const unregister = gameLoop.registerGameLoopCallback(() => {});
 
   unregister();
+
   expect(unregister).not.toThrow();
 });
 

--- a/libs/game/game-rendering/src/remove-satellite.test.ts
+++ b/libs/game/game-rendering/src/remove-satellite.test.ts
@@ -6,6 +6,7 @@ import { useSatelliteStore } from './use-satellite-store';
 test('it removes a registered satellite entry', () => {
   registerSatellite('avatar', { element: 'viewer', keepAlive: false });
   removeSatellite('avatar');
+
   expect(useSatelliteStore.getState().satellites.has('avatar')).toBeFalse();
 });
 
@@ -13,6 +14,7 @@ test('it leaves other entries untouched', () => {
   registerSatellite('avatar', { element: 'viewer', keepAlive: false });
   registerSatellite('item', { element: 'inspector', keepAlive: false });
   removeSatellite('avatar');
+
   expect(useSatelliteStore.getState().satellites.has('item')).toBeTrue();
 });
 

--- a/libs/game/game-rendering/src/satellite-host.test.tsx
+++ b/libs/game/game-rendering/src/satellite-host.test.tsx
@@ -13,6 +13,7 @@ test('it renders every registered satellite element', () => {
   registerSatellite('avatar', { element: <span>avatar viewer</span>, keepAlive: false });
   registerSatellite('item', { element: <span>item inspector</span>, keepAlive: false });
   render(<SatelliteHost />);
+
   expect(screen.getByText('avatar viewer')).toBeInTheDocument();
   expect(screen.getByText('item inspector')).toBeInTheDocument();
 });

--- a/libs/game/game-rendering/test-setup.ts
+++ b/libs/game/game-rendering/test-setup.ts
@@ -5,6 +5,7 @@ import { useSatelliteStore } from './src/use-satellite-store';
 import { useSceneStateStore } from './src/use-scene-state-store';
 
 GlobalRegistrator.register();
+
 expect.extend(jestDOMMatchers);
 
 // dynamic import: RTL reads `document` at import time, so it must load after registration

--- a/libs/game/idle-client/src/components/avatar-unit-plate.test.tsx
+++ b/libs/game/idle-client/src/components/avatar-unit-plate.test.tsx
@@ -13,6 +13,7 @@ test('it renders the avatar identity, life, and swing timer', () => {
   });
 
   render(<AvatarUnitPlate avatar={avatar} />);
+
   expect(screen.getByText('Vanguard')).toBeInTheDocument();
   expect(screen.getByText('LV 5')).toBeInTheDocument();
   expect(screen.getByText(makeNodeTextMatcher('80 / 100'))).toBeInTheDocument();
@@ -23,6 +24,7 @@ test('it prefers the display name over the sim-reported name', () => {
   const avatar = createMockAvatarSnapshot({ name: 'avatar_1' });
 
   render(<AvatarUnitPlate avatar={avatar} displayName="Aria" />);
+
   expect(screen.getByText('Aria')).toBeInTheDocument();
   expect(screen.queryByText('avatar_1')).not.toBeInTheDocument();
 });

--- a/libs/game/idle-client/src/components/enemy-unit-plate.test.tsx
+++ b/libs/game/idle-client/src/components/enemy-unit-plate.test.tsx
@@ -13,6 +13,7 @@ test('it renders the enemy identity, life, and swing timer', () => {
   });
 
   render(<EnemyUnitPlate enemy={enemy} />);
+
   expect(screen.getByText('Rift Shade')).toBeInTheDocument();
   expect(screen.getByText('LV 3')).toBeInTheDocument();
   expect(screen.getByText(makeNodeTextMatcher('12 / 30'))).toBeInTheDocument();
@@ -23,5 +24,6 @@ test('it marks a defeated enemy', () => {
   const enemy = createMockEnemySnapshot({ isAlive: false, life: 0 });
 
   render(<EnemyUnitPlate enemy={enemy} />);
+
   expect(screen.getByText('DEFEATED')).toBeInTheDocument();
 });

--- a/libs/game/idle-client/src/components/mission-header.test.tsx
+++ b/libs/game/idle-client/src/components/mission-header.test.tsx
@@ -19,6 +19,7 @@ test('it reports the encounter name, cleared waves, enemies left, and banked xp'
   });
 
   render(<MissionHeader activity={activity} />);
+
   expect(screen.getByText('World Map Encounter')).toBeInTheDocument();
 
   expect(

--- a/libs/game/idle-client/src/resync/run-fast-forward.test.ts
+++ b/libs/game/idle-client/src/resync/run-fast-forward.test.ts
@@ -294,6 +294,7 @@ test('it reports the final row it left off at, for a caller to attach directly',
   const lastStarted = ctx.startedActivities.at(-1);
 
   invariant(lastStarted !== undefined, 'expected at least one server-started continuation');
+
   expect(report.activity).toStrictEqual(lastStarted);
   expect(report.appendedHead).toBe(0);
 });

--- a/libs/game/idle-client/src/resync/run-reconstruction.test.ts
+++ b/libs/game/idle-client/src/resync/run-reconstruction.test.ts
@@ -27,6 +27,7 @@ test('it reconstructs a simulation to the confirmed head, matching the original 
 
   invariant(priorCheckpoint !== undefined, 'expected the prior original checkpoint to exist');
   invariant(expectedNextCheckpoint !== undefined, 'expected the next original checkpoint to exist');
+
   expect(result.lastCheckpoint.nextSeed).toBe(priorCheckpoint.nextSeed);
 
   let nextCheckpoint = null;

--- a/libs/game/idle-client/src/state/advance-writer-generation.test.ts
+++ b/libs/game/idle-client/src/state/advance-writer-generation.test.ts
@@ -6,8 +6,11 @@ test('it ticks the generation and resets the handshake in one transition', () =>
   useIdleStore.setState({ initialized: true });
 
   advanceWriterGeneration();
+
   expect(useIdleStore.getState().writerGeneration).toBe(1);
   expect(useIdleStore.getState().initialized).toBeFalse();
+
   advanceWriterGeneration();
+
   expect(useIdleStore.getState().writerGeneration).toBe(2);
 });

--- a/libs/game/idle-client/src/state/set-checkpoint-flush-stall.test.ts
+++ b/libs/game/idle-client/src/state/set-checkpoint-flush-stall.test.ts
@@ -15,6 +15,7 @@ test('it records the flush stall report', () => {
 test('it clears a consumed flush stall report', () => {
   setCheckpointFlushStall({ activityID: 'activity_1', reason: 'network down', traceID: 'trace_1' });
   setCheckpointFlushStall(null);
+
   expect(useIdleStore.getState().checkpointFlushStall).toBeNull();
 });
 
@@ -25,5 +26,6 @@ test('it leaves the reward-slot ledger untouched when a flush stalls', () => {
   });
 
   setCheckpointFlushStall({ activityID: 'activity_1', reason: 'network down', traceID: 'trace_1' });
+
   expect(useIdleStore.getState().rewardSlotLedger).toStrictEqual([{ count: 2, version: 1 }]);
 });

--- a/libs/game/idle-client/src/state/set-checkpoint-stream-error.test.ts
+++ b/libs/game/idle-client/src/state/set-checkpoint-stream-error.test.ts
@@ -21,6 +21,7 @@ test('it clears the reward-slot ledger when the stream is rejected', () => {
   });
 
   setCheckpointStreamError({ activityID: 'activity_1', reason: 'broken-chain-link' });
+
   expect(useIdleStore.getState().rewardSlotLedger).toStrictEqual([]);
 
   expect(useIdleStore.getState().checkpointStreamError).toStrictEqual({

--- a/libs/game/idle-client/src/state/set-connection-status.test.ts
+++ b/libs/game/idle-client/src/state/set-connection-status.test.ts
@@ -4,7 +4,10 @@ import { useIdleStore } from './use-idle-store';
 
 test('it replaces the stored connection status wholesale', () => {
   setConnectionStatus(false);
+
   expect(useIdleStore.getState().connectionOnline).toBeFalse();
+
   setConnectionStatus(true);
+
   expect(useIdleStore.getState().connectionOnline).toBeTrue();
 });

--- a/libs/game/idle-client/src/state/set-failure-action.test.ts
+++ b/libs/game/idle-client/src/state/set-failure-action.test.ts
@@ -5,7 +5,10 @@ import { useIdleStore } from './use-idle-store';
 
 test('it replaces the stored failure action wholesale', () => {
   setFailureAction(ActivityFailureAction.Retry);
+
   expect(useIdleStore.getState().failureAction).toBe(ActivityFailureAction.Retry);
+
   setFailureAction(ActivityFailureAction.Abort);
+
   expect(useIdleStore.getState().failureAction).toBe(ActivityFailureAction.Abort);
 });

--- a/libs/game/idle-client/src/state/set-resync-status.test.ts
+++ b/libs/game/idle-client/src/state/set-resync-status.test.ts
@@ -12,5 +12,6 @@ test('it replaces the stored resync status wholesale, including clearing it', ()
   });
 
   setResyncStatus(null);
+
   expect(useIdleStore.getState().resyncStatus).toBeNull();
 });

--- a/libs/game/idle-client/src/state/set-simulation-initialized.test.ts
+++ b/libs/game/idle-client/src/state/set-simulation-initialized.test.ts
@@ -7,6 +7,7 @@ test('it updates the simulation initialized state', () => {
   const hook = renderHook(() => useSimulationInitialized());
 
   expect(hook.result.current).toBeFalse();
+
   setSimulationInitialized(true);
 
   hook.rerender();

--- a/libs/game/idle-client/src/state/set-simulation-snapshot.test.ts
+++ b/libs/game/idle-client/src/state/set-simulation-snapshot.test.ts
@@ -17,6 +17,7 @@ test('it applies a whole snapshot in one update', () => {
   });
 
   unsubscribe();
+
   expect(notifications).toBe(1);
   expect(useIdleStore.getState().combat).toStrictEqual({ elapsed: 1000 });
   expect(useIdleStore.getState().failureAction).toBe(ActivityFailureAction.Retry);
@@ -31,6 +32,7 @@ test('it clears fields the snapshot omits', () => {
   });
 
   setSimulationSnapshot({ failureAction: ActivityFailureAction.Abort });
+
   expect(useIdleStore.getState().activity).toBeNull();
   expect(useIdleStore.getState().avatar).toBeNull();
   expect(useIdleStore.getState().combat).toBeNull();

--- a/libs/game/idle-client/src/state/set-writer-displaced-activity-id.test.ts
+++ b/libs/game/idle-client/src/state/set-writer-displaced-activity-id.test.ts
@@ -4,7 +4,10 @@ import { useIdleStore } from './use-idle-store';
 
 test('it replaces the stored displaced activity wholesale, including clearing it', () => {
   setWriterDisplacedActivityID('activity-1');
+
   expect(useIdleStore.getState().writerDisplacedActivityID).toBe('activity-1');
+
   setWriterDisplacedActivityID(null);
+
   expect(useIdleStore.getState().writerDisplacedActivityID).toBeNull();
 });

--- a/libs/game/idle-client/src/state/update-reward-slot-ledger.test.ts
+++ b/libs/game/idle-client/src/state/update-reward-slot-ledger.test.ts
@@ -28,6 +28,7 @@ test('it drops a message naming an activity the ledger was not built for', () =>
   });
 
   updateRewardSlotLedger({ activityID: 'activity_2', count: 4, version: 1 });
+
   expect(useIdleStore.getState().rewardSlotLedger).toStrictEqual([{ count: 2, version: 1 }]);
   expect(useIdleStore.getState().rewardSlotLedgerActivityID).toBe('activity_1');
 });
@@ -41,6 +42,7 @@ test('it installs the first entry when the ledger has no activity and the messag
   });
 
   updateRewardSlotLedger({ activityID: 'activity_1', count: 2, version: 1 });
+
   expect(useIdleStore.getState().rewardSlotLedger).toStrictEqual([{ count: 2, version: 1 }]);
   expect(useIdleStore.getState().rewardSlotLedgerActivityID).toBe('activity_1');
 });
@@ -53,5 +55,6 @@ test('it ignores a message while the stream for that activity is rejected', () =
   });
 
   updateRewardSlotLedger({ activityID: 'activity_1', count: 2, version: 1 });
+
   expect(useIdleStore.getState().rewardSlotLedger).toStrictEqual([]);
 });

--- a/libs/game/idle-client/src/worker/apply-eviction.test.ts
+++ b/libs/game/idle-client/src/worker/apply-eviction.test.ts
@@ -20,6 +20,7 @@ test('it clears the displaced live simulation and broadcasts the displacement', 
   context.setSimulation(createSimulation());
 
   applyEviction(context, activity.id);
+
   expect(context.getActivity()).toBeNull();
   expect(context.getWriterDisplacedActivityID()).toBe(activity.id);
 
@@ -41,6 +42,7 @@ test('it leaves an unrelated live run untouched while still recording the displa
   context.setActivity(liveActivity);
 
   applyEviction(context, 'some-other-activity');
+
   expect(context.getActivity()).toStrictEqual(liveActivity);
   expect(context.getWriterDisplacedActivityID()).toBe('some-other-activity');
 });
@@ -53,6 +55,7 @@ test('it skips entirely once a registration has superseded the eviction', async 
   context.setActivity(activity);
 
   applyEviction(context, activity.id);
+
   expect(context.getActivity()).toStrictEqual(activity);
   expect(context.getWriterDisplacedActivityID()).toBeNull();
 

--- a/libs/game/idle-client/src/worker/create-worker-runtime.test.ts
+++ b/libs/game/idle-client/src/worker/create-worker-runtime.test.ts
@@ -208,6 +208,7 @@ test('it resumes into a fresh row once a same-row CONFLICT resync drains a held 
       );
 
       invariant(minted !== undefined, 'expected the same-row CONFLICT resync to mint a fresh row');
+
       expect(minted.id).not.toBe(activity.id);
     },
 
@@ -219,6 +220,7 @@ test('it resumes into a fresh row once a same-row CONFLICT resync drains a held 
   const closed = db.activityCollection.findFirst((q) => q.where({ id: activity.id }));
 
   invariant(closed !== undefined, 'expected the seeded activity to still exist');
+
   expect(closed.status).toBe('stopped');
 });
 
@@ -291,12 +293,14 @@ test('it resumes into a fresh row once a reconnect drains a held terminal append
     );
 
     invariant(minted !== undefined, 'expected the reconnect resync to mint a fresh row');
+
     expect(minted.id).not.toBe(activity.id);
   });
 
   const closed = db.activityCollection.findFirst((q) => q.where({ id: activity.id }));
 
   invariant(closed !== undefined, 'expected the seeded activity to still exist');
+
   expect(closed.status).toBe('stopped');
 });
 
@@ -354,6 +358,7 @@ test("it resumes the held start intent's avatar on reconnect over an earlier ava
     );
 
     invariant(minted !== undefined, 'expected the reconnect to resume the pending avatar');
+
     expect(minted.id).not.toBe(source.id);
   });
 });
@@ -441,6 +446,7 @@ test('it recovers a stop parked offline once a flush answer proves the connectio
       const stopped = db.activityCollection.findFirst((q) => q.where({ id: other.id }));
 
       invariant(stopped !== undefined, "expected the parked stop's row to survive");
+
       expect(stopped.status).toBe('stopped');
     },
 

--- a/libs/game/idle-client/src/worker/flush-pending-start.test.ts
+++ b/libs/game/idle-client/src/worker/flush-pending-start.test.ts
@@ -48,6 +48,7 @@ test('it mints the continued row and releases the intent', async () => {
 
   invariant(minted !== undefined, 'expected the delivery to mint an active row');
   invariant(result.outcome === 'delivered', 'expected the flush to deliver');
+
   expect(result.started.id).toBe(minted.id);
   expect(minted.scopeID).toBe(source.scopeID);
   expect(context.getSimulation().activity).toBeNull();
@@ -126,6 +127,7 @@ test('it releases a stale intent when a different claim owns the avatar', async 
   const survivor = db.activityCollection.findFirst((q) => q.where({ id: foreign.id }));
 
   invariant(survivor !== undefined, 'expected the foreign claim to survive');
+
   expect(survivor.status).toBe('active');
 });
 
@@ -299,6 +301,7 @@ test('it stops the minted row back when a stop lands while the start is in fligh
   );
 
   invariant(minted !== undefined, 'expected the minted row to survive');
+
   expect(minted.status).toBe('stopped');
 
   const heldStop = await readPendingStopIntent();

--- a/libs/game/idle-client/src/worker/flush-pending-stop.test.ts
+++ b/libs/game/idle-client/src/worker/flush-pending-stop.test.ts
@@ -45,6 +45,7 @@ test('it flushes the queue, stops the row, and releases the intent', async () =>
   const row = db.activityCollection.findFirst((q) => q.where({ id: activity.id }));
 
   invariant(row !== undefined, 'expected the targeted row to survive');
+
   expect(row.status).toBe('stopped');
 
   const intent = await readPendingStopIntent();
@@ -95,6 +96,7 @@ test('it never touches a row other than the targeted one', async () => {
   const survivor = db.activityCollection.findFirst((q) => q.where({ id: newer.id }));
 
   invariant(survivor !== undefined, 'expected the newer row to survive');
+
   expect(survivor.status).toBe('active');
 });
 
@@ -166,5 +168,6 @@ test('it releases a stop another writer superseded, leaving the row active', asy
   const row = db.activityCollection.findFirst((q) => q.where({ id: activity.id }));
 
   invariant(row !== undefined, 'expected the targeted row to survive');
+
   expect(row.status).toBe('active');
 });

--- a/libs/game/idle-client/src/worker/handle-disconnect-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-disconnect-message.test.ts
@@ -8,6 +8,7 @@ test('it removes the port from the connections set', () => {
   const context = createStubWorkerContext({ connections: [channel.port2] });
 
   handleDisconnectMessage(context, channel.port2);
+
   expect(context.connections.has(channel.port2)).toBeFalse();
 });
 

--- a/libs/game/idle-client/src/worker/handle-initialize-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-initialize-message.test.ts
@@ -84,6 +84,7 @@ test('it does not create a new simulation if one already exists', () => {
   };
 
   handleInitializeMessage(context, message);
+
   expect(context.getSimulation()).toBe(existingSimulation);
 });
 

--- a/libs/game/idle-client/src/worker/handle-start-activity-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-start-activity-message.test.ts
@@ -59,6 +59,7 @@ test('it mints a row, installs it, and broadcasts the started status', async () 
   );
 
   invariant(minted !== undefined, 'expected the start to mint an active row');
+
   expect(minted.scopeID).toBe('a9lp75');
   expect(minted.startKey).toBe(message.requestID);
   expect(context.getSimulation()?.activity?.id).toBe(minted.id);
@@ -78,8 +79,11 @@ test('it mints a row, installs it, and broadcasts the started status', async () 
   );
 
   invariant(report?.type === WorkerMessageType.StartStatus, 'expected a start status broadcast');
+
   expect(report.requestID).toBe(message.requestID);
+
   invariant(report.status.kind === 'started', 'expected a started status');
+
   expect(report.status.activity.id).toBe(minted.id);
 });
 
@@ -102,6 +106,7 @@ test('it installs a simulation even when none was initialized yet', async () => 
   );
 
   invariant(minted !== undefined, 'expected the start to mint an active row');
+
   expect(context.getSimulation()?.activity?.id).toBe(minted.id);
 });
 
@@ -150,8 +155,11 @@ test('it answers a duplicate delivery with the row the first attempt minted', as
   );
 
   invariant(report?.type === WorkerMessageType.StartStatus, 'expected a start status broadcast');
+
   expect(report.requestID).toBe(message.requestID);
+
   invariant(report.status.kind === 'started', 'expected a started status');
+
   expect(report.status.activity.id).toBe(existing.id);
 });
 
@@ -223,6 +231,7 @@ test('it flushes and stops a different scope before starting the requested one',
   const stopped = db.activityCollection.findFirst((q) => q.where({ id: previous.id }));
 
   invariant(stopped !== undefined, 'expected the previous row to survive');
+
   expect(stopped.status).toBe('stopped');
   expect(submitter.flushNow).toHaveBeenCalledExactlyOnceWith(previous.id);
 
@@ -231,6 +240,7 @@ test('it flushes and stops a different scope before starting the requested one',
   );
 
   invariant(minted !== undefined, 'expected the start to mint an active row');
+
   expect(minted.scopeID).toBe('a9lp75');
   expect(context.getSimulation()?.activity?.id).toBe(minted.id);
 });
@@ -279,6 +289,7 @@ test('it stops the minted row back when a stop lands mid-start', async () => {
   const row = db.activityCollection.findFirst((q) => q.where({ id: minted.id }));
 
   invariant(row !== undefined, 'expected the minted row to survive');
+
   expect(row.status).toBe('stopped');
   expect(context.getActivity()).toBeNull();
 
@@ -333,6 +344,7 @@ test('it abandons a superseded request without touching the fresher claim', asyn
   const row = db.activityCollection.findFirst((q) => q.where({ id: minted.id }));
 
   invariant(row !== undefined, 'expected the minted row to survive');
+
   expect(row.status).toBe('active');
   expect(context.getActivity()).toBeNull();
 });
@@ -455,7 +467,9 @@ test('it runs interleaved starts one at a time, the fresher claim winning', asyn
   );
 
   expect(active).toHaveLength(1);
+
   invariant(active[0] !== undefined, 'expected one active row');
+
   expect(active[0].scopeID).toBe('a9lp75');
   expect(context.getActivity()?.id).toBe(active[0].id);
 });
@@ -513,6 +527,7 @@ test('it takes over and stops a different scope another writer owns before start
   const stopped = db.activityCollection.findFirst((q) => q.where({ id: previous.id }));
 
   invariant(stopped !== undefined, 'expected the previous row to survive');
+
   expect(stopped.status).toBe('stopped');
 
   const minted = db.activityCollection.findFirst((q) =>
@@ -520,6 +535,7 @@ test('it takes over and stops a different scope another writer owns before start
   );
 
   invariant(minted !== undefined, 'expected the start to mint an active row');
+
   expect(minted.scopeID).toBe('a9lp75');
   expect(context.getSimulation()?.activity?.id).toBe(minted.id);
 });

--- a/libs/game/idle-client/src/worker/handle-stop-activity-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-stop-activity-message.test.ts
@@ -153,6 +153,7 @@ test('it delivers the targeted server stop and releases the intent', async () =>
   const stopped = db.activityCollection.findFirst((q) => q.where({ id: row.id }));
 
   invariant(stopped !== undefined, 'expected the targeted row to survive');
+
   expect(stopped.status).toBe('stopped');
   expect(submitter.flushNow).toHaveBeenCalledExactlyOnceWith(row.id);
 
@@ -208,6 +209,7 @@ test('it halts nothing but still delivers when no simulation is installed', asyn
   const stopped = db.activityCollection.findFirst((q) => q.where({ id: row.id }));
 
   invariant(stopped !== undefined, 'expected the targeted row to survive');
+
   expect(stopped.status).toBe('stopped');
 });
 

--- a/libs/game/idle-client/src/worker/run-continuation.test.ts
+++ b/libs/game/idle-client/src/worker/run-continuation.test.ts
@@ -52,6 +52,7 @@ test('it adopts a fresh server-started row for the same scope and registers from
   );
 
   invariant(minted !== undefined, 'expected the continuation to mint an active row');
+
   expect(minted.scopeID).toBe(previousActivity.scopeID);
   expect(simulation.activity?.id).toBe(minted.id);
   expect(context.getActivity()).toStrictEqual(minted);
@@ -268,6 +269,7 @@ test('it stops the row it started when a stop lands mid-flight', async () => {
   const row = db.activityCollection.findFirst((q) => q.where({ id: started.id }));
 
   invariant(row !== undefined, 'expected the started row to survive');
+
   expect(row.status).toBe('stopped');
 
   const intent = await readPendingStopIntent();

--- a/libs/game/idle-client/src/worker/run-reconnect-recovery.test.ts
+++ b/libs/game/idle-client/src/worker/run-reconnect-recovery.test.ts
@@ -46,6 +46,7 @@ test("it resyncs the held start intent's avatar over the reported one", async ()
   );
 
   invariant(minted !== undefined, "expected the drain to mint the intent avatar's next row");
+
   expect(minted.id).not.toBe(source.id);
   expect(ctx.context.getResyncAvatarID()).toBe(avatar.id);
 });
@@ -151,6 +152,7 @@ test('it delivers a stop raised offline even when no resync follows', async () =
   const stopped = db.activityCollection.findFirst((q) => q.where({ id: row.id }));
 
   invariant(stopped !== undefined, 'expected the targeted row to survive');
+
   expect(stopped.status).toBe('stopped');
 
   const intent = await readPendingStopIntent();

--- a/libs/game/idle-client/src/worker/run-resync-turn.test.ts
+++ b/libs/game/idle-client/src/worker/run-resync-turn.test.ts
@@ -418,6 +418,7 @@ test('it fast-forwards a short gap, broadcasts progress and final tallies, and i
   );
 
   invariant(minted !== undefined, 'expected the fast-forward to mint an active continuation');
+
   expect(minted.id).not.toBe(activity.id);
 
   const simulation = ctx.context.getSimulation();
@@ -590,6 +591,7 @@ test('it flushes a dirty local failure action to the server during resync, clear
   const updatedAvatar = db.avatarCollection.findFirst((q) => q.where({ id: viewer.avatar.id }));
 
   invariant(updatedAvatar !== undefined, 'expected the seeded avatar to still exist');
+
   expect(updatedAvatar.failureAction).toBe('retry');
 });
 
@@ -661,6 +663,7 @@ test("it starts a fresh row, installs a live simulation with the worker's failur
   );
 
   invariant(minted !== undefined, 'expected the drained intent to mint a fresh row');
+
   expect(minted.scopeID).toBe(stopped.scopeID);
 
   const simulation = ctx.context.getSimulation();
@@ -714,6 +717,7 @@ test('it attaches the foreign row that races in ahead of the continuation', asyn
   );
 
   invariant(racing !== undefined, 'expected the racing row to survive');
+
   expect(installed.activity?.id).toBe(racing.id);
 
   const heldIntent = await readPendingStartIntent();
@@ -953,6 +957,7 @@ test('it stops back an attach-live row when a stop lands during its registration
   const stoppedBack = db.activityCollection.findFirst((q) => q.where({ id: row.id }));
 
   invariant(stoppedBack !== undefined, 'expected the targeted row to survive');
+
   expect(stoppedBack.status).toBe('stopped');
 });
 
@@ -989,6 +994,7 @@ test('it delivers a blocked intent after the pass closes its source row and atta
   );
 
   invariant(minted !== undefined, 'expected the retried intent to mint a fresh row');
+
   expect(minted.id).not.toBe(source.id);
 
   const installed = ctx.context.getSimulation();
@@ -1138,6 +1144,7 @@ test('it delivers the held stop before planning, leaving the stopped run cleared
   const stopped = db.activityCollection.findFirst((q) => q.where({ id: row.id }));
 
   invariant(stopped !== undefined, 'expected the targeted row to survive');
+
   expect(stopped.status).toBe('stopped');
 
   const intent = await readPendingStopIntent();

--- a/libs/game/idle-client/src/worker/run-simulation.test.ts
+++ b/libs/game/idle-client/src/worker/run-simulation.test.ts
@@ -77,6 +77,7 @@ test('it continues into a fresh server-started row if it fails and the failure a
   );
 
   invariant(minted !== undefined, 'the continuation minted an active row');
+
   expect(startedSpy).toHaveBeenCalled();
   expect(simulation.activity).not.toBeNull();
   expect(minted.scopeID).toBe(sourceRow.scopeID);
@@ -148,6 +149,7 @@ test.each([[ActivityFailureAction.Abort], [ActivityFailureAction.Retry]])(
     );
 
     invariant(minted !== undefined, 'the continuation minted an active row');
+
     expect(startedSpy).toHaveBeenCalled();
     expect(simulation.activity).not.toBe(startingActivity);
     expect(context.getActivity()).toStrictEqual(minted);

--- a/libs/game/idle-client/src/worker/submit-stop-intent.test.ts
+++ b/libs/game/idle-client/src/worker/submit-stop-intent.test.ts
@@ -22,6 +22,7 @@ test('it delivers the targeted stop and leaves no intent held', async () => {
   const stopped = db.activityCollection.findFirst((q) => q.where({ id: row.id }));
 
   invariant(stopped !== undefined, 'expected the targeted row to survive');
+
   expect(stopped.status).toBe('stopped');
 
   const intent = await readPendingStopIntent();

--- a/libs/game/idle-client/src/worker/update-writer-displaced-status.test.ts
+++ b/libs/game/idle-client/src/worker/update-writer-displaced-status.test.ts
@@ -9,6 +9,7 @@ test('it records the displacement and broadcasts it to every connection', async 
   const context = createStubWorkerContext({ connections: [connection.port] });
 
   updateWriterDisplacedStatus(context, 'activity-1');
+
   expect(context.getWriterDisplacedActivityID()).toBe('activity-1');
 
   await connection.waitForMessages(1);

--- a/libs/game/idle-client/test-setup.ts
+++ b/libs/game/idle-client/test-setup.ts
@@ -15,6 +15,7 @@ MC4CAQAwBQYDK2VwBCIEIBMom57erggdVdDCIdRWS+NKMykK+I5BUKpuHziAq+0W
 -----END PRIVATE KEY-----`;
 
 GlobalRegistrator.register();
+
 expect.extend(jestDOMMatchers);
 
 // installs the zustand `create` wrapper before any store module below imports it; bun runs every

--- a/libs/game/idle-core/src/behaviours/avatar-weapon-attack/handle-tick.test.ts
+++ b/libs/game/idle-core/src/behaviours/avatar-weapon-attack/handle-tick.test.ts
@@ -40,11 +40,13 @@ test('it schedules attacks on the tick event', () => {
   combatExecutor.run(1000);
 
   handleTick(avatar, behaviour, combatExecutor);
+
   expect(wave?.remaining).toBe(1);
 
   combatExecutor.run(1);
 
   handleTick(avatar, behaviour, combatExecutor);
+
   expect(wave?.remaining).toBe(0);
   expect(behaviour.state.lastAttackTime).toBe(1000);
 });

--- a/libs/game/idle-core/src/behaviours/enemy-primary-attack/handle-tick.test.ts
+++ b/libs/game/idle-core/src/behaviours/enemy-primary-attack/handle-tick.test.ts
@@ -36,11 +36,13 @@ test('it schedules attacks on the tick event', () => {
   combatExecutor.run(1000);
 
   handleTick(enemy, behaviour, combatExecutor);
+
   expect(avatar.status).toBe(EntityStatus.Alive);
 
   combatExecutor.run(1);
 
   handleTick(enemy, behaviour, combatExecutor);
+
   expect(avatar.status).toBe(EntityStatus.Dead);
   expect(behaviour.state.lastAttackTime).toBe(1000);
 });

--- a/libs/game/idle-core/src/core/build-simulation-input.test.ts
+++ b/libs/game/idle-core/src/core/build-simulation-input.test.ts
@@ -115,6 +115,7 @@ test('it returns a fresh encounter and weapon on every call, never a shared refe
   const secondEnemy = second.activity.encounter.waves[0]?.[0];
 
   invariant(firstEnemy && secondEnemy, 'derived encounters must open with a populated wave');
+
   expect(firstEnemy).not.toBe(secondEnemy);
 
   expect(first.avatar.paperdoll[EquipmentSlot.MainHand]).not.toBe(

--- a/libs/game/idle-core/src/core/handle-enemy-attack.test.ts
+++ b/libs/game/idle-core/src/core/handle-enemy-attack.test.ts
@@ -38,6 +38,7 @@ test('it applies damage from the enemy to the avatar', () => {
   };
 
   handleEnemyAttack(event, avatar, activity);
+
   expect(avatar.life).toBe(90);
 });
 
@@ -73,6 +74,7 @@ test('it does nothing if the enemy is dead', () => {
   };
 
   handleEnemyAttack(event, avatar, activity);
+
   expect(avatar.life).toBe(100);
 });
 
@@ -113,5 +115,6 @@ test('it correctly resolves the correct event source', () => {
   firstEnemy.receiveDamage(100);
 
   handleEnemyAttack(event, avatar, activity);
+
   expect(avatar.life).toBe(100);
 });

--- a/libs/game/idle-core/src/entities/utils/handle-receive-avatar-damage.test.ts
+++ b/libs/game/idle-core/src/entities/utils/handle-receive-avatar-damage.test.ts
@@ -11,6 +11,7 @@ test('it reduces the life of the entity by the amount of damage received', () =>
   const avatar = createAvatar(avatarData, ctx);
 
   handleReceiveAvatarDamage(10, avatar);
+
   expect(avatar.life).toBe(90);
 });
 
@@ -20,6 +21,7 @@ test('it sets the status to dead if the life is 0 or less', () => {
   const avatar = createAvatar(avatarData, ctx);
 
   handleReceiveAvatarDamage(100, avatar);
+
   expect(avatar.status).toBe(EntityStatus.Dead);
 });
 
@@ -29,5 +31,6 @@ test('it does not reduce the life below 0', () => {
   const avatar = createAvatar(avatarData, ctx);
 
   handleReceiveAvatarDamage(100, avatar);
+
   expect(avatar.life).toBe(0);
 });

--- a/libs/game/idle-core/src/entities/utils/handle-receive-enemy-damage.test.ts
+++ b/libs/game/idle-core/src/entities/utils/handle-receive-enemy-damage.test.ts
@@ -11,6 +11,7 @@ test('it reduces the life of the entity by the amount of damage received', () =>
   const enemy = createEnemy(data, ctx);
 
   handleReceiveEnemyDamage(10, enemy);
+
   expect(enemy.life).toBe(90);
 });
 
@@ -20,6 +21,7 @@ test('it sets the status to dead if the life is 0 or less', () => {
   const enemy = createEnemy(data, ctx);
 
   handleReceiveEnemyDamage(100, enemy);
+
   expect(enemy.status).toBe(EntityStatus.Dead);
 });
 
@@ -29,5 +31,6 @@ test('it does not reduce the life below 0', () => {
   const enemy = createEnemy(data, ctx);
 
   handleReceiveEnemyDamage(100, enemy);
+
   expect(enemy.life).toBe(0);
 });

--- a/libs/game/worldmap-client/src/state/set-selected-node.test.ts
+++ b/libs/game/worldmap-client/src/state/set-selected-node.test.ts
@@ -22,5 +22,6 @@ test('it clears the object reference when a node is selected without one', () =>
   const node = createMockWorldMapNode({ id: 'node2', position: [0, 0] });
 
   setSelectedNode(node);
+
   expect(useWorldmapStore.getState().selectedObject3D).toBeNull();
 });

--- a/libs/game/worldmap-client/src/state/toggle-axes-helper.test.ts
+++ b/libs/game/worldmap-client/src/state/toggle-axes-helper.test.ts
@@ -7,11 +7,13 @@ test('it toggles axes helper visibility', () => {
   const hook = renderHook(() => useIsAxesHelperVisible());
 
   expect(hook.result.current).toBeFalse();
+
   toggleAxesHelper();
 
   hook.rerender();
 
   expect(hook.result.current).toBeTrue();
+
   toggleAxesHelper();
 
   hook.rerender();

--- a/libs/game/worldmap-client/src/state/toggle-dev-camera.test.ts
+++ b/libs/game/worldmap-client/src/state/toggle-dev-camera.test.ts
@@ -7,11 +7,13 @@ test('it toggles dev camera state from false to true', () => {
   const hook = renderHook(() => useIsDevCameraActive());
 
   expect(hook.result.current).toBeFalse();
+
   toggleDevCamera();
 
   hook.rerender();
 
   expect(hook.result.current).toBeTrue();
+
   toggleDevCamera();
 
   hook.rerender();

--- a/libs/game/worldmap-client/test-setup.ts
+++ b/libs/game/worldmap-client/test-setup.ts
@@ -4,6 +4,7 @@ import * as jestDOMMatchers from '@testing-library/jest-dom/matchers';
 import { registerZustandReset } from '@vers/client-test-utils';
 
 GlobalRegistrator.register();
+
 expect.extend(jestDOMMatchers);
 
 // installs the zustand `create` wrapper before any store module below imports it; bun runs every

--- a/libs/service/jobs/src/create-job-queue.test.ts
+++ b/libs/service/jobs/src/create-job-queue.test.ts
@@ -434,5 +434,6 @@ test('it runs each drained job inside its own trace context', async () => {
 
   invariant(firstTraceID !== undefined, 'the first job ran inside a trace context');
   invariant(secondTraceID !== undefined, 'the second job ran inside a trace context');
+
   expect(firstTraceID).not.toBe(secondTraceID);
 });

--- a/libs/service/service-runtime/src/create-service.test.ts
+++ b/libs/service/service-runtime/src/create-service.test.ts
@@ -110,6 +110,7 @@ test('it parses a service-specific envShape variable onto env', async () => {
 
   expectTypeOf(service.env.PORT).toEqualTypeOf<number>();
   expectTypeOf(service.env.CUSTOM_GREETING).toEqualTypeOf<string>();
+
   expect(service.env.CUSTOM_GREETING).toBe('hi there');
 });
 
@@ -469,6 +470,7 @@ test('it reports the OTel span trace id as x-trace-id when no traceparent came i
 
   invariant(result.traceID !== null, 'expected an active span inside the handler');
   invariant(response !== undefined, 'expected the RPC response to be captured');
+
   expect(result.traceID).toMatch(/^[0-9a-f]{32}$/);
   expect(response.headers.get('x-trace-id')).toBe(result.traceID);
 });

--- a/libs/testing/mock-services/src/create-authed-service-client.test.ts
+++ b/libs/testing/mock-services/src/create-authed-service-client.test.ts
@@ -50,6 +50,7 @@ test("it mints a client whose calls carry the user's bearer token to the service
   const result = await client.echoAuthorization({});
 
   invariant(result.authorization !== null, 'expected the call to carry an authorization header');
+
   expect(result.authorization).toStartWith('Bearer ');
 
   const payload = jose.decodeJwt(result.authorization.slice('Bearer '.length));

--- a/libs/testing/mock-services/src/resolve-service-url.test.ts
+++ b/libs/testing/mock-services/src/resolve-service-url.test.ts
@@ -8,5 +8,6 @@ test('it falls back to the dev port when no env var is set', () => {
 
 test('it prefers the service env var', () => {
   updateEnv('ACTIVITY_SERVICE_URL', 'http://activity.internal:9000');
+
   expect(resolveServiceURL('activity')).toBe('http://activity.internal:9000');
 });

--- a/libs/testing/test-utils/src/bun/register-bun-test-cleanup.test.ts
+++ b/libs/testing/test-utils/src/bun/register-bun-test-cleanup.test.ts
@@ -6,6 +6,7 @@ import { updateEnv } from './update-env';
 
 test('it overrides an env var for this test only', () => {
   updateEnv('REGISTER_BUN_TEST_CLEANUP_PROBE', 'overridden');
+
   expect(process.env['REGISTER_BUN_TEST_CLEANUP_PROBE']).toBe('overridden');
 });
 

--- a/libs/testing/test-utils/src/bun/remove-env-overrides.test.ts
+++ b/libs/testing/test-utils/src/bun/remove-env-overrides.test.ts
@@ -7,6 +7,7 @@ test('it restores a previously-set var to its original value', () => {
 
   updateEnv('ENV_OVERRIDES_TEST_RESTORE', 'overridden');
   removeEnvOverrides();
+
   expect(process.env['ENV_OVERRIDES_TEST_RESTORE']).toBe('original');
   delete process.env['ENV_OVERRIDES_TEST_RESTORE'];
 });
@@ -15,5 +16,6 @@ test('it deletes a previously-unset var rather than leaving it overridden', () =
   delete process.env['ENV_OVERRIDES_TEST_UNSET'];
   updateEnv('ENV_OVERRIDES_TEST_UNSET', 'overridden');
   removeEnvOverrides();
+
   expect(process.env['ENV_OVERRIDES_TEST_UNSET']).toBeUndefined();
 });

--- a/libs/testing/test-utils/src/bun/update-env.test.ts
+++ b/libs/testing/test-utils/src/bun/update-env.test.ts
@@ -4,7 +4,9 @@ import { updateEnv } from './update-env';
 
 test('it overrides an env var for the duration of the override', () => {
   updateEnv('ENV_OVERRIDES_TEST_OVERRIDE', 'overridden');
+
   expect(process.env['ENV_OVERRIDES_TEST_OVERRIDE']).toBe('overridden');
+
   removeEnvOverrides();
 });
 
@@ -12,8 +14,11 @@ test('it unsets an env var for the duration of the override', () => {
   process.env['ENV_OVERRIDES_TEST_UNSET'] = 'original';
 
   updateEnv('ENV_OVERRIDES_TEST_UNSET', undefined);
+
   expect(process.env['ENV_OVERRIDES_TEST_UNSET']).toBeUndefined();
+
   removeEnvOverrides();
+
   expect(process.env['ENV_OVERRIDES_TEST_UNSET']).toBe('original');
   delete process.env['ENV_OVERRIDES_TEST_UNSET'];
 });
@@ -24,6 +29,7 @@ test('it keeps the first recorded original across repeated overrides of the same
   updateEnv('ENV_OVERRIDES_TEST_REPEATED', 'overridden-once');
   updateEnv('ENV_OVERRIDES_TEST_REPEATED', 'overridden-twice');
   removeEnvOverrides();
+
   expect(process.env['ENV_OVERRIDES_TEST_REPEATED']).toBe('first-original');
   delete process.env['ENV_OVERRIDES_TEST_REPEATED'];
 });

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
       "@vitejs/plugin-rsc": "0.5.27",
       "@zgeoff/bun-test-extended": "0.0.3",
       "@zgeoff/dbhub": "0.23.4",
-      "@zgeoff/format-codemod": "0.0.6",
+      "@zgeoff/format-codemod": "0.0.8",
       "@zgeoff/oxlint-config": "0.0.6",
       "autoprefixer": "10.5.2",
       "babel-plugin-react-compiler": "1.0.0",

--- a/services/replay/src/metrics/record-backlog-claimed.test.ts
+++ b/services/replay/src/metrics/record-backlog-claimed.test.ts
@@ -42,6 +42,7 @@ test('it records one drain cycle backlog count', async () => {
     .find((metric) => metric.descriptor.name === 'vers.replay.backlog_claimed');
 
   invariant(histogram?.dataPointType === DataPointType.HISTOGRAM, 'expected a histogram metric');
+
   expect(histogram.dataPoints[0]?.value.sum).toBe(4);
 });
 

--- a/services/replay/src/metrics/record-drain-duration.test.ts
+++ b/services/replay/src/metrics/record-drain-duration.test.ts
@@ -42,6 +42,7 @@ test('it records one drain cycle duration', async () => {
     .find((metric) => metric.descriptor.name === 'vers.replay.drain_duration');
 
   invariant(histogram?.dataPointType === DataPointType.HISTOGRAM, 'expected a histogram metric');
+
   expect(histogram.dataPoints[0]?.value.sum).toBe(1.5);
 });
 

--- a/services/replay/src/metrics/record-verification-lag.test.ts
+++ b/services/replay/src/metrics/record-verification-lag.test.ts
@@ -42,6 +42,7 @@ test('it records one verified append lag reading', async () => {
     .find((metric) => metric.descriptor.name === 'vers.replay.verification_lag');
 
   invariant(histogram?.dataPointType === DataPointType.HISTOGRAM, 'expected a histogram metric');
+
   expect(histogram.dataPoints[0]?.value.sum).toBe(12.5);
 });
 

--- a/services/replay/src/worker/run-frontier.test.ts
+++ b/services/replay/src/worker/run-frontier.test.ts
@@ -108,6 +108,7 @@ test('it settles the terminal checkpoint reward into the avatar xp and level on 
   const terminal = fixture.engineCheckpoints.at(-1);
 
   invariant(terminal !== undefined, 'the fixture always ends on a checkpoint');
+
   expect(terminal.rewards.xp).toBeGreaterThan(0);
 
   // a non-zero baseline distinguishes the delta add from an absolute overwrite


### PR DESCRIPTION
## Description

Bumps `@zgeoff/format-codemod` to 0.0.8, which adds an `expect` statement kind: runs of assertions stay glued while the boundary with any acting statement takes a blank line. The reformat across 73 test files is `bun run format` under the new rule.

- Whitespace-only changes outside `package.json`/`bun.lock`
- Local `bun test` failures match main's baseline (DB-backed suites without local infra) — CI is ground truth

## Testing

- [x] `bun run typecheck` passes
- [ ] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality (not applicable — formatting only)