### PR TITLE
fix(#757): stamp build snapshots from optimistic progression

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1161,9 +1161,12 @@
     "kysely-codegen@0.20.0": "patches/kysely-codegen@0.20.0.patch",
   },
   "overrides": {
+    "@hono/node-server": "2.0.10",
+    "@opentelemetry/propagator-jaeger": "2.9.0",
     "@opentelemetry/sdk-node": "0.220.0",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
+    "fast-uri": "3.1.4",
   },
   "catalog": {
     "@ark-ui/react": "5.37.2",
@@ -1580,7 +1583,7 @@
 
     "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.10.6", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.10.6" } }, "sha512-Nu/IjRkkNxmeG2ywWsyJSO4d1BrWTqVzxCPL+gXj0b97klhmjd6wLzt6Bx/laNpkZ3WLW7zNCqmtMIbIlahqug=="],
 
-    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+    "@hono/node-server": ["@hono/node-server@2.0.10", "", { "peerDependencies": { "hono": "^4" } }, "sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
 
@@ -1752,7 +1755,7 @@
 
     "@opentelemetry/propagator-b3": ["@opentelemetry/propagator-b3@1.30.1", "", { "dependencies": { "@opentelemetry/core": "1.30.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-oATwWWDIJzybAZ4pO76ATN5N6FFbOA1otibAVlS8v90B4S1wClnhRUk7K+2CHAwN1JKYuj4jh/lpCEG5BAqFuQ=="],
 
-    "@opentelemetry/propagator-jaeger": ["@opentelemetry/propagator-jaeger@1.30.1", "", { "dependencies": { "@opentelemetry/core": "1.30.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-Pj/BfnYEKIOImirH76M4hDaBSx6HyZ2CXUqk+Kj02m6BB80c/yo4BdWkn/1gDFfU+YPY+bPR2U0DKBfdxCKwmg=="],
+    "@opentelemetry/propagator-jaeger": ["@opentelemetry/propagator-jaeger@2.9.0", "", { "dependencies": { "@opentelemetry/core": "2.9.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-4mYGty27rYvSM0jtp1ZUOqd3LfVRCYg9H5G9OFzSx5HViYToU21MFhWfco7x1HwXr7ER8yGOiCIHZUwjPksc0Q=="],
 
     "@opentelemetry/resources": ["@opentelemetry/resources@2.9.0", "", { "dependencies": { "@opentelemetry/core": "2.9.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg=="],
 
@@ -3296,7 +3299,7 @@
 
     "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
 
-    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+    "fast-uri": ["fast-uri@3.1.4", "", {}, "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="],
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
 
@@ -4758,8 +4761,6 @@
 
     "@opentelemetry/propagator-b3/@opentelemetry/core": ["@opentelemetry/core@1.30.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "1.28.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ=="],
 
-    "@opentelemetry/propagator-jaeger/@opentelemetry/core": ["@opentelemetry/core@1.30.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "1.28.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ=="],
-
     "@opentelemetry/sdk-node/@opentelemetry/exporter-trace-otlp-grpc": ["@opentelemetry/exporter-trace-otlp-grpc@0.220.0", "", { "dependencies": { "@grpc/grpc-js": "^1.14.3", "@opentelemetry/otlp-exporter-base": "0.220.0", "@opentelemetry/otlp-grpc-exporter-base": "0.220.0", "@opentelemetry/otlp-transformer": "0.220.0", "@opentelemetry/sdk-trace": "2.9.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-bv1xmNhmNwIM6MdUBw4yYuJeVcEViVLk3uD69vOQMwueHBnfyl/u0HnBlB1FNY/Te0UOzJzvcbyR8wN6b+iGbA=="],
 
     "@opentelemetry/sdk-node/@opentelemetry/exporter-zipkin": ["@opentelemetry/exporter-zipkin@2.9.0", "", { "dependencies": { "@opentelemetry/core": "2.9.0", "@opentelemetry/resources": "2.9.0", "@opentelemetry/sdk-trace": "2.9.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0" } }, "sha512-RwINoce2BH8T4obT5pMcAla2sWma1YZvYuaktWmTluQ0PkQdvv5D060rWI1+kawX+J2qBRcMbwrZJJNcMJUauQ=="],
@@ -4769,8 +4770,6 @@
     "@opentelemetry/sdk-node/@opentelemetry/otlp-grpc-exporter-base": ["@opentelemetry/otlp-grpc-exporter-base@0.220.0", "", { "dependencies": { "@grpc/grpc-js": "^1.14.3", "@opentelemetry/core": "2.9.0", "@opentelemetry/otlp-exporter-base": "0.220.0", "@opentelemetry/otlp-transformer": "0.220.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-/eIkBPMBTIvM3x/0mDX4aJeSkYifYClnBPr68PL1h5LV4VQv4+SV6CGrpiZ4fIWDnobVmhTWCm1J/QRdAWUfvA=="],
 
     "@opentelemetry/sdk-node/@opentelemetry/propagator-b3": ["@opentelemetry/propagator-b3@2.9.0", "", { "dependencies": { "@opentelemetry/core": "2.9.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-WrOT1WsOUG+B7hstD2RYoMPIOK76G8E9AQHhMjUvrQaGx/oA7rPWQvvr1Rqv7+yy4R0ZMVwWLC4vW2xnkgWPAQ=="],
-
-    "@opentelemetry/sdk-node/@opentelemetry/propagator-jaeger": ["@opentelemetry/propagator-jaeger@2.9.0", "", { "dependencies": { "@opentelemetry/core": "2.9.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-4mYGty27rYvSM0jtp1ZUOqd3LfVRCYg9H5G9OFzSx5HViYToU21MFhWfco7x1HwXr7ER8yGOiCIHZUwjPksc0Q=="],
 
     "@oxc-resolver/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q=="],
 
@@ -5205,8 +5204,6 @@
     "@opentelemetry/otlp-grpc-exporter-base/@opentelemetry/otlp-transformer/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@1.30.1", "", { "dependencies": { "@opentelemetry/core": "1.30.1", "@opentelemetry/resources": "1.30.1", "@opentelemetry/semantic-conventions": "1.28.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg=="],
 
     "@opentelemetry/propagator-b3/@opentelemetry/core/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
-
-    "@opentelemetry/propagator-jaeger/@opentelemetry/core/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
 
     "@opentelemetry/sdk-node/@opentelemetry/instrumentation/require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -20,6 +20,8 @@ minimumReleaseAge = 604800
 # @zgeoff/dbhub 0.23.4 (published 2026-07-12) ages past the 7-day gate ~2026-07-19 — remove then (#478)
 # brace-expansion 2.1.2/5.0.7 (published 2026-07-20, patch GHSA-3jxr-9vmj-r5cp) age past the gate ~2026-07-28 — remove then (#735)
 # protobufjs 7.6.5 (published 2026-07-20, patches GHSA-j3f2-48v5-ccww) ages past the gate ~2026-07-28 — remove then (#735)
+# @hono/node-server 2.0.10 (published 2026-07-15, patches GHSA-9mqv-5hh9-4cgg) ages past the gate ~2026-07-22 — remove then (#767)
+# fast-uri 3.1.4 (published 2026-07-19, patches GHSA-v2hh-gcrm-f6hx) ages past the gate ~2026-07-26 — remove then (#765)
 minimumReleaseAgeExcludes = [
   "@zgeoff/format-codemod",
   "@zgeoff/bun-test-extended",
@@ -31,6 +33,8 @@ minimumReleaseAgeExcludes = [
   "vite",
   "brace-expansion",
   "protobufjs",
+  "@hono/node-server",
+  "fast-uri",
 ]
 
 [test]

--- a/package.json
+++ b/package.json
@@ -215,9 +215,12 @@
     "zod": "catalog:"
   },
   "overrides": {
+    "@hono/node-server": "2.0.10",
+    "@opentelemetry/propagator-jaeger": "2.9.0",
     "@opentelemetry/sdk-node": "0.220.0",
     "@types/react": "19.2.17",
-    "@types/react-dom": "19.2.3"
+    "@types/react-dom": "19.2.3",
+    "fast-uri": "3.1.4"
   },
   "packageManager": "bun@1.3.10",
   "patchedDependencies": {

--- a/services/activity/src/handlers/get-avatar-progression.ts
+++ b/services/activity/src/handlers/get-avatar-progression.ts
@@ -1,6 +1,6 @@
 import type { DB } from '@vers/db';
 import type { Kysely } from 'kysely';
-import * as z from 'zod';
+import { parseTerminalCheckpointXP } from '../parse-terminal-checkpoint-xp';
 import type { MissingSessionPayload } from '../types';
 
 /**
@@ -70,17 +70,6 @@ export async function getAvatarProgression(
   return { level: settled.level, pending, xp: settled.xp };
 }
 
-/**
- * Checkpoint types whose `rewards.xp` is a run's final earned total rather than one checkpoint's
- * own delta — the shape a pending entry's `xpDelta` displays, matching what the verifier settles.
- */
-const TERMINAL_CHECKPOINT_TYPES = new Set(['completed', 'failed']);
-
-const TerminalCheckpointPayloadSchema = z.object({
-  rewards: z.object({ xp: z.number() }),
-  type: z.string(),
-});
-
 interface PendingCandidateRow {
   readonly id: null | string;
   readonly payload: unknown;
@@ -89,19 +78,18 @@ interface PendingCandidateRow {
 /**
  * Builds a pending entry from a candidate row, or nothing when the row carries no pending activity
  * — a null activity id from the left join, a checkpoint that failed to append past `verifiedHead`
- * at all, or a checkpoint whose payload doesn't parse or isn't a terminal type. Appended data is
- * untrusted, so a malformed or non-terminal payload contributes nothing rather than throwing.
+ * at all, or a checkpoint whose payload doesn't parse or isn't a terminal type.
  */
 function findPendingEntry(row: Readonly<PendingCandidateRow>): Array<PendingXPEntry> {
   if (row.id === null) {
     return [];
   }
 
-  const parsed = TerminalCheckpointPayloadSchema.safeParse(row.payload);
+  const xpDelta = parseTerminalCheckpointXP(row.payload);
 
-  if (!parsed.success || !TERMINAL_CHECKPOINT_TYPES.has(parsed.data.type)) {
+  if (xpDelta === undefined) {
     return [];
   }
 
-  return [{ activityID: row.id, xpDelta: parsed.data.rewards.xp }];
+  return [{ activityID: row.id, xpDelta }];
 }

--- a/services/activity/src/handlers/start-activity.test.ts
+++ b/services/activity/src/handlers/start-activity.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'bun:test';
 import type { ActivityContract } from '@vers/contract-activity';
 import { buildStartHash } from '@vers/contract-activity';
 import { CURRENT_CONTENT_VERSION } from '@vers/game-utils';
+import { buildLevelFromXP } from '@vers/idle-core';
 import {
   createAnonymousViewer,
   createServiceToken,
@@ -15,6 +16,7 @@ import { buildRPCTestClient, waitFor } from '@vers/test-utils';
 import { sql } from 'kysely';
 import { createActivityService } from '../create-activity-service';
 import { createAvatarRow } from '../test-utils/create-avatar-row';
+import { createMockCheckpointBatch } from '../test-utils/factories/create-mock-checkpoint-batch';
 
 /**
  * `startActivity` opens its own `db.transaction()` to root the new activity under the chain-row
@@ -52,7 +54,7 @@ test('it starts an activity for an avatar owned by the acting user', async () =>
     appendedAt: null,
     appendedHead: 0,
     avatarID: avatar.id,
-    buildSnapshot: { level: 5, xp: 42 },
+    buildSnapshot: { level: 1, xp: 42 },
     contentVersion: CURRENT_CONTENT_VERSION,
     createdAt: expect.toBeValidDate(),
     encounterNode: { difficulty: 0 },
@@ -764,4 +766,100 @@ test('it conflicts a keyed duplicate naming a different scope', async () => {
       startKey: 'start_request_1',
     }),
   ).rejects.toMatchObject({ code: 'CONFLICT', data: { activity: { id: first.id } } });
+});
+
+test("it includes a stopped-but-unverified terminal activity's xp in a new build snapshot", async () => {
+  await using ctx = await setupTest();
+
+  await createSimVersionRow(ctx.db);
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { level: 1, userId: viewer.user.id, xp: 0 });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const first = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'a9lp75',
+    scopeType: 'world_map_node',
+  });
+
+  const batch = createMockCheckpointBatch({
+    finalPayloadOverrides: { rewards: { xp: 150 }, type: 'completed' },
+    startPrevHash: first.startHash,
+    startVersion: 1,
+  });
+
+  await client.trackActivityProgress({ activityID: first.id, checkpoints: batch, expectedHead: 0 });
+
+  const second = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'a9lp75',
+    scopeType: 'world_map_node',
+  });
+
+  expect(second.buildSnapshot).toStrictEqual({ level: buildLevelFromXP(150), xp: 150 });
+});
+
+test("it excludes a rejected activity's xp from a new build snapshot", async () => {
+  await using ctx = await setupTest();
+
+  await createSimVersionRow(ctx.db);
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { level: 1, userId: viewer.user.id, xp: 0 });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const first = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'a9lp75',
+    scopeType: 'world_map_node',
+  });
+
+  const batch = createMockCheckpointBatch({
+    finalPayloadOverrides: { rewards: { xp: 150 }, type: 'completed' },
+    startPrevHash: first.startHash,
+    startVersion: 1,
+  });
+
+  await client.trackActivityProgress({ activityID: first.id, checkpoints: batch, expectedHead: 0 });
+
+  await ctx.db
+    .updateTable('activities')
+    .set({ status: 'rejected' })
+    .where('id', '=', first.id)
+    .execute();
+
+  const second = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'a9lp75',
+    scopeType: 'world_map_node',
+  });
+
+  expect(second.buildSnapshot).toStrictEqual({ level: buildLevelFromXP(0), xp: 0 });
+});
+
+test('it stamps the build snapshot from settled xp/level alone when the avatar carries no pending work', async () => {
+  await using ctx = await setupTest();
+
+  await createSimVersionRow(ctx.db);
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+
+  const avatar = await createAvatarRow(ctx.db, {
+    level: buildLevelFromXP(500),
+    userId: viewer.user.id,
+    xp: 500,
+  });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const activity = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'a9lp75',
+    scopeType: 'world_map_node',
+  });
+
+  expect(activity.buildSnapshot).toStrictEqual({ level: buildLevelFromXP(500), xp: 500 });
 });

--- a/services/activity/src/handlers/start-activity.test.ts
+++ b/services/activity/src/handlers/start-activity.test.ts
@@ -2,7 +2,6 @@ import { expect, test } from 'bun:test';
 import type { ActivityContract } from '@vers/contract-activity';
 import { buildStartHash } from '@vers/contract-activity';
 import { CURRENT_CONTENT_VERSION } from '@vers/game-utils';
-import { buildLevelFromXP } from '@vers/idle-core';
 import {
   createAnonymousViewer,
   createServiceToken,
@@ -798,7 +797,7 @@ test("it includes a stopped-but-unverified terminal activity's xp in a new build
     scopeType: 'world_map_node',
   });
 
-  expect(second.buildSnapshot).toStrictEqual({ level: buildLevelFromXP(150), xp: 150 });
+  expect(second.buildSnapshot).toStrictEqual({ level: 2, xp: 150 });
 });
 
 test("it excludes a rejected activity's xp from a new build snapshot", async () => {
@@ -837,7 +836,7 @@ test("it excludes a rejected activity's xp from a new build snapshot", async () 
     scopeType: 'world_map_node',
   });
 
-  expect(second.buildSnapshot).toStrictEqual({ level: buildLevelFromXP(0), xp: 0 });
+  expect(second.buildSnapshot).toStrictEqual({ level: 1, xp: 0 });
 });
 
 test('it stamps the build snapshot from settled xp/level alone when the avatar carries no pending work', async () => {
@@ -848,7 +847,7 @@ test('it stamps the build snapshot from settled xp/level alone when the avatar c
   const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
 
   const avatar = await createAvatarRow(ctx.db, {
-    level: buildLevelFromXP(500),
+    level: 3,
     userId: viewer.user.id,
     xp: 500,
   });
@@ -861,5 +860,5 @@ test('it stamps the build snapshot from settled xp/level alone when the avatar c
     scopeType: 'world_map_node',
   });
 
-  expect(activity.buildSnapshot).toStrictEqual({ level: buildLevelFromXP(500), xp: 500 });
+  expect(activity.buildSnapshot).toStrictEqual({ level: 3, xp: 500 });
 });

--- a/services/activity/src/handlers/start-activity.ts
+++ b/services/activity/src/handlers/start-activity.ts
@@ -2,8 +2,10 @@ import { createId } from '@paralleldrive/cuid2';
 import type { ActivityData, BuildSnapshot } from '@vers/contract-activity';
 import { buildStartHash, createGenesisSeed } from '@vers/contract-activity';
 import type { DB } from '@vers/db';
+import { buildLevelFromXP } from '@vers/idle-core';
 import { findCurrentSimVersion, findSimVersion } from '@vers/sim-registry';
 import type { Kysely } from 'kysely';
+import { parseTerminalCheckpointXP } from '../parse-terminal-checkpoint-xp';
 import { resolveEncounterNode } from '../resolve-encounter-node';
 import type {
   ActiveActivityConflictPayload,
@@ -50,14 +52,17 @@ interface StartActivityOpts {
 }
 
 /**
- * Starts an activity for an avatar owned by the acting user, snapshotting the avatar's current
- * progression as the build the stream plays against, and stamping the acting session as the
- * stream's writer. Resolves the scope node's encounter params server-side and freezes them on the
- * new row, throwing NODE_UNKNOWN when the scope doesn't resolve to a known node. The partial
- * unique index serializes concurrent starts; a duplicate delivery — same key, same scope, never
- * appended, caller already the writer or none stamped — succeeds with the existing row, and every
- * other conflict throws CONFLICT carrying it. A chain whose
- * replay frontier is quarantined admits no new starts until it is adjudicated.
+ * Starts an activity for an avatar owned by the acting user, snapshotting the build the stream
+ * plays against, and stamping the acting session as the stream's writer. The snapshot carries the
+ * avatar's settled xp/level plus the xp of every terminal-but-unsettled activity of its own — a
+ * stopped, capped, quarantined, or parked activity whose verified anchor hasn't caught up to its
+ * appended tail — so a chain of activities started faster than the verifier settles them each
+ * builds against the last one's outcome rather than replaying stale progression. Resolves the scope
+ * node's encounter params server-side and freezes them on the new row, throwing NODE_UNKNOWN when
+ * the scope doesn't resolve to a known node. The partial unique index serializes concurrent starts;
+ * a duplicate delivery — same key, same scope, never appended, caller already the writer or none
+ * stamped — succeeds with the existing row, and every other conflict throws CONFLICT carrying it. A
+ * chain whose replay frontier is quarantined admits no new starts until it is adjudicated.
  */
 export async function startActivity(
   deps: StartActivityDeps,
@@ -103,7 +108,6 @@ export async function startActivity(
 
   const id = `act_${createId()}`;
   const genesisSeed = createGenesisSeed();
-  const buildSnapshot: BuildSnapshot = { level: avatar.level, xp: avatar.xp };
 
   try {
     // One transaction, chain row first: the upsert's write lock is held until commit, so a
@@ -131,6 +135,11 @@ export async function startActivity(
         .executeTakeFirstOrThrow();
 
       const seed = chain.appendedNextSeed;
+
+      const pendingXP = await getPendingXP(trx, opts.input.avatarID);
+
+      const totalXP = avatar.xp + pendingXP;
+      const buildSnapshot: BuildSnapshot = { level: buildLevelFromXP(totalXP), xp: totalXP };
 
       const startHash = buildStartHash({
         activityID: id,
@@ -243,6 +252,29 @@ async function resolveSimVersionStamp(
   }
 
   throw errors.SIM_VERSION_EXPIRED({ data: { currentSimVersion } });
+}
+
+/**
+ * Sums the xp delta of an avatar's terminal-but-unsettled activities — a stopped, capped,
+ * quarantined, or parked activity whose verified anchor hasn't caught up to its appended tail.
+ * Malformed or non-terminal tail payloads contribute nothing.
+ */
+async function getPendingXP(trx: Kysely<DB>, avatarID: string): Promise<number> {
+  const rows = await trx
+    .selectFrom('activities')
+    .innerJoin('activityCheckpoints', (join) =>
+      join
+        .onRef('activityCheckpoints.activityId', '=', 'activities.id')
+        .onRef('activityCheckpoints.version', '=', 'activities.appendedHead'),
+    )
+    .select('activityCheckpoints.payload')
+    .where('activities.avatarId', '=', avatarID)
+    .where('activities.status', '!=', 'active')
+    .where('activities.status', '!=', 'rejected')
+    .whereRef('activities.verifiedHead', '<', 'activities.appendedHead')
+    .execute();
+
+  return rows.reduce((total, row) => total + (parseTerminalCheckpointXP(row.payload) ?? 0), 0);
 }
 
 /**

--- a/services/activity/src/handlers/start-activity.ts
+++ b/services/activity/src/handlers/start-activity.ts
@@ -5,6 +5,7 @@ import type { DB } from '@vers/db';
 import { buildLevelFromXP } from '@vers/idle-core';
 import { findCurrentSimVersion, findSimVersion } from '@vers/sim-registry';
 import type { Kysely } from 'kysely';
+import invariant from 'tiny-invariant';
 import { parseTerminalCheckpointXP } from '../parse-terminal-checkpoint-xp';
 import { resolveEncounterNode } from '../resolve-encounter-node';
 import type {
@@ -136,9 +137,8 @@ export async function startActivity(
 
       const seed = chain.appendedNextSeed;
 
-      const pendingXP = await getPendingXP(trx, opts.input.avatarID);
+      const totalXP = await getOptimisticXP(trx, opts.input.avatarID);
 
-      const totalXP = avatar.xp + pendingXP;
       const buildSnapshot: BuildSnapshot = { level: buildLevelFromXP(totalXP), xp: totalXP };
 
       const startHash = buildStartHash({
@@ -255,26 +255,42 @@ async function resolveSimVersionStamp(
 }
 
 /**
- * Sums the xp delta of an avatar's terminal-but-unsettled activities — a stopped, capped,
- * quarantined, or parked activity whose verified anchor hasn't caught up to its appended tail.
- * Malformed or non-terminal tail payloads contribute nothing.
+ * Sums an avatar's settled xp with the xp delta of its terminal-but-unsettled activities — a
+ * stopped, capped, quarantined, or parked activity whose verified anchor hasn't caught up to its
+ * appended tail. The settled row and the pending set are read in one statement, so a concurrent
+ * verifier commit can't land its delta in the gap between two separate reads. Malformed or
+ * non-terminal tail payloads contribute nothing.
  */
-async function getPendingXP(trx: Kysely<DB>, avatarID: string): Promise<number> {
+async function getOptimisticXP(trx: Kysely<DB>, avatarID: string): Promise<number> {
   const rows = await trx
-    .selectFrom('activities')
-    .innerJoin('activityCheckpoints', (join) =>
+    .selectFrom('avatars')
+    .leftJoin('activities', (join) =>
+      join
+        .onRef('activities.avatarId', '=', 'avatars.id')
+        .on('activities.status', '!=', 'active')
+        .on('activities.status', '!=', 'rejected')
+        .onRef('activities.verifiedHead', '<', 'activities.appendedHead'),
+    )
+    .leftJoin('activityCheckpoints', (join) =>
       join
         .onRef('activityCheckpoints.activityId', '=', 'activities.id')
         .onRef('activityCheckpoints.version', '=', 'activities.appendedHead'),
     )
-    .select('activityCheckpoints.payload')
-    .where('activities.avatarId', '=', avatarID)
-    .where('activities.status', '!=', 'active')
-    .where('activities.status', '!=', 'rejected')
-    .whereRef('activities.verifiedHead', '<', 'activities.appendedHead')
+    .select(['avatars.xp', 'activityCheckpoints.payload'])
+    .where('avatars.id', '=', avatarID)
     .execute();
 
-  return rows.reduce((total, row) => total + (parseTerminalCheckpointXP(row.payload) ?? 0), 0);
+  const [settled] = rows;
+
+  invariant(
+    settled !== undefined,
+    'avatar must still exist inside the transaction that starts its activity',
+  );
+
+  return rows.reduce(
+    (total, row) => total + (parseTerminalCheckpointXP(row.payload) ?? 0),
+    settled.xp,
+  );
 }
 
 /**

--- a/services/activity/src/handlers/track-activity-progress.ts
+++ b/services/activity/src/handlers/track-activity-progress.ts
@@ -7,6 +7,7 @@ import type { Kysely } from 'kysely';
 import invariant from 'tiny-invariant';
 import * as z from 'zod';
 import { recordTerminalTransition } from '../metrics/record-terminal-transition';
+import { parseTerminalCheckpointXP } from '../parse-terminal-checkpoint-xp';
 import type {
   CappedPayload,
   CheckpointInvalidPayload,
@@ -134,7 +135,7 @@ export async function trackActivityProgress(
   const newLastHash = lastCheckpoint?.hash ?? head.lastHash;
   const newTimeMs = lastCheckpoint?.payload.time ?? appendedTimeMs;
   const timeDelta = newTimeMs - appendedTimeMs;
-  const terminalRewardsXP = lastCheckpoint && findTerminalRewardsXP(lastCheckpoint.payload);
+  const terminalRewardsXP = lastCheckpoint && parseTerminalCheckpointXP(lastCheckpoint.payload);
 
   // The budget decision is only meaningful against the head the batch claims to extend; a stale
   // batch falls through to the transaction's guarded update and resolves as CONFLICT.
@@ -548,27 +549,4 @@ function pickAppendRaceOutcome(
   }
 
   return errors.CONFLICT({ data: { appendedHead: current.appendedHead } });
-}
-
-/**
- * Checkpoint types whose `rewards.xp` is a final running total the avatar row settles against.
- */
-const TERMINAL_CHECKPOINT_TYPES = new Set(['completed', 'failed']);
-
-const TerminalRewardsSchema = z.object({ xp: z.number() });
-
-/**
- * The final rewards total a terminal checkpoint's payload carries, or `undefined` when the
- * checkpoint isn't terminal or its `rewards` shape doesn't parse — the latter settles no xp rather
- * than throwing, since the hash chain doesn't cover `rewards` and a malformed value isn't
- * distinguishable here from a stale or non-terminal client payload.
- */
-function findTerminalRewardsXP(payload: Readonly<CheckpointPayload>): number | undefined {
-  if (!TERMINAL_CHECKPOINT_TYPES.has(payload.type)) {
-    return undefined;
-  }
-
-  const parsed = TerminalRewardsSchema.safeParse(payload['rewards']);
-
-  return parsed.success ? parsed.data.xp : undefined;
 }

--- a/services/activity/src/parse-terminal-checkpoint-xp.ts
+++ b/services/activity/src/parse-terminal-checkpoint-xp.ts
@@ -1,0 +1,28 @@
+import * as z from 'zod';
+
+/**
+ * Parses a checkpoint payload for the terminal xp delta it carries — a run's final earned total
+ * rather than one checkpoint's own delta, the same total a verifier apply settles. Undefined for a
+ * payload that doesn't parse or isn't a terminal ('completed'/'failed') type; appended data is
+ * untrusted, so a malformed payload reports as absent rather than throwing.
+ */
+export function parseTerminalCheckpointXP(payload: unknown): number | undefined {
+  const parsed = TerminalCheckpointPayloadSchema.safeParse(payload);
+
+  if (!parsed.success || !TERMINAL_CHECKPOINT_TYPES.has(parsed.data.type)) {
+    return undefined;
+  }
+
+  return parsed.data.rewards.xp;
+}
+
+/**
+ * Checkpoint types whose `rewards.xp` is a run's final earned total rather than one checkpoint's
+ * own delta.
+ */
+const TERMINAL_CHECKPOINT_TYPES = new Set(['completed', 'failed']);
+
+const TerminalCheckpointPayloadSchema = z.object({
+  rewards: z.object({ xp: z.number() }),
+  type: z.string(),
+});

--- a/services/activity/src/parse-terminal-checkpoint-xp.ts
+++ b/services/activity/src/parse-terminal-checkpoint-xp.ts
@@ -1,6 +1,17 @@
 import * as z from 'zod';
 
 /**
+ * Checkpoint types whose `rewards.xp` is a run's final earned total rather than one checkpoint's
+ * own delta.
+ */
+const TERMINAL_CHECKPOINT_TYPES = new Set(['completed', 'failed']);
+
+const TerminalCheckpointPayloadSchema = z.object({
+  rewards: z.object({ xp: z.number() }),
+  type: z.string(),
+});
+
+/**
  * Parses a checkpoint payload for the terminal xp delta it carries — a run's final earned total
  * rather than one checkpoint's own delta, the same total a verifier apply settles. Undefined for a
  * payload that doesn't parse or isn't a terminal ('completed'/'failed') type; appended data is
@@ -15,14 +26,3 @@ export function parseTerminalCheckpointXP(payload: unknown): number | undefined 
 
   return parsed.data.rewards.xp;
 }
-
-/**
- * Checkpoint types whose `rewards.xp` is a run's final earned total rather than one checkpoint's
- * own delta.
- */
-const TERMINAL_CHECKPOINT_TYPES = new Set(['completed', 'failed']);
-
-const TerminalCheckpointPayloadSchema = z.object({
-  rewards: z.object({ xp: z.number() }),
-  type: z.string(),
-});


### PR DESCRIPTION
## Description

Closes #757

`startActivity` was stamping a new activity's build snapshot from the avatar's settled xp/level alone, so a chain of activities started faster than the verifier settles them replayed stale progression instead of building on the last one's outcome.

- `getOptimisticXP` sums the avatar's settled xp with the xp delta of its terminal-but-unsettled activities (stopped, capped, quarantined, or parked, with `verifiedHead < appendedHead`) in one joined statement, so a concurrent verifier commit can't land in the gap between two separate reads
- the build snapshot now stamps `{ level: buildLevelFromXP(totalXP), xp: totalXP }` using the shared `@vers/idle-core` deriver, the same one the verifier uses when applying a segment
- checkpoint-payload parsing for a terminal xp delta is extracted into `parseTerminalCheckpointXP`, shared between `startActivity` and `getAvatarProgression` rather than duplicated
- a rejected activity's xp is excluded; an avatar with no pending work stamps identical to settled xp/level

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
