### PR TITLE
refactor(#744): dedupe resync attach and start-flow helpers

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -181,6 +181,8 @@
           // a structural MessagePort union: no readonly form, the same DOM callback shape as
           // MessagePort/EventListenerOrEventListenerObject below
           { "from": "package", "name": "SupportedMessagePort", "package": "@orpc/client" },
+          // an Error subclass: the same mutable message/stack state as lib Error below
+          { "from": "package", "name": "ORPCError", "package": "@orpc/client" },
           { "from": "package", "name": "SetupServer", "package": "msw" },
           // a response resolver's request context: wraps the live fetch Request; no readonly form
           { "from": "package", "name": "ResponseResolverInfo", "package": "msw" },

--- a/libs/game/idle-client/src/submission/checkpoint-submitter-machine.ts
+++ b/libs/game/idle-client/src/submission/checkpoint-submitter-machine.ts
@@ -75,35 +75,32 @@ export const checkpointSubmitterMachine = setup({
                   }),
                 ],
               ]),
-            evictedActivityIDs: (args) => {
-              if (!args.context.evictedActivityIDs.has(args.event.activityID)) {
-                return args.context.evictedActivityIDs;
-              }
-
-              const next = new Set(args.context.evictedActivityIDs);
-
-              next.delete(args.event.activityID);
-
-              return next;
-            },
+            evictedActivityIDs: (args) =>
+              buildEvictionsWithout(args.context.evictedActivityIDs, args.event.activityID),
           }),
         },
         REMOVE_EVICTION: {
           actions: assign({
-            evictedActivityIDs: (args) => {
-              if (!args.context.evictedActivityIDs.has(args.event.activityID)) {
-                return args.context.evictedActivityIDs;
-              }
-
-              const next = new Set(args.context.evictedActivityIDs);
-
-              next.delete(args.event.activityID);
-
-              return next;
-            },
+            evictedActivityIDs: (args) =>
+              buildEvictionsWithout(args.context.evictedActivityIDs, args.event.activityID),
           }),
         },
       },
     },
   },
 });
+
+function buildEvictionsWithout(
+  evictedActivityIDs: ReadonlySet<string>,
+  activityID: string,
+): ReadonlySet<string> {
+  if (!evictedActivityIDs.has(activityID)) {
+    return evictedActivityIDs;
+  }
+
+  const next = new Set(evictedActivityIDs);
+
+  next.delete(activityID);
+
+  return next;
+}

--- a/libs/game/idle-client/src/submission/create-checkpoint-submitter.ts
+++ b/libs/game/idle-client/src/submission/create-checkpoint-submitter.ts
@@ -410,14 +410,11 @@ export function createCheckpointSubmitter(
 
   const flushHeld = async (): Promise<void> => {
     await Promise.allSettled(
-      [...writeCursors.keys()]
-        .map((activityID) => findChild(activityID))
-        .filter((child) => child !== undefined)
-        .map((child) => {
-          child.send({ type: 'FLUSH_HELD' });
+      [...parentActor.getSnapshot().context.children.values()].map((child) => {
+        child.send({ type: 'FLUSH_HELD' });
 
-          return waitFor(child, (snapshot) => !snapshot.matches('flushing'));
-        }),
+        return waitFor(child, (snapshot) => !snapshot.matches('flushing'));
+      }),
     );
   };
 

--- a/libs/game/idle-client/src/worker/handle-start-activity-message.ts
+++ b/libs/game/idle-client/src/worker/handle-start-activity-message.ts
@@ -1,3 +1,4 @@
+import type { ORPCError } from '@orpc/client';
 import { isDefinedError, safe } from '@orpc/client';
 import type { ActivityData } from '@vers/contract-activity';
 import { handleSetActivityMessage } from './handle-set-activity-message';
@@ -71,16 +72,7 @@ async function runStart(
   // a pure unwind: no row has been minted yet, so there is nothing to compensate
   signals.cancel.throwIfAborted();
 
-  // start calls mint a server row and run unsigned: the response is the only handle on the minted
-  // row, and the stop-back compensation needs it
-  const [error, started] = await safe(
-    context.getClient().startActivity({
-      avatarID: input.avatarID,
-      scopeID: input.scopeID,
-      scopeType: input.scopeType,
-      startKey: token,
-    }),
-  );
+  const [error, started] = await tryStartActivity(context, input, token);
 
   if (error === null) {
     return setLiveStartedRow(context, token, started, signals);
@@ -130,14 +122,7 @@ async function runStart(
     return { kind: 'failed' };
   }
 
-  const [retryError, retried] = await safe(
-    context.getClient().startActivity({
-      avatarID: input.avatarID,
-      scopeID: input.scopeID,
-      scopeType: input.scopeType,
-      startKey: token,
-    }),
-  );
+  const [retryError, retried] = await tryStartActivity(context, input, token);
 
   if (retryError !== null) {
     if (!isDefinedError(retryError)) {
@@ -155,6 +140,33 @@ function isSuperseded(context: WorkerContext, token: string): boolean {
 }
 
 /**
+ * One start-activity mint, deliberately unsigned: the response is the only handle on the minted
+ * row, and the stop-back compensation needs it.
+ */
+function tryStartActivity(
+  context: WorkerContext,
+  input: Readonly<StartActivityInput>,
+  token: string,
+) {
+  return safe(
+    context.getClient().startActivity({
+      avatarID: input.avatarID,
+      scopeID: input.scopeID,
+      scopeType: input.scopeType,
+      startKey: token,
+    }),
+  );
+}
+
+/**
+ * Whether a stop attempt achieved all a stop can: the call succeeded, or `NOT_FOUND` says the row
+ * already left `active`.
+ */
+function isStopSettled(error: Error | null | ORPCError<string, unknown>): boolean {
+  return error === null || (isDefinedError(error) && error.code === 'NOT_FOUND');
+}
+
+/**
  * Stops the different-scope row a replace-flow start conflicts with, reporting whether the row is
  * closed to further appends. A stop rejected with SESSION_EVICTED means another session's writer
  * owns the run — the player's start here is a deliberate act that supersedes it, so this session
@@ -169,7 +181,7 @@ async function stopConflictingRow(
 ): Promise<boolean> {
   const [stopError] = await safe(context.getClient().stopActivity({ activityID, avatarID }));
 
-  if (stopError === null || (isDefinedError(stopError) && stopError.code === 'NOT_FOUND')) {
+  if (isStopSettled(stopError)) {
     return true;
   }
 
@@ -199,7 +211,7 @@ async function stopConflictingRow(
 
   const [retryError] = await safe(context.getClient().stopActivity({ activityID, avatarID }));
 
-  if (retryError === null || (isDefinedError(retryError) && retryError.code === 'NOT_FOUND')) {
+  if (isStopSettled(retryError)) {
     return true;
   }
 

--- a/libs/game/idle-client/src/worker/run-resync-flow.ts
+++ b/libs/game/idle-client/src/worker/run-resync-flow.ts
@@ -18,6 +18,7 @@ import { readFailureActionCache } from '../submission/read-failure-action-cache'
 import { readPendingStartIntent } from '../submission/read-pending-start-intent';
 import { removePendingStartIntent } from '../submission/remove-pending-start-intent';
 import { sweepStaleCheckpoints } from '../submission/sweep-stale-checkpoints';
+import type { ActivitySubmissionContext } from '../submission/types';
 import { writeFailureActionCache } from '../submission/write-failure-action-cache';
 import { WorkerMessageType } from '../types';
 import type { PendingStartFlushResult } from './flush-pending-start';
@@ -142,7 +143,13 @@ async function runResyncPass(
     submitter: context.getSubmitter(),
   });
 
-  await sweepStaleActivities(context, result);
+  try {
+    await sweepStaleCheckpoints(pickKeepActivityIDs(context, result));
+  } catch (error) {
+    // a stranded row costs nothing but disk until the next sweep
+    reportWorkerFault('resync', error);
+  }
+
   await applyResyncResult(context, result, signals);
 
   return result;
@@ -278,31 +285,22 @@ async function updateFailureActionFromServer(
 }
 
 /**
- * Sweeps every queued checkpoint outside the resync's determined latest activity and whichever
- * activity is live at sweep time (its queue is its running writer's pipeline, never stranded
- * work). Nothing else is worth keeping: a worker restart has no delivery path for a stranded row
- * and the server settles rewards authoritatively. Failure only reports the fault — a stranded
- * row costs nothing but disk until the next sweep.
+ * The activities whose queued checkpoints survive the post-resync sweep: the resync's determined
+ * latest activity and whichever activity is live at sweep time (its queue is its running writer's
+ * pipeline, never stranded work). Nothing else is worth keeping: a worker restart has no delivery
+ * path for a stranded row and the server settles rewards authoritatively.
  */
-async function sweepStaleActivities(
+function pickKeepActivityIDs(
   context: WorkerContext,
   result: Readonly<ResyncResult>,
-): Promise<Array<string>> {
-  try {
-    const keepActivityIDs = [
-      ...new Set(
-        [pickLatestActivityID(result), context.getSimulation().activity?.id].filter(
-          (activityID): activityID is string => activityID !== undefined,
-        ),
+): Array<string> {
+  return [
+    ...new Set(
+      [pickLatestActivityID(result), context.getSimulation().activity?.id].filter(
+        (activityID): activityID is string => activityID !== undefined,
       ),
-    ];
-
-    return await sweepStaleCheckpoints(keepActivityIDs);
-  } catch (error) {
-    reportWorkerFault('resync', error);
-
-    return [];
-  }
+    ),
+  ];
 }
 
 function pickLatestActivityID(result: Readonly<ResyncResult>): string | undefined {
@@ -391,40 +389,9 @@ async function applyAttachLive(
     'an attach-live plan always carries the progress it was decided from',
   );
 
-  const input = buildSimulationInput(progress.activity, {
-    failureAction: context.getFailureAction(),
+  await applyHeadAttach(context, progress.activity, plan.context, signals, {
+    skipTerminalHead: false,
   });
-
-  if (plan.context.appendedHead === 0) {
-    await context.getSubmitter().registerActivity(plan.context);
-
-    const simulation = createSimulation();
-
-    simulation.startActivity(input.avatar, input.activity);
-
-    await setLiveSimulationOrStopBack(context, progress.activity, simulation, signals);
-
-    return;
-  }
-
-  const reconstruction = await runReconstruction({
-    activity: input.activity,
-    appendedHead: plan.context.appendedHead,
-    avatar: input.avatar,
-  });
-
-  if ('divergence' in reconstruction) {
-    emitDivergence(context, plan.context.activityID);
-
-    return;
-  }
-
-  await context.getSubmitter().registerActivity({
-    ...plan.context,
-    previousNextSeed: reconstruction.lastCheckpoint.nextSeed,
-  });
-
-  await setLiveSimulationOrStopBack(context, progress.activity, reconstruction.simulation, signals);
 }
 
 async function applyFastForward(
@@ -442,7 +409,18 @@ async function applyFastForward(
   }
 
   if (report.activity.status === 'active' && !report.finalRowTerminal) {
-    await applyFastForwardAttach(context, report, signals);
+    await applyHeadAttach(
+      context,
+      report.activity,
+      {
+        activityID: report.activity.id,
+        appendedHead: report.appendedHead,
+        lastHash: report.activity.lastHash,
+        startChainIndex: report.activity.startChainIndex,
+      },
+      signals,
+      { skipTerminalHead: true },
+    );
   }
 
   emitResyncStatus(context, {
@@ -452,65 +430,65 @@ async function applyFastForward(
   });
 }
 
+interface HeadAttachOptions {
+  /**
+   * Skip the attach when the reconstructed head is itself a terminal checkpoint — a row adopted
+   * mid-stream with nothing left to submit.
+   */
+  readonly skipTerminalHead: boolean;
+}
+
 /**
- * Attaches the fast-forward's final row live, chaining onto its confirmed head: a checkpoint-0
- * simulation when nothing is confirmed yet, otherwise one reconstructed to the head so the
- * registered cursor's `previousNextSeed` matches what the engine emits next. The caller filters
- * fast-forward-closed streams via the report's terminal flag; the reconstruction's terminal
- * check covers a row adopted mid-stream whose confirmed head is already terminal, skipping an
- * attach with nothing left to submit.
+ * Attaches an activity live, chained onto the confirmed head the submission context names: a
+ * zero head starts a checkpoint-0 simulation, a nonzero head reconstructs to the head first so
+ * the registered cursor's `previousNextSeed` matches what the engine emits next. A reconstruction
+ * divergence broadcasts the invalid stream and attaches nothing.
  */
-async function applyFastForwardAttach(
+async function applyHeadAttach(
   context: WorkerContext,
-  report: FastForwardReport,
+  activity: Readonly<ActivityData>,
+  submission: Readonly<ActivitySubmissionContext>,
   signals: Readonly<FlowSignals>,
+  options: HeadAttachOptions,
 ): Promise<void> {
-  const input = buildSimulationInput(report.activity, {
+  const input = buildSimulationInput(activity, {
     failureAction: context.getFailureAction(),
   });
 
-  if (report.appendedHead === 0) {
-    await context.getSubmitter().registerActivity({
-      activityID: report.activity.id,
-      appendedHead: 0,
-      lastHash: report.activity.lastHash,
-      startChainIndex: report.activity.startChainIndex,
-    });
+  if (submission.appendedHead === 0) {
+    await context.getSubmitter().registerActivity(submission);
 
     const simulation = createSimulation();
 
     simulation.startActivity(input.avatar, input.activity);
 
-    await setLiveSimulationOrStopBack(context, report.activity, simulation, signals);
+    await setLiveSimulationOrStopBack(context, activity, simulation, signals);
 
     return;
   }
 
   const reconstruction = await runReconstruction({
     activity: input.activity,
-    appendedHead: report.appendedHead,
+    appendedHead: submission.appendedHead,
     avatar: input.avatar,
   });
 
   if ('divergence' in reconstruction) {
-    emitDivergence(context, report.activity.id);
+    emitDivergence(context, activity.id);
 
     return;
   }
 
-  if (isTerminalCheckpoint(reconstruction.lastCheckpoint)) {
+  if (options.skipTerminalHead && isTerminalCheckpoint(reconstruction.lastCheckpoint)) {
     return;
   }
 
   await context.getSubmitter().registerActivity({
-    activityID: report.activity.id,
-    appendedHead: report.appendedHead,
-    lastHash: report.activity.lastHash,
+    ...submission,
     previousNextSeed: reconstruction.lastCheckpoint.nextSeed,
-    startChainIndex: report.activity.startChainIndex,
   });
 
-  await setLiveSimulationOrStopBack(context, report.activity, reconstruction.simulation, signals);
+  await setLiveSimulationOrStopBack(context, activity, reconstruction.simulation, signals);
 }
 
 function isTerminalCheckpoint(checkpoint: ActivityCheckpoint): boolean {


### PR DESCRIPTION
## Description

Closes #744

Behavior-preserving cleanup of the resync flow and submitter adapter, landed under the existing resync-turn behavioral suite as the parity gate; the no-convert decision for #744 is recorded on the issue.

- fold the attach-live and fast-forward attach paths into one `applyHeadAttach` helper, keeping the terminal-head skip a fast-forward-only option so attach-live semantics are untouched
- extract the start flow's duplicated start-activity mint and its thrice-repeated stop-settled verdict
- share the eviction-removal reducer between the submitter machine's two clearing transitions
- drive `flushHeld` from the machine's children map, dropping the implicit lockstep with the write-cursor map
- inline the stale-checkpoint sweep at its call site with a pure keep-set picker, removing an unused return
- allow `ORPCError` in the readonly-parameter-types allow list (an `Error` subclass, which the list already carries)

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality