### PR TITLE
fix(web-e2e): retry the create-avatar submit on its navigation outcome

### DIFF
--- a/apps/web-e2e/specs/signup-journey.spec.ts
+++ b/apps/web-e2e/specs/signup-journey.spec.ts
@@ -24,8 +24,9 @@ test('it signs up, creates an avatar, and can navigate the shell to settings and
 
   await expect(page.locator('canvas').first()).toBeVisible();
 
-  // the game canvas's initial scene setup blocks the main thread for a variable stretch, long
-  // enough that a click fired mid-block is silently dropped — retry until the nav visibly opens
+  // a click fired while the main thread is blocked is silently dropped — the game shell's
+  // hydration always costs a variable stretch, and the canvas's scene setup adds more in suites
+  // that run with the renderer flag on — so retry until the nav visibly opens
   await expect(async () => {
     await page.getByRole('link', { exact: true, name: 'Settings' }).click();
 
@@ -147,7 +148,7 @@ async function runSignUpIntoGame(page: Page, journey: Readonly<SignUpJourney>): 
     }
 
     await expect(page).toHaveURL(/\/explore$/, { timeout: 5000 });
-  }).toPass({ timeout: 30_000 });
+  }).toPass({ timeout: 20_000 });
 }
 
 /**

--- a/apps/web-e2e/specs/signup-journey.spec.ts
+++ b/apps/web-e2e/specs/signup-journey.spec.ts
@@ -131,18 +131,23 @@ async function runSignUpIntoGame(page: Page, journey: Readonly<SignUpJourney>): 
 
   const nameField = page.getByLabel('Name', { exact: true });
 
-  // the create-avatar form is plain client state (no Conform action) that mounts after hydration;
-  // a fill landing on the still-server-rendered markup gets discarded when hydration takes over —
-  // retry until the typed value survives
+  // the create-avatar form's client mount replaces the server-rendered markup, so a name typed
+  // before the swap passes a value assertion yet submits as an empty form — and gating on the
+  // root hydration marker instead would serialize on the whole game shell, which can take far
+  // longer than the form needs. So the whole fill-and-submit cycle retries on the navigation
+  // outcome: an empty submit is rejected server-side without creating anything, which makes the
+  // retry safe, and the URL guard keeps a slow success from being submitted twice.
   await expect(async () => {
-    await nameField.fill(journey.avatarName);
+    if (new URL(page.url()).pathname !== '/explore') {
+      await nameField.fill(journey.avatarName);
 
-    await expect(nameField).toHaveValue(journey.avatarName, { timeout: 1000 });
-  }).toPass({ timeout: 15_000 });
+      await expect(nameField).toHaveValue(journey.avatarName, { timeout: 1000 });
 
-  await page.getByRole('button', { name: 'Create Avatar' }).click();
+      await page.getByRole('button', { name: 'Create Avatar' }).click();
+    }
 
-  await expect(page).toHaveURL(/\/explore$/, { timeout: 20_000 });
+    await expect(page).toHaveURL(/\/explore$/, { timeout: 5000 });
+  }).toPass({ timeout: 30_000 });
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes the `signup-journey` flake where cold-cache CI runs strand the journey at `/avatars/create`: the create-avatar form's client mount replaces server-rendered markup, so a name typed before the swap passes the value assertion yet submits as an empty form. The fill-and-submit cycle now retries on the navigation outcome.

- Empty submits are rejected server-side without creating anything, so the retry is safe; a URL guard prevents re-submitting a slow success
- Gating on `html[data-hydrated]` instead was tried and rejected — it serializes on full shell hydration, far longer than the form needs
- Stress-validated locally: 8/8 at double CI parallelism (previously 4/8), three clean full-suite runs at CI's 2 workers

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality (not applicable — flake fix in an existing spec)