### PR TITLE
perf(#729): defer log construction, hoist event comparator, drop dead ctx param

### DIFF
--- a/libs/game/idle-core/src/behaviours/avatar-weapon-attack/handle-tick.ts
+++ b/libs/game/idle-core/src/behaviours/avatar-weapon-attack/handle-tick.ts
@@ -11,8 +11,6 @@ export function handleTick(
   behaviour: AvatarWeaponAttackBehaviour,
   executor: CombatExecutor,
 ): void {
-  const label = createLogLabel('avatar', entity.id);
-
   // loop to allow high APS to function correctly w/ server simulation batching
   while (isAttackReady(entity, behaviour.state, executor)) {
     const time = getNextAttackTime(entity, behaviour.state);
@@ -24,6 +22,6 @@ export function handleTick(
       draft.lastAttackTime = time;
     });
 
-    logger.debug(`${label} scheduled attack at ${event.time}`);
+    logger.debug(() => `${createLogLabel('avatar', entity.id)} scheduled attack at ${event.time}`);
   }
 }

--- a/libs/game/idle-core/src/behaviours/enemy-primary-attack/handle-tick.ts
+++ b/libs/game/idle-core/src/behaviours/enemy-primary-attack/handle-tick.ts
@@ -11,8 +11,6 @@ export function handleTick(
   behaviour: EnemyPrimaryAttackBehaviour,
   executor: CombatExecutor,
 ): void {
-  const label = createLogLabel('enemy', entity.id);
-
   // loop to allow high APS to function correctly w/ server simulation batching
   while (isAttackReady(entity, behaviour.state, executor)) {
     const time = getNextAttackTime(entity, behaviour.state);
@@ -24,6 +22,6 @@ export function handleTick(
       draftState.lastAttackTime = time;
     });
 
-    logger.debug(`${label} scheduled attack at ${event.time}`);
+    logger.debug(() => `${createLogLabel('enemy', entity.id)} scheduled attack at ${event.time}`);
   }
 }

--- a/libs/game/idle-core/src/core/create-combat-executor.test.ts
+++ b/libs/game/idle-core/src/core/create-combat-executor.test.ts
@@ -53,6 +53,30 @@ test('it processes events', () => {
   expect(avatar.life).toBe(60);
 });
 
+test('it processes a tick with a single scheduled event', () => {
+  const enemyData = createMockEnemyData({
+    life: 100,
+    primaryAttack: {
+      maxDamage: 40,
+      minDamage: 40,
+      speed: 1,
+    },
+  });
+
+  // default avatar weapon speed (0.8, 1.25s interval) keeps the avatar from attacking within this
+  // 1s tick, so only the enemy's attack is scheduled
+  const avatarData = createMockAvatarData({ life: 200 });
+  const activityData = createMockActivityInput({ encounter: { waves: [[enemyData]] } });
+  const ctx = createMockSimulationContext();
+  const avatar = createAvatar(avatarData, ctx);
+  const activity = createActivity(activityData, ctx);
+  const combatExecutor = createCombatExecutor(activity, avatar, ctx);
+
+  combatExecutor.run(1000);
+
+  expect(avatar.life).toBe(160);
+});
+
 test('it returns the expected combat executor state for a client app', () => {
   const ctx = createMockSimulationContext();
   const activity = createActivity(createMockActivityInput(), ctx);

--- a/libs/game/idle-core/src/core/create-combat-executor.ts
+++ b/libs/game/idle-core/src/core/create-combat-executor.ts
@@ -16,6 +16,7 @@ export function createCombatExecutor(
 ): CombatExecutor {
   let elapsed = 0;
   let scheduledEvents: Array<CombatEvent> = [];
+  const sortEvents = createEventSorter(avatar);
 
   const getSnapshot = (): CombatExecutorSnapshot => ({
     elapsed,
@@ -26,9 +27,9 @@ export function createCombatExecutor(
   };
 
   const applyEvents = () => {
-    const sortEvents = createEventSorter(avatar);
-
-    scheduledEvents.sort(sortEvents);
+    if (scheduledEvents.length >= 2) {
+      scheduledEvents.sort(sortEvents);
+    }
 
     scheduledEvents.forEach((event: CombatEvent) => {
       handleEvent(event, avatar, activity, ctx);
@@ -58,10 +59,10 @@ export function createCombatExecutor(
   const run = (delta: number) => {
     elapsed += delta;
 
-    avatar.handleTick(executor, ctx);
+    avatar.handleTick(executor);
 
     activity.currentWave?.enemies.forEach((enemy) => {
-      enemy.handleTick(executor, ctx);
+      enemy.handleTick(executor);
     });
 
     applyEvents();

--- a/libs/game/idle-core/src/core/handle-avatar-attack.ts
+++ b/libs/game/idle-core/src/core/handle-avatar-attack.ts
@@ -3,13 +3,15 @@ import { createLogLabel } from '../utils/create-log-label';
 import { logger } from '../utils/logger';
 
 export function handleAvatarAttack(_event: AvatarAttackEvent, avatar: Avatar, activity: Activity) {
-  const label = createLogLabel('avatar', avatar.id);
   const enemy = activity.currentWave?.nextLivingEnemy;
 
   if (enemy) {
     const damage = avatar.rollAttackDamage();
 
-    logger.debug(`${label} --> ${damage} damage to ${enemy.id}`);
+    logger.debug(
+      () => `${createLogLabel('avatar', avatar.id)} --> ${damage} damage to ${enemy.id}`,
+    );
+
     enemy.receiveDamage(damage);
   }
 }

--- a/libs/game/idle-core/src/core/handle-enemy-attack.ts
+++ b/libs/game/idle-core/src/core/handle-enemy-attack.ts
@@ -6,10 +6,12 @@ export function handleEnemyAttack(event: EnemyAttackEvent, avatar: Avatar, activ
   const enemy = activity.currentWave?.enemies.find((candidate) => candidate.id === event.source);
 
   if (enemy?.isAlive === true && avatar.isAlive) {
-    const label = createLogLabel('enemy', event.source);
     const damage = enemy.rollAttackDamage();
 
-    logger.debug(`${label} --> ${damage} damage to ${avatar.id}`);
+    logger.debug(
+      () => `${createLogLabel('enemy', event.source)} --> ${damage} damage to ${avatar.id}`,
+    );
+
     avatar.receiveDamage(damage);
   }
 }

--- a/libs/game/idle-core/src/core/run-activity.ts
+++ b/libs/game/idle-core/src/core/run-activity.ts
@@ -21,13 +21,14 @@ export async function* runActivity(
   ctx: SimulationContext,
 ): ActivityCheckpointGenerator {
   const timestep = yield createStartedCheckpoint(ctx);
-  const label = `[activity:${activity.type}]`;
 
-  logger.debug(() => `${label} starting activity with ${activity.waves.length} waves`);
+  logger.debug(
+    () => `[activity:${activity.type}] starting activity with ${activity.waves.length} waves`,
+  );
 
   logger.debug(
     () =>
-      `${label} starting combat with first wave of ${activity.currentWave?.enemies.length} enemies`,
+      `[activity:${activity.type}] starting combat with first wave of ${activity.currentWave?.enemies.length} enemies`,
   );
 
   while (avatar.isAlive && activity.isWavesRemaining) {
@@ -57,7 +58,7 @@ export async function* runActivity(
       }
 
       yield checkpoint;
-      logger.debug(() => `${label} moving to next wave`);
+      logger.debug(() => `[activity:${activity.type}] moving to next wave`);
 
       // move to the next wave
       executor.reset();

--- a/libs/game/idle-core/src/core/run-activity.ts
+++ b/libs/game/idle-core/src/core/run-activity.ts
@@ -23,10 +23,11 @@ export async function* runActivity(
   const timestep = yield createStartedCheckpoint(ctx);
   const label = `[activity:${activity.type}]`;
 
-  logger.debug(`${label} starting activity with ${activity.waves.length} waves`);
+  logger.debug(() => `${label} starting activity with ${activity.waves.length} waves`);
 
   logger.debug(
-    `${label} starting combat with first wave of ${activity.currentWave?.enemies.length} enemies`,
+    () =>
+      `${label} starting combat with first wave of ${activity.currentWave?.enemies.length} enemies`,
   );
 
   while (avatar.isAlive && activity.isWavesRemaining) {
@@ -56,7 +57,7 @@ export async function* runActivity(
       }
 
       yield checkpoint;
-      logger.debug(`${label} moving to next wave`);
+      logger.debug(() => `${label} moving to next wave`);
 
       // move to the next wave
       executor.reset();

--- a/libs/game/idle-core/src/entities/create-avatar.test.ts
+++ b/libs/game/idle-core/src/entities/create-avatar.test.ts
@@ -93,7 +93,7 @@ test('it calls all registered handlers when handling a tick', () => {
   };
 
   avatar.registerBehaviour(behaviour);
-  avatar.handleTick(combatExecutor, ctx);
+  avatar.handleTick(combatExecutor);
 
   expect(handlerSpy).toHaveBeenCalledWith(avatar, combatExecutor, ctx);
 });
@@ -120,7 +120,7 @@ test('it allows removing behaviours', () => {
 
   avatar.registerBehaviour(behaviour);
   avatar.removeBehaviour(BehaviourID.Test);
-  avatar.handleTick(combatExecutor, ctx);
+  avatar.handleTick(combatExecutor);
 
   expect(handlerSpy).not.toHaveBeenCalled();
 });

--- a/libs/game/idle-core/src/entities/create-avatar.ts
+++ b/libs/game/idle-core/src/entities/create-avatar.ts
@@ -25,7 +25,6 @@ interface ResetConfig {
 }
 
 export function createAvatar(data: AvatarData, ctx: SimulationContext): Avatar {
-  const label = createLogLabel('avatar', data.id);
   let state = getInitialState(data);
   let currentLevel = data.level;
 
@@ -128,7 +127,10 @@ export function createAvatar(data: AvatarData, ctx: SimulationContext): Avatar {
     receiveDamage: (amount: number) => {
       handleReceiveAvatarDamage(amount, avatar);
 
-      logger.debug(`${label} <-- ${amount} damage (${state.life} life remains)`);
+      logger.debug(
+        () =>
+          `${createLogLabel('avatar', data.id)} <-- ${amount} damage (${state.life} life remains)`,
+      );
     },
     reset,
     updateLevel: (level: number) => {

--- a/libs/game/idle-core/src/entities/create-enemy.test.ts
+++ b/libs/game/idle-core/src/entities/create-enemy.test.ts
@@ -87,7 +87,7 @@ test('it calls all registered handlers when handling a tick', () => {
   invariant(enemy, 'enemy is required');
 
   enemy.registerBehaviour(behaviour);
-  enemy.handleTick(combatExecutor, ctx);
+  enemy.handleTick(combatExecutor);
 
   expect(handlerSpy).toHaveBeenCalledWith(enemy, combatExecutor, ctx);
 });
@@ -119,7 +119,7 @@ test('it allows removing behaviours', () => {
 
   enemy.registerBehaviour(behaviour);
   enemy.removeBehaviour(BehaviourID.Test);
-  enemy.handleTick(combatExecutor, ctx);
+  enemy.handleTick(combatExecutor);
 
   expect(handlerSpy).not.toHaveBeenCalled();
 });

--- a/libs/game/idle-core/src/entities/create-enemy.ts
+++ b/libs/game/idle-core/src/entities/create-enemy.ts
@@ -23,7 +23,6 @@ const DEFAULT_BEHAVIOUR_FACTORIES = [createEnemyPrimaryAttackBehaviour];
 
 export function createEnemy(data: EnemyData, ctx: SimulationContext): Enemy {
   const id = createId();
-  const label = createLogLabel('enemy', id);
   let state = getInitialState(data);
 
   const getSnapshot = (): EnemySnapshot => {
@@ -102,7 +101,9 @@ export function createEnemy(data: EnemyData, ctx: SimulationContext): Enemy {
     receiveDamage: (amount: number) => {
       handleReceiveEnemyDamage(amount, enemy);
 
-      logger.debug(`${label} <-- ${amount} damage (${state.life} life remains)`);
+      logger.debug(
+        () => `${createLogLabel('enemy', id)} <-- ${amount} damage (${state.life} life remains)`,
+      );
     },
   };
 

--- a/libs/game/idle-core/src/types/entities.ts
+++ b/libs/game/idle-core/src/types/entities.ts
@@ -2,7 +2,6 @@ import type { AvatarBehaviour, Behaviour, BehaviourID, EnemyBehaviour } from './
 import type { CombatExecutor } from './combat';
 import type { SetEntityStateFn } from './core';
 import type { EquipmentSlot, EquipmentWeapon } from './equipment';
-import type { SimulationContext } from './simulation';
 
 export interface AvatarData {
   id: string;
@@ -41,7 +40,7 @@ interface IEntity<State extends object, EntitySnapshot extends object> {
   // oxlint-disable-next-line typescript/method-signature-style -- subtypes narrow the behaviour param; method syntax keeps the bivariant check that permits it
   registerBehaviour(behaviour: Behaviour): void;
   getSnapshot: () => EntitySnapshot;
-  handleTick: (combatExecutor: CombatExecutor, ctx: SimulationContext) => void;
+  handleTick: (combatExecutor: CombatExecutor) => void;
   removeBehaviour: (id: BehaviourID) => void;
   setState: (setStateFn: SetEntityStateFn<State>) => void;
 

--- a/libs/game/idle-core/src/utils/logger.test.ts
+++ b/libs/game/idle-core/src/utils/logger.test.ts
@@ -1,0 +1,10 @@
+import { expect, mock, test } from 'bun:test';
+import { logger } from './logger';
+
+test('it never invokes the message thunk when debug logging is disabled', () => {
+  const buildMessage = mock(() => 'unreachable');
+
+  logger.debug(buildMessage);
+
+  expect(buildMessage).not.toHaveBeenCalled();
+});

--- a/libs/game/idle-core/src/utils/logger.ts
+++ b/libs/game/idle-core/src/utils/logger.ts
@@ -1,9 +1,13 @@
 const isDebugEnabled = false;
 
 export const logger = {
-  debug: (message: string) => {
+  /**
+   * Invokes `buildMessage` only when debug logging is enabled, so callers can defer string
+   * construction to the call site instead of paying for it on every invocation.
+   */
+  debug: (buildMessage: () => string) => {
     if (isDebugEnabled) {
-      console.log(message);
+      console.log(buildMessage());
     }
   },
   info: (message: string) => {


### PR DESCRIPTION
## Description

Part of #729.

Applies three of the four idle-core tick micro-optimizations from the perf plan: deferred debug logging, a hoisted combat event comparator, and a dropped dead parameter. All changes are behavior-preserving.

- `logger.debug` now takes a `() => string` thunk invoked only when debug logging is enabled; every call site was converted, with `createLogLabel` moved inside the thunk where it existed only for logging
- `createCombatExecutor` builds its event comparator once at executor creation instead of per tick, and skips sorting when fewer than 2 events are scheduled
- Dropped the unused `ctx: SimulationContext` second parameter from `IEntity.handleTick` and its two call sites
- Skipped the wave-liveness O(1) scan: making `isWavesRemaining` O(1) needs a live enemy/wave counter with no existing hook, requiring plumbing beyond `create-activity.ts` — left as-is per the plan's own escape hatch

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality

## Context

Change 4 (wave-liveness O(1) tracking) is deliberately deferred — see bullet above.

