### PR TITLE
test(#729): pin replay goldens and add engine bench harness

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -593,6 +593,7 @@
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
         "@zgeoff/bun-test-extended": "catalog:",
+        "mitata": "catalog:",
         "typescript": "catalog:",
       },
     },
@@ -1270,6 +1271,7 @@
     "kysely-postgres-js": "3.0.0",
     "lefthook": "2.1.9",
     "lru-cache": "11.5.2",
+    "mitata": "1.0.34",
     "msw": "2.14.6",
     "ora": "9.4.1",
     "oxfmt": "0.57.0",
@@ -3871,6 +3873,8 @@
     "minipass-sized": ["minipass-sized@2.0.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA=="],
 
     "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
+
+    "mitata": ["mitata@1.0.34", "", {}, "sha512-Mc3zrtNBKIMeHSCQ0XqRLo1vbdIx1wvFV9c8NJAiyho6AjNfMY8bVhbS12bwciUdd1t4rj8099CH3N3NFahaUA=="],
 
     "mkdirp": ["mkdirp@3.0.1", "", { "bin": { "mkdirp": "dist/cjs/src/bin.js" } }, "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg=="],
 

--- a/libs/game/idle-core/package.json
+++ b/libs/game/idle-core/package.json
@@ -9,6 +9,7 @@
     "./test-utils": "./src/test-utils/index.ts"
   },
   "scripts": {
+    "bench": "bun src/replay.bench.ts",
     "test": "bun test",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
@@ -25,6 +26,7 @@
     "@types/bun": "catalog:",
     "@types/node": "catalog:",
     "@zgeoff/bun-test-extended": "catalog:",
+    "mitata": "catalog:",
     "typescript": "catalog:"
   }
 }

--- a/libs/game/idle-core/src/replay.bench.ts
+++ b/libs/game/idle-core/src/replay.bench.ts
@@ -1,0 +1,59 @@
+import { buildStateFromSeed } from '@vers/game-utils';
+import { bench, run } from 'mitata';
+import { buildSimulationInput } from './core/build-simulation-input';
+import type { SimulationInputSource } from './core/build-simulation-input';
+import { createSimulation } from './core/create-simulation';
+import { createSimulationDriver } from './core/create-simulation-driver';
+import { SIMULATION_TIMESTEP_MS } from './core/simulation-timestep-ms';
+import { ActivityFailureAction } from './types';
+import { isCompletedCheckpoint } from './utils/is-completed-checkpoint';
+import { isFailedCheckpoint } from './utils/is-failed-checkpoint';
+
+/**
+ * Macro benchmarks for the two engine consumers: the listener-free driver every replay path runs
+ * (verifier, reconstruction, fast-forward) and the live worker loop with an `updated` listener
+ * attached. Run `bun run bench` from this package on an idle machine and paste before/after
+ * numbers into any PR that touches the tick path. One simulated hour is 72,000 engine ticks.
+ */
+
+const SIMULATED_HOUR_MS = 3_600_000;
+
+const SOURCE: SimulationInputSource = {
+  avatarID: 'avatar-bench',
+  buildSnapshot: { level: 5, xp: 0 },
+  contentVersion: '1',
+  encounterNode: { difficulty: 3 },
+  id: 'activity-bench',
+  seed: buildStateFromSeed(3_047_525_658),
+};
+
+bench('replay driver · 1 simulated hour', async () => {
+  const input = buildSimulationInput(SOURCE, {
+    failureAction: ActivityFailureAction.Retry,
+  });
+
+  const driver = createSimulationDriver(input.activity, input.avatar);
+
+  await driver.advanceToDuration(SIMULATED_HOUR_MS);
+});
+
+bench('live loop with updated listener · 1 simulated hour', async () => {
+  const input = buildSimulationInput(SOURCE, {
+    failureAction: ActivityFailureAction.Retry,
+  });
+
+  const simulation = createSimulation();
+
+  simulation.addEventListener('updated', () => {});
+  simulation.startActivity(input.avatar, input.activity);
+
+  while (simulation.elapsed < SIMULATED_HOUR_MS) {
+    const checkpoint = await simulation.run(SIMULATION_TIMESTEP_MS);
+
+    if (checkpoint && (isFailedCheckpoint(checkpoint) || isCompletedCheckpoint(checkpoint))) {
+      simulation.restartActivity();
+    }
+  }
+});
+
+await run();

--- a/libs/game/idle-core/src/replay.test.ts
+++ b/libs/game/idle-core/src/replay.test.ts
@@ -1,0 +1,1157 @@
+import { expect, test } from 'bun:test';
+import { buildStateFromSeed } from '@vers/game-utils';
+import invariant from 'tiny-invariant';
+import { buildSimulationInput } from './core/build-simulation-input';
+import { createSimulationDriver } from './core/create-simulation-driver';
+import { runAttempt } from './core/run-attempt';
+import { ActivityFailureAction } from './types';
+
+/**
+ * Golden replay fixtures: literal simulation inputs run through the production derivation
+ * (`buildSimulationInput`) and pinned as inline snapshots. An output-identical engine change
+ * leaves every snapshot untouched; a deliberate simVersion bump regenerates them via
+ * `bun test -u` and the diff is reviewed like any code change. Inputs are literals, never
+ * factories — every field here determines the pinned stream.
+ */
+
+test('it replays a completed attempt to an identical checkpoint stream', async () => {
+  const input = buildSimulationInput({
+    avatarID: 'avatar-golden-completed',
+    buildSnapshot: { level: 10, xp: 0 },
+    contentVersion: '1',
+    encounterNode: { difficulty: 1 },
+    id: 'activity-golden-completed',
+    seed: buildStateFromSeed(1_111_111),
+  });
+
+  const result = await runAttempt(input.activity, input.avatar, { maxDurationMs: 600_000 });
+
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "checkpoints": [
+        {
+          "nextSeed": "ffffffffffef0bb80010f44700000000",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "seed": "ffffffffffef0bb80010f44700000000",
+          "time": 0,
+          "type": "started",
+        },
+        {
+          "nextSeed": "964b5a51d7ed6a504028276af605916c",
+          "rewardSlots": [
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 0,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 1,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 2,
+            },
+          ],
+          "rewards": {
+            "xp": 28,
+          },
+          "time": 10000,
+          "type": "progress",
+        },
+        {
+          "nextSeed": "dbf6b912f764c7bf1622e2c689dc6ac2",
+          "rewardSlots": [
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 0,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 1,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 2,
+            },
+          ],
+          "rewards": {
+            "xp": 26,
+          },
+          "time": 17500,
+          "type": "progress",
+        },
+        {
+          "nextSeed": "f9cb6472f1d9f3b273cd14df7a2695f2",
+          "rewardSlots": [
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 0,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 1,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 2,
+            },
+          ],
+          "rewards": {
+            "xp": 24,
+          },
+          "time": 25000,
+          "type": "progress",
+        },
+        {
+          "levelUp": {
+            "from": 1,
+            "to": 2,
+          },
+          "nextSeed": "cfc222316498a5228501305b2b1253b3",
+          "rewardSlots": [
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 0,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 1,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 2,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 3,
+            },
+          ],
+          "rewards": {
+            "xp": 34,
+          },
+          "time": 35000,
+          "type": "progress",
+        },
+        {
+          "nextSeed": "e5965522f63a455fbcc01a22595d64b9",
+          "rewardSlots": [
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 0,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 1,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 2,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 3,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 4,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 5,
+            },
+          ],
+          "rewards": {
+            "xp": 54,
+          },
+          "time": 51250,
+          "type": "progress",
+        },
+        {
+          "nextSeed": "1c4a3bcf245eaf477ca23c5770fb5190",
+          "rewardSlots": [
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 0,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 1,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 2,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 3,
+            },
+          ],
+          "rewards": {
+            "xp": 36,
+          },
+          "time": 62500,
+          "type": "progress",
+        },
+        {
+          "nextSeed": "1c4a3bcf245eaf477ca23c5770fb5190",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 227,
+          },
+          "time": 62500,
+          "type": "completed",
+        },
+      ],
+      "elapsed": 62600,
+      "outcome": "completed",
+    }
+  `);
+});
+
+test('it replays a failed attempt to an identical checkpoint stream', async () => {
+  const input = buildSimulationInput({
+    avatarID: 'avatar-golden-failed',
+    buildSnapshot: { level: 1, xp: 0 },
+    contentVersion: '1',
+    encounterNode: { difficulty: 12 },
+    id: 'activity-golden-failed',
+    seed: buildStateFromSeed(2_222_222),
+  });
+
+  const result = await runAttempt(input.activity, input.avatar, { maxDurationMs: 600_000 });
+
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "checkpoints": [
+        {
+          "nextSeed": "ffffffffffde17710021e88e00000000",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "seed": "ffffffffffde17710021e88e00000000",
+          "time": 0,
+          "type": "started",
+        },
+        {
+          "nextSeed": "336b5d111a74eb4c355b4ed8ee62e7a5",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "time": 2900,
+          "type": "failed",
+        },
+      ],
+      "elapsed": 3000,
+      "outcome": "failed",
+    }
+  `);
+});
+
+test('it replays a retrying multi-attempt stream to an identical checkpoint stream', async () => {
+  const input = buildSimulationInput(
+    {
+      avatarID: 'avatar-golden-retry',
+      buildSnapshot: { level: 1, xp: 0 },
+      contentVersion: '1',
+      encounterNode: { difficulty: 12 },
+      id: 'activity-golden-retry',
+      seed: buildStateFromSeed(3_333_333),
+    },
+    { failureAction: ActivityFailureAction.Retry },
+  );
+
+  const driver = createSimulationDriver(input.activity, input.avatar);
+
+  const result = await driver.advanceToDuration(120_000);
+
+  expect({ checkpoints: result.checkpoints, rngState: driver.rngState }).toMatchInlineSnapshot(`
+    {
+      "checkpoints": [
+        {
+          "nextSeed": "ffffffffffcd232a0032dcd500000000",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "seed": "ffffffffffcd232a0032dcd500000000",
+          "time": 0,
+          "type": "started",
+        },
+        {
+          "nextSeed": "e2f6c85f7c3e615b848cbc6b90c0fed2",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "time": 4000,
+          "type": "failed",
+        },
+        {
+          "nextSeed": "e2f6c85f7c3e615b848cbc6b90c0fed2",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "seed": "e2f6c85f7c3e615b848cbc6b90c0fed2",
+          "time": 0,
+          "type": "started",
+        },
+        {
+          "nextSeed": "876b63e631336aab39ed89066ba8e901",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "time": 6000,
+          "type": "failed",
+        },
+        {
+          "nextSeed": "876b63e631336aab39ed89066ba8e901",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "seed": "876b63e631336aab39ed89066ba8e901",
+          "time": 0,
+          "type": "started",
+        },
+        {
+          "nextSeed": "b48f4ef63058faf85466cc87c7b6a6bb",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "time": 6000,
+          "type": "failed",
+        },
+        {
+          "nextSeed": "b48f4ef63058faf85466cc87c7b6a6bb",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "seed": "b48f4ef63058faf85466cc87c7b6a6bb",
+          "time": 0,
+          "type": "started",
+        },
+        {
+          "nextSeed": "7113010cb4448d5f0d884642c3a35039",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "time": 6000,
+          "type": "failed",
+        },
+        {
+          "nextSeed": "7113010cb4448d5f0d884642c3a35039",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "seed": "7113010cb4448d5f0d884642c3a35039",
+          "time": 0,
+          "type": "started",
+        },
+        {
+          "nextSeed": "a064865377d770677dbd08e4f7a766fe",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "time": 6000,
+          "type": "failed",
+        },
+        {
+          "nextSeed": "a064865377d770677dbd08e4f7a766fe",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "seed": "a064865377d770677dbd08e4f7a766fe",
+          "time": 0,
+          "type": "started",
+        },
+        {
+          "nextSeed": "d5f9300c16a7eba753ad63b2deee0b1b",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "time": 6000,
+          "type": "failed",
+        },
+        {
+          "nextSeed": "d5f9300c16a7eba753ad63b2deee0b1b",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "seed": "d5f9300c16a7eba753ad63b2deee0b1b",
+          "time": 0,
+          "type": "started",
+        },
+        {
+          "nextSeed": "6fa040fa4c999b666fb3a048a31916a4",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "time": 6000,
+          "type": "failed",
+        },
+        {
+          "nextSeed": "6fa040fa4c999b666fb3a048a31916a4",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "seed": "6fa040fa4c999b666fb3a048a31916a4",
+          "time": 0,
+          "type": "started",
+        },
+        {
+          "nextSeed": "16525c72b2b3abcd0758b58b41d0da7a",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "time": 6000,
+          "type": "failed",
+        },
+        {
+          "nextSeed": "16525c72b2b3abcd0758b58b41d0da7a",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "seed": "16525c72b2b3abcd0758b58b41d0da7a",
+          "time": 0,
+          "type": "started",
+        },
+        {
+          "nextSeed": "b7e9554620a7e3c9d140fb5c5e644419",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "time": 6000,
+          "type": "failed",
+        },
+        {
+          "nextSeed": "b7e9554620a7e3c9d140fb5c5e644419",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "seed": "b7e9554620a7e3c9d140fb5c5e644419",
+          "time": 0,
+          "type": "started",
+        },
+        {
+          "nextSeed": "9991099d9a3c605aaf297ebc75b7e5d8",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "time": 4000,
+          "type": "failed",
+        },
+        {
+          "nextSeed": "9991099d9a3c605aaf297ebc75b7e5d8",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "seed": "9991099d9a3c605aaf297ebc75b7e5d8",
+          "time": 0,
+          "type": "started",
+        },
+        {
+          "nextSeed": "f10d80b59a1015cfba99ed8ed50a75e9",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "time": 6000,
+          "type": "failed",
+        },
+        {
+          "nextSeed": "f10d80b59a1015cfba99ed8ed50a75e9",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "seed": "f10d80b59a1015cfba99ed8ed50a75e9",
+          "time": 0,
+          "type": "started",
+        },
+        {
+          "nextSeed": "33678f6fc0d1182ace67018bcf90c53c",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "time": 4000,
+          "type": "failed",
+        },
+        {
+          "nextSeed": "33678f6fc0d1182ace67018bcf90c53c",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "seed": "33678f6fc0d1182ace67018bcf90c53c",
+          "time": 0,
+          "type": "started",
+        },
+        {
+          "nextSeed": "3cac6402920275e1b9f8dccf342b0d1d",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "time": 6000,
+          "type": "failed",
+        },
+        {
+          "nextSeed": "3cac6402920275e1b9f8dccf342b0d1d",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "seed": "3cac6402920275e1b9f8dccf342b0d1d",
+          "time": 0,
+          "type": "started",
+        },
+        {
+          "nextSeed": "f61eb06b3ba430eaccf269a3c7db2b9c",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "time": 6000,
+          "type": "failed",
+        },
+        {
+          "nextSeed": "f61eb06b3ba430eaccf269a3c7db2b9c",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "seed": "f61eb06b3ba430eaccf269a3c7db2b9c",
+          "time": 0,
+          "type": "started",
+        },
+        {
+          "nextSeed": "456ec34b2b4df4d5e3517f3fe5fa61bc",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "time": 6000,
+          "type": "failed",
+        },
+        {
+          "nextSeed": "456ec34b2b4df4d5e3517f3fe5fa61bc",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "seed": "456ec34b2b4df4d5e3517f3fe5fa61bc",
+          "time": 0,
+          "type": "started",
+        },
+        {
+          "nextSeed": "c88b625cd8e33850b3c1a61f1b739f26",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "time": 6000,
+          "type": "failed",
+        },
+        {
+          "nextSeed": "c88b625cd8e33850b3c1a61f1b739f26",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "seed": "c88b625cd8e33850b3c1a61f1b739f26",
+          "time": 0,
+          "type": "started",
+        },
+        {
+          "nextSeed": "443465bd9a684a3a1f7cc6d79eabcb1a",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "time": 4000,
+          "type": "failed",
+        },
+        {
+          "nextSeed": "443465bd9a684a3a1f7cc6d79eabcb1a",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "seed": "443465bd9a684a3a1f7cc6d79eabcb1a",
+          "time": 0,
+          "type": "started",
+        },
+        {
+          "nextSeed": "719f5ad6cf23be3c4d9865af552102c0",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "time": 4000,
+          "type": "failed",
+        },
+        {
+          "nextSeed": "719f5ad6cf23be3c4d9865af552102c0",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "seed": "719f5ad6cf23be3c4d9865af552102c0",
+          "time": 0,
+          "type": "started",
+        },
+        {
+          "nextSeed": "01ac827123dcd3b2519af73c0346744a",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "time": 4000,
+          "type": "failed",
+        },
+        {
+          "nextSeed": "01ac827123dcd3b2519af73c0346744a",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "seed": "01ac827123dcd3b2519af73c0346744a",
+          "time": 0,
+          "type": "started",
+        },
+        {
+          "nextSeed": "fe60a43757b89176102b9b061d1a9209",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "time": 6000,
+          "type": "failed",
+        },
+        {
+          "nextSeed": "fe60a43757b89176102b9b061d1a9209",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "seed": "fe60a43757b89176102b9b061d1a9209",
+          "time": 0,
+          "type": "started",
+        },
+        {
+          "nextSeed": "325edfbc5ea1188296eeb2d4ff055b9e",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "time": 6000,
+          "type": "failed",
+        },
+        {
+          "nextSeed": "325edfbc5ea1188296eeb2d4ff055b9e",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "seed": "325edfbc5ea1188296eeb2d4ff055b9e",
+          "time": 0,
+          "type": "started",
+        },
+      ],
+      "rngState": "547cf5d53a053c8f2962ecbd9a584989",
+    }
+  `);
+});
+
+test('it replays a multi-clear stream to an identical checkpoint stream', async () => {
+  const input = buildSimulationInput({
+    avatarID: 'avatar-golden-clears',
+    buildSnapshot: { level: 10, xp: 0 },
+    contentVersion: '1',
+    encounterNode: { difficulty: 1 },
+    id: 'activity-golden-clears',
+    seed: buildStateFromSeed(4_444_444),
+  });
+
+  const driver = createSimulationDriver(input.activity, input.avatar);
+
+  const result = await driver.advanceToDuration(120_000);
+
+  expect({ checkpoints: result.checkpoints, rngState: driver.rngState }).toMatchInlineSnapshot(`
+    {
+      "checkpoints": [
+        {
+          "nextSeed": "ffffffffffbc2ee30043d11c00000000",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "seed": "ffffffffffbc2ee30043d11c00000000",
+          "time": 0,
+          "type": "started",
+        },
+        {
+          "nextSeed": "eaf086353e813a8603e71193023882e0",
+          "rewardSlots": [
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 0,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 1,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 2,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 3,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 4,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 5,
+            },
+          ],
+          "rewards": {
+            "xp": 52,
+          },
+          "time": 15000,
+          "type": "progress",
+        },
+        {
+          "nextSeed": "6ad191418169b6e6a1cca5fb2919ecfe",
+          "rewardSlots": [
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 0,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 1,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 2,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 3,
+            },
+          ],
+          "rewards": {
+            "xp": 36,
+          },
+          "time": 26250,
+          "type": "progress",
+        },
+        {
+          "levelUp": {
+            "from": 1,
+            "to": 2,
+          },
+          "nextSeed": "826452a79a66b918903d2d6927f88e4e",
+          "rewardSlots": [
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 0,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 1,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 2,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 3,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 4,
+            },
+          ],
+          "rewards": {
+            "xp": 46,
+          },
+          "time": 41250,
+          "type": "progress",
+        },
+        {
+          "nextSeed": "5b525f8d259b9a6668e715a4b15d38ae",
+          "rewardSlots": [
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 0,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 1,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 2,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 3,
+            },
+          ],
+          "rewards": {
+            "xp": 36,
+          },
+          "time": 53750,
+          "type": "progress",
+        },
+        {
+          "nextSeed": "5b525f8d259b9a6668e715a4b15d38ae",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 195,
+          },
+          "time": 53750,
+          "type": "completed",
+        },
+        {
+          "nextSeed": "5b525f8d259b9a6668e715a4b15d38ae",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "seed": "5b525f8d259b9a6668e715a4b15d38ae",
+          "time": 0,
+          "type": "started",
+        },
+        {
+          "nextSeed": "1f8b5a200542fd85ea049de64ccc36eb",
+          "rewardSlots": [
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 0,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 1,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 2,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 3,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 4,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 5,
+            },
+          ],
+          "rewards": {
+            "xp": 52,
+          },
+          "time": 16250,
+          "type": "progress",
+        },
+        {
+          "nextSeed": "1c9062e9a05197d7831e7b8596b99718",
+          "rewardSlots": [
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 0,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 1,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 2,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 3,
+            },
+          ],
+          "rewards": {
+            "xp": 36,
+          },
+          "time": 27500,
+          "type": "progress",
+        },
+        {
+          "levelUp": {
+            "from": 1,
+            "to": 2,
+          },
+          "nextSeed": "06bf46f013f04e4dc6f2bcb01046d682",
+          "rewardSlots": [
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 0,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 1,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 2,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 3,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 4,
+            },
+          ],
+          "rewards": {
+            "xp": 46,
+          },
+          "time": 43750,
+          "type": "progress",
+        },
+        {
+          "nextSeed": "335c10958e8269acf3160b165678e7fa",
+          "rewardSlots": [
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 0,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 1,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 2,
+            },
+            {
+              "context": {
+                "nodeTier": 1,
+              },
+              "ordinal": 3,
+            },
+          ],
+          "rewards": {
+            "xp": 36,
+          },
+          "time": 55000,
+          "type": "progress",
+        },
+        {
+          "nextSeed": "335c10958e8269acf3160b165678e7fa",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 195,
+          },
+          "time": 55000,
+          "type": "completed",
+        },
+        {
+          "nextSeed": "335c10958e8269acf3160b165678e7fa",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "seed": "335c10958e8269acf3160b165678e7fa",
+          "time": 0,
+          "type": "started",
+        },
+      ],
+      "rngState": "bcab53dc82325d3b557d35da5903f12b",
+    }
+  `);
+});
+
+const EQUIVALENCE_SEEDS = [17, 90_210, 8_675_309, 424_242_424, 3_047_525_658, 555_000_111];
+
+/**
+ * Every replay path must consume the stamped seed identically: the single-attempt runner and the
+ * checkpoint-capturing driver are separate orchestrations of the same engine, so their streams for
+ * one input must match checkpoint-for-checkpoint. Chunked-advance equivalence is pinned separately
+ * beside the driver.
+ */
+test('it produces one identical checkpoint stream across the attempt and driver paths', async () => {
+  for (const seed of EQUIVALENCE_SEEDS) {
+    const source = {
+      avatarID: 'avatar-equivalence',
+      buildSnapshot: { level: 5, xp: 0 },
+      contentVersion: '1',
+      encounterNode: { difficulty: 3 },
+      id: `activity-equivalence-${seed}`,
+      seed: buildStateFromSeed(seed),
+    };
+
+    const attemptInput = buildSimulationInput(source);
+
+    const attempt = await runAttempt(attemptInput.activity, attemptInput.avatar, {
+      maxDurationMs: 120_000,
+    });
+
+    invariant(attempt.outcome !== 'exceeded-budget', `seed ${seed} must terminate in budget`);
+
+    const driverInput = buildSimulationInput(source);
+    const driver = createSimulationDriver(driverInput.activity, driverInput.avatar);
+
+    const advanced = await driver.advanceToDuration(120_000, undefined, attempt.checkpoints.length);
+
+    expect(advanced.checkpoints).toStrictEqual(attempt.checkpoints);
+  }
+}, 20_000);

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
       "kysely-postgres-js": "3.0.0",
       "lefthook": "2.1.9",
       "lru-cache": "11.5.2",
+      "mitata": "1.0.34",
       "msw": "2.14.6",
       "ora": "9.4.1",
       "oxfmt": "0.57.0",


### PR DESCRIPTION
## Description

Part of #729. Adds the measurement and equivalence harness every engine optimization PR will prove itself against.

- Golden inline-snapshot fixtures pin four replay checkpoint streams (completed, failed, retrying, multi-clear) through the production `buildSimulationInput` derivation — an output-identical change leaves them untouched; a simVersion bump regenerates them with `bun test -u` for review.
- Cross-path equivalence test asserts `runAttempt` and `createSimulationDriver` emit identical streams over six fixed seeds; chunked-advance equivalence was already pinned beside the driver.
- `mitata` macro bench (`bun run bench` in idle-core) baselines the tick loop: ~1.6s per simulated hour, so a full 24h replay costs ~35s of engine CPU today.
- Bench is manual-only by design — not a turbo task, not in CI; numbers come from an idle dev machine.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality