### PR TITLE
fix(#729): order same-tick events and enemy ids deterministically

### DIFF
--- a/docs/architecture/game/game-simulation.md
+++ b/docs/architecture/game/game-simulation.md
@@ -34,6 +34,13 @@ determine every tick. The engine `@vers/idle-core` and world map encounter deriv
 process that replays submitted checkpoints — import them and compute byte-identical results from the
 same inputs.
 
+Purity rests on three invariants. Every random draw comes from the seeded `rng` stream, never
+`Math.random` or a wall-clock read. Every entity's id derives from its position in the input — an
+enemy's from its wave index and slot within the wave — never from a randomly minted value. Combat
+events resolve into one total order: ascending time, the avatar's own events before others' at an
+equal timestamp, then the monotonic sequence number the combat executor stamps on each event as it's
+scheduled — never an event id or the scan order that discovered the event that tick.
+
 The client does all real-time simulation. One writer per browser profile runs the fixed-timestep
 loop; every other tab is a pure viewer, rendering the writer's **sim snapshot** — the engine's
 serializable `*Snapshot` projection from `getSnapshot()`, distinct from the server-authored **build

--- a/libs/game/idle-core/src/behaviours/avatar-weapon-attack/create-avatar-attack-event.test.ts
+++ b/libs/game/idle-core/src/behaviours/avatar-weapon-attack/create-avatar-attack-event.test.ts
@@ -13,7 +13,6 @@ test('it creates an avatar attack event', () => {
   const event = createAvatarAttackEvent(avatar, time);
 
   expect(event).toStrictEqual({
-    id: expect.toBeString(),
     source: avatar.id,
     time,
     type: CombatEventType.AvatarAttack,

--- a/libs/game/idle-core/src/behaviours/avatar-weapon-attack/create-avatar-attack-event.ts
+++ b/libs/game/idle-core/src/behaviours/avatar-weapon-attack/create-avatar-attack-event.ts
@@ -1,10 +1,8 @@
-import { createId } from '@paralleldrive/cuid2';
 import type { Avatar, AvatarAttackEvent } from '../../types';
 import { CombatEventType } from '../../types';
 
 export function createAvatarAttackEvent(entity: Avatar, time: number): AvatarAttackEvent {
   const event: AvatarAttackEvent = {
-    id: createId(),
     source: entity.id,
     time,
     type: CombatEventType.AvatarAttack,

--- a/libs/game/idle-core/src/behaviours/enemy-primary-attack/create-enemy-attack-event.test.ts
+++ b/libs/game/idle-core/src/behaviours/enemy-primary-attack/create-enemy-attack-event.test.ts
@@ -8,12 +8,11 @@ import { createEnemyAttackEvent } from './create-enemy-attack-event';
 test('it creates an enemy attack event', () => {
   const enemyData = createMockEnemyData();
   const ctx = createMockSimulationContext();
-  const enemy = createEnemy(enemyData, ctx);
+  const enemy = createEnemy('test-enemy', enemyData, ctx);
   const time = 1000;
   const event = createEnemyAttackEvent(enemy, time);
 
   expect(event).toStrictEqual({
-    id: expect.toBeString(),
     source: enemy.id,
     time,
     type: CombatEventType.EnemyAttack,

--- a/libs/game/idle-core/src/behaviours/enemy-primary-attack/create-enemy-attack-event.ts
+++ b/libs/game/idle-core/src/behaviours/enemy-primary-attack/create-enemy-attack-event.ts
@@ -1,10 +1,8 @@
-import { createId } from '@paralleldrive/cuid2';
 import type { Enemy, EnemyAttackEvent } from '../../types';
 import { CombatEventType } from '../../types';
 
 export function createEnemyAttackEvent(entity: Enemy, time: number): EnemyAttackEvent {
   const event: EnemyAttackEvent = {
-    id: createId(),
     source: entity.id,
     time,
     type: CombatEventType.EnemyAttack,

--- a/libs/game/idle-core/src/behaviours/enemy-primary-attack/create.test.ts
+++ b/libs/game/idle-core/src/behaviours/enemy-primary-attack/create.test.ts
@@ -15,7 +15,7 @@ test('it creates a behaviour with the correct values', () => {
   });
 
   const ctx = createMockSimulationContext();
-  const enemy = createEnemy(enemyData, ctx);
+  const enemy = createEnemy('test-enemy', enemyData, ctx);
   const behaviour = create(enemy);
 
   expect(behaviour.lastAttackTime).toBe(0);
@@ -25,7 +25,7 @@ test('it creates a behaviour with the correct values', () => {
 test('it exposes a method for getting the state', () => {
   const enemyData = createMockEnemyData();
   const ctx = createMockSimulationContext();
-  const enemy = createEnemy(enemyData, ctx);
+  const enemy = createEnemy('test-enemy', enemyData, ctx);
   const behaviour = create(enemy);
 
   expect(behaviour.getState()).toStrictEqual({
@@ -36,7 +36,7 @@ test('it exposes a method for getting the state', () => {
 test('it exposes a method for setting the state', () => {
   const enemyData = createMockEnemyData();
   const ctx = createMockSimulationContext();
-  const enemy = createEnemy(enemyData, ctx);
+  const enemy = createEnemy('test-enemy', enemyData, ctx);
   const behaviour = create(enemy);
 
   behaviour.setState((draft) => {
@@ -73,7 +73,7 @@ test('it handles the reset event', () => {
   });
 
   const ctx = createMockSimulationContext();
-  const enemy = createEnemy(enemyData, ctx);
+  const enemy = createEnemy('test-enemy', enemyData, ctx);
   const behaviour = create(enemy);
 
   behaviour.setState((draft) => {

--- a/libs/game/idle-core/src/behaviours/enemy-primary-attack/create.test.ts
+++ b/libs/game/idle-core/src/behaviours/enemy-primary-attack/create.test.ts
@@ -51,7 +51,7 @@ test('it exposes a method for setting the state', () => {
 test('it leaves a previously captured state object unchanged after a later setState call', () => {
   const enemyData = createMockEnemyData();
   const ctx = createMockSimulationContext();
-  const enemy = createEnemy(enemyData, ctx);
+  const enemy = createEnemy('test-enemy', enemyData, ctx);
   const behaviour = create(enemy);
   const capturedState = behaviour.getState();
 

--- a/libs/game/idle-core/src/behaviours/enemy-primary-attack/get-attack-interval-ms.test.ts
+++ b/libs/game/idle-core/src/behaviours/enemy-primary-attack/get-attack-interval-ms.test.ts
@@ -14,7 +14,7 @@ test('it calculates the primary attack interval', () => {
   });
 
   const ctx = createMockSimulationContext();
-  const enemy = createEnemy(enemyData, ctx);
+  const enemy = createEnemy('test-enemy', enemyData, ctx);
   const interval = getAttackIntervalMS(enemy);
 
   expect(interval).toBe(1818); // 1000ms / 0.55 = 1818ms

--- a/libs/game/idle-core/src/behaviours/enemy-primary-attack/get-next-attack-time.test.ts
+++ b/libs/game/idle-core/src/behaviours/enemy-primary-attack/get-next-attack-time.test.ts
@@ -14,7 +14,7 @@ test('it calculates the next attack time', () => {
   });
 
   const ctx = createMockSimulationContext();
-  const enemy = createEnemy(enemyData, ctx);
+  const enemy = createEnemy('test-enemy', enemyData, ctx);
   const state = { lastAttackTime: 1000 };
   const nextAttackTime = getNextAttackTime(enemy, state);
 

--- a/libs/game/idle-core/src/behaviours/enemy-primary-attack/has-primary-attack.test.ts
+++ b/libs/game/idle-core/src/behaviours/enemy-primary-attack/has-primary-attack.test.ts
@@ -14,7 +14,7 @@ test('it returns true when enemy has a primary attack', () => {
   });
 
   const ctx = createMockSimulationContext();
-  const enemy = createEnemy(enemyData, ctx);
+  const enemy = createEnemy('test-enemy', enemyData, ctx);
   const result = hasPrimaryAttack(enemy);
 
   expect(result).toBeTrue();

--- a/libs/game/idle-core/src/core/create-combat-executor.test.ts
+++ b/libs/game/idle-core/src/core/create-combat-executor.test.ts
@@ -1,11 +1,12 @@
 import { expect, test } from 'bun:test';
+import invariant from 'tiny-invariant';
 import { createAvatar } from '../entities/create-avatar';
 import { createMockActivityInput } from '../test-utils/factories/create-mock-activity-input';
 import { createMockAvatarData } from '../test-utils/factories/create-mock-avatar-data';
 import { createMockEnemyData } from '../test-utils/factories/create-mock-enemy-data';
 import { createMockSimulationContext } from '../test-utils/factories/create-mock-simulation-context';
-import type { EquipmentWeapon } from '../types';
-import { EquipmentSlot } from '../types';
+import type { EnemyAttackEvent, EquipmentWeapon } from '../types';
+import { CombatEventType, EquipmentSlot } from '../types';
 import { createActivity } from './create-activity';
 import { createCombatExecutor } from './create-combat-executor';
 
@@ -77,6 +78,17 @@ test('it processes a tick with a single scheduled event', () => {
   expect(avatar.life).toBe(160);
 });
 
+test('it applies same-time enemy events in schedule order, not enemy array order', () => {
+  // scheduling the lethal hit first means the avatar dies before the weak enemy's event is
+  // handled, so that event's damage roll never draws from the rng; scheduling the weak hit first
+  // lets it draw before the avatar dies to the lethal hit — the two schedule orders must consume
+  // a different number of draws, even though both scenarios use the same enemy array order
+  const stateWhenLethalActsFirst = buildFinalRngState('lethal');
+  const stateWhenWeakActsFirst = buildFinalRngState('weak');
+
+  expect(stateWhenLethalActsFirst).not.toBe(stateWhenWeakActsFirst);
+});
+
 test('it returns the expected combat executor state for a client app', () => {
   const ctx = createMockSimulationContext();
   const activity = createActivity(createMockActivityInput(), ctx);
@@ -88,3 +100,59 @@ test('it returns the expected combat executor state for a client app', () => {
     elapsed: 0,
   });
 });
+
+/**
+ * Runs a two-enemy tick where one enemy's hit is lethal on its own and the other's isn't,
+ * scheduling `firstToAct`'s attack event ahead of the other's, then returns the rng's final
+ * state — letting a caller compare draw counts across schedule orders.
+ */
+function buildFinalRngState(firstToAct: 'lethal' | 'weak'): string {
+  const enemyDataLethal = createMockEnemyData({
+    life: 100,
+    primaryAttack: { maxDamage: 150, minDamage: 150, speed: 1 },
+  });
+
+  const enemyDataWeak = createMockEnemyData({
+    life: 100,
+    primaryAttack: { maxDamage: 10, minDamage: 1, speed: 1 },
+  });
+
+  const avatarData = createMockAvatarData({ life: 100 });
+
+  const activityData = createMockActivityInput({
+    encounter: { waves: [[enemyDataLethal, enemyDataWeak]] },
+  });
+
+  const ctx = createMockSimulationContext();
+  const avatar = createAvatar(avatarData, ctx);
+  const activity = createActivity(activityData, ctx);
+  const combatExecutor = createCombatExecutor(activity, avatar, ctx);
+  const [lethalEnemy, weakEnemy] = activity.currentWave?.enemies ?? [];
+
+  invariant(lethalEnemy && weakEnemy, 'both enemies are required');
+
+  const lethalEvent: EnemyAttackEvent = {
+    source: lethalEnemy.id,
+    time: 0,
+    type: CombatEventType.EnemyAttack,
+  };
+
+  const weakEvent: EnemyAttackEvent = {
+    source: weakEnemy.id,
+    time: 0,
+    type: CombatEventType.EnemyAttack,
+  };
+
+  const orderedEvents =
+    firstToAct === 'lethal' ? [lethalEvent, weakEvent] : [weakEvent, lethalEvent];
+
+  orderedEvents.forEach((event) => {
+    combatExecutor.scheduleEvent(event);
+  });
+
+  // a zero delta leaves both entities' own attack timers unready, so only our manually
+  // scheduled events are applied this tick
+  combatExecutor.run(0);
+
+  return ctx.rng.getState();
+}

--- a/libs/game/idle-core/src/core/create-combat-executor.ts
+++ b/libs/game/idle-core/src/core/create-combat-executor.ts
@@ -5,6 +5,7 @@ import type {
   CombatEvent,
   CombatExecutor,
   CombatExecutorSnapshot,
+  ScheduledCombatEvent,
   SimulationContext,
 } from '../types';
 import { handleEvent } from './handle-event';
@@ -15,15 +16,18 @@ export function createCombatExecutor(
   ctx: SimulationContext,
 ): CombatExecutor {
   let elapsed = 0;
-  let scheduledEvents: Array<CombatEvent> = [];
+  let nextSequence = 0;
+  let scheduledEvents: Array<ScheduledCombatEvent> = [];
   const sortEvents = createEventSorter(avatar);
 
   const getSnapshot = (): CombatExecutorSnapshot => ({
     elapsed,
   });
 
+  // stamps a monotonic sequence number so same-time ties resolve in schedule order, independent of
+  // the scan order that discovered the event this tick
   const scheduleEvent = (event: CombatEvent) => {
-    scheduledEvents.push(event);
+    scheduledEvents.push({ ...event, sequence: nextSequence++ });
   };
 
   const applyEvents = () => {
@@ -31,7 +35,7 @@ export function createCombatExecutor(
       scheduledEvents.sort(sortEvents);
     }
 
-    scheduledEvents.forEach((event: CombatEvent) => {
+    scheduledEvents.forEach((event: ScheduledCombatEvent) => {
       handleEvent(event, avatar, activity, ctx);
     });
 

--- a/libs/game/idle-core/src/core/handle-avatar-attack.test.ts
+++ b/libs/game/idle-core/src/core/handle-avatar-attack.test.ts
@@ -43,7 +43,6 @@ test('it applies damage to the first living enemy', () => {
   firstEnemy?.receiveDamage(100);
 
   const event: AvatarAttackEvent = {
-    id: 'event-1',
     source: avatar.id,
     time: 100,
     type: CombatEventType.AvatarAttack,

--- a/libs/game/idle-core/src/core/handle-enemy-attack.test.ts
+++ b/libs/game/idle-core/src/core/handle-enemy-attack.test.ts
@@ -31,7 +31,6 @@ test('it applies damage from the enemy to the avatar', () => {
   const enemy = activity.currentWave!.nextLivingEnemy!;
 
   const event: EnemyAttackEvent = {
-    id: 'event-1',
     source: enemy.id,
     time: 100,
     type: CombatEventType.EnemyAttack,
@@ -67,7 +66,6 @@ test('it does nothing if the enemy is dead', () => {
   enemy.receiveDamage(100);
 
   const event: EnemyAttackEvent = {
-    id: 'event-1',
     source: enemy.id,
     time: 100,
     type: CombatEventType.EnemyAttack,
@@ -105,7 +103,6 @@ test('it correctly resolves the correct event source', () => {
   const firstEnemy = activity.currentWave!.nextLivingEnemy!;
 
   const event: EnemyAttackEvent = {
-    id: 'event-1',
     source: firstEnemy.id,
     time: 100,
     type: CombatEventType.EnemyAttack,

--- a/libs/game/idle-core/src/core/utils/create-event-sorter.test.ts
+++ b/libs/game/idle-core/src/core/utils/create-event-sorter.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'bun:test';
 import { createAvatar } from '../../entities/create-avatar';
 import { createMockAvatarData } from '../../test-utils/factories/create-mock-avatar-data';
 import { createMockSimulationContext } from '../../test-utils/factories/create-mock-simulation-context';
-import type { AvatarAttackEvent, EnemyAttackEvent } from '../../types';
+import type { ScheduledCombatEvent } from '../../types';
 import { CombatEventType } from '../../types';
 import { createEventSorter } from './create-event-sorter';
 
@@ -11,15 +11,15 @@ test('it sorts events by time', () => {
   const data = createMockAvatarData();
   const avatar = createAvatar(data, ctx);
 
-  const event1: EnemyAttackEvent = {
-    id: 'event-1',
+  const event1: ScheduledCombatEvent = {
+    sequence: 0,
     source: 'enemy-1',
     time: 100,
     type: CombatEventType.EnemyAttack,
   };
 
-  const event2: EnemyAttackEvent = {
-    id: 'event-2',
+  const event2: ScheduledCombatEvent = {
+    sequence: 1,
     source: 'enemy-2',
     time: 50,
     type: CombatEventType.EnemyAttack,
@@ -38,22 +38,22 @@ test('it prioritizes avatar events when time is equal', () => {
   const data = createMockAvatarData();
   const avatar = createAvatar(data, ctx);
 
-  const avatarEvent: AvatarAttackEvent = {
-    id: 'event-1',
+  const avatarEvent: ScheduledCombatEvent = {
+    sequence: 0,
     source: avatar.id,
     time: 100,
     type: CombatEventType.AvatarAttack,
   };
 
-  const enemyEvent2: EnemyAttackEvent = {
-    id: 'event-2',
+  const enemyEvent2: ScheduledCombatEvent = {
+    sequence: 1,
     source: 'enemy-1',
     time: 100,
     type: CombatEventType.EnemyAttack,
   };
 
-  const enemyEvent3: EnemyAttackEvent = {
-    id: 'event-3',
+  const enemyEvent3: ScheduledCombatEvent = {
+    sequence: 2,
     source: 'enemy-2',
     time: 100,
     type: CombatEventType.EnemyAttack,
@@ -67,20 +67,20 @@ test('it prioritizes avatar events when time is equal', () => {
   expect(events).toStrictEqual([avatarEvent, enemyEvent2, enemyEvent3]);
 });
 
-test('it breaks same-source ties by id, independent of scheduling order', () => {
+test('it breaks same-source ties by sequence, in schedule order regardless of array order', () => {
   const ctx = createMockSimulationContext();
   const data = createMockAvatarData();
   const avatar = createAvatar(data, ctx);
 
-  const enemyA: EnemyAttackEvent = {
-    id: 'event-a',
+  const enemyA: ScheduledCombatEvent = {
+    sequence: 0,
     source: 'enemy-1',
     time: 100,
     type: CombatEventType.EnemyAttack,
   };
 
-  const enemyB: EnemyAttackEvent = {
-    id: 'event-b',
+  const enemyB: ScheduledCombatEvent = {
+    sequence: 1,
     source: 'enemy-1',
     time: 100,
     type: CombatEventType.EnemyAttack,

--- a/libs/game/idle-core/src/core/utils/create-event-sorter.ts
+++ b/libs/game/idle-core/src/core/utils/create-event-sorter.ts
@@ -1,12 +1,12 @@
-import type { Avatar, CombatEvent } from '../../types';
+import type { Avatar, ScheduledCombatEvent } from '../../types';
 
 /**
  * Orders combat events into a deterministic total order: ascending time, then the avatar's own
- * events before others' at an equal timestamp, then by event id so same-source ties resolve the
- * same way regardless of the order the events were scheduled in.
+ * events before others' at an equal timestamp, then by the executor-assigned sequence number so
+ * same-source ties resolve in the order the events were scheduled.
  */
 export function createEventSorter(avatar: Avatar) {
-  return (a: CombatEvent, b: CombatEvent) => {
+  return (a: ScheduledCombatEvent, b: ScheduledCombatEvent) => {
     const timeDiff = a.time - b.time;
 
     if (timeDiff !== 0) {
@@ -20,14 +20,6 @@ export function createEventSorter(avatar: Avatar) {
       return aIsAvatar ? -1 : 1;
     }
 
-    if (a.id < b.id) {
-      return -1;
-    }
-
-    if (a.id > b.id) {
-      return 1;
-    }
-
-    return 0;
+    return a.sequence - b.sequence;
   };
 }

--- a/libs/game/idle-core/src/core/utils/create-wave.test.ts
+++ b/libs/game/idle-core/src/core/utils/create-wave.test.ts
@@ -18,6 +18,13 @@ test('it derives its id from its wave index', () => {
   expect(wave.id).toBe('wave-3');
 });
 
+test('it derives each enemy id from the wave id and the enemy position within the wave', () => {
+  const ctx = createMockSimulationContext();
+  const wave = createWave(2, [createMockEnemyData(), createMockEnemyData()], ctx);
+
+  expect(wave.enemies.map((enemy) => enemy.id)).toStrictEqual(['wave-2-enemy-0', 'wave-2-enemy-1']);
+});
+
 test('it returns the correct remaining count as enemies are killed', () => {
   const enemyData = createMockEnemyData({
     life: 100,

--- a/libs/game/idle-core/src/core/utils/create-wave.ts
+++ b/libs/game/idle-core/src/core/utils/create-wave.ts
@@ -3,7 +3,9 @@ import type { EnemyData, SimulationContext, Wave, WaveSnapshot } from '../../typ
 
 /**
  * Builds a wave from its already-resolved enemy data verbatim — `index` names this wave's position
- * within its encounter's ordered wave list, giving each wave a stable, deterministic id.
+ * within its encounter's ordered wave list, giving each wave a stable, deterministic id. Each
+ * enemy's id derives from that wave id plus its position within the wave, keeping enemy identity
+ * deterministic too.
  */
 export function createWave(
   index: number,
@@ -11,7 +13,11 @@ export function createWave(
   ctx: SimulationContext,
 ): Wave {
   const id = `wave-${index}`;
-  const enemies = enemyData.map((data) => createEnemy(data, ctx));
+
+  const enemies = enemyData.map((data, enemyIndex) =>
+    createEnemy(`${id}-enemy-${enemyIndex}`, data, ctx),
+  );
+
   const getRemainingEnemies = () => enemies.filter((enemy) => enemy.isAlive);
 
   const getSnapshot = (): WaveSnapshot => ({

--- a/libs/game/idle-core/src/entities/create-enemy.test.ts
+++ b/libs/game/idle-core/src/entities/create-enemy.test.ts
@@ -15,9 +15,9 @@ import { createEnemy } from './create-enemy';
 test('it creates an enemy with correct initial values', () => {
   const ctx = createMockSimulationContext();
   const data = createMockEnemyData();
-  const enemy = createEnemy(data, ctx);
+  const enemy = createEnemy('test-enemy', data, ctx);
 
-  expect(enemy.id).toBeString();
+  expect(enemy.id).toBe('test-enemy');
   expect(enemy.level).toBe(data.level);
   expect(enemy.name).toBe(data.name);
   expect(enemy.type).toBe(EntityType.Enemy);
@@ -30,7 +30,7 @@ test('it creates an enemy with correct initial values', () => {
 test('it exposes a method for setting the enemy state', () => {
   const ctx = createMockSimulationContext();
   const data = createMockEnemyData();
-  const enemy = createEnemy(data, ctx);
+  const enemy = createEnemy('test-enemy', data, ctx);
 
   enemy.setState((draftState) => {
     draftState.life = 9999;
@@ -46,7 +46,7 @@ test('it reduces life and updates status when killed', () => {
     life: 100,
   });
 
-  const enemy = createEnemy(data, ctx);
+  const enemy = createEnemy('test-enemy', data, ctx);
 
   enemy.receiveDamage(10);
 
@@ -127,7 +127,7 @@ test('it allows removing behaviours', () => {
 test('it returns the expected enemy state for a client app', () => {
   const ctx = createMockSimulationContext();
   const data = createMockEnemyData();
-  const enemy = createEnemy(data, ctx);
+  const enemy = createEnemy('test-enemy', data, ctx);
   const state = enemy.getSnapshot();
 
   expect(state).toStrictEqual({

--- a/libs/game/idle-core/src/entities/create-enemy.ts
+++ b/libs/game/idle-core/src/entities/create-enemy.ts
@@ -1,4 +1,3 @@
-import { createId } from '@paralleldrive/cuid2';
 import { createEnemyPrimaryAttackBehaviour } from '../behaviours/enemy-primary-attack';
 import type {
   BehaviourID,
@@ -20,8 +19,12 @@ import { rollEnemyAttackDamage } from './utils/roll-enemy-attack-damage';
 
 const DEFAULT_BEHAVIOUR_FACTORIES = [createEnemyPrimaryAttackBehaviour];
 
-export function createEnemy(data: EnemyData, ctx: SimulationContext): Enemy {
-  const id = createId();
+/**
+ * `id` must be deterministic — it becomes an attack event's `source` and is matched back to the
+ * enemy that owns it when the event is handled, so a random id would make replays diverge on
+ * scheduling order.
+ */
+export function createEnemy(id: string, data: EnemyData, ctx: SimulationContext): Enemy {
   let state = getInitialState(data);
 
   const getSnapshot = (): EnemySnapshot => {

--- a/libs/game/idle-core/src/entities/utils/handle-receive-enemy-damage.test.ts
+++ b/libs/game/idle-core/src/entities/utils/handle-receive-enemy-damage.test.ts
@@ -8,7 +8,7 @@ import { handleReceiveEnemyDamage } from './handle-receive-enemy-damage';
 test('it reduces the life of the entity by the amount of damage received', () => {
   const ctx = createMockSimulationContext();
   const data = createMockEnemyData({ life: 100 });
-  const enemy = createEnemy(data, ctx);
+  const enemy = createEnemy('test-enemy', data, ctx);
 
   handleReceiveEnemyDamage(10, enemy);
 
@@ -18,7 +18,7 @@ test('it reduces the life of the entity by the amount of damage received', () =>
 test('it sets the status to dead if the life is 0 or less', () => {
   const ctx = createMockSimulationContext();
   const data = createMockEnemyData({ life: 100 });
-  const enemy = createEnemy(data, ctx);
+  const enemy = createEnemy('test-enemy', data, ctx);
 
   handleReceiveEnemyDamage(100, enemy);
 
@@ -28,7 +28,7 @@ test('it sets the status to dead if the life is 0 or less', () => {
 test('it does not reduce the life below 0', () => {
   const ctx = createMockSimulationContext();
   const data = createMockEnemyData({ life: 10 });
-  const enemy = createEnemy(data, ctx);
+  const enemy = createEnemy('test-enemy', data, ctx);
 
   handleReceiveEnemyDamage(100, enemy);
 

--- a/libs/game/idle-core/src/entities/utils/roll-enemy-attack-damage.test.ts
+++ b/libs/game/idle-core/src/entities/utils/roll-enemy-attack-damage.test.ts
@@ -14,7 +14,7 @@ test('it calculates the damage for an enemy attack', () => {
   });
 
   const ctx = createMockSimulationContext();
-  const enemy = createEnemy(enemyData, ctx);
+  const enemy = createEnemy('test-enemy', enemyData, ctx);
   const damage = rollEnemyAttackDamage(enemy, ctx);
 
   expect(damage).toBe(10);

--- a/libs/game/idle-core/src/replay.test.ts
+++ b/libs/game/idle-core/src/replay.test.ts
@@ -298,6 +298,55 @@ test('it replays a failed attempt to an identical checkpoint stream', async () =
   `);
 });
 
+/**
+ * This seed/difficulty/level combination's wave lands two enemies' attacks on the exact same
+ * tick, and the first one applied kills the avatar before the second's damage roll draws from
+ * the rng — the scenario `create-event-sorter.ts`'s executor-assigned sequence exists to order
+ * deterministically. Reordering that tick's application changes how many draws the run consumes,
+ * so this fixture's `nextSeed` pins the executor's schedule-order tie-break at the replay level,
+ * not just the unit level.
+ */
+test('it replays a same-tick multi-enemy avatar-death stream to an identical checkpoint stream', async () => {
+  const input = buildSimulationInput({
+    avatarID: 'avatar-golden-divergence',
+    buildSnapshot: { level: 2, xp: 0 },
+    contentVersion: '1',
+    encounterNode: { difficulty: 8 },
+    id: 'activity-golden-divergence',
+    seed: buildStateFromSeed(4),
+  });
+
+  const result = await runAttempt(input.activity, input.avatar, { maxDurationMs: 600_000 });
+
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "checkpoints": [
+        {
+          "nextSeed": "fffffffffffffffb0000000400000000",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "seed": "fffffffffffffffb0000000400000000",
+          "time": 0,
+          "type": "started",
+        },
+        {
+          "nextSeed": "cae74db90a879eb757eb51948b1b6fdb",
+          "rewardSlots": [],
+          "rewards": {
+            "xp": 0,
+          },
+          "time": 10000,
+          "type": "failed",
+        },
+      ],
+      "elapsed": 10100,
+      "outcome": "failed",
+    }
+  `);
+});
+
 test('it replays a retrying multi-attempt stream to an identical checkpoint stream', async () => {
   const input = buildSimulationInput(
     {

--- a/libs/game/idle-core/src/types/combat.ts
+++ b/libs/game/idle-core/src/types/combat.ts
@@ -25,7 +25,6 @@ export interface CombatExecutor extends ActivityExecutor {
 }
 
 interface ICombatEvent {
-  readonly id: string;
   readonly source: string;
   readonly time: number;
   readonly type: CombatEventType;
@@ -47,3 +46,9 @@ export interface EnemyAttackEvent extends ICombatEvent {
 export type CombatEvent = AvatarAttackEvent | EnemyAttackEvent;
 
 export type AttackEvent = AvatarAttackEvent | EnemyAttackEvent;
+
+/**
+ * A combat event once the executor has assigned it its schedule-order sequence number, used to
+ * break same-time ties deterministically regardless of scan or draw order.
+ */
+export type ScheduledCombatEvent = CombatEvent & { readonly sequence: number };


### PR DESCRIPTION
## Description

Part of #729.

Same-tick combat events and enemy identity both had a hidden source of nondeterminism: event ties broke on a randomly minted `id`, and enemies got a random `id` unrelated to their position in the wave. Both now derive from deterministic inputs so replays produce byte-identical results regardless of scan order.

- `ICombatEvent` drops its random `id`; a new `ScheduledCombatEvent` carries a monotonic `sequence` the combat executor stamps at schedule time, and the event sorter's tie-break now compares `sequence` instead of `id`
- `createEnemy` takes `id` as a parameter instead of minting one with `createId()`; `createWave` derives it from the wave id and enemy index (`wave-2-enemy-0`)
- `@paralleldrive/cuid2` stays in idle-core's `package.json` for its test-utils factories, which still mint ids for mock data
- Added a `docs/architecture/game/game-simulation.md` paragraph naming the three determinism invariants (seeded rng only, deterministic entity identity, deterministic total event order)
- Regenerating the replay goldens (`bun test -u`) produced no diff — none of the five existing golden encounters land two same-class events on the identical tick with a mid-batch avatar death, so a new fixture pins that exact scenario at the replay level instead

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality

## Context

`bun run deadcode` and `bun run format:check` also pass; no package outside `@vers/idle-core` and the one doc file was touched.

