### PR TITLE
perf(#729): step the idle-core engine synchronously

### DIFF
--- a/libs/game/idle-client/src/resync/run-reconstruction.test.ts
+++ b/libs/game/idle-client/src/resync/run-reconstruction.test.ts
@@ -14,7 +14,7 @@ test('it reconstructs a simulation to the confirmed head, matching the original 
 
   const targetHead = attempt.checkpoints.length - 1;
 
-  const result = await runReconstruction({
+  const result = runReconstruction({
     activity,
     appendedHead: targetHead,
     avatar,
@@ -33,7 +33,7 @@ test('it reconstructs a simulation to the confirmed head, matching the original 
   let nextCheckpoint = null;
 
   while (nextCheckpoint === null) {
-    nextCheckpoint = await result.simulation.run(SIMULATION_TIMESTEP_MS);
+    nextCheckpoint = result.simulation.run(SIMULATION_TIMESTEP_MS);
   }
 
   expect(nextCheckpoint).toStrictEqual(expectedNextCheckpoint);
@@ -45,7 +45,7 @@ test('it reports a divergence when the local engine terminates before the confir
 
   const attempt = await runAttempt(activity, avatar, { maxDurationMs: 120_000 });
 
-  const result = await runReconstruction({
+  const result = runReconstruction({
     activity,
     appendedHead: attempt.checkpoints.length + 5,
     avatar,

--- a/libs/game/idle-client/src/resync/run-reconstruction.ts
+++ b/libs/game/idle-client/src/resync/run-reconstruction.ts
@@ -26,9 +26,9 @@ type RunReconstructionResult =
  * that reaches its terminal checkpoint before matching the confirmed count can never reproduce the
  * rest of the server's stream, so that's reported as a divergence rather than a result to attach.
  */
-export async function runReconstruction(
+export function runReconstruction(
   options: Readonly<RunReconstructionOptions>,
-): Promise<RunReconstructionResult> {
+): RunReconstructionResult {
   invariant(
     options.appendedHead >= 1,
     'reconstruction requires at least one confirmed checkpoint to target',
@@ -49,7 +49,7 @@ export async function runReconstruction(
   let lastCheckpoint: ActivityCheckpoint | undefined;
 
   while (count < options.appendedHead) {
-    const checkpoint = await simulation.run(timestepMs);
+    const checkpoint = simulation.run(timestepMs);
 
     if (checkpoint === null) {
       continue;

--- a/libs/game/idle-client/src/worker/handle-stop-activity-message.ts
+++ b/libs/game/idle-client/src/worker/handle-stop-activity-message.ts
@@ -28,8 +28,7 @@ export async function handleStopActivityMessage(
   }
 
   context.advanceStopScope();
-
-  await context.getSimulation().stopActivity();
+  context.getSimulation().stopActivity();
 
   resetSimulation(context);
 

--- a/libs/game/idle-client/src/worker/register-simulation-listeners.test.ts
+++ b/libs/game/idle-client/src/worker/register-simulation-listeners.test.ts
@@ -16,7 +16,7 @@ test('it broadcasts a simulation update once the installed simulation reports on
   simulation.startActivity(createMockAvatarData(), createMockActivityInput());
 
   for (let tick = 0; tick < 20; tick += 1) {
-    await simulation.run(500);
+    simulation.run(500);
   }
 
   await waitFor(() => {

--- a/libs/game/idle-client/src/worker/run-continuation.ts
+++ b/libs/game/idle-client/src/worker/run-continuation.ts
@@ -66,7 +66,7 @@ export async function runContinuation(
       await parkContinuation(activity, signals);
     }
 
-    await stopAndReset(context, simulation);
+    stopAndReset(context, simulation);
 
     // called inner-to-inner: this flow already holds the mailbox turn, and queueing a resync
     // behind itself would deadlock. An automatic continuation never claims the writer — the
@@ -76,7 +76,7 @@ export async function runContinuation(
     return;
   }
 
-  await stopAndReset(context, simulation);
+  stopAndReset(context, simulation);
 
   if (!isDefinedError(error)) {
     if (!signals.stop.aborted) {
@@ -110,8 +110,8 @@ async function startContinuationFrom(
  * still owns the runtime; a concurrent stop may have installed its own replacement, which must
  * not be evicted.
  */
-async function stopAndReset(context: WorkerContext, simulation: Simulation): Promise<void> {
-  await simulation.stopActivity();
+function stopAndReset(context: WorkerContext, simulation: Simulation): void {
+  simulation.stopActivity();
 
   if (context.getSimulation() === simulation) {
     resetSimulation(context);

--- a/libs/game/idle-client/src/worker/run-resync-flow.ts
+++ b/libs/game/idle-client/src/worker/run-resync-flow.ts
@@ -476,7 +476,7 @@ async function applyHeadAttach(
     return;
   }
 
-  const reconstruction = await runReconstruction({
+  const reconstruction = runReconstruction({
     activity: input.activity,
     appendedHead: submission.appendedHead,
     avatar: input.avatar,

--- a/libs/game/idle-client/src/worker/run-resync-turn.test.ts
+++ b/libs/game/idle-client/src/worker/run-resync-turn.test.ts
@@ -348,7 +348,7 @@ test('it reconstructs and installs a live simulation mid-stream, registering fro
   let checkpoint: ActivityCheckpoint | null = null;
 
   while (checkpoint === null) {
-    checkpoint = await simulation.run(SIMULATION_TIMESTEP_MS);
+    checkpoint = simulation.run(SIMULATION_TIMESTEP_MS);
   }
 
   await ctx.context.getSubmitter().submit(activity.id, checkpoint);
@@ -460,7 +460,7 @@ test('it fast-forwards a short gap, broadcasts progress and final tallies, and i
   let checkpoint: ActivityCheckpoint | null = null;
 
   while (checkpoint === null) {
-    checkpoint = await simulation.run(SIMULATION_TIMESTEP_MS);
+    checkpoint = simulation.run(SIMULATION_TIMESTEP_MS);
   }
 
   // proves the fresh continuation's registration actually happened: an unregistered activity's
@@ -508,7 +508,7 @@ test('it reconstructs a fast-forward report left mid-stream and registers from i
   let checkpoint: ActivityCheckpoint | null = null;
 
   while (checkpoint === null) {
-    checkpoint = await simulation.run(SIMULATION_TIMESTEP_MS);
+    checkpoint = simulation.run(SIMULATION_TIMESTEP_MS);
   }
 
   await ctx.context.getSubmitter().submit(activity.id, checkpoint);

--- a/libs/game/idle-client/src/worker/run-simulation.ts
+++ b/libs/game/idle-client/src/worker/run-simulation.ts
@@ -25,7 +25,7 @@ export async function runSimulation(
     return;
   }
 
-  const checkpoint = await simulation.run(timestep);
+  const checkpoint = simulation.run(timestep);
 
   if (!checkpoint) {
     return;
@@ -60,7 +60,7 @@ export async function runSimulation(
   });
 
   if (action === 'stop') {
-    await simulation.stopActivity();
+    simulation.stopActivity();
 
     return;
   }

--- a/libs/game/idle-core/src/core/create-simulation-driver.ts
+++ b/libs/game/idle-core/src/core/create-simulation-driver.ts
@@ -33,12 +33,12 @@ export function createSimulationDriver(
 
   let isTerminated = false;
 
-  // oxlint-disable-next-line require-await -- kept async so cross-package callers can keep awaiting this driver-facing API; the engine now steps synchronously with no internal await
+  // oxlint-disable-next-line require-await -- kept async so cross-package callers can keep awaiting this driver-facing API; the engine step itself is synchronous
   const advanceToDuration = async (
     duration: number,
     stopAtState?: string,
     expectedCheckpointCount?: number,
-    // oxlint-disable-next-line typescript/require-await -- kept async so cross-package callers can keep awaiting this driver-facing API; the engine now steps synchronously with no internal await
+    // oxlint-disable-next-line typescript/require-await -- kept async so cross-package callers can keep awaiting this driver-facing API; the engine step itself is synchronous
   ): Promise<SimulationAdvanceResult> => {
     const checkpoints: Array<ActivityCheckpoint> = [];
 

--- a/libs/game/idle-core/src/core/create-simulation-driver.ts
+++ b/libs/game/idle-core/src/core/create-simulation-driver.ts
@@ -33,10 +33,12 @@ export function createSimulationDriver(
 
   let isTerminated = false;
 
+  // oxlint-disable-next-line require-await -- kept async so cross-package callers can keep awaiting this driver-facing API; the engine now steps synchronously with no internal await
   const advanceToDuration = async (
     duration: number,
     stopAtState?: string,
     expectedCheckpointCount?: number,
+    // oxlint-disable-next-line typescript/require-await -- kept async so cross-package callers can keep awaiting this driver-facing API; the engine now steps synchronously with no internal await
   ): Promise<SimulationAdvanceResult> => {
     const checkpoints: Array<ActivityCheckpoint> = [];
 
@@ -45,7 +47,7 @@ export function createSimulationDriver(
     }
 
     while (simulation.elapsed < duration) {
-      const checkpoint = await simulation.run(SIMULATION_TIMESTEP_MS);
+      const checkpoint = simulation.run(SIMULATION_TIMESTEP_MS);
 
       if (!checkpoint) {
         continue;
@@ -112,6 +114,10 @@ export function createSimulationDriver(
     get rngState() {
       return simulation.rngState;
     },
-    stop: () => simulation.stopActivity(),
+    stop: () => {
+      simulation.stopActivity();
+
+      return Promise.resolve();
+    },
   };
 }

--- a/libs/game/idle-core/src/core/create-simulation.test.ts
+++ b/libs/game/idle-core/src/core/create-simulation.test.ts
@@ -37,19 +37,18 @@ test('it calls an event listener when starting an activity', () => {
   expect(listenerSpy).toHaveBeenCalledExactlyOnceWith(simulation.state);
 });
 
-test('it stops an activity', async () => {
+test('it stops an activity', () => {
   const avatarData = createMockAvatarData();
   const activityData = createMockActivityInput();
   const simulation = createSimulation();
 
   simulation.startActivity(avatarData, activityData);
-
-  await simulation.stopActivity();
+  simulation.stopActivity();
 
   expect(simulation.activity).toBeNull();
 });
 
-test('it calls an event listener when stopping an activity', async () => {
+test('it calls an event listener when stopping an activity', () => {
   const avatarData = createMockAvatarData();
   const activityData = createMockActivityInput();
   const simulation = createSimulation();
@@ -57,8 +56,7 @@ test('it calls an event listener when stopping an activity', async () => {
 
   simulation.addEventListener('stopped', listenerSpy);
   simulation.startActivity(avatarData, activityData);
-
-  await simulation.stopActivity();
+  simulation.stopActivity();
 
   expect(listenerSpy).toHaveBeenCalledExactlyOnceWith(simulation.state);
 });
@@ -105,14 +103,14 @@ test('it resets the avatar when restarting an activity', () => {
   expect(simulation.state.avatar?.life).toBe(100);
 });
 
-test('it runs an activity and returns checkpoints', async () => {
+test('it runs an activity and returns checkpoints', () => {
   const avatarData = createMockAvatarData();
   const simulation = createSimulation();
   const activityData = createMockActivityInput();
 
   simulation.startActivity(avatarData, activityData);
 
-  const firstCheckpoint = await simulation.run(100);
+  const firstCheckpoint = simulation.run(100);
 
   expect(firstCheckpoint).toStrictEqual({
     nextSeed: expect.toBeString(),
@@ -123,7 +121,7 @@ test('it runs an activity and returns checkpoints', async () => {
     type: ActivityCheckpointType.Started,
   });
 
-  const secondCheckpoint = await simulation.run(10_000);
+  const secondCheckpoint = simulation.run(10_000);
 
   expect(secondCheckpoint).toStrictEqual({
     nextSeed: expect.toBeString(),
@@ -136,7 +134,7 @@ test('it runs an activity and returns checkpoints', async () => {
   expect(simulation.elapsed).toBe(10_100);
 });
 
-test('it calls an event listener when the state updates', async () => {
+test('it calls an event listener when the state updates', () => {
   const avatarData = createMockAvatarData();
   const simulation = createSimulation();
   const activityData = createMockActivityInput();
@@ -146,10 +144,10 @@ test('it calls an event listener when the state updates', async () => {
   simulation.startActivity(avatarData, activityData);
 
   // skip our initialisation state
-  await simulation.run(1);
+  simulation.run(1);
 
   // run long enough for an attack cycle to occur
-  await simulation.run(5000);
+  simulation.run(5000);
 
   expect(listenerSpy).toHaveBeenCalledExactlyOnceWith(simulation.state);
 });
@@ -190,7 +188,7 @@ test('it calls an event listener when the failure action updates', () => {
   expect(listenerSpy).toHaveBeenCalledExactlyOnceWith(simulation.state);
 });
 
-test('it produces an identical checkpoint stream with and without an updated listener', async () => {
+test('it produces an identical checkpoint stream with and without an updated listener', () => {
   const avatarData = createMockAvatarData();
   const activityData = createMockActivityInput();
   const withoutListener = createSimulation();
@@ -198,9 +196,9 @@ test('it produces an identical checkpoint stream with and without an updated lis
   withoutListener.startActivity(avatarData, activityData);
 
   const checkpointsWithoutListener = [
-    await withoutListener.run(1),
-    await withoutListener.run(5000),
-    await withoutListener.run(10_000),
+    withoutListener.run(1),
+    withoutListener.run(5000),
+    withoutListener.run(10_000),
   ];
 
   const withListener = createSimulation();
@@ -209,9 +207,9 @@ test('it produces an identical checkpoint stream with and without an updated lis
   withListener.startActivity(avatarData, activityData);
 
   const checkpointsWithListener = [
-    await withListener.run(1),
-    await withListener.run(5000),
-    await withListener.run(10_000),
+    withListener.run(1),
+    withListener.run(5000),
+    withListener.run(10_000),
   ];
 
   expect(checkpointsWithListener).toStrictEqual(checkpointsWithoutListener);

--- a/libs/game/idle-core/src/core/create-simulation.ts
+++ b/libs/game/idle-core/src/core/create-simulation.ts
@@ -67,7 +67,7 @@ export function createSimulation(): Simulation {
     updated: [],
   };
 
-  const startActivity = async (avatarData: AvatarData, activityData: ActivityInput) => {
+  const startActivity = (avatarData: AvatarData, activityData: ActivityInput) => {
     const isSameActivity = _activityData?.id === activityData.id;
     const isSameAvatar = _avatar?.id === avatarData.id;
 
@@ -76,7 +76,7 @@ export function createSimulation(): Simulation {
     }
 
     if (_generator) {
-      await stopActivity();
+      stopActivity();
     }
 
     _activityData = activityData;
@@ -93,12 +93,12 @@ export function createSimulation(): Simulation {
   };
 
   // cleans up our activity and notifies listeners
-  const stopActivity = async () => {
+  const stopActivity = () => {
     _activity = null;
 
     if (!_done) {
       // @ts-expect-error - we're not passing a return value during cleanup
-      await _generator?.return();
+      _generator?.return();
     }
 
     _done = true;
@@ -133,15 +133,14 @@ export function createSimulation(): Simulation {
     }
   };
 
-  const run = async (timestep: number): Promise<ActivityCheckpoint | null> => {
+  const run = (timestep: number): ActivityCheckpoint | null => {
     if (!_generator) {
       return null;
     }
 
     const shouldNotify = listeners.updated.length > 0;
     const prevState = shouldNotify ? getSnapshot(state) : null;
-
-    const next = await _generator.next(timestep);
+    const next = _generator.next(timestep);
 
     _done = next.done ?? false;
 
@@ -197,9 +196,7 @@ export function createSimulation(): Simulation {
     restartActivity,
     run,
     setFailureAction,
-    startActivity: (avatarData: AvatarData, activityData: ActivityInput) => {
-      void startActivity(avatarData, activityData);
-    },
+    startActivity,
     stopActivity,
   };
 }

--- a/libs/game/idle-core/src/core/run-activity.test.ts
+++ b/libs/game/idle-core/src/core/run-activity.test.ts
@@ -19,7 +19,7 @@ import { createActivity } from './create-activity';
 import { createCombatExecutor } from './create-combat-executor';
 import { runActivity } from './run-activity';
 
-test('it immediately generates a started checkpoint', async () => {
+test('it immediately generates a started checkpoint', () => {
   const avatarData = createMockAvatarData();
   const enemyData = createMockEnemyData();
 
@@ -32,9 +32,7 @@ test('it immediately generates a started checkpoint', async () => {
   const avatar = createAvatar(avatarData, ctx);
   const executor = createCombatExecutor(activity, avatar, ctx);
   const generator = runActivity(executor, activity, avatar, ctx);
-
-  const firstResult = await generator.next();
-
+  const firstResult = generator.next();
   const firstCheckpoint = firstResult.value;
 
   expect(firstCheckpoint).toStrictEqual({
@@ -47,7 +45,7 @@ test('it immediately generates a started checkpoint', async () => {
   });
 });
 
-test('it clears a wave from a difficulty-0 source node without crashing on the reward-slot tier', async () => {
+test('it clears a wave from a difficulty-0 source node without crashing on the reward-slot tier', () => {
   const built = buildSimulationInput({
     avatarID: 'avatar_1',
     buildSnapshot: { level: 1, xp: 0 },
@@ -86,11 +84,11 @@ test('it clears a wave from a difficulty-0 source node without crashing on the r
   const generator = runActivity(executor, activity, avatar, ctx);
 
   // skip the started checkpoint
-  await generator.next(1000);
+  generator.next(1000);
 
   // clearing the activity's only wave computes its reward-slot tier from the floored difficulty —
   // the crash site an unfloored difficulty-0 activity throws its invariant from
-  const waveClearResult = await generator.next(1000);
+  const waveClearResult = generator.next(1000);
 
   invariant(waveClearResult.value, 'the wave clear must produce a checkpoint');
 
@@ -98,16 +96,16 @@ test('it clears a wave from a difficulty-0 source node without crashing on the r
     { context: { nodeTier: 1 }, ordinal: 0 },
   ]);
 
-  let result = await generator.next(1000);
+  let result = generator.next(1000);
 
   while (result.done !== true) {
-    result = await generator.next(1000);
+    result = generator.next(1000);
   }
 
   expect(result.value.type).toBe(ActivityCheckpointType.Completed);
 });
 
-test('it generates wave killed checkpoints', async () => {
+test('it generates wave killed checkpoints', () => {
   const weapon: EquipmentWeapon = {
     id: 'test-weapon',
     maxDamage: 9999,
@@ -141,17 +139,14 @@ test('it generates wave killed checkpoints', async () => {
   const generator = runActivity(executor, activity, avatar, ctx);
 
   // skip the started checkpoint
-  await generator.next(1000);
+  generator.next(1000);
 
-  const secondResult = await generator.next(1000);
-
+  const secondResult = generator.next(1000);
   const secondCheckpoint = secondResult.value;
-
-  const thirdResult = await generator.next(1000);
-
+  const thirdResult = generator.next(1000);
   const thirdCheckpoint = thirdResult.value;
 
-  await generator.next(1000);
+  generator.next(1000);
 
   const expectedRewardSlots = Array.from({ length: 5 }, (_unused, ordinal) => ({
     context: { nodeTier: 1 },
@@ -175,7 +170,7 @@ test('it generates wave killed checkpoints', async () => {
   });
 });
 
-test('it accrues rewards across multiple cleared waves', async () => {
+test('it accrues rewards across multiple cleared waves', () => {
   const weapon: EquipmentWeapon = {
     id: 'test-weapon',
     maxDamage: 9999,
@@ -207,20 +202,20 @@ test('it accrues rewards across multiple cleared waves', async () => {
   const generator = runActivity(executor, activity, avatar, ctx);
 
   // skip the started checkpoint
-  await generator.next(1000);
+  generator.next(1000);
 
   // clear the first wave
-  await generator.next(1000);
+  generator.next(1000);
 
   expect(activity.rewards).toStrictEqual({ xp: 50 });
 
   // clear the second wave
-  await generator.next(1000);
+  generator.next(1000);
 
   expect(activity.rewards).toStrictEqual({ xp: 100 });
 });
 
-test('it generates a failed checkpoint when the avatar dies', async () => {
+test('it generates a failed checkpoint when the avatar dies', () => {
   const avatarData = createMockAvatarData({ life: 1 });
 
   const enemyData = createMockEnemyData({
@@ -238,11 +233,10 @@ test('it generates a failed checkpoint when the avatar dies', async () => {
   const avatar = createAvatar(avatarData, ctx);
   const executor = createCombatExecutor(activity, avatar, ctx);
   const generator = runActivity(executor, activity, avatar, ctx);
-
-  let result = await generator.next(1000);
+  let result = generator.next(1000);
 
   while (result.done !== true) {
-    result = await generator.next(1000);
+    result = generator.next(1000);
   }
 
   const checkpoint = result.value;
@@ -256,7 +250,7 @@ test('it generates a failed checkpoint when the avatar dies', async () => {
   });
 });
 
-test('it returns a completed checkpoint that folds in the completion bonus', async () => {
+test('it returns a completed checkpoint that folds in the completion bonus', () => {
   const weapon: EquipmentWeapon = {
     id: 'test-weapon',
     maxDamage: 9999,
@@ -286,11 +280,10 @@ test('it returns a completed checkpoint that folds in the completion bonus', asy
   const avatar = createAvatar(avatarData, ctx);
   const executor = createCombatExecutor(activity, avatar, ctx);
   const generator = runActivity(executor, activity, avatar, ctx);
-
-  let result = await generator.next(1000);
+  let result = generator.next(1000);
 
   while (result.done !== true) {
-    result = await generator.next(1000);
+    result = generator.next(1000);
   }
 
   const checkpoint = result.value;
@@ -304,7 +297,7 @@ test('it returns a completed checkpoint that folds in the completion bonus', asy
   });
 });
 
-test('it carries a levelUp when a completion bonus crosses a level threshold', async () => {
+test('it carries a levelUp when a completion bonus crosses a level threshold', () => {
   const weapon: EquipmentWeapon = {
     id: 'test-weapon',
     maxDamage: 9999,
@@ -332,11 +325,10 @@ test('it carries a levelUp when a completion bonus crosses a level threshold', a
   const avatar = createAvatar(avatarData, ctx);
   const executor = createCombatExecutor(activity, avatar, ctx);
   const generator = runActivity(executor, activity, avatar, ctx);
-
-  let result = await generator.next(1000);
+  let result = generator.next(1000);
 
   while (result.done !== true) {
-    result = await generator.next(1000);
+    result = generator.next(1000);
   }
 
   const checkpoint = result.value;
@@ -346,7 +338,7 @@ test('it carries a levelUp when a completion bonus crosses a level threshold', a
   expect(avatar.getSnapshot().level).toBe(2);
 });
 
-test('it records a levelUp checkpoint when a group clear crosses a level threshold', async () => {
+test('it records a levelUp checkpoint when a group clear crosses a level threshold', () => {
   const weapon: EquipmentWeapon = {
     id: 'test-weapon',
     maxDamage: 9999,
@@ -376,10 +368,9 @@ test('it records a levelUp checkpoint when a group clear crosses a level thresho
   const generator = runActivity(executor, activity, avatar, ctx);
 
   // skip the started checkpoint
-  await generator.next(1000);
+  generator.next(1000);
 
-  const waveClearResult = await generator.next(1000);
-
+  const waveClearResult = generator.next(1000);
   const checkpoint = waveClearResult.value;
 
   expect(checkpoint?.type).toBe(ActivityCheckpointType.Progress);
@@ -387,7 +378,7 @@ test('it records a levelUp checkpoint when a group clear crosses a level thresho
   expect(avatar.getSnapshot().level).toBe(2);
 });
 
-test('it keeps xp and a level-up earned on the same tick the avatar dies', async () => {
+test('it keeps xp and a level-up earned on the same tick the avatar dies', () => {
   const avatarWeapon: EquipmentWeapon = {
     id: 'test-weapon',
     maxDamage: 9999,
@@ -426,11 +417,10 @@ test('it keeps xp and a level-up earned on the same tick the avatar dies', async
   const generator = runActivity(executor, activity, avatar, ctx);
 
   // skip the started checkpoint
-  await generator.next(1000);
+  generator.next(1000);
 
   // the wave's only enemy and the avatar both die within this same combat tick
-  const waveClearResult = await generator.next(1000);
-
+  const waveClearResult = generator.next(1000);
   const progressCheckpoint = waveClearResult.value;
 
   expect(avatar.isAlive).toBeFalse();
@@ -438,7 +428,7 @@ test('it keeps xp and a level-up earned on the same tick the avatar dies', async
   expect(progressCheckpoint?.levelUp).toStrictEqual({ from: 1, to: 2 });
   expect(avatar.getSnapshot().level).toBe(2);
 
-  const failedResult = await generator.next(1000);
+  const failedResult = generator.next(1000);
 
   invariant(failedResult.done === true, 'the activity must resolve to a failed checkpoint');
 

--- a/libs/game/idle-core/src/core/run-activity.ts
+++ b/libs/game/idle-core/src/core/run-activity.ts
@@ -13,8 +13,7 @@ import { createFailedCheckpoint } from './utils/create-failed-checkpoint';
 import { createProgressCheckpoint } from './utils/create-progress-checkpoint';
 import { createStartedCheckpoint } from './utils/create-started-checkpoint';
 
-// oxlint-disable-next-line typescript/require-await -- callers drive this generator with awaited next()/return() calls, so it must satisfy the AsyncGenerator contract even though its own body has no await
-export async function* runActivity(
+export function* runActivity(
   executor: ActivityExecutor,
   activity: Activity,
   avatar: Avatar,

--- a/libs/game/idle-core/src/core/run-attempt.ts
+++ b/libs/game/idle-core/src/core/run-attempt.ts
@@ -34,6 +34,7 @@ interface RunAttemptResult {
  * the caller's. The result is committed only when its terminal landed at or under
  * `maxDurationMs`; the tick that crosses the budget contributes nothing.
  */
+// oxlint-disable-next-line typescript/require-await -- kept async so cross-package callers can keep awaiting this driver-facing API; the engine now steps synchronously with no internal await
 export async function runAttempt(
   activity: ActivityInput,
   avatar: AvatarData,
@@ -47,7 +48,7 @@ export async function runAttempt(
   const checkpoints: Array<ActivityCheckpoint> = [];
 
   while (simulation.elapsed < config.maxDurationMs) {
-    const checkpoint = await simulation.run(timestepMs);
+    const checkpoint = simulation.run(timestepMs);
 
     if (simulation.elapsed > config.maxDurationMs) {
       break;
@@ -68,7 +69,7 @@ export async function runAttempt(
     }
   }
 
-  await simulation.stopActivity();
+  simulation.stopActivity();
 
   return { checkpoints: [], elapsed: simulation.elapsed, outcome: 'exceeded-budget' };
 }

--- a/libs/game/idle-core/src/core/run-attempt.ts
+++ b/libs/game/idle-core/src/core/run-attempt.ts
@@ -34,7 +34,7 @@ interface RunAttemptResult {
  * the caller's. The result is committed only when its terminal landed at or under
  * `maxDurationMs`; the tick that crosses the budget contributes nothing.
  */
-// oxlint-disable-next-line typescript/require-await -- kept async so cross-package callers can keep awaiting this driver-facing API; the engine now steps synchronously with no internal await
+// oxlint-disable-next-line typescript/require-await -- kept async so cross-package callers can keep awaiting this driver-facing API; the engine step itself is synchronous
 export async function runAttempt(
   activity: ActivityInput,
   avatar: AvatarData,

--- a/libs/game/idle-core/src/replay.bench.ts
+++ b/libs/game/idle-core/src/replay.bench.ts
@@ -37,7 +37,7 @@ bench('replay driver · 1 simulated hour', async () => {
   await driver.advanceToDuration(SIMULATED_HOUR_MS);
 });
 
-bench('live loop with updated listener · 1 simulated hour', async () => {
+bench('live loop with updated listener · 1 simulated hour', () => {
   const input = buildSimulationInput(SOURCE, {
     failureAction: ActivityFailureAction.Retry,
   });
@@ -48,7 +48,7 @@ bench('live loop with updated listener · 1 simulated hour', async () => {
   simulation.startActivity(input.avatar, input.activity);
 
   while (simulation.elapsed < SIMULATED_HOUR_MS) {
-    const checkpoint = await simulation.run(SIMULATION_TIMESTEP_MS);
+    const checkpoint = simulation.run(SIMULATION_TIMESTEP_MS);
 
     if (checkpoint && (isFailedCheckpoint(checkpoint) || isCompletedCheckpoint(checkpoint))) {
       simulation.restartActivity();

--- a/libs/game/idle-core/src/types/activity.ts
+++ b/libs/game/idle-core/src/types/activity.ts
@@ -94,7 +94,7 @@ export interface Activity {
   setLevelUp: (levelUp: ActivityLevelUp) => void;
 }
 
-export type ActivityCheckpointGenerator = AsyncGenerator<
+export type ActivityCheckpointGenerator = Generator<
   ActivityCheckpoint | null,
   ActivityCheckpoint,
   number

--- a/libs/game/idle-core/src/types/simulation.ts
+++ b/libs/game/idle-core/src/types/simulation.ts
@@ -43,10 +43,10 @@ export interface Simulation {
   addEventListener: (eventName: SimulationEventName, listener: SimulationListener) => void;
   getSnapshot: () => SimulationSnapshot;
   restartActivity: () => void;
-  run: (time: number) => Promise<ActivityCheckpoint | null>;
+  run: (time: number) => ActivityCheckpoint | null;
   setFailureAction: (action: ActivityFailureAction) => void;
   startActivity: (avatarData: AvatarData, activityData: ActivityInput) => void;
-  stopActivity: () => Promise<void>;
+  stopActivity: () => void;
 }
 
 export interface SimulationContext {


### PR DESCRIPTION
## Description

Part of #729

Converts idle-core's engine step from async to sync: `runActivity`'s generator carried no internal `await`, so every tick paid promise-microtask scheduling for zero real asynchrony.

- `runActivity` is a plain sync generator; `createSimulation`'s `run`/`startActivity`/`stopActivity` and the `ActivityCheckpointGenerator`/`Simulation` types drop their `Promise` wrapping.
- `createSimulationDriver.advanceToDuration` and `runAttempt` keep their `Promise`-returning signatures unchanged, each with an inline `require-await` disable noting why, so `services/replay` and idle-client callers keep compiling untouched.
- All idle-client call sites (worker flows, resync reconstruction) and every affected test drop their now-dead `await`s.
- Bench (mitata, before/after on the same machine) showed no measurable wall-clock change — per-tick combat-simulation work dominates over the removed microtask overhead here, contrary to the initial expectation of a substantial cut.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality

## Context

The shared-stepping-primitive dedupe across the driver/reconstruction/run-attempt loops is a deliberate follow-up, not in scope here.
