### PR TITLE
fix(#771): run the stack e2e with the game renderer flagged off

### DIFF
--- a/apps/web-e2e/docker-compose.stack.yml
+++ b/apps/web-e2e/docker-compose.stack.yml
@@ -120,6 +120,9 @@ services:
     environment:
       # canvas-persistence.spec.ts clicks through to the Market nav link, gated behind this flag
       FEATURE_MARKET: 'true'
+      # inert placeholder canvases, matching the dev-mode e2e config — the flag defaults on, and
+      # the live WebGPU/WebGL renderer is neither intended nor reliable on a headless CI runner
+      FEATURE_GAME_RENDERER: 'false'
       ACTIVITY_SERVICE_URL: http://service-activity:3000
       AVATAR_SERVICE_URL: http://service-avatar:3000
       EMAIL_SERVICE_URL: http://service-email:3000


### PR DESCRIPTION
## What

Sets `FEATURE_GAME_RENDERER: 'false'` in the stack compose's app-web env, matching the dev-mode e2e config that has always pinned it off.

- the flag defaults on, so the stack e2e was running the live WebGPU world canvas and a real WebGL avatar satellite on headless CI chromium
- the satellite's GL context intermittently lost the 10s assertion race on loaded runners — four consecutive Full-stack E2E failures blocked main's Deploy for 9752a5f7
- with placeholders the spec passes a fresh local stack in 4.9s (vs 7.1s with the live renderer), deterministic and GPU-free

Verified against the exact CI images via the compose stack, fresh volume, before and after.

Closes #771