### PR TITLE
feat(#676): hold and switch between multiple avatars

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -34,6 +34,7 @@
           "restart",
           "roll",
           "schedule",
+          "select",
           "serve",
           "submit",
           "sweep",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,7 +186,7 @@ Project-level additions to the shared function-naming taxonomy, under the same r
 | `restart`   | return a long-running resource to service from its initial state                       | `restartActivity`       |
 | `roll`      | consume typed draws from a roll stream to produce an outcome, advancing its cursor     | `rollItemFromStream`    |
 | `schedule`  | enqueue an event or callback for deferred execution                                    | `scheduleEvent`         |
-| `select`    | persist the caller's choice among owned alternatives as the new state                 | `selectAvatar`          |
+| `select`    | persist the caller's choice among owned alternatives as the new state                  | `selectAvatar`          |
 | `serve`     | answer a request for a static resource, else defer                                     | `serveClientAssets`     |
 | `submit`    | accept a payload into a durable outbound queue and schedule its delivery               | `submit`                |
 | `sweep`     | bulk-remove stale or orphaned resources found by a scan, returning the set removed     | `sweepDevDBs`           |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,6 +186,7 @@ Project-level additions to the shared function-naming taxonomy, under the same r
 | `restart`   | return a long-running resource to service from its initial state                       | `restartActivity`       |
 | `roll`      | consume typed draws from a roll stream to produce an outcome, advancing its cursor     | `rollItemFromStream`    |
 | `schedule`  | enqueue an event or callback for deferred execution                                    | `scheduleEvent`         |
+| `select`    | persist the caller's choice among owned alternatives as the new state                 | `selectAvatar`          |
 | `serve`     | answer a request for a static resource, else defer                                     | `serveClientAssets`     |
 | `submit`    | accept a payload into a durable outbound queue and schedule its delivery               | `submit`                |
 | `sweep`     | bulk-remove stale or orphaned resources found by a scan, returning the set removed     | `sweepDevDBs`           |

--- a/agents/project.md
+++ b/agents/project.md
@@ -24,6 +24,7 @@ Project-level additions to the shared function-naming taxonomy, under the same r
 | `restart`   | return a long-running resource to service from its initial state                       | `restartActivity`       |
 | `roll`      | consume typed draws from a roll stream to produce an outcome, advancing its cursor     | `rollItemFromStream`    |
 | `schedule`  | enqueue an event or callback for deferred execution                                    | `scheduleEvent`         |
+| `select`    | persist the caller's choice among owned alternatives as the new state                  | `selectAvatar`          |
 | `serve`     | answer a request for a static resource, else defer                                     | `serveClientAssets`     |
 | `submit`    | accept a payload into a durable outbound queue and schedule its delivery               | `submit`                |
 | `sweep`     | bulk-remove stale or orphaned resources found by a scan, returning the set removed     | `sweepDevDBs`           |

--- a/apps/web-e2e/specs/avatar-roster.spec.ts
+++ b/apps/web-e2e/specs/avatar-roster.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from '../src/test';
+import { waitForHoneypotWindow } from '../src/wait-for-honeypot-window';
+
+/**
+ * The multi-avatar journey: create a second avatar from the roster (which auto-selects it),
+ * switch back to the first, and prove the choice survives a full reload — the selection is
+ * persisted server-side, not a client artifact.
+ */
+test('it creates a second avatar, switches back, and keeps the choice across a reload', async ({
+  page,
+}) => {
+  await page.setExtraHTTPHeaders({ 'x-forwarded-for': '127.0.0.1' });
+  await page.goto('/login');
+
+  // hydration gate: the login form's submit handler attaches only once React commits; an earlier
+  // click falls back to the browser's native GET submit and never leaves /login
+  await page.locator('html[data-hydrated]').waitFor();
+  await page.getByLabel('Email').fill('e2e-avatar-roster@vers.test');
+  await page.getByLabel('Password').fill('password123');
+
+  await waitForHoneypotWindow(page);
+
+  await page.getByRole('button', { exact: true, name: 'Login' }).click();
+
+  // the seeded account carries an active avatar, so the gate lands it in-game
+  await expect(page).toHaveURL(/\/respite$/);
+
+  // the rail chip names the active avatar and opens the roster
+  await page.getByRole('link', { name: 'Switch avatar (RosterPrime)' }).click();
+
+  await expect(page).toHaveURL(/\/avatars$/);
+
+  await page.getByRole('link', { name: '+ Create avatar' }).click();
+
+  await expect(page).toHaveURL(/\/avatars\/create$/);
+
+  await page.getByLabel('Name').fill('RosterSecond');
+  await page.getByRole('button', { exact: true, name: 'Create Avatar' }).click();
+
+  // creating selects the newcomer and re-enters the game as them
+  await expect(page).toHaveURL(/\/explore$/);
+  await expect(page.getByRole('link', { name: 'Switch avatar (RosterSecond)' })).toBeVisible();
+
+  // switch back to the first avatar from the roster
+  await page.getByRole('link', { name: 'Switch avatar (RosterSecond)' }).click();
+
+  await expect(page).toHaveURL(/\/avatars$/);
+
+  const rosterCards = page.getByRole('button', { name: /Roster/ });
+
+  await expect(rosterCards).toHaveCount(2);
+  await expect(page.getByRole('button', { name: /RosterSecond/ })).toContainText('Active');
+
+  await page.getByRole('button', { name: /RosterPrime/ }).click();
+
+  await expect(page).toHaveURL(/\/explore$/);
+  await expect(page.getByRole('link', { name: 'Switch avatar (RosterPrime)' })).toBeVisible();
+
+  // the selection is server-persisted: a fresh document load still enters as the switched avatar
+  await page.reload();
+
+  await expect(page.getByRole('link', { name: 'Switch avatar (RosterPrime)' })).toBeVisible();
+});

--- a/apps/web-e2e/src/create-stack-seed.ts
+++ b/apps/web-e2e/src/create-stack-seed.ts
@@ -32,9 +32,15 @@ async function createStackSeed(): Promise<void> {
         .executeTakeFirstOrThrow();
 
       if (account.avatarName !== null) {
-        await db
+        const avatar = await db
           .insertInto('avatars')
           .values({ id: crypto.randomUUID(), name: account.avatarName, userId: user.id })
+          .returning('id')
+          .executeTakeFirstOrThrow();
+
+        await db
+          .insertInto('activeAvatars')
+          .values({ avatarId: avatar.id, userId: user.id })
           .execute();
       }
     }

--- a/apps/web/src/lib/activity/require-active-activity.ts
+++ b/apps/web/src/lib/activity/require-active-activity.ts
@@ -5,17 +5,17 @@ import { activityClient } from '../rpc/clients/activity-client';
 import { avatarClient } from '../rpc/clients/avatar-client';
 
 /**
- * The per-screen gate for the engagement view: redirects a caller with no avatar to the create
- * sheet and a caller with no running activity back to explore, so the screen can assume a live
- * activity to render.
+ * The per-screen gate for the engagement view: redirects a caller with no active avatar to the
+ * create sheet or roster, and a caller with no running activity back to explore, so the screen
+ * can assume a live activity to render.
  */
 export const requireActiveActivity = createServerFn({ method: 'GET' }).handler(async () => {
-  const avatars = await avatarClient.getAvatars({});
+  const roster = await avatarClient.getAvatars({});
 
-  const avatar = findActiveAvatar(avatars);
+  const avatar = findActiveAvatar(roster);
 
   if (avatar === null) {
-    throw redirect({ href: '/avatars/create' });
+    throw redirect({ href: roster.avatars.length === 0 ? '/avatars/create' : '/avatars' });
   }
 
   const activity = await activityClient.getCurrentActivity({ avatarID: avatar.id });

--- a/apps/web/src/lib/avatar/find-active-avatar.test.ts
+++ b/apps/web/src/lib/avatar/find-active-avatar.test.ts
@@ -1,33 +1,20 @@
 import { expect, test } from 'bun:test';
-import type { AvatarData } from '@vers/contract-avatar';
+import { createMockAvatar } from '../../test-utils/factories/create-mock-avatar';
 import { findActiveAvatar } from './find-active-avatar';
 
-function buildAvatar(id: string): AvatarData {
-  return {
-    createdAt: new Date('2026-01-01'),
-    id,
-    level: 1,
-    mode: 'trade',
-    name: `Avatar${id}`,
-    updatedAt: new Date('2026-01-01'),
-    userID: 'user-1',
-    xp: 0,
-  };
-}
-
 test('it resolves the selected avatar by id', () => {
-  const first = buildAvatar('a');
-  const second = buildAvatar('b');
+  const first = createMockAvatar();
+  const second = createMockAvatar();
 
-  expect(findActiveAvatar({ activeAvatarID: 'b', avatars: [first, second] })).toBe(second);
+  expect(findActiveAvatar({ activeAvatarID: second.id, avatars: [first, second] })).toBe(second);
 });
 
 test('it answers null when nothing is selected', () => {
-  expect(findActiveAvatar({ activeAvatarID: null, avatars: [buildAvatar('a')] })).toBeNull();
+  expect(findActiveAvatar({ activeAvatarID: null, avatars: [createMockAvatar()] })).toBeNull();
 });
 
 test('it answers null when the selection points at no listed avatar', () => {
-  expect(findActiveAvatar({ activeAvatarID: 'gone', avatars: [buildAvatar('a')] })).toBeNull();
+  expect(findActiveAvatar({ activeAvatarID: 'gone', avatars: [createMockAvatar()] })).toBeNull();
 });
 
 test('it answers null for an empty roster', () => {

--- a/apps/web/src/lib/avatar/find-active-avatar.test.ts
+++ b/apps/web/src/lib/avatar/find-active-avatar.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from 'bun:test';
+import type { AvatarData } from '@vers/contract-avatar';
+import { findActiveAvatar } from './find-active-avatar';
+
+function buildAvatar(id: string): AvatarData {
+  return {
+    createdAt: new Date('2026-01-01'),
+    id,
+    level: 1,
+    mode: 'trade',
+    name: `Avatar${id}`,
+    updatedAt: new Date('2026-01-01'),
+    userID: 'user-1',
+    xp: 0,
+  };
+}
+
+test('it resolves the selected avatar by id', () => {
+  const first = buildAvatar('a');
+  const second = buildAvatar('b');
+
+  expect(findActiveAvatar({ activeAvatarID: 'b', avatars: [first, second] })).toBe(second);
+});
+
+test('it answers null when nothing is selected', () => {
+  expect(findActiveAvatar({ activeAvatarID: null, avatars: [buildAvatar('a')] })).toBeNull();
+});
+
+test('it answers null when the selection points at no listed avatar', () => {
+  expect(findActiveAvatar({ activeAvatarID: 'gone', avatars: [buildAvatar('a')] })).toBeNull();
+});
+
+test('it answers null for an empty roster', () => {
+  expect(findActiveAvatar({ activeAvatarID: null, avatars: [] })).toBeNull();
+});

--- a/apps/web/src/lib/avatar/find-active-avatar.ts
+++ b/apps/web/src/lib/avatar/find-active-avatar.ts
@@ -1,10 +1,15 @@
 import type { AvatarData } from '@vers/contract-avatar';
 
+interface ActiveAvatarSource {
+  readonly activeAvatarID: null | string;
+  readonly avatars: ReadonlyArray<AvatarData>;
+}
+
 /**
- * The app's one active-avatar rule: the caller's first avatar, or null with none. Every reader —
- * query select and loader alike — routes through here, the single place the rule changes once an
- * account can hold more than one avatar.
+ * The app's one active-avatar rule: the roster's persisted selection resolved to its avatar, or
+ * null when nothing is selected. Every reader — query select and loader alike — routes through
+ * here.
  */
-export function findActiveAvatar(avatars: ReadonlyArray<AvatarData>): AvatarData | null {
-  return avatars[0] ?? null;
+export function findActiveAvatar(roster: ActiveAvatarSource): AvatarData | null {
+  return roster.avatars.find((avatar) => avatar.id === roster.activeAvatarID) ?? null;
 }

--- a/apps/web/src/lib/avatar/get-avatar-content.tsx
+++ b/apps/web/src/lib/avatar/get-avatar-content.tsx
@@ -10,9 +10,9 @@ import { findActiveAvatar } from './find-active-avatar';
  * an avatarless caller to the roster before any shell route loads, so an active avatar is present.
  */
 export const getAvatarContent = createServerFn({ method: 'GET' }).handler(async () => {
-  const avatars = await avatarClient.getAvatars({});
+  const roster = await avatarClient.getAvatars({});
 
-  const avatar = findActiveAvatar(avatars);
+  const avatar = findActiveAvatar(roster);
 
   invariant(avatar, 'a shell route loaded without an active avatar');
 

--- a/apps/web/src/lib/avatar/require-active-avatar.test.ts
+++ b/apps/web/src/lib/avatar/require-active-avatar.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'bun:test';
 import { isRedirect } from '@tanstack/react-router';
 import * as db from '@vers/mock-services/db';
+import { createActiveAvatar } from '../../test-utils/create-active-avatar';
 import { createSignedInUser } from '../../test-utils/create-signed-in-user';
 import { withRequestContext } from '../../test-utils/with-request-context';
 import { requireActiveAvatar } from './require-active-avatar';
@@ -17,10 +18,24 @@ test('it redirects to the create sheet when the caller has no avatar', async () 
   expect(outcome.value).toBe('/avatars/create');
 });
 
-test('it does not redirect when the caller has an avatar', async () => {
+test('it redirects to the roster when avatars exist but none is active', async () => {
   const signedIn = await createSignedInUser();
 
   await db.avatarCollection.create({ name: 'Karnak', userID: signedIn.userID });
+
+  const outcome = await withRequestContext({ cookies: signedIn.cookies }, () =>
+    requireActiveAvatar()
+      .then(() => null)
+      .catch((error: unknown) => (isRedirect(error) ? error.options.href : null)),
+  );
+
+  expect(outcome.value).toBe('/avatars');
+});
+
+test('it does not redirect when the caller has an active avatar', async () => {
+  const signedIn = await createSignedInUser();
+
+  await createActiveAvatar({ name: 'Karnak', userID: signedIn.userID });
 
   const outcome = await withRequestContext({ cookies: signedIn.cookies }, () =>
     requireActiveAvatar()

--- a/apps/web/src/lib/avatar/require-active-avatar.ts
+++ b/apps/web/src/lib/avatar/require-active-avatar.ts
@@ -4,16 +4,17 @@ import { avatarClient } from '../rpc/clients/avatar-client';
 import { findActiveAvatar } from './find-active-avatar';
 
 /**
- * The per-screen gate for avatar-dependent routes: redirects a caller with no avatar to the create
- * sheet, so the screen can assume an active avatar exists.
+ * The per-screen gate for avatar-dependent routes: a caller with no avatars goes to the create
+ * sheet, one with avatars but no selection goes to the roster to pick, so the screen can assume
+ * an active avatar exists.
  */
 export const requireActiveAvatar = createServerFn({ method: 'GET' }).handler(async () => {
-  const avatars = await avatarClient.getAvatars({});
+  const roster = await avatarClient.getAvatars({});
 
-  const avatar = findActiveAvatar(avatars);
+  const avatar = findActiveAvatar(roster);
 
   if (avatar === null) {
-    throw redirect({ href: '/avatars/create' });
+    throw redirect({ href: roster.avatars.length === 0 ? '/avatars/create' : '/avatars' });
   }
 
   return { avatar };

--- a/apps/web/src/routes/-activity/activity-panel.test.tsx
+++ b/apps/web/src/routes/-activity/activity-panel.test.tsx
@@ -4,6 +4,7 @@ import { setSimulationSnapshot } from '@vers/idle-client';
 import { ActivityFailureAction } from '@vers/idle-core';
 import { createMockActivitySnapshot, createMockAvatarSnapshot } from '@vers/idle-core/test-utils';
 import * as db from '@vers/mock-services/db';
+import { createActiveAvatar } from '../../test-utils/create-active-avatar';
 import { createSignedInUser } from '../../test-utils/create-signed-in-user';
 import { createStubWorkerClient } from '../../test-utils/create-stub-worker-client';
 import { render } from '../../test-utils/render';
@@ -21,7 +22,7 @@ test('it renders the engagement title with no settling indicator by default', ()
 
 test('it shows the settling indicator while appended progress is still settling', async () => {
   const signedIn = await createSignedInUser();
-  const avatar = await db.avatarCollection.create({ userID: signedIn.userID });
+  const avatar = await createActiveAvatar({ userID: signedIn.userID });
 
   await db.activityCollection.create({
     appendedHead: 3,
@@ -41,7 +42,7 @@ test('it shows the settling indicator while appended progress is still settling'
 
 test('it shows no settling indicator once the appended progress is fully verified', async () => {
   const signedIn = await createSignedInUser();
-  const avatar = await db.avatarCollection.create({ userID: signedIn.userID });
+  const avatar = await createActiveAvatar({ userID: signedIn.userID });
 
   await db.activityCollection.create({
     appendedHead: 2,
@@ -63,7 +64,7 @@ test('it shows no settling indicator once the appended progress is fully verifie
 
 test('it hands END RUN to the worker and never awaits the server', async () => {
   const signedIn = await createSignedInUser();
-  const avatar = await db.avatarCollection.create({ userID: signedIn.userID });
+  const avatar = await createActiveAvatar({ userID: signedIn.userID });
   const activity = await db.activityCollection.create({ avatarID: avatar.id, status: 'active' });
 
   const client = createStubWorkerClient();

--- a/apps/web/src/routes/-avatar-create/avatar-create-form.tsx
+++ b/apps/web/src/routes/-avatar-create/avatar-create-form.tsx
@@ -1,8 +1,10 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { useServerFn } from '@tanstack/react-start';
 import type { AvatarMode } from '@vers/contract-avatar';
 import { Field, Heading, StatusButton, Text } from '@vers/design-system';
 import { css } from '@vers/styled-system/css';
 import { useState } from 'react';
+import { buildActiveAvatarQueryOptions } from '../../lib/avatar/build-active-avatar-query-options';
 import { sendAnalyticsEvent } from '../../lib/send-analytics-event';
 import { avatarCreate } from './avatar-create';
 import type { AvatarCreateResult } from './types';
@@ -44,6 +46,7 @@ const modeWarningStyles = css({
 
 export function AvatarCreateForm() {
   const avatarCreateFn = useServerFn(avatarCreate);
+  const queryClient = useQueryClient();
   const [fieldErrors, setFieldErrors] = useState<AvatarCreateResult['fieldErrors']>({});
   const [isPending, setIsPending] = useState(false);
   const [mode, setMode] = useState<AvatarMode>('trade');
@@ -61,6 +64,12 @@ export function AvatarCreateForm() {
 
       if (result === undefined) {
         sendAnalyticsEvent('avatar-created');
+
+        // the create auto-selected the newcomer server-side; the cached roster still names the
+        // previous avatar until it refetches
+        void queryClient.invalidateQueries({
+          queryKey: buildActiveAvatarQueryOptions().queryKey,
+        });
 
         return;
       }

--- a/apps/web/src/routes/-avatar-create/avatar-create-form.tsx
+++ b/apps/web/src/routes/-avatar-create/avatar-create-form.tsx
@@ -123,6 +123,11 @@ export function AvatarCreateForm() {
               moved to another avatar. A player who never trades loses nothing by staying Trade.
             </Text>
           )}
+          {fieldErrors.mode !== undefined && (
+            <Text className={modeWarningStyles} role="alert">
+              {fieldErrors.mode}
+            </Text>
+          )}
         </div>
         <StatusButton
           disabled={isPending}

--- a/apps/web/src/routes/-avatar-create/run-avatar-create.ts
+++ b/apps/web/src/routes/-avatar-create/run-avatar-create.ts
@@ -27,7 +27,16 @@ export async function runAvatarCreate(formData: FormData): Promise<AvatarCreateR
   );
 
   if (error) {
-    // only the declared name conflict is normal flow; any other failure — transport, or a defined
+    if (isDefinedError(error) && error.code === 'LIMIT_REACHED') {
+      const modeLabel = error.data.mode === 'self_found' ? 'Self-Found' : 'Trade';
+
+      return {
+        fieldErrors: { mode: `You already hold ${error.data.cap} ${modeLabel} avatars` },
+        status: 'invalid-fields',
+      };
+    }
+
+    // only the declared errors are normal flow; any other failure — transport, or a defined
     // error the conflict message would misreport — is logged
     if (!isDefinedError(error) || error.code !== 'CONFLICT') {
       logger.error({ err: error }, 'avatar creation failed');

--- a/apps/web/src/routes/-avatar-create/types.ts
+++ b/apps/web/src/routes/-avatar-create/types.ts
@@ -3,6 +3,6 @@
  * `/avatar` instead of a value here.
  */
 export interface AvatarCreateResult {
-  readonly fieldErrors: Readonly<Partial<Record<'name', string>>>;
+  readonly fieldErrors: Readonly<Partial<Record<'mode' | 'name', string>>>;
   readonly status: 'invalid-fields';
 }

--- a/apps/web/src/routes/-avatar/avatar-progression.test.tsx
+++ b/apps/web/src/routes/-avatar/avatar-progression.test.tsx
@@ -3,6 +3,7 @@ import { waitFor } from '@testing-library/react';
 import { ActivityFailureAction } from '@vers/idle-core';
 import { createMockActivitySnapshot, createMockAvatarSnapshot } from '@vers/idle-core/test-utils';
 import * as db from '@vers/mock-services/db';
+import { createActiveAvatar } from '../../test-utils/create-active-avatar';
 import { createSignedInUser } from '../../test-utils/create-signed-in-user';
 import { render } from '../../test-utils/render';
 import { setIdleWorkerHandle } from '../../test-utils/set-idle-worker-handle';
@@ -22,7 +23,7 @@ test('it renders nothing without a signed-in avatar', async () => {
 test('it renders the settled row with no settling marker when nothing is pending', async () => {
   const signedIn = await createSignedInUser();
 
-  await db.avatarCollection.create({ level: 5, userID: signedIn.userID, xp: 900 });
+  await createActiveAvatar({ level: 5, userID: signedIn.userID, xp: 900 });
 
   await withRequestContext({ cookies: signedIn.cookies }, async () => {
     const rendered = render(<AvatarProgression />);
@@ -37,7 +38,7 @@ test('it renders the settled row with no settling marker when nothing is pending
 
 test('it sums a pending entry onto the settled xp and shows the settling marker', async () => {
   const signedIn = await createSignedInUser();
-  const avatar = await db.avatarCollection.create({ level: 1, userID: signedIn.userID, xp: 400 });
+  const avatar = await createActiveAvatar({ level: 1, userID: signedIn.userID, xp: 400 });
 
   const activity = await db.activityCollection.create({
     appendedHead: 1,
@@ -74,7 +75,7 @@ test('it sums a pending entry onto the settled xp and shows the settling marker'
 
 test('it shows the optimistic sim overlay and the settling marker while an activity is current', async () => {
   const signedIn = await createSignedInUser();
-  const avatar = await db.avatarCollection.create({ level: 3, userID: signedIn.userID, xp: 450 });
+  const avatar = await createActiveAvatar({ level: 3, userID: signedIn.userID, xp: 450 });
 
   const activity = await db.activityCollection.create({
     avatarID: avatar.id,

--- a/apps/web/src/routes/-avatars/avatar-roster.test.tsx
+++ b/apps/web/src/routes/-avatars/avatar-roster.test.tsx
@@ -1,17 +1,18 @@
 import { expect, test } from 'bun:test';
 import { screen } from '@testing-library/react';
+import { AVATAR_MODE_CAP } from '@vers/contract-avatar';
 import { createMockAvatar } from '../../test-utils/factories/create-mock-avatar';
 import { renderWithRouter } from '../../test-utils/render-with-router';
 import { AvatarRoster } from './avatar-roster';
 
-test('it links each avatar into the game and offers a create slot', async () => {
+test('it renders each avatar as a selectable card and offers a create slot', async () => {
   const avatar = createMockAvatar({ name: 'Karnak' });
 
-  renderWithRouter(<AvatarRoster avatars={[avatar]} />);
+  renderWithRouter(<AvatarRoster roster={{ activeAvatarID: null, avatars: [avatar] }} />);
 
-  const card = await screen.findByRole('link', { name: /Karnak/ });
+  const card = await screen.findByRole('button', { name: /Karnak/ });
 
-  expect(card).toHaveAttribute('href', '/explore');
+  expect(card).toBeEnabled();
 
   expect(screen.getByRole('link', { name: /Create avatar/ })).toHaveAttribute(
     'href',
@@ -19,11 +20,40 @@ test('it links each avatar into the game and offers a create slot', async () => 
   );
 });
 
+test('it marks the active avatar', async () => {
+  const active = createMockAvatar({ name: 'Karnak' });
+  const idle = createMockAvatar({ name: 'Zetha' });
+
+  renderWithRouter(
+    <AvatarRoster roster={{ activeAvatarID: active.id, avatars: [active, idle] }} />,
+  );
+
+  const activeCard = await screen.findByRole('button', { name: /Karnak/ });
+
+  const idleCard = screen.getByRole('button', { name: /Zetha/ });
+
+  expect(activeCard).toHaveTextContent('Active');
+  expect(idleCard).not.toHaveTextContent('Active');
+});
+
 test('it shows only the create slot when the account has no avatars', async () => {
-  renderWithRouter(<AvatarRoster avatars={[]} />);
+  renderWithRouter(<AvatarRoster roster={{ activeAvatarID: null, avatars: [] }} />);
 
   const createLink = await screen.findByRole('link', { name: /Create avatar/ });
 
   expect(createLink).toHaveAttribute('href', '/avatars/create');
   expect(screen.queryByText(/Level/)).not.toBeInTheDocument();
+});
+
+test('it hides the create slot when every mode is at its cap', async () => {
+  const avatars = [
+    ...Array.from({ length: AVATAR_MODE_CAP }, () => createMockAvatar({ mode: 'trade' })),
+    ...Array.from({ length: AVATAR_MODE_CAP }, () => createMockAvatar({ mode: 'self_found' })),
+  ];
+
+  renderWithRouter(<AvatarRoster roster={{ activeAvatarID: null, avatars }} />);
+
+  await screen.findByRole('heading', { name: /Choose your avatar/ });
+
+  expect(screen.queryByRole('link', { name: /Create avatar/ })).not.toBeInTheDocument();
 });

--- a/apps/web/src/routes/-avatars/avatar-roster.tsx
+++ b/apps/web/src/routes/-avatars/avatar-roster.tsx
@@ -1,7 +1,12 @@
 import { Link } from '@tanstack/react-router';
+import { useServerFn } from '@tanstack/react-start';
 import type { AvatarData } from '@vers/contract-avatar';
+import { AVATAR_MODE_CAP } from '@vers/contract-avatar';
 import { Heading, Text } from '@vers/design-system';
-import { css } from '@vers/styled-system/css';
+import { css, cx } from '@vers/styled-system/css';
+import { useState } from 'react';
+import { avatarSelect } from './avatar-select';
+import type { AvatarSelectResult } from './types';
 
 const screen = css({
   alignItems: 'center',
@@ -31,10 +36,13 @@ const card = css({
   gap: '2',
   minHeight: 'tileMin',
   padding: '5',
+  textAlign: 'left',
   transitionDuration: 'fast',
   transitionProperty: '[border-color]',
   _hover: { borderColor: 'border.strong' },
 });
+
+const activeCard = css({ borderColor: 'border.strong' });
 
 const createSlot = css({
   alignItems: 'center',
@@ -55,26 +63,96 @@ const createSlot = css({
 
 const cardName = css({ fontSize: 'lg', fontWeight: 'semibold' });
 const cardMeta = css({ color: 'text.muted', fontSize: 'sm' });
+const cardActiveMark = css({ color: 'text.primary', fontSize: 'sm' });
+
+const rejection = css({
+  borderColor: 'border.danger',
+  borderWidth: '[1px]',
+  color: 'text.danger',
+  fontSize: 'sm',
+  padding: '3',
+});
+
+interface AvatarRosterProps {
+  readonly roster: {
+    readonly activeAvatarID: null | string;
+    readonly avatars: ReadonlyArray<AvatarData>;
+  };
+}
 
 /**
- * The pre-shell roster: pick an avatar to enter the game as, or take the empty slot to create one.
+ * The roster sheet: pick an avatar to persist as active and enter the game as, or take the empty
+ * slot to create one. A selection a live activity rejects renders inline, naming the run's owner.
  */
-export function AvatarRoster(props: Readonly<{ avatars: ReadonlyArray<AvatarData> }>) {
+export function AvatarRoster(props: AvatarRosterProps) {
+  const avatarSelectFn = useServerFn(avatarSelect);
+  const [isPending, setIsPending] = useState(false);
+  const [message, setMessage] = useState<null | string>(null);
+
+  const handleSelect = async (avatarID: string) => {
+    setIsPending(true);
+    setMessage(null);
+
+    try {
+      // a successful pick ends in a redirect that useServerFn already navigated to, resolving
+      // this call with no value
+      const result: AvatarSelectResult | undefined = await avatarSelectFn({ data: { avatarID } });
+
+      if (result === undefined) {
+        return;
+      }
+
+      const rejectionMessage =
+        result.status === 'activity-locked'
+          ? `${result.owningAvatarName} is out on an activity — finish or stop it to switch`
+          : 'Something went wrong selecting that avatar';
+
+      setMessage(rejectionMessage);
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  const isAtCap = (['trade', 'self_found'] as const).every(
+    (mode) =>
+      props.roster.avatars.filter((avatar) => avatar.mode === mode).length >= AVATAR_MODE_CAP,
+  );
+
   return (
     <main className={screen}>
       <Heading level={1}>Choose your avatar</Heading>
+      {message !== null && (
+        <Text className={rejection} role="alert">
+          {message}
+        </Text>
+      )}
       <div className={grid}>
-        {props.avatars.map((avatar) => (
-          <Link key={avatar.id} className={card} to="/explore">
-            <span className={cardName}>{avatar.name}</span>
-            <span className={cardMeta}>
-              Level {avatar.level} · {avatar.mode === 'self_found' ? 'Self-Found' : 'Trade'}
-            </span>
+        {props.roster.avatars.map((avatar) => {
+          const isActive = avatar.id === props.roster.activeAvatarID;
+
+          return (
+            <button
+              key={avatar.id}
+              className={cx(card, isActive && activeCard)}
+              disabled={isPending}
+              type="button"
+              onClick={() => {
+                void handleSelect(avatar.id);
+              }}
+            >
+              <span className={cardName}>{avatar.name}</span>
+              <span className={cardMeta}>
+                Level {avatar.level} · {avatar.mode === 'self_found' ? 'Self-Found' : 'Trade'}
+              </span>
+              {isActive && <span className={cardActiveMark}>Active</span>}
+            </button>
+          );
+        })}
+        {!isAtCap && (
+          <Link className={createSlot} to="/avatars/create">
+            <Text>+ Create avatar</Text>
           </Link>
-        ))}
-        <Link className={createSlot} to="/avatars/create">
-          <Text>+ Create avatar</Text>
-        </Link>
+        )}
       </div>
     </main>
   );

--- a/apps/web/src/routes/-avatars/avatar-roster.tsx
+++ b/apps/web/src/routes/-avatars/avatar-roster.tsx
@@ -117,6 +117,8 @@ export function AvatarRoster(props: AvatarRosterProps) {
           : 'Something went wrong selecting that avatar';
 
       setMessage(rejectionMessage);
+    } catch {
+      setMessage('Something went wrong selecting that avatar');
     } finally {
       setIsPending(false);
     }

--- a/apps/web/src/routes/-avatars/avatar-roster.tsx
+++ b/apps/web/src/routes/-avatars/avatar-roster.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { useServerFn } from '@tanstack/react-start';
 import type { AvatarData } from '@vers/contract-avatar';
@@ -5,6 +6,7 @@ import { AVATAR_MODE_CAP } from '@vers/contract-avatar';
 import { Heading, Text } from '@vers/design-system';
 import { css, cx } from '@vers/styled-system/css';
 import { useState } from 'react';
+import { buildActiveAvatarQueryOptions } from '../../lib/avatar/build-active-avatar-query-options';
 import { avatarSelect } from './avatar-select';
 import type { AvatarSelectResult } from './types';
 
@@ -86,6 +88,7 @@ interface AvatarRosterProps {
  */
 export function AvatarRoster(props: AvatarRosterProps) {
   const avatarSelectFn = useServerFn(avatarSelect);
+  const queryClient = useQueryClient();
   const [isPending, setIsPending] = useState(false);
   const [message, setMessage] = useState<null | string>(null);
 
@@ -99,6 +102,12 @@ export function AvatarRoster(props: AvatarRosterProps) {
       const result: AvatarSelectResult | undefined = await avatarSelectFn({ data: { avatarID } });
 
       if (result === undefined) {
+        // the selection changed server-side; the cached roster still names the previous avatar
+        // until it refetches
+        void queryClient.invalidateQueries({
+          queryKey: buildActiveAvatarQueryOptions().queryKey,
+        });
+
         return;
       }
 

--- a/apps/web/src/routes/-avatars/avatar-select.ts
+++ b/apps/web/src/routes/-avatars/avatar-select.ts
@@ -1,0 +1,9 @@
+import { createServerFn } from '@tanstack/react-start';
+import * as z from 'zod';
+import { runAvatarSelect } from './run-avatar-select';
+
+const AvatarSelectInputSchema = z.object({ avatarID: z.string() });
+
+export const avatarSelect = createServerFn({ method: 'POST' })
+  .validator((input: unknown) => AvatarSelectInputSchema.parse(input))
+  .handler((ctx) => runAvatarSelect(ctx.data.avatarID));

--- a/apps/web/src/routes/-avatars/run-avatar-select.ts
+++ b/apps/web/src/routes/-avatars/run-avatar-select.ts
@@ -1,0 +1,28 @@
+import { isDefinedError, safe } from '@orpc/client';
+import { redirect } from '@tanstack/react-router';
+import { requireAuth } from '../../lib/auth/require-auth';
+import { avatarClient } from '../../lib/rpc/clients/avatar-client';
+import { logger } from '../../server/logger';
+import type { AvatarSelectResult } from './types';
+
+/**
+ * Persists the picked avatar as active and re-enters the game as them; a live activity's hold on
+ * the selection comes back as a named rejection for the roster to render instead of a redirect.
+ */
+export async function runAvatarSelect(avatarID: string): Promise<AvatarSelectResult> {
+  await requireAuth();
+
+  const [error] = await safe(avatarClient.selectAvatar({ id: avatarID }));
+
+  if (error) {
+    if (isDefinedError(error) && error.code === 'CONFLICT') {
+      return { owningAvatarName: error.data.owningAvatarName, status: 'activity-locked' };
+    }
+
+    logger.error({ err: error }, 'avatar selection failed');
+
+    return { status: 'failed' };
+  }
+
+  throw redirect({ href: '/explore' });
+}

--- a/apps/web/src/routes/-avatars/types.ts
+++ b/apps/web/src/routes/-avatars/types.ts
@@ -1,0 +1,7 @@
+/**
+ * The roster selection's non-redirect outcome. A successful pick ends in a thrown redirect to
+ * `/explore` instead of a value here.
+ */
+export type AvatarSelectResult =
+  | { readonly owningAvatarName: string; readonly status: 'activity-locked' }
+  | { readonly status: 'failed' };

--- a/apps/web/src/routes/-explore-current/explore-current-panel.test.tsx
+++ b/apps/web/src/routes/-explore-current/explore-current-panel.test.tsx
@@ -6,11 +6,11 @@ import type { StartStatus } from '@vers/idle-client';
 import { advanceWriterGeneration } from '@vers/idle-client';
 import { ActivityFailureAction } from '@vers/idle-core';
 import { createMockActivitySnapshot } from '@vers/idle-core/test-utils';
-import * as db from '@vers/mock-services/db';
 import { setSelectedNode } from '@vers/worldmap-client';
 import { createMockWorldMapNode } from '@vers/worldmap-client/test-utils';
 import invariant from 'tiny-invariant';
 import { orpc } from '../../lib/rpc/orpc';
+import { createActiveAvatar } from '../../test-utils/create-active-avatar';
 import { createSignedInUser } from '../../test-utils/create-signed-in-user';
 import { createStubWorkerClient } from '../../test-utils/create-stub-worker-client';
 import { render } from '../../test-utils/render';
@@ -40,7 +40,7 @@ test('it shows a spinner and calls initialize before the worker reports its stat
 test('it re-sends the start intent against a promoted writer', async () => {
   const signedIn = await createSignedInUser();
 
-  await db.avatarCollection.create({ userID: signedIn.userID });
+  await createActiveAvatar({ userID: signedIn.userID });
 
   setSelectedNode(createMockWorldMapNode({ id: 'a9lp75' }));
 
@@ -74,7 +74,7 @@ test('it re-sends the start intent against a promoted writer', async () => {
 
 test('it sends one start call for the selected node once initialized', async () => {
   const signedIn = await createSignedInUser();
-  const avatar = await db.avatarCollection.create({ userID: signedIn.userID });
+  const avatar = await createActiveAvatar({ userID: signedIn.userID });
 
   setSelectedNode(createMockWorldMapNode({ id: 'a9lp75' }));
 
@@ -106,7 +106,7 @@ test('it sends one start call for the selected node once initialized', async () 
 
 test('it renders the node and its codex fragment once the worker reports the start', async () => {
   const signedIn = await createSignedInUser();
-  const avatar = await db.avatarCollection.create({ userID: signedIn.userID });
+  const avatar = await createActiveAvatar({ userID: signedIn.userID });
 
   setSelectedNode(createMockWorldMapNode({ id: 'a9lp75' }));
 
@@ -149,7 +149,7 @@ test('it renders the node and its codex fragment once the worker reports the sta
 test('it treats an attached report as ready once the simulation carries that row', async () => {
   const signedIn = await createSignedInUser();
 
-  await db.avatarCollection.create({ userID: signedIn.userID });
+  await createActiveAvatar({ userID: signedIn.userID });
 
   setSelectedNode(createMockWorldMapNode({ id: 'a9lp75' }));
 
@@ -189,7 +189,7 @@ test('it treats an attached report as ready once the simulation carries that row
 test('it offers a retry on a failed report and sends a fresh call on demand', async () => {
   const signedIn = await createSignedInUser();
 
-  await db.avatarCollection.create({ userID: signedIn.userID });
+  await createActiveAvatar({ userID: signedIn.userID });
 
   setSelectedNode(createMockWorldMapNode({ id: 'a9lp75' }));
 
@@ -224,7 +224,7 @@ test('it offers a retry on a failed report and sends a fresh call on demand', as
 
 test('it renders the auto-retry checkbox unchecked by default and dispatches the toggle', async () => {
   const signedIn = await createSignedInUser();
-  const avatar = await db.avatarCollection.create({ userID: signedIn.userID });
+  const avatar = await createActiveAvatar({ userID: signedIn.userID });
 
   setSelectedNode(createMockWorldMapNode({ id: 'a9lp75' }));
 
@@ -277,7 +277,7 @@ test('it renders the auto-retry checkbox unchecked by default and dispatches the
 test('it ignores a start reply for a node the selection has left behind', async () => {
   const signedIn = await createSignedInUser();
 
-  await db.avatarCollection.create({ userID: signedIn.userID });
+  await createActiveAvatar({ userID: signedIn.userID });
 
   setSelectedNode(createMockWorldMapNode({ id: 'node-a' }));
 

--- a/apps/web/src/routes/-game/game-simulation-mount.test.tsx
+++ b/apps/web/src/routes/-game/game-simulation-mount.test.tsx
@@ -1,7 +1,7 @@
 import { expect, test } from 'bun:test';
 import { waitFor } from '@testing-library/react';
 import { ActivityFailureAction } from '@vers/idle-core';
-import * as db from '@vers/mock-services/db';
+import { createActiveAvatar } from '../../test-utils/create-active-avatar';
 import { createSignedInUser } from '../../test-utils/create-signed-in-user';
 import { createStubWorkerClient } from '../../test-utils/create-stub-worker-client';
 import { render } from '../../test-utils/render';
@@ -58,7 +58,7 @@ test('it calls nothing before a worker has connected', () => {
 
 test('it calls initialize then reports online once the active avatar resolves', async () => {
   const signedIn = await createSignedInUser();
-  const avatar = await db.avatarCollection.create({ userID: signedIn.userID });
+  const avatar = await createActiveAvatar({ userID: signedIn.userID });
 
   const client = createStubWorkerClient();
 
@@ -106,7 +106,7 @@ test('it never reports online without a known avatar', async () => {
 
 test('it reports online only once across re-renders', async () => {
   const signedIn = await createSignedInUser();
-  const avatar = await db.avatarCollection.create({ userID: signedIn.userID });
+  const avatar = await createActiveAvatar({ userID: signedIn.userID });
 
   const client = createStubWorkerClient();
 
@@ -139,7 +139,7 @@ test('it reports online only once across re-renders', async () => {
 
 test('it reports online again when the browser comes back online', async () => {
   const signedIn = await createSignedInUser();
-  const avatar = await db.avatarCollection.create({ userID: signedIn.userID });
+  const avatar = await createActiveAvatar({ userID: signedIn.userID });
 
   const client = createStubWorkerClient();
 

--- a/apps/web/src/routes/-game/playing-elsewhere-notice.test.tsx
+++ b/apps/web/src/routes/-game/playing-elsewhere-notice.test.tsx
@@ -3,7 +3,7 @@ import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { setWriterDisplacedActivityID } from '@vers/idle-client';
 import { ActivityFailureAction } from '@vers/idle-core';
-import * as db from '@vers/mock-services/db';
+import { createActiveAvatar } from '../../test-utils/create-active-avatar';
 import { createSignedInUser } from '../../test-utils/create-signed-in-user';
 import { createStubWorkerClient } from '../../test-utils/create-stub-worker-client';
 import { render } from '../../test-utils/render';
@@ -29,7 +29,7 @@ test('it claims the run back with a claiming report on continue-here', async () 
   const user = userEvent.setup();
 
   const signedIn = await createSignedInUser();
-  const avatar = await db.avatarCollection.create({ userID: signedIn.userID });
+  const avatar = await createActiveAvatar({ userID: signedIn.userID });
 
   const client = createStubWorkerClient();
 

--- a/apps/web/src/routes/-respite/respite-panel.test.tsx
+++ b/apps/web/src/routes/-respite/respite-panel.test.tsx
@@ -1,7 +1,7 @@
 import { expect, test } from 'bun:test';
 import { screen } from '@testing-library/react';
-import * as db from '@vers/mock-services/db';
 import { orpc } from '../../lib/rpc/orpc';
+import { createActiveAvatar } from '../../test-utils/create-active-avatar';
 import { createSignedInUser } from '../../test-utils/create-signed-in-user';
 import { renderWithRouter } from '../../test-utils/render-with-router';
 import { withRequestContext } from '../../test-utils/with-request-context';
@@ -23,7 +23,7 @@ test('it shows a call to action for a caller with no avatar', async () => {
 test('it shows the respite hud for a caller with an avatar', async () => {
   const signedIn = await createSignedInUser();
 
-  await db.avatarCollection.create({ name: 'Karnak', userID: signedIn.userID });
+  await createActiveAvatar({ name: 'Karnak', userID: signedIn.userID });
 
   await withRequestContext({ cookies: signedIn.cookies }, async () => {
     renderWithRouter(<RespitePanel orpc={orpc} />);

--- a/apps/web/src/routes/-respite/respite-panel.test.tsx
+++ b/apps/web/src/routes/-respite/respite-panel.test.tsx
@@ -1,5 +1,6 @@
 import { expect, test } from 'bun:test';
 import { screen } from '@testing-library/react';
+import * as db from '@vers/mock-services/db';
 import { orpc } from '../../lib/rpc/orpc';
 import { createActiveAvatar } from '../../test-utils/create-active-avatar';
 import { createSignedInUser } from '../../test-utils/create-signed-in-user';
@@ -17,6 +18,21 @@ test('it shows a call to action for a caller with no avatar', async () => {
 
     expect(callToAction).toBeVisible();
     expect(callToAction.closest('a')).toHaveAttribute('href', '/avatars/create');
+  });
+});
+
+test('it routes a caller with avatars but no selection to the roster', async () => {
+  const signedIn = await createSignedInUser();
+
+  await db.avatarCollection.create({ name: 'Karnak', userID: signedIn.userID });
+
+  await withRequestContext({ cookies: signedIn.cookies }, async () => {
+    renderWithRouter(<RespitePanel orpc={orpc} />);
+
+    const callToAction = await screen.findByText('Choose your Avatar');
+
+    expect(callToAction).toBeVisible();
+    expect(callToAction.closest('a')).toHaveAttribute('href', '/avatars');
   });
 });
 

--- a/apps/web/src/routes/-respite/respite-panel.tsx
+++ b/apps/web/src/routes/-respite/respite-panel.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { Heading, Text } from '@vers/design-system';
 import { ScreenPanel } from '../../components/screen-panel';
+import { findActiveAvatar } from '../../lib/avatar/find-active-avatar';
 import type { OrpcQueryUtils } from '../../lib/rpc/orpc';
 
 interface RespitePanelProps {
@@ -22,9 +23,9 @@ export function RespitePanel(props: RespitePanelProps) {
     return <Text data-testid="respite-error">{message}</Text>;
   }
 
-  const [avatar] = query.data;
+  const avatar = findActiveAvatar(query.data);
 
-  if (avatar === undefined) {
+  if (avatar === null) {
     return (
       <>
         <Heading level={1}>Destiny Awaits a Vessel</Heading>

--- a/apps/web/src/routes/-respite/respite-panel.tsx
+++ b/apps/web/src/routes/-respite/respite-panel.tsx
@@ -25,13 +25,25 @@ export function RespitePanel(props: RespitePanelProps) {
 
   const avatar = findActiveAvatar(query.data);
 
-  if (avatar === null) {
+  // no avatars at all → forge one; avatars but no selection (the active one was deleted, or the
+  // cached roster went stale) → the roster, where an existing avatar can be picked
+  if (avatar === null && query.data.avatars.length === 0) {
     return (
       <>
         <Heading level={1}>Destiny Awaits a Vessel</Heading>
         <Text>What is an Arbiter without a champion?</Text>
         <Text>Call forth your Avatar and guide their path across the World.</Text>
         <Link to="/avatars/create">Awaken your Avatar</Link>
+      </>
+    );
+  }
+
+  if (avatar === null) {
+    return (
+      <>
+        <Heading level={1}>Destiny Awaits a Vessel</Heading>
+        <Text>Your champions await your word.</Text>
+        <Link to="/avatars">Choose your Avatar</Link>
       </>
     );
   }

--- a/apps/web/src/routes/_game/avatars.tsx
+++ b/apps/web/src/routes/_game/avatars.tsx
@@ -5,12 +5,12 @@ import { readAvatars } from '../../lib/avatar/read-avatars';
 export const Route = createFileRoute('/_game/avatars')({
   component: AvatarsPage,
   head: () => ({ meta: [{ title: 'vers | Avatars' }] }),
-  loader: async () => ({ avatars: await readAvatars() }),
+  loader: async () => ({ roster: await readAvatars() }),
   staticData: { presentation: 'ambient' },
 });
 
 function AvatarsPage() {
   const data = Route.useLoaderData();
 
-  return <AvatarRoster avatars={data.avatars} />;
+  return <AvatarRoster roster={data.roster} />;
 }

--- a/apps/web/src/test-utils/create-active-avatar.ts
+++ b/apps/web/src/test-utils/create-active-avatar.ts
@@ -1,0 +1,18 @@
+import * as db from '@vers/mock-services/db';
+import type { AvatarRowSchema } from '@vers/mock-services/db';
+import type * as z from 'zod';
+
+/**
+ * Creates an avatar row and marks it the owner's active selection, mirroring the create flow's
+ * auto-select — tests that render as "the player's avatar" need both rows now that the active
+ * avatar is a persisted choice, not the first row.
+ */
+export async function createActiveAvatar(
+  avatar: Readonly<Partial<z.input<typeof AvatarRowSchema>>> = {},
+): Promise<z.output<typeof AvatarRowSchema>> {
+  const created = await db.avatarCollection.create(avatar);
+
+  await db.activeAvatarCollection.create({ avatarID: created.id, userID: created.userID });
+
+  return created;
+}

--- a/contracts/avatar/src/avatar-contract.ts
+++ b/contracts/avatar/src/avatar-contract.ts
@@ -3,6 +3,14 @@ import * as z from 'zod';
 import { AvatarDataSchema } from './avatar-data-schema';
 import { AvatarModeSchema } from './avatar-mode-schema';
 import { AvatarNameSchema } from './avatar-name-schema';
+import { AvatarRosterSchema } from './avatar-roster-schema';
+
+const LimitReachedDataSchema = z.object({ cap: z.int(), mode: AvatarModeSchema });
+
+const SwitchLockedDataSchema = z.object({
+  owningAvatarID: z.string(),
+  owningAvatarName: z.string(),
+});
 
 /**
  * The avatar service's API: every procedure is authed and owner-scoped by `actingUserId`.
@@ -15,6 +23,11 @@ export const avatarContract = {
     .errors(
       defineErrors({
         CONFLICT: { data: z.object({}), message: 'An avatar with that name already exists' },
+        LIMIT_REACHED: {
+          data: LimitReachedDataSchema,
+          message: 'The avatar limit for this mode is reached',
+          status: 409,
+        },
       }),
     ),
 
@@ -38,9 +51,31 @@ export const avatarContract = {
     .output(AvatarDataSchema.nullable()),
 
   getAvatars: authedRoute
-    .route({ method: 'GET', path: '/avatars', summary: 'List avatars owned by the caller' })
+    .route({
+      method: 'GET',
+      path: '/avatars',
+      summary: 'List avatars owned by the caller with the active selection',
+    })
     .input(z.object({}))
-    .output(z.array(AvatarDataSchema)),
+    .output(AvatarRosterSchema),
+
+  selectAvatar: authedRoute
+    .route({
+      method: 'POST',
+      path: '/avatars/{id}/select',
+      summary: 'Make an avatar owned by the caller the active one',
+    })
+    .input(z.object({ id: z.string() }))
+    .output(z.object({ activeAvatarID: z.string() }))
+    .errors(
+      defineErrors({
+        CONFLICT: {
+          data: SwitchLockedDataSchema,
+          message: 'A live activity holds the active avatar',
+        },
+        NOT_FOUND: { data: z.object({}), message: 'Avatar not found' },
+      }),
+    ),
 
   /**
    * `name` is the only user-editable field by design: `level`/`xp` are server-owned progression.

--- a/contracts/avatar/src/avatar-mode-cap.ts
+++ b/contracts/avatar/src/avatar-mode-cap.ts
@@ -1,0 +1,5 @@
+/**
+ * How many avatars an account may hold per economy mode; `createAvatar` rejects past it with
+ * LIMIT_REACHED, and clients may hide the create affordance once every mode is full.
+ */
+export const AVATAR_MODE_CAP = 5;

--- a/contracts/avatar/src/avatar-roster-schema.ts
+++ b/contracts/avatar/src/avatar-roster-schema.ts
@@ -1,0 +1,14 @@
+import * as z from 'zod';
+import { AvatarDataSchema } from './avatar-data-schema';
+
+/**
+ * The caller's avatars together with the persisted active selection, answered as one shape so the
+ * roster and the active answer can never disagree. `activeAvatarID` is null until the caller
+ * selects an avatar or after the selected one is deleted.
+ */
+export const AvatarRosterSchema = z.object({
+  activeAvatarID: z.string().nullable(),
+  avatars: z.array(AvatarDataSchema),
+});
+
+export type AvatarRoster = z.infer<typeof AvatarRosterSchema>;

--- a/contracts/avatar/src/index.ts
+++ b/contracts/avatar/src/index.ts
@@ -1,7 +1,10 @@
 export type { AvatarContract } from './avatar-contract';
+export { AVATAR_MODE_CAP } from './avatar-mode-cap';
 export { avatarContract } from './avatar-contract';
 export type { AvatarData } from './avatar-data-schema';
 export { AvatarDataSchema } from './avatar-data-schema';
 export type { AvatarMode } from './avatar-mode-schema';
 export { AvatarModeSchema } from './avatar-mode-schema';
 export { AvatarNameSchema } from './avatar-name-schema';
+export type { AvatarRoster } from './avatar-roster-schema';
+export { AvatarRosterSchema } from './avatar-roster-schema';

--- a/libs/data/db/.kysely-codegenrc.json
+++ b/libs/data/db/.kysely-codegenrc.json
@@ -2,6 +2,7 @@
   "overrides": {
     "columns": {
       "activities.build_snapshot": "import('./types').Json",
+      "activities.encounter_node": "import('./types').Json",
       "activity_checkpoints.payload": "import('./types').Json",
       "avatar_items.affixes": "import('./types').Json"
     }

--- a/libs/data/db/migrations/1784643637283_active_avatars.ts
+++ b/libs/data/db/migrations/1784643637283_active_avatars.ts
@@ -3,10 +3,16 @@ import { sql } from 'kysely';
 
 /**
  * Creates the `active_avatars` table: one row per user naming the avatar the account plays as.
- * Deleting the avatar cascades the row away — dropping the selection — and deleting the user
- * removes it with the account.
+ * The composite foreign key onto `avatars (id, user_id)` makes a cross-user selection
+ * unrepresentable, and deleting the avatar cascades the row away — dropping the selection;
+ * deleting the user removes it with the account.
  */
 export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable('avatars')
+    .addUniqueConstraint('avatars_id_user_id_unique', ['id', 'user_id'])
+    .execute();
+
   await db.schema
     .createTable('active_avatars')
     .addColumn('user_id', 'text', (col) => col.primaryKey())
@@ -21,10 +27,10 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       (fk) => fk.onDelete('cascade').onUpdate('cascade'),
     )
     .addForeignKeyConstraint(
-      'active_avatars_avatar_id_avatars_id_fk',
-      ['avatar_id'],
+      'active_avatars_avatar_id_user_id_avatars_fk',
+      ['avatar_id', 'user_id'],
       'avatars',
-      ['id'],
+      ['id', 'user_id'],
       (fk) => fk.onDelete('cascade').onUpdate('cascade'),
     )
     .execute();
@@ -32,4 +38,5 @@ export async function up(db: Kysely<unknown>): Promise<void> {
 
 export async function down(db: Kysely<unknown>): Promise<void> {
   await db.schema.dropTable('active_avatars').execute();
+  await db.schema.alterTable('avatars').dropConstraint('avatars_id_user_id_unique').execute();
 }

--- a/libs/data/db/migrations/1784643637283_active_avatars.ts
+++ b/libs/data/db/migrations/1784643637283_active_avatars.ts
@@ -1,0 +1,35 @@
+import type { Kysely } from 'kysely';
+import { sql } from 'kysely';
+
+/**
+ * Creates the `active_avatars` table: one row per user naming the avatar the account plays as.
+ * Deleting the avatar cascades the row away — dropping the selection — and deleting the user
+ * removes it with the account.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable('active_avatars')
+    .addColumn('user_id', 'text', (col) => col.primaryKey())
+    .addColumn('avatar_id', 'text', (col) => col.notNull())
+    .addColumn('created_at', 'timestamp', (col) => col.notNull().defaultTo(sql`now()`))
+    .addColumn('updated_at', 'timestamp', (col) => col.notNull().defaultTo(sql`now()`))
+    .addForeignKeyConstraint(
+      'active_avatars_user_id_users_id_fk',
+      ['user_id'],
+      'users',
+      ['id'],
+      (fk) => fk.onDelete('cascade').onUpdate('cascade'),
+    )
+    .addForeignKeyConstraint(
+      'active_avatars_avatar_id_avatars_id_fk',
+      ['avatar_id'],
+      'avatars',
+      ['id'],
+      (fk) => fk.onDelete('cascade').onUpdate('cascade'),
+    )
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable('active_avatars').execute();
+}

--- a/libs/data/db/src/schema.generated.ts
+++ b/libs/data/db/src/schema.generated.ts
@@ -28,6 +28,13 @@ export type Timestamp = ColumnType<Date, Date | string, Date | string>;
 
 export type VerificationType = '2fa' | '2fa-setup' | 'change-email' | 'onboarding';
 
+export interface ActiveAvatars {
+  avatarId: string;
+  createdAt: Generated<Timestamp>;
+  updatedAt: Generated<Timestamp>;
+  userId: string;
+}
+
 export interface Activities {
   appendedAt: Timestamp | null;
   appendedHead: Generated<number>;
@@ -193,6 +200,7 @@ export interface Verifications {
 }
 
 export interface DB {
+  activeAvatars: ActiveAvatars;
   activities: Activities;
   activityChains: ActivityChains;
   activityCheckpoints: ActivityCheckpoints;

--- a/libs/game/idle-client/src/worker/run-resync-flow.test.ts
+++ b/libs/game/idle-client/src/worker/run-resync-flow.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from 'bun:test';
+import { createMockActivityData } from '@vers/contract-activity/test-utils';
+import { createAuthedServiceClient, createViewer } from '@vers/mock-services';
+import type { ActivityServiceClient } from '../submission/types';
+import { createStubWorkerContext } from '../test-utils/create-stub-worker-context';
+import { runResyncFlow } from './run-resync-flow';
+import type { FlowSignals } from './types';
+
+test('it resets a held run belonging to another avatar before installing', async () => {
+  const viewer = await createViewer();
+  const client = await createAuthedServiceClient<ActivityServiceClient>('activity', viewer.user.id);
+
+  const context = createStubWorkerContext({ client });
+
+  // a run held for a different avatar can only arrive through the switch guard's TOCTOU gap
+  context.setActivity(createMockActivityData({ avatarID: 'someone-else' }));
+
+  const before = context.getSimulation();
+
+  const signals: FlowSignals = {
+    cancel: context.getCancelSignal(),
+    stop: context.getStopSignal(),
+  };
+
+  await runResyncFlow(context, viewer.avatar.id, false, signals);
+
+  expect(context.getActivity()).toBeNull();
+  expect(context.getSimulation()).not.toBe(before);
+});

--- a/libs/game/idle-client/src/worker/run-resync-flow.ts
+++ b/libs/game/idle-client/src/worker/run-resync-flow.ts
@@ -53,6 +53,15 @@ export async function runResyncFlow(
   claim: boolean,
   signals: Readonly<FlowSignals>,
 ): Promise<void> {
+  const heldActivity = context.getActivity();
+
+  // a held run can only belong to another avatar when the account's active avatar changed under
+  // a live activity (the switch guard is best-effort against a concurrent start); never install
+  // on top of it — reset first so no snapshot of the old avatar outlives the switch
+  if (heldActivity !== null && heldActivity.avatarID !== avatarID) {
+    resetSimulation(context);
+  }
+
   context.setResyncAvatarID(avatarID);
 
   try {

--- a/libs/testing/mock-services/src/avatar/avatar-router.ts
+++ b/libs/testing/mock-services/src/avatar/avatar-router.ts
@@ -2,6 +2,7 @@ import { createAvatar } from './create-avatar';
 import { deleteAvatar } from './delete-avatar';
 import { getAvatar } from './get-avatar';
 import { getAvatars } from './get-avatars';
+import { selectAvatar } from './select-avatar';
 import { updateAvatar } from './update-avatar';
 
 export const avatarRouter = {
@@ -9,5 +10,6 @@ export const avatarRouter = {
   deleteAvatar,
   getAvatar,
   getAvatars,
+  selectAvatar,
   updateAvatar,
 };

--- a/libs/testing/mock-services/src/avatar/create-avatar.ts
+++ b/libs/testing/mock-services/src/avatar/create-avatar.ts
@@ -1,11 +1,15 @@
 import { createId } from '@paralleldrive/cuid2';
+import { AVATAR_MODE_CAP } from '@vers/contract-avatar';
 import * as db from '../db';
+import { findLiveActivityAvatar } from './find-live-activity-avatar';
 import { os } from './os';
+import { upsertActiveAvatar } from './upsert-active-avatar';
 
 /**
- * Avatar names are unique globally, not per user, mirroring the real service.
+ * Avatar names are unique globally, not per user, mirroring the real service; so are the per-mode
+ * cap and the auto-select that yields to a live activity's hold on the selection.
  */
-export const createAvatar = os.createAvatar.handler((opts) => {
+export const createAvatar = os.createAvatar.handler(async (opts) => {
   const actingUserId = opts.context.actingUserId;
 
   if (actingUserId === null) {
@@ -16,9 +20,17 @@ export const createAvatar = os.createAvatar.handler((opts) => {
     throw opts.errors.CONFLICT({ data: {} });
   }
 
+  const held = db.avatarCollection.findMany((q) =>
+    q.where({ mode: opts.input.mode, userID: actingUserId }),
+  );
+
+  if (held.length >= AVATAR_MODE_CAP) {
+    throw opts.errors.LIMIT_REACHED({ data: { cap: AVATAR_MODE_CAP, mode: opts.input.mode } });
+  }
+
   const now = new Date();
 
-  return db.avatarCollection.create({
+  const avatar = await db.avatarCollection.create({
     createdAt: now,
     id: createId(),
     level: 1,
@@ -28,4 +40,10 @@ export const createAvatar = os.createAvatar.handler((opts) => {
     userID: actingUserId,
     xp: 0,
   });
+
+  if (findLiveActivityAvatar(actingUserId) === null) {
+    await upsertActiveAvatar(actingUserId, avatar.id);
+  }
+
+  return avatar;
 });

--- a/libs/testing/mock-services/src/avatar/delete-avatar.ts
+++ b/libs/testing/mock-services/src/avatar/delete-avatar.ts
@@ -18,5 +18,14 @@ export const deleteAvatar = os.deleteAvatar.handler((opts) => {
 
   db.avatarCollection.delete(avatar);
 
+  // mirrors the real table's FK cascade: deleting the active avatar drops the selection
+  const selection = db.activeAvatarCollection.findFirst((q) =>
+    q.where({ avatarID: avatar.id, userID: actingUserId }),
+  );
+
+  if (selection !== undefined) {
+    db.activeAvatarCollection.delete(selection);
+  }
+
   return { deletedID: avatar.id };
 });

--- a/libs/testing/mock-services/src/avatar/find-live-activity-avatar.ts
+++ b/libs/testing/mock-services/src/avatar/find-live-activity-avatar.ts
@@ -1,0 +1,21 @@
+import * as db from '../db';
+
+/**
+ * Finds the avatar owning the user's live mock activity, or null when no run is live, mirroring
+ * the real service's guard query.
+ */
+export function findLiveActivityAvatar(userID: string): { id: string; name: string } | null {
+  const avatars = db.avatarCollection.findMany((q) => q.where({ userID }));
+
+  for (const avatar of avatars) {
+    const live = db.activityCollection.findFirst((q) =>
+      q.where({ avatarID: avatar.id, status: 'active' }),
+    );
+
+    if (live !== undefined) {
+      return { id: avatar.id, name: avatar.name };
+    }
+  }
+
+  return null;
+}

--- a/libs/testing/mock-services/src/avatar/get-avatars.ts
+++ b/libs/testing/mock-services/src/avatar/get-avatars.ts
@@ -8,5 +8,8 @@ export const getAvatars = os.getAvatars.handler((opts) => {
     throw opts.errors.UNAUTHORIZED({ data: { reason: 'missing-session' } });
   }
 
-  return db.avatarCollection.findMany((q) => q.where({ userID: actingUserId }));
+  const avatars = db.avatarCollection.findMany((q) => q.where({ userID: actingUserId }));
+  const active = db.activeAvatarCollection.findFirst((q) => q.where({ userID: actingUserId }));
+
+  return { activeAvatarID: active?.avatarID ?? null, avatars };
 });

--- a/libs/testing/mock-services/src/avatar/select-avatar.ts
+++ b/libs/testing/mock-services/src/avatar/select-avatar.ts
@@ -1,0 +1,32 @@
+import * as db from '../db';
+import { findLiveActivityAvatar } from './find-live-activity-avatar';
+import { os } from './os';
+import { upsertActiveAvatar } from './upsert-active-avatar';
+
+export const selectAvatar = os.selectAvatar.handler(async (opts) => {
+  const actingUserId = opts.context.actingUserId;
+
+  if (actingUserId === null) {
+    throw opts.errors.UNAUTHORIZED({ data: { reason: 'missing-session' } });
+  }
+
+  const avatar = db.avatarCollection.findFirst((q) =>
+    q.where({ id: opts.input.id, userID: actingUserId }),
+  );
+
+  if (avatar === undefined) {
+    throw opts.errors.NOT_FOUND({ data: {} });
+  }
+
+  const liveAvatar = findLiveActivityAvatar(actingUserId);
+
+  if (liveAvatar !== null && liveAvatar.id !== avatar.id) {
+    throw opts.errors.CONFLICT({
+      data: { owningAvatarID: liveAvatar.id, owningAvatarName: liveAvatar.name },
+    });
+  }
+
+  await upsertActiveAvatar(actingUserId, avatar.id);
+
+  return { activeAvatarID: avatar.id };
+});

--- a/libs/testing/mock-services/src/avatar/upsert-active-avatar.ts
+++ b/libs/testing/mock-services/src/avatar/upsert-active-avatar.ts
@@ -1,0 +1,21 @@
+import * as db from '../db';
+
+/**
+ * Writes the user's active-avatar selection, replacing any existing row, mirroring the real
+ * service's keyed upsert.
+ */
+export async function upsertActiveAvatar(userID: string, avatarID: string): Promise<void> {
+  const existing = db.activeAvatarCollection.findFirst((q) => q.where({ userID }));
+
+  if (existing === undefined) {
+    await db.activeAvatarCollection.create({ avatarID, userID });
+
+    return;
+  }
+
+  await db.activeAvatarCollection.update(existing, {
+    data(record) {
+      record.avatarID = avatarID;
+    },
+  });
+}

--- a/libs/testing/mock-services/src/create-demo-seed.ts
+++ b/libs/testing/mock-services/src/create-demo-seed.ts
@@ -1,4 +1,5 @@
 import { createId } from '@paralleldrive/cuid2';
+import { activeAvatarCollection } from './db/active-avatar-collection';
 import { avatarCollection } from './db/avatar-collection';
 import { userCollection } from './db/user-collection';
 import { DEMO_ACCOUNTS } from './demo-accounts';
@@ -24,13 +25,15 @@ export async function createDemoSeed(): Promise<void> {
     });
 
     if (account.avatarName !== null) {
-      await avatarCollection.create({
+      const avatar = await avatarCollection.create({
         createdAt: new Date(),
         id: createId(),
         name: account.avatarName,
         updatedAt: new Date(),
         userID,
       });
+
+      await activeAvatarCollection.create({ avatarID: avatar.id, userID });
     }
   }
 }

--- a/libs/testing/mock-services/src/create-viewer.ts
+++ b/libs/testing/mock-services/src/create-viewer.ts
@@ -1,7 +1,7 @@
 import type * as z from 'zod';
 import { createTestAccessToken } from './create-test-access-token';
 import type { AvatarRowSchema, UserRowSchema } from './db';
-import { avatarCollection, userCollection } from './db';
+import { activeAvatarCollection, avatarCollection, userCollection } from './db';
 
 interface CreateViewerConfig {
   readonly avatar?: z.input<typeof AvatarRowSchema>;
@@ -15,11 +15,11 @@ interface Viewer {
 }
 
 /**
- * An acting user seeded into the mock store: a user row, an avatar row linked to it, and an access
- * token minted for the user — the MSW-regime counterpart of the real-database viewer composite.
- * Overrides pass through to the collections' defaults; the avatar's user linkage comes free, though
- * an explicit `avatar.userID` override still wins. Returns data only — callers build their own
- * client for the transport they exercise.
+ * An acting user seeded into the mock store: a user row, an avatar row linked to it and marked as
+ * the user's active selection, and an access token minted for the user — the MSW-regime
+ * counterpart of the real-database viewer composite. Overrides pass through to the collections'
+ * defaults; the avatar's user linkage comes free, though an explicit `avatar.userID` override
+ * still wins. Returns data only — callers build their own client for the transport they exercise.
  */
 export async function createViewer(config: Readonly<CreateViewerConfig> = {}): Promise<Viewer> {
   const user = await userCollection.create(config.user ?? {});
@@ -28,6 +28,8 @@ export async function createViewer(config: Readonly<CreateViewerConfig> = {}): P
     ...config.avatar,
     userID: config.avatar?.userID ?? user.id,
   });
+
+  await activeAvatarCollection.create({ avatarID: avatar.id, userID: avatar.userID });
 
   const token = await createTestAccessToken(user.id);
 

--- a/libs/testing/mock-services/src/db/active-avatar-collection.ts
+++ b/libs/testing/mock-services/src/db/active-avatar-collection.ts
@@ -1,0 +1,14 @@
+import { Collection } from '@msw/data';
+import { createId } from '@paralleldrive/cuid2';
+import * as z from 'zod';
+
+/**
+ * A stored mock active-avatar selection: one row per user naming the avatar the account plays as,
+ * mirroring the real service's `active_avatars` table.
+ */
+const ActiveAvatarRowSchema = z.object({
+  avatarID: z.string().default(() => createId()),
+  userID: z.string().default(() => createId()),
+});
+
+export const activeAvatarCollection = new Collection({ schema: ActiveAvatarRowSchema });

--- a/libs/testing/mock-services/src/db/index.ts
+++ b/libs/testing/mock-services/src/db/index.ts
@@ -1,3 +1,4 @@
+export { activeAvatarCollection } from './active-avatar-collection';
 export { activityCollection } from './activity-collection';
 export { avatarCollection, AvatarRowSchema } from './avatar-collection';
 export { avatarItemCollection } from './avatar-item-collection';

--- a/libs/testing/mock-services/src/demo-accounts.ts
+++ b/libs/testing/mock-services/src/demo-accounts.ts
@@ -54,4 +54,11 @@ export const DEMO_ACCOUNTS: ReadonlyArray<DemoAccount> = [
     password: 'password123',
     username: 'e2e-web-locks',
   },
+  {
+    avatarName: 'RosterPrime',
+    email: 'e2e-avatar-roster@vers.test',
+    name: 'Avatar Roster Demo Account',
+    password: 'password123',
+    username: 'e2e-avatar-roster',
+  },
 ];

--- a/services/avatar/src/build-router.ts
+++ b/services/avatar/src/build-router.ts
@@ -7,6 +7,7 @@ import { createAvatar } from './handlers/create-avatar';
 import { getAvatar } from './handlers/get-avatar';
 import { getAvatars } from './handlers/get-avatars';
 import { removeAvatar } from './handlers/remove-avatar';
+import { selectAvatar } from './handlers/select-avatar';
 import { updateAvatar } from './handlers/update-avatar';
 
 interface BuildAvatarRouterDeps {
@@ -24,6 +25,7 @@ export function buildAvatarRouter(deps: BuildAvatarRouterDeps) {
     deleteAvatar: os.deleteAvatar.handler((opts) => removeAvatar(deps.db, opts)),
     getAvatar: os.getAvatar.handler((opts) => getAvatar(deps.db, opts)),
     getAvatars: os.getAvatars.handler((opts) => getAvatars(deps.db, opts)),
+    selectAvatar: os.selectAvatar.handler((opts) => selectAvatar(deps.db, opts)),
     updateAvatar: os.updateAvatar.handler((opts) => updateAvatar(deps.db, opts)),
   };
 }

--- a/services/avatar/src/handlers/create-avatar.test.ts
+++ b/services/avatar/src/handlers/create-avatar.test.ts
@@ -1,8 +1,10 @@
 import { expect, test } from 'bun:test';
 import type { AvatarContract } from '@vers/contract-avatar';
+import { AVATAR_MODE_CAP } from '@vers/contract-avatar';
 import { createAnonymousViewer, createTestDB, createViewer } from '@vers/service-test-utils/bun';
 import { buildRPCTestClient } from '@vers/test-utils';
 import { createAvatarService } from '../create-avatar-service';
+import { createActivityRow } from '../test-utils/create-activity-row';
 
 async function setupTest() {
   const db = await createTestDB();
@@ -56,6 +58,72 @@ test('it rejects a second avatar with a duplicate name with CONFLICT', async () 
   expect(client.createAvatar({ name: 'Duplicatus' })).rejects.toMatchObject({
     code: 'CONFLICT',
   });
+});
+
+test('it makes the created avatar the active one', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-avatar', db: ctx.db });
+
+  const client = buildRPCTestClient<AvatarContract>(ctx.app, { token: viewer.token });
+
+  await client.createAvatar({ name: 'Elder' });
+
+  const younger = await client.createAvatar({ name: 'Younger' });
+  const roster = await client.getAvatars({});
+
+  expect(roster.activeAvatarID).toBe(younger.id);
+});
+
+test('it leaves the selection alone when a live activity holds it', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-avatar', db: ctx.db });
+
+  const client = buildRPCTestClient<AvatarContract>(ctx.app, { token: viewer.token });
+
+  const runner = await client.createAvatar({ name: 'Runner' });
+
+  await createActivityRow(ctx.db, { avatarId: runner.id, status: 'active' });
+
+  await client.createAvatar({ name: 'Newcomer' });
+
+  const roster = await client.getAvatars({});
+
+  expect(roster.activeAvatarID).toBe(runner.id);
+});
+
+test('it rejects a create past the per-mode cap with LIMIT_REACHED', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-avatar', db: ctx.db });
+
+  const client = buildRPCTestClient<AvatarContract>(ctx.app, { token: viewer.token });
+
+  for (let index = 0; index < AVATAR_MODE_CAP; index += 1) {
+    await client.createAvatar({ name: `TradeAvatar${String.fromCodePoint(65 + index)}` });
+  }
+
+  expect(client.createAvatar({ name: 'OneTooMany' })).rejects.toMatchObject({
+    code: 'LIMIT_REACHED',
+    data: { cap: AVATAR_MODE_CAP, mode: 'trade' },
+  });
+});
+
+test('it counts the cap per mode, not per account', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-avatar', db: ctx.db });
+
+  const client = buildRPCTestClient<AvatarContract>(ctx.app, { token: viewer.token });
+
+  for (let index = 0; index < AVATAR_MODE_CAP; index += 1) {
+    await client.createAvatar({ name: `TradeAvatar${String.fromCodePoint(65 + index)}` });
+  }
+
+  const selfFound = await client.createAvatar({ mode: 'self_found', name: 'StillRoom' });
+
+  expect(selfFound.mode).toBe('self_found');
 });
 
 test('it rejects an anonymous acting user with UNAUTHORIZED', async () => {

--- a/services/avatar/src/handlers/create-avatar.ts
+++ b/services/avatar/src/handlers/create-avatar.ts
@@ -1,9 +1,19 @@
 import { createId } from '@paralleldrive/cuid2';
 import type { AvatarData, AvatarMode } from '@vers/contract-avatar';
+import { AVATAR_MODE_CAP } from '@vers/contract-avatar';
 import type { DB } from '@vers/db';
 import type { Kysely } from 'kysely';
+import { sql } from 'kysely';
 import type { EmptyErrorPayload, MissingSessionPayload } from '../types';
+import { findLiveActivityAvatar } from './find-live-activity-avatar';
 import { toAvatarData } from './to-avatar-data';
+
+/**
+ * Payload shape for createAvatar's LIMIT_REACHED: the mode whose cap the caller hit.
+ */
+interface LimitReachedPayload {
+  readonly data: { readonly cap: number; readonly mode: AvatarMode };
+}
 
 /**
  * oRPC handler opts for the authed `createAvatar` procedure.
@@ -12,32 +22,31 @@ interface CreateAvatarOpts {
   readonly context: { readonly actingUserId: null | string };
   readonly errors: {
     readonly CONFLICT: (payload: EmptyErrorPayload) => Error;
+    readonly LIMIT_REACHED: (payload: LimitReachedPayload) => Error;
     readonly UNAUTHORIZED: (payload: MissingSessionPayload) => Error;
   };
   readonly input: { readonly mode: AvatarMode; readonly name: string };
 }
 
 /**
- * Creates an avatar owned by the acting user; throws CONFLICT when the name is already taken.
+ * Creates an avatar owned by the acting user and makes it the active one, unless a live activity
+ * holds the selection — then the new avatar lands unselected, since taking the slot would steal
+ * it from the running avatar. Throws CONFLICT when the name is already taken and LIMIT_REACHED at
+ * the per-mode cap; the per-user advisory lock serializes the count against concurrent creates
+ * (a row lock can't fence inserts that don't exist yet). Runs inside the caller's transaction
+ * when given one, or opens its own otherwise.
  */
 export async function createAvatar(db: Kysely<DB>, opts: CreateAvatarOpts): Promise<AvatarData> {
-  if (opts.context.actingUserId === null) {
+  const actingUserId = opts.context.actingUserId;
+
+  if (actingUserId === null) {
     throw opts.errors.UNAUTHORIZED({ data: { reason: 'missing-session' } });
   }
 
   try {
-    const row = await db
-      .insertInto('avatars')
-      .values({
-        id: createId(),
-        mode: opts.input.mode,
-        name: opts.input.name,
-        userId: opts.context.actingUserId,
-      })
-      .returningAll()
-      .executeTakeFirstOrThrow();
-
-    return toAvatarData(row);
+    return db.isTransaction
+      ? await runCreateWrites(db, actingUserId, opts)
+      : await db.transaction().execute((trx) => runCreateWrites(trx, actingUserId, opts));
   } catch (error: unknown) {
     if (isUniqueViolation(error)) {
       throw opts.errors.CONFLICT({ data: {} });
@@ -45,6 +54,50 @@ export async function createAvatar(db: Kysely<DB>, opts: CreateAvatarOpts): Prom
 
     throw error;
   }
+}
+
+async function runCreateWrites(
+  trx: Kysely<DB>,
+  actingUserId: string,
+  opts: CreateAvatarOpts,
+): Promise<AvatarData> {
+  await sql`select pg_advisory_xact_lock(hashtext(${actingUserId}))`.execute(trx);
+
+  const counted = await trx
+    .selectFrom('avatars')
+    .select((eb) => eb.fn.countAll<number>().as('held'))
+    .where('userId', '=', actingUserId)
+    .where('mode', '=', opts.input.mode)
+    .executeTakeFirstOrThrow();
+
+  if (counted.held >= AVATAR_MODE_CAP) {
+    throw opts.errors.LIMIT_REACHED({
+      data: { cap: AVATAR_MODE_CAP, mode: opts.input.mode },
+    });
+  }
+
+  const row = await trx
+    .insertInto('avatars')
+    .values({
+      id: createId(),
+      mode: opts.input.mode,
+      name: opts.input.name,
+      userId: actingUserId,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
+
+  if ((await findLiveActivityAvatar(trx, actingUserId)) === null) {
+    await trx
+      .insertInto('activeAvatars')
+      .values({ avatarId: row.id, userId: actingUserId })
+      .onConflict((oc) =>
+        oc.column('userId').doUpdateSet({ avatarId: row.id, updatedAt: sql`now()` }),
+      )
+      .execute();
+  }
+
+  return toAvatarData(row);
 }
 
 /**

--- a/services/avatar/src/handlers/find-live-activity-avatar.ts
+++ b/services/avatar/src/handlers/find-live-activity-avatar.ts
@@ -1,0 +1,21 @@
+import type { DB } from '@vers/db';
+import type { Kysely } from 'kysely';
+
+/**
+ * Finds the avatar owning the user's live activity, or null when no run is live. At most one
+ * activity per account is live by design, so the first match is the answer.
+ */
+export async function findLiveActivityAvatar(
+  db: Kysely<DB>,
+  userId: string,
+): Promise<{ id: string; name: string } | null> {
+  const row = await db
+    .selectFrom('activities')
+    .innerJoin('avatars', 'avatars.id', 'activities.avatarId')
+    .select(['avatars.id', 'avatars.name'])
+    .where('avatars.userId', '=', userId)
+    .where('activities.status', '=', 'active')
+    .executeTakeFirst();
+
+  return row ?? null;
+}

--- a/services/avatar/src/handlers/get-avatars.test.ts
+++ b/services/avatar/src/handlers/get-avatars.test.ts
@@ -22,9 +22,9 @@ test('it lists only the acting user avatars', async () => {
   await client.createAvatar({ name: 'OwnerAvatarOne' });
   await client.createAvatar({ name: 'OwnerAvatarTwo' });
 
-  const avatars = await client.getAvatars({});
+  const roster = await client.getAvatars({});
 
-  expect(avatars.map((avatar) => avatar.name)).toIncludeSameMembers([
+  expect(roster.avatars.map((avatar) => avatar.name)).toIncludeSameMembers([
     'OwnerAvatarOne',
     'OwnerAvatarTwo',
   ]);
@@ -40,9 +40,42 @@ test('it excludes avatars owned by another user', async () => {
 
   const client = buildRPCTestClient<AvatarContract>(ctx.app, { token: viewer.token });
 
-  const avatars = await client.getAvatars({});
+  const roster = await client.getAvatars({});
 
-  expect(avatars).toBeEmpty();
+  expect(roster).toStrictEqual({ activeAvatarID: null, avatars: [] });
+});
+
+test('it answers null active selection when avatars exist but none is selected', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-avatar', db: ctx.db });
+
+  const client = buildRPCTestClient<AvatarContract>(ctx.app, { token: viewer.token });
+
+  const avatar = await client.createAvatar({ name: 'Lingering' });
+
+  await ctx.db.deleteFrom('activeAvatars').where('userId', '=', viewer.user.id).execute();
+
+  const roster = await client.getAvatars({});
+
+  expect(roster.avatars.map((entry) => entry.id)).toEqual([avatar.id]);
+  expect(roster.activeAvatarID).toBeNull();
+});
+
+test('it drops the active selection when the active avatar is deleted', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-avatar', db: ctx.db });
+
+  const client = buildRPCTestClient<AvatarContract>(ctx.app, { token: viewer.token });
+
+  const avatar = await client.createAvatar({ name: 'Ephemeral' });
+
+  await client.deleteAvatar({ id: avatar.id });
+
+  const roster = await client.getAvatars({});
+
+  expect(roster.activeAvatarID).toBeNull();
 });
 
 test('it rejects an anonymous acting user with UNAUTHORIZED', async () => {

--- a/services/avatar/src/handlers/get-avatars.ts
+++ b/services/avatar/src/handlers/get-avatars.ts
@@ -15,7 +15,9 @@ interface GetAvatarsOpts {
 }
 
 /**
- * Lists every avatar owned by the acting user together with the persisted active selection.
+ * Lists every avatar owned by the acting user together with the persisted active selection. One
+ * joined statement, so the list and the selection come from the same snapshot and the answer can
+ * never name an avatar it doesn't list.
  */
 export async function getAvatars(db: Kysely<DB>, opts: GetAvatarsOpts): Promise<AvatarRoster> {
   if (opts.context.actingUserId === null) {
@@ -24,18 +26,18 @@ export async function getAvatars(db: Kysely<DB>, opts: GetAvatarsOpts): Promise<
 
   const rows = await db
     .selectFrom('avatars')
-    .selectAll()
-    .where('userId', '=', opts.context.actingUserId)
+    .leftJoin('activeAvatars', (join) =>
+      join
+        .onRef('activeAvatars.avatarId', '=', 'avatars.id')
+        .onRef('activeAvatars.userId', '=', 'avatars.userId'),
+    )
+    .selectAll('avatars')
+    .select('activeAvatars.avatarId as selectedAvatarId')
+    .where('avatars.userId', '=', opts.context.actingUserId)
     .execute();
 
-  const active = await db
-    .selectFrom('activeAvatars')
-    .select(['avatarId'])
-    .where('userId', '=', opts.context.actingUserId)
-    .executeTakeFirst();
-
   return {
-    activeAvatarID: active?.avatarId ?? null,
+    activeAvatarID: rows.find((row) => row.selectedAvatarId !== null)?.id ?? null,
     avatars: rows.map((row) => toAvatarData(row)),
   };
 }

--- a/services/avatar/src/handlers/get-avatars.ts
+++ b/services/avatar/src/handlers/get-avatars.ts
@@ -1,4 +1,4 @@
-import type { AvatarData } from '@vers/contract-avatar';
+import type { AvatarRoster } from '@vers/contract-avatar';
 import type { DB } from '@vers/db';
 import type { Kysely } from 'kysely';
 import type { MissingSessionPayload } from '../types';
@@ -15,9 +15,9 @@ interface GetAvatarsOpts {
 }
 
 /**
- * Lists every avatar owned by the acting user.
+ * Lists every avatar owned by the acting user together with the persisted active selection.
  */
-export async function getAvatars(db: Kysely<DB>, opts: GetAvatarsOpts): Promise<Array<AvatarData>> {
+export async function getAvatars(db: Kysely<DB>, opts: GetAvatarsOpts): Promise<AvatarRoster> {
   if (opts.context.actingUserId === null) {
     throw opts.errors.UNAUTHORIZED({ data: { reason: 'missing-session' } });
   }
@@ -28,5 +28,14 @@ export async function getAvatars(db: Kysely<DB>, opts: GetAvatarsOpts): Promise<
     .where('userId', '=', opts.context.actingUserId)
     .execute();
 
-  return rows.map((row) => toAvatarData(row));
+  const active = await db
+    .selectFrom('activeAvatars')
+    .select(['avatarId'])
+    .where('userId', '=', opts.context.actingUserId)
+    .executeTakeFirst();
+
+  return {
+    activeAvatarID: active?.avatarId ?? null,
+    avatars: rows.map((row) => toAvatarData(row)),
+  };
 }

--- a/services/avatar/src/handlers/select-avatar.test.ts
+++ b/services/avatar/src/handlers/select-avatar.test.ts
@@ -1,0 +1,113 @@
+import { expect, test } from 'bun:test';
+import type { AvatarContract } from '@vers/contract-avatar';
+import { createAnonymousViewer, createTestDB, createViewer } from '@vers/service-test-utils/bun';
+import { buildRPCTestClient } from '@vers/test-utils';
+import { createAvatarService } from '../create-avatar-service';
+import { createActivityRow } from '../test-utils/create-activity-row';
+import { createAvatarRow } from '../test-utils/create-avatar-row';
+
+async function setupTest() {
+  const db = await createTestDB();
+  const service = await createAvatarService({ db: db.db });
+
+  return { app: service.app, db: db.db, [Symbol.asyncDispose]: db[Symbol.asyncDispose] };
+}
+
+test('it persists the selected avatar as the active one', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-avatar', db: ctx.db });
+
+  const client = buildRPCTestClient<AvatarContract>(ctx.app, { token: viewer.token });
+
+  const first = await client.createAvatar({ name: 'FirstPick' });
+  const second = await client.createAvatar({ name: 'SecondPick' });
+  const selected = await client.selectAvatar({ id: first.id });
+
+  expect(selected).toStrictEqual({ activeAvatarID: first.id });
+  expect(second.id).not.toBe(first.id);
+
+  const roster = await client.getAvatars({});
+
+  expect(roster.activeAvatarID).toBe(first.id);
+});
+
+test('it rejects selecting an avatar owned by another user with NOT_FOUND', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-avatar', db: ctx.db });
+  const other = await createViewer({ audience: 'service-avatar', db: ctx.db });
+  const foreign = await createAvatarRow(ctx.db, { name: 'NotYours', userId: other.user.id });
+
+  const client = buildRPCTestClient<AvatarContract>(ctx.app, { token: viewer.token });
+
+  expect(client.selectAvatar({ id: foreign.id })).rejects.toMatchObject({
+    code: 'NOT_FOUND',
+  });
+});
+
+test('it rejects switching away from an avatar with a live activity with CONFLICT', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-avatar', db: ctx.db });
+
+  const client = buildRPCTestClient<AvatarContract>(ctx.app, { token: viewer.token });
+
+  const runner = await client.createAvatar({ name: 'Runner' });
+  const idle = await client.createAvatar({ name: 'Idler' });
+
+  await createActivityRow(ctx.db, { avatarId: runner.id, status: 'active' });
+
+  expect(client.selectAvatar({ id: idle.id })).rejects.toMatchObject({
+    code: 'CONFLICT',
+    data: { owningAvatarID: runner.id, owningAvatarName: 'Runner' },
+  });
+});
+
+test('it allows re-selecting the avatar that owns the live activity', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-avatar', db: ctx.db });
+
+  const client = buildRPCTestClient<AvatarContract>(ctx.app, { token: viewer.token });
+
+  const runner = await client.createAvatar({ name: 'Runner' });
+
+  await client.createAvatar({ name: 'Idler' });
+
+  await createActivityRow(ctx.db, { avatarId: runner.id, status: 'active' });
+
+  const selected = await client.selectAvatar({ id: runner.id });
+
+  expect(selected).toStrictEqual({ activeAvatarID: runner.id });
+});
+
+test('it ignores a finished activity when switching', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-avatar', db: ctx.db });
+
+  const client = buildRPCTestClient<AvatarContract>(ctx.app, { token: viewer.token });
+
+  const runner = await client.createAvatar({ name: 'Runner' });
+  const idle = await client.createAvatar({ name: 'Idler' });
+
+  await createActivityRow(ctx.db, { avatarId: runner.id, status: 'stopped' });
+
+  const selected = await client.selectAvatar({ id: idle.id });
+
+  expect(selected).toStrictEqual({ activeAvatarID: idle.id });
+});
+
+test('it rejects an anonymous acting user with UNAUTHORIZED', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createAnonymousViewer({ audience: 'service-avatar' });
+
+  const client = buildRPCTestClient<AvatarContract>(ctx.app, { token: viewer.token });
+
+  expect(client.selectAvatar({ id: 'anything' })).rejects.toMatchObject({
+    code: 'UNAUTHORIZED',
+    data: { reason: 'missing-session' },
+  });
+});

--- a/services/avatar/src/handlers/select-avatar.ts
+++ b/services/avatar/src/handlers/select-avatar.ts
@@ -1,0 +1,86 @@
+import type { DB } from '@vers/db';
+import type { Kysely } from 'kysely';
+import { sql } from 'kysely';
+import type { EmptyErrorPayload, MissingSessionPayload } from '../types';
+import { findLiveActivityAvatar } from './find-live-activity-avatar';
+
+/**
+ * Payload shape for selectAvatar's CONFLICT: the live run's avatar, named so the client can tell
+ * the player who holds the active slot.
+ */
+interface ActivityLockedPayload {
+  readonly data: { readonly owningAvatarID: string; readonly owningAvatarName: string };
+}
+
+/**
+ * oRPC handler opts for the authed `selectAvatar` procedure.
+ */
+interface SelectAvatarOpts {
+  readonly context: { readonly actingUserId: null | string };
+  readonly errors: {
+    readonly CONFLICT: (payload: ActivityLockedPayload) => Error;
+    readonly NOT_FOUND: (payload: EmptyErrorPayload) => Error;
+    readonly UNAUTHORIZED: (payload: MissingSessionPayload) => Error;
+  };
+  readonly input: { readonly id: string };
+}
+
+/**
+ * Persists the caller's active avatar. A live activity locks the selection to the avatar running
+ * it: selecting any other avatar throws CONFLICT naming the run's owner, while re-selecting the
+ * owner (or the already-active avatar) is a no-op success. The per-user advisory lock serializes
+ * this against concurrent creates; the live-activity read is best-effort against a run starting
+ * concurrently until activity starts are gated to the active avatar. Runs inside the caller's
+ * transaction when given one, or opens its own otherwise.
+ */
+export function selectAvatar(
+  db: Kysely<DB>,
+  opts: SelectAvatarOpts,
+): Promise<{ activeAvatarID: string }> {
+  const actingUserId = opts.context.actingUserId;
+
+  if (actingUserId === null) {
+    throw opts.errors.UNAUTHORIZED({ data: { reason: 'missing-session' } });
+  }
+
+  return db.isTransaction
+    ? runSelectWrites(db, actingUserId, opts)
+    : db.transaction().execute((trx) => runSelectWrites(trx, actingUserId, opts));
+}
+
+async function runSelectWrites(
+  trx: Kysely<DB>,
+  actingUserId: string,
+  opts: SelectAvatarOpts,
+): Promise<{ activeAvatarID: string }> {
+  await sql`select pg_advisory_xact_lock(hashtext(${actingUserId}))`.execute(trx);
+
+  const avatar = await trx
+    .selectFrom('avatars')
+    .select(['id'])
+    .where('id', '=', opts.input.id)
+    .where('userId', '=', actingUserId)
+    .executeTakeFirst();
+
+  if (avatar === undefined) {
+    throw opts.errors.NOT_FOUND({ data: {} });
+  }
+
+  const liveAvatar = await findLiveActivityAvatar(trx, actingUserId);
+
+  if (liveAvatar !== null && liveAvatar.id !== avatar.id) {
+    throw opts.errors.CONFLICT({
+      data: { owningAvatarID: liveAvatar.id, owningAvatarName: liveAvatar.name },
+    });
+  }
+
+  await trx
+    .insertInto('activeAvatars')
+    .values({ avatarId: avatar.id, userId: actingUserId })
+    .onConflict((oc) =>
+      oc.column('userId').doUpdateSet({ avatarId: avatar.id, updatedAt: sql`now()` }),
+    )
+    .execute();
+
+  return { activeAvatarID: avatar.id };
+}

--- a/services/avatar/src/test-utils/create-activity-row.ts
+++ b/services/avatar/src/test-utils/create-activity-row.ts
@@ -1,0 +1,38 @@
+import { faker } from '@faker-js/faker';
+import { createId } from '@paralleldrive/cuid2';
+import type { Activities, DB } from '@vers/db';
+import type { Insertable, Kysely, Selectable } from 'kysely';
+
+interface CreateActivityRowData extends Partial<Insertable<Activities>> {
+  readonly avatarId: string;
+}
+
+/**
+ * Seeds an activity head row for an existing avatar — the live-activity guard tests need a real
+ * `status = 'active'` row. Hash and content fields default to opaque strings: the guard reads
+ * status and ownership, never the chain.
+ */
+export function createActivityRow(
+  db: Kysely<DB>,
+  data: Readonly<CreateActivityRowData>,
+): Promise<Selectable<Activities>> {
+  const startHash = faker.string.hexadecimal({ casing: 'lower', length: 64, prefix: '' });
+
+  return db
+    .insertInto('activities')
+    .values({
+      buildSnapshot: { level: 1, xp: 0 },
+      contentVersion: '0.0.0-dev',
+      encounterNode: { difficulty: 1 },
+      id: `act_${createId()}`,
+      lastHash: startHash,
+      scopeId: faker.string.alphanumeric({ casing: 'lower', length: 8 }),
+      scopeType: 'world_map_node',
+      seed: faker.string.hexadecimal({ casing: 'lower', length: 32, prefix: '' }),
+      simVersion: '0.0.0-dev',
+      startHash,
+      ...data,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
+}


### PR DESCRIPTION
## Description

Closes #676

Makes the active avatar a persisted server-side selection and lets an account hold several: a new `active_avatars` table, a `selectAvatar` procedure, a per-mode create cap, and a roster that really switches.

- `getAvatars` now answers `{ avatars, activeAvatarID }`; `findActiveAvatar` resolves the persisted id instead of `avatars[0]`.
- A live activity locks the selection: `selectAvatar` rejects with the owning avatar named; create auto-selects only when no run is live. Guard is best-effort until #725 gates activity starts.
- Create is capped at 5 per mode (`LIMIT_REACHED`), enforced in a per-user advisory-lock transaction.
- Deleting the active avatar drops the selection via FK cascade; the gate then routes to the roster.
- Worker resets a held simulation whose avatar differs from the resync target, closing the cross-avatar leak.
- Mock services mirror all of it; new roster e2e covers create-switch-reload.
- Adds `select` to the function-verb taxonomy.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality