### PR TITLE
perf(#729): skip tick snapshots when no updated listener is attached

### DIFF
--- a/libs/game/idle-core/src/core/create-simulation.test.ts
+++ b/libs/game/idle-core/src/core/create-simulation.test.ts
@@ -189,3 +189,30 @@ test('it calls an event listener when the failure action updates', () => {
 
   expect(listenerSpy).toHaveBeenCalledExactlyOnceWith(simulation.state);
 });
+
+test('it produces an identical checkpoint stream with and without an updated listener', async () => {
+  const avatarData = createMockAvatarData();
+  const activityData = createMockActivityInput();
+  const withoutListener = createSimulation();
+
+  withoutListener.startActivity(avatarData, activityData);
+
+  const checkpointsWithoutListener = [
+    await withoutListener.run(1),
+    await withoutListener.run(5000),
+    await withoutListener.run(10_000),
+  ];
+
+  const withListener = createSimulation();
+
+  withListener.addEventListener('updated', () => {});
+  withListener.startActivity(avatarData, activityData);
+
+  const checkpointsWithListener = [
+    await withListener.run(1),
+    await withListener.run(5000),
+    await withListener.run(10_000),
+  ];
+
+  expect(checkpointsWithListener).toStrictEqual(checkpointsWithoutListener);
+});

--- a/libs/game/idle-core/src/core/create-simulation.ts
+++ b/libs/game/idle-core/src/core/create-simulation.ts
@@ -138,7 +138,8 @@ export function createSimulation(): Simulation {
       return null;
     }
 
-    const prevState = getSnapshot(state);
+    const shouldNotify = listeners.updated.length > 0;
+    const prevState = shouldNotify ? getSnapshot(state) : null;
 
     const next = await _generator.next(timestep);
 
@@ -148,9 +149,7 @@ export function createSimulation(): Simulation {
       _generator = null;
     }
 
-    const currentState = getSnapshot(state);
-
-    if (!deepEqual(prevState, currentState)) {
+    if (shouldNotify && !deepEqual(prevState, getSnapshot(state))) {
       for (const listener of listeners.updated) {
         listener(state);
       }


### PR DESCRIPTION
## Description

Closes #729

The idle-worker replay/live loop snapshotted and deep-compared engine state on every tick even when no `updated` listener was attached to observe it. `run()` now checks `listeners.updated.length > 0` once per call and only takes the before/after snapshots and runs the deep-equal comparison when a listener is actually registered — the checkpoint return value and all other listener events are unchanged.

- Adds a test asserting the checkpoint stream is byte-identical with and without an `updated` listener attached
- Benchmarked with mitata (`bun run bench`): the zero-listener replay path drops from ~1.33s/iter to ~950-980ms/iter per simulated hour; the listener-attached path is unaffected by design (run-to-run noise only)

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
