### PR TITLE
feat(#773): add provider-mode entrypoint for replay

### DIFF
--- a/deploy.config.ts
+++ b/deploy.config.ts
@@ -84,7 +84,7 @@ export default defineDeployManifest({
       configDir: 'services/replay',
       dockerfile: 'services/replay/Dockerfile',
       exposure: 'flycast',
-      simVersionProvider: true,
+      simVersionProvider: { region: 'syd' },
       trigger: { kind: 'turbo-affected', pkg: '@vers/service-replay' },
     },
     {

--- a/knip.json
+++ b/knip.json
@@ -60,7 +60,7 @@
       "ignoreDependencies": ["@orpc/contract"]
     },
     "services/replay": {
-      "entry": ["src/serve.ts"]
+      "entry": ["src/serve.ts", "src/serve-provider.ts"]
     },
     "libs/service/service-utils": {
       "ignoreDependencies": ["pino-pretty"]

--- a/scripts/src/bin/deploy.ts
+++ b/scripts/src/bin/deploy.ts
@@ -505,6 +505,7 @@ async function runSimVersionReconcile(target: DeployTarget): Promise<void> {
     providerMachineExists: providerAppState.hasMachine,
     providerMachineID: providerAppState.machineID,
     providerMachineImageDigest: providerAppState.machineImageDigest,
+    providerMachineRegion: providerAppState.machineRegion,
     region: target.simVersionProvider.region,
     registryRow,
   });

--- a/scripts/src/bin/deploy.ts
+++ b/scripts/src/bin/deploy.ts
@@ -483,7 +483,7 @@ async function runScheduledMachineReconcile(target: DeployTarget): Promise<void>
  * the `sim_versions` registry row current. A no-op for every other target.
  */
 async function runSimVersionReconcile(target: DeployTarget): Promise<void> {
-  if (target.simVersionProvider !== true) {
+  if (target.simVersionProvider === undefined) {
     return;
   }
 
@@ -503,6 +503,9 @@ async function runSimVersionReconcile(target: DeployTarget): Promise<void> {
     fleetImage,
     providerAppExists: providerAppState.exists,
     providerMachineExists: providerAppState.hasMachine,
+    providerMachineID: providerAppState.machineID,
+    providerMachineImageDigest: providerAppState.machineImageDigest,
+    region: target.simVersionProvider.region,
     registryRow,
   });
 

--- a/scripts/src/deploy/apply-sim-version-actions.ts
+++ b/scripts/src/deploy/apply-sim-version-actions.ts
@@ -51,14 +51,17 @@ async function applySimVersionAction(action: SimVersionAction): Promise<void> {
   }
 
   if (action.kind === 'run-provider-machine') {
-    await runProviderMachine(action.app, action.image, action.region);
+    await runProviderMachine(action.app, action.image, action.region, requireProviderJWKS());
 
     return;
   }
 
   if (action.kind === 'replace-provider-machine') {
+    // resolved before the destroy, so a missing secret fails with the old machine still in place
+    const jwks = requireProviderJWKS();
+
     await runFlyctl(['machine', 'destroy', '--force', action.machineID, '-a', action.app]);
-    await runProviderMachine(action.app, action.image, action.region);
+    await runProviderMachine(action.app, action.image, action.region, jwks);
 
     return;
   }
@@ -66,12 +69,19 @@ async function applySimVersionAction(action: SimVersionAction): Promise<void> {
   await upsertRegistryRow(action.input);
 }
 
-async function runProviderMachine(app: string, image: string, region: string): Promise<void> {
-  const jwks = requireEnvVar(
+function requireProviderJWKS(): string {
+  return requireEnvVar(
     'SERVICE_AUTH_JWKS',
     'a sim-version provider machine must verify inbound s2s calls',
   );
+}
 
+async function runProviderMachine(
+  app: string,
+  image: string,
+  region: string,
+  jwks: string,
+): Promise<void> {
   await runFlyctl([
     'machine',
     'run',

--- a/scripts/src/deploy/apply-sim-version-actions.ts
+++ b/scripts/src/deploy/apply-sim-version-actions.ts
@@ -17,6 +17,13 @@ const PROVIDER_MACHINE_FLAGS = [
 ];
 
 /**
+ * Container command a provider machine runs — the image's `CMD` starts the full-service `server`
+ * binary, which a provider machine's narrowed env would fail to boot; this positional cleanly
+ * replaces it with the provider-mode binary.
+ */
+const PROVIDER_MACHINE_COMMAND = 'provider';
+
+/**
  * Runs the planner's actions against Fly and the shared database, in order —
  * the provider app before its flycast IP, the IP before the machine that
  * needs it, and the registry row last so it never points at an app that
@@ -44,7 +51,14 @@ async function applySimVersionAction(action: SimVersionAction): Promise<void> {
   }
 
   if (action.kind === 'run-provider-machine') {
-    await runProviderMachine(action.app, action.image);
+    await runProviderMachine(action.app, action.image, action.region);
+
+    return;
+  }
+
+  if (action.kind === 'replace-provider-machine') {
+    await runFlyctl(['machine', 'destroy', '--force', action.machineID, '-a', action.app]);
+    await runProviderMachine(action.app, action.image, action.region);
 
     return;
   }
@@ -52,7 +66,7 @@ async function applySimVersionAction(action: SimVersionAction): Promise<void> {
   await upsertRegistryRow(action.input);
 }
 
-async function runProviderMachine(app: string, image: string): Promise<void> {
+async function runProviderMachine(app: string, image: string, region: string): Promise<void> {
   const jwks = requireEnvVar(
     'SERVICE_AUTH_JWKS',
     'a sim-version provider machine must verify inbound s2s calls',
@@ -62,8 +76,11 @@ async function runProviderMachine(app: string, image: string): Promise<void> {
     'machine',
     'run',
     image,
+    PROVIDER_MACHINE_COMMAND,
     '-a',
     app,
+    '--region',
+    region,
     ...PROVIDER_MACHINE_FLAGS,
     '--env',
     `SERVICE_AUTH_JWKS=${jwks}`,

--- a/scripts/src/deploy/plan-sim-version-actions.test.ts
+++ b/scripts/src/deploy/plan-sim-version-actions.test.ts
@@ -6,6 +6,7 @@ import type { FleetImage } from './types';
 
 const ENGINE_HASH = 'a1b2c3d4e5f6'.padEnd(64, '0');
 const PROVIDER_APP = 'vers-replay-a1b2c3d4e5f6';
+const REGION = 'syd';
 
 const fleetImage: FleetImage = {
   digest: 'sha256:current',
@@ -20,6 +21,9 @@ test('it provisions everything for a fresh engine hash', () => {
     fleetImage,
     providerAppExists: false,
     providerMachineExists: false,
+    providerMachineID: null,
+    providerMachineImageDigest: null,
+    region: REGION,
     registryRow: undefined,
   });
 
@@ -30,6 +34,7 @@ test('it provisions everything for a fresh engine hash', () => {
       app: PROVIDER_APP,
       image: `${fleetImage.repository}:${fleetImage.tag}`,
       kind: 'run-provider-machine',
+      region: REGION,
     },
     {
       input: {
@@ -43,13 +48,34 @@ test('it provisions everything for a fresh engine hash', () => {
   ]);
 });
 
-test('it takes no action when the registry row is current and the app already exists', () => {
+test('it carries the declared region on a fresh provision', () => {
+  const actions = planSimVersionActions({
+    bunVersion: '1.3.10',
+    engineHash: ENGINE_HASH,
+    fleetImage,
+    providerAppExists: false,
+    providerMachineExists: false,
+    providerMachineID: null,
+    providerMachineImageDigest: null,
+    region: REGION,
+    registryRow: undefined,
+  });
+
+  const runAction = actions.find((action) => action.kind === 'run-provider-machine');
+
+  expect(runAction?.kind === 'run-provider-machine' && runAction.region).toBe(REGION);
+});
+
+test('it takes no action when the registry row is current and the machine runs the fleet digest', () => {
   const actions = planSimVersionActions({
     bunVersion: '1.3.10',
     engineHash: ENGINE_HASH,
     fleetImage,
     providerAppExists: true,
     providerMachineExists: true,
+    providerMachineID: 'machine-1',
+    providerMachineImageDigest: fleetImage.digest,
+    region: REGION,
     registryRow: createMockSimVersionRow({
       imageRef: `${fleetImage.repository}@${fleetImage.digest}`,
     }),
@@ -65,6 +91,9 @@ test('it recreates the provider app and refreshes the row when the app is missin
     fleetImage,
     providerAppExists: false,
     providerMachineExists: false,
+    providerMachineID: null,
+    providerMachineImageDigest: null,
+    region: REGION,
     registryRow: createMockSimVersionRow({
       imageRef: `${fleetImage.repository}@${fleetImage.digest}`,
     }),
@@ -77,6 +106,7 @@ test('it recreates the provider app and refreshes the row when the app is missin
       app: PROVIDER_APP,
       image: `${fleetImage.repository}:${fleetImage.tag}`,
       kind: 'run-provider-machine',
+      region: REGION,
     },
     {
       input: {
@@ -97,6 +127,9 @@ test('it only refreshes the registry row when the fleet digest has drifted from 
     fleetImage,
     providerAppExists: true,
     providerMachineExists: true,
+    providerMachineID: 'machine-1',
+    providerMachineImageDigest: fleetImage.digest,
+    region: REGION,
     registryRow: createMockSimVersionRow({
       imageRef: `${fleetImage.repository}@sha256:stale`,
     }),
@@ -122,6 +155,9 @@ test('it relaunches only the machine when the app survives but its machine is go
     fleetImage,
     providerAppExists: true,
     providerMachineExists: false,
+    providerMachineID: null,
+    providerMachineImageDigest: null,
+    region: REGION,
     registryRow: createMockSimVersionRow({
       imageRef: `${fleetImage.repository}@${fleetImage.digest}`,
     }),
@@ -132,6 +168,42 @@ test('it relaunches only the machine when the app survives but its machine is go
       app: PROVIDER_APP,
       image: `${fleetImage.repository}:${fleetImage.tag}`,
       kind: 'run-provider-machine',
+      region: REGION,
+    },
+    {
+      input: {
+        bunVersion: '1.3.10',
+        engineHash: ENGINE_HASH,
+        imageRef: `${fleetImage.repository}@${fleetImage.digest}`,
+        providerURL: `http://${PROVIDER_APP}.flycast`,
+      },
+      kind: 'upsert-registry-row',
+    },
+  ]);
+});
+
+test('it replaces a running machine whose image digest has drifted from the fleet', () => {
+  const actions = planSimVersionActions({
+    bunVersion: '1.3.10',
+    engineHash: ENGINE_HASH,
+    fleetImage,
+    providerAppExists: true,
+    providerMachineExists: true,
+    providerMachineID: 'machine-1',
+    providerMachineImageDigest: 'sha256:stale',
+    region: REGION,
+    registryRow: createMockSimVersionRow({
+      imageRef: `${fleetImage.repository}@${fleetImage.digest}`,
+    }),
+  });
+
+  expect(actions).toStrictEqual([
+    {
+      app: PROVIDER_APP,
+      image: `${fleetImage.repository}:${fleetImage.tag}`,
+      kind: 'replace-provider-machine',
+      machineID: 'machine-1',
+      region: REGION,
     },
     {
       input: {
@@ -152,6 +224,9 @@ test('it refreshes only the row when the app and machine exist but the row is mi
     fleetImage,
     providerAppExists: true,
     providerMachineExists: true,
+    providerMachineID: 'machine-1',
+    providerMachineImageDigest: fleetImage.digest,
+    region: REGION,
     registryRow: undefined,
   });
 
@@ -175,6 +250,9 @@ test('it launches the provider machine by tag, never by digest', () => {
     fleetImage,
     providerAppExists: false,
     providerMachineExists: false,
+    providerMachineID: null,
+    providerMachineImageDigest: null,
+    region: REGION,
     registryRow: undefined,
   });
 
@@ -184,6 +262,25 @@ test('it launches the provider machine by tag, never by digest', () => {
   expect(runAction?.image).not.toInclude('sha256:');
 });
 
+test('it replaces the provider machine by tag, never by digest', () => {
+  const actions = planSimVersionActions({
+    bunVersion: '1.3.10',
+    engineHash: ENGINE_HASH,
+    fleetImage,
+    providerAppExists: true,
+    providerMachineExists: true,
+    providerMachineID: 'machine-1',
+    providerMachineImageDigest: 'sha256:stale',
+    region: REGION,
+    registryRow: undefined,
+  });
+
+  const replaceAction = actions.find((action) => action.kind === 'replace-provider-machine');
+
+  expect(replaceAction?.image).toBe(`${fleetImage.repository}:${fleetImage.tag}`);
+  expect(replaceAction?.image).not.toInclude('sha256:');
+});
+
 test('it derives the provider app name and flycast URL from the first 12 hex chars of the engine hash', () => {
   const actions = planSimVersionActions({
     bunVersion: '1.3.10',
@@ -191,6 +288,9 @@ test('it derives the provider app name and flycast URL from the first 12 hex cha
     fleetImage,
     providerAppExists: false,
     providerMachineExists: false,
+    providerMachineID: null,
+    providerMachineImageDigest: null,
+    region: REGION,
     registryRow: undefined,
   });
 
@@ -212,6 +312,9 @@ test('it takes no action when the fleet has no single resolved image', () => {
     fleetImage: null,
     providerAppExists: false,
     providerMachineExists: false,
+    providerMachineID: null,
+    providerMachineImageDigest: null,
+    region: REGION,
     registryRow: undefined,
   });
 

--- a/scripts/src/deploy/plan-sim-version-actions.test.ts
+++ b/scripts/src/deploy/plan-sim-version-actions.test.ts
@@ -23,6 +23,7 @@ test('it provisions everything for a fresh engine hash', () => {
     providerMachineExists: false,
     providerMachineID: null,
     providerMachineImageDigest: null,
+    providerMachineRegion: null,
     region: REGION,
     registryRow: undefined,
   });
@@ -57,6 +58,7 @@ test('it carries the declared region on a fresh provision', () => {
     providerMachineExists: false,
     providerMachineID: null,
     providerMachineImageDigest: null,
+    providerMachineRegion: null,
     region: REGION,
     registryRow: undefined,
   });
@@ -75,6 +77,7 @@ test('it takes no action when the registry row is current and the machine runs t
     providerMachineExists: true,
     providerMachineID: 'machine-1',
     providerMachineImageDigest: fleetImage.digest,
+    providerMachineRegion: REGION,
     region: REGION,
     registryRow: createMockSimVersionRow({
       imageRef: `${fleetImage.repository}@${fleetImage.digest}`,
@@ -93,6 +96,7 @@ test('it recreates the provider app and refreshes the row when the app is missin
     providerMachineExists: false,
     providerMachineID: null,
     providerMachineImageDigest: null,
+    providerMachineRegion: null,
     region: REGION,
     registryRow: createMockSimVersionRow({
       imageRef: `${fleetImage.repository}@${fleetImage.digest}`,
@@ -129,6 +133,7 @@ test('it only refreshes the registry row when the fleet digest has drifted from 
     providerMachineExists: true,
     providerMachineID: 'machine-1',
     providerMachineImageDigest: fleetImage.digest,
+    providerMachineRegion: REGION,
     region: REGION,
     registryRow: createMockSimVersionRow({
       imageRef: `${fleetImage.repository}@sha256:stale`,
@@ -157,6 +162,7 @@ test('it relaunches only the machine when the app survives but its machine is go
     providerMachineExists: false,
     providerMachineID: null,
     providerMachineImageDigest: null,
+    providerMachineRegion: null,
     region: REGION,
     registryRow: createMockSimVersionRow({
       imageRef: `${fleetImage.repository}@${fleetImage.digest}`,
@@ -191,6 +197,43 @@ test('it replaces a running machine whose image digest has drifted from the flee
     providerMachineExists: true,
     providerMachineID: 'machine-1',
     providerMachineImageDigest: 'sha256:stale',
+    providerMachineRegion: REGION,
+    region: REGION,
+    registryRow: createMockSimVersionRow({
+      imageRef: `${fleetImage.repository}@${fleetImage.digest}`,
+    }),
+  });
+
+  expect(actions).toStrictEqual([
+    {
+      app: PROVIDER_APP,
+      image: `${fleetImage.repository}:${fleetImage.tag}`,
+      kind: 'replace-provider-machine',
+      machineID: 'machine-1',
+      region: REGION,
+    },
+    {
+      input: {
+        bunVersion: '1.3.10',
+        engineHash: ENGINE_HASH,
+        imageRef: `${fleetImage.repository}@${fleetImage.digest}`,
+        providerURL: `http://${PROVIDER_APP}.flycast`,
+      },
+      kind: 'upsert-registry-row',
+    },
+  ]);
+});
+
+test('it replaces a running machine sitting outside the declared region even when its image is current', () => {
+  const actions = planSimVersionActions({
+    bunVersion: '1.3.10',
+    engineHash: ENGINE_HASH,
+    fleetImage,
+    providerAppExists: true,
+    providerMachineExists: true,
+    providerMachineID: 'machine-1',
+    providerMachineImageDigest: fleetImage.digest,
+    providerMachineRegion: 'iad',
     region: REGION,
     registryRow: createMockSimVersionRow({
       imageRef: `${fleetImage.repository}@${fleetImage.digest}`,
@@ -226,6 +269,7 @@ test('it refreshes only the row when the app and machine exist but the row is mi
     providerMachineExists: true,
     providerMachineID: 'machine-1',
     providerMachineImageDigest: fleetImage.digest,
+    providerMachineRegion: REGION,
     region: REGION,
     registryRow: undefined,
   });
@@ -252,6 +296,7 @@ test('it launches the provider machine by tag, never by digest', () => {
     providerMachineExists: false,
     providerMachineID: null,
     providerMachineImageDigest: null,
+    providerMachineRegion: null,
     region: REGION,
     registryRow: undefined,
   });
@@ -271,6 +316,7 @@ test('it replaces the provider machine by tag, never by digest', () => {
     providerMachineExists: true,
     providerMachineID: 'machine-1',
     providerMachineImageDigest: 'sha256:stale',
+    providerMachineRegion: REGION,
     region: REGION,
     registryRow: undefined,
   });
@@ -290,6 +336,7 @@ test('it derives the provider app name and flycast URL from the first 12 hex cha
     providerMachineExists: false,
     providerMachineID: null,
     providerMachineImageDigest: null,
+    providerMachineRegion: null,
     region: REGION,
     registryRow: undefined,
   });
@@ -314,6 +361,7 @@ test('it takes no action when the fleet has no single resolved image', () => {
     providerMachineExists: false,
     providerMachineID: null,
     providerMachineImageDigest: null,
+    providerMachineRegion: null,
     region: REGION,
     registryRow: undefined,
   });

--- a/scripts/src/deploy/plan-sim-version-actions.ts
+++ b/scripts/src/deploy/plan-sim-version-actions.ts
@@ -1,3 +1,4 @@
+import invariant from 'tiny-invariant';
 import { buildProviderAppName } from './build-provider-app-name';
 import type { SimVersionAction, SimVersionActionInput } from './types';
 
@@ -5,13 +6,15 @@ import type { SimVersionAction, SimVersionActionInput } from './types';
  * Decides what a replay deploy still needs to provision for an engine hash:
  * a fresh hash gets a new per-version provider app, its flycast IP, a
  * machine launched from the fleet's just-deployed tag, and a registry row;
- * an existing app with a machine whose registry row already points at the
- * fleet's resolved digest needs nothing. A missing provider app is always
- * recreated, an app that lost its machine gets a fresh machine, and every
- * non-current state refreshes the row — the fleet, not the row, is the
- * source of truth. Launching always targets the fleet's tag, never its
- * digest — `flyctl machine run` mangles a `@sha256:` ref. No actions come
- * back when the fleet has no single resolved image to provision from.
+ * an existing app with a machine already running the fleet's resolved digest
+ * and a registry row that already points at it needs nothing. A missing
+ * provider app is always recreated, an app that lost its machine gets a
+ * fresh machine, a machine running any other digest is replaced, and every
+ * non-current state refreshes the row — the fleet, not the row or the
+ * running machine, is the source of truth. Launching and replacing always
+ * target the fleet's tag, never its digest — `flyctl machine run` mangles a
+ * `@sha256:` ref. No actions come back when the fleet has no single resolved
+ * image to provision from.
  */
 export function planSimVersionActions(
   input: Readonly<SimVersionActionInput>,
@@ -23,12 +26,14 @@ export function planSimVersionActions(
   const providerApp = buildProviderAppName(input.engineHash);
   const imageRef = `${input.fleetImage.repository}@${input.fleetImage.digest}`;
   const rowIsCurrent = input.registryRow?.imageRef === imageRef;
+  const machineIsCurrent = input.providerMachineImageDigest === input.fleetImage.digest;
 
-  if (rowIsCurrent && input.providerAppExists && input.providerMachineExists) {
+  if (rowIsCurrent && input.providerAppExists && input.providerMachineExists && machineIsCurrent) {
     return [];
   }
 
   const actions: Array<SimVersionAction> = [];
+  const tagRef = `${input.fleetImage.repository}:${input.fleetImage.tag}`;
 
   if (!input.providerAppExists) {
     actions.push(
@@ -40,8 +45,19 @@ export function planSimVersionActions(
   if (!input.providerAppExists || !input.providerMachineExists) {
     actions.push({
       app: providerApp,
-      image: `${input.fleetImage.repository}:${input.fleetImage.tag}`,
+      image: tagRef,
       kind: 'run-provider-machine',
+      region: input.region,
+    });
+  } else if (!machineIsCurrent) {
+    invariant(input.providerMachineID !== null, 'a provider machine that exists carries an id');
+
+    actions.push({
+      app: providerApp,
+      image: tagRef,
+      kind: 'replace-provider-machine',
+      machineID: input.providerMachineID,
+      region: input.region,
     });
   }
 

--- a/scripts/src/deploy/plan-sim-version-actions.ts
+++ b/scripts/src/deploy/plan-sim-version-actions.ts
@@ -9,7 +9,8 @@ import type { SimVersionAction, SimVersionActionInput } from './types';
  * an existing app with a machine already running the fleet's resolved digest
  * and a registry row that already points at it needs nothing. A missing
  * provider app is always recreated, an app that lost its machine gets a
- * fresh machine, a machine running any other digest is replaced, and every
+ * fresh machine, a machine running any other digest or sitting in any other
+ * region is replaced, and every
  * non-current state refreshes the row — the fleet, not the row or the
  * running machine, is the source of truth. Launching and replacing always
  * target the fleet's tag, never its digest — `flyctl machine run` mangles a
@@ -26,7 +27,10 @@ export function planSimVersionActions(
   const providerApp = buildProviderAppName(input.engineHash);
   const imageRef = `${input.fleetImage.repository}@${input.fleetImage.digest}`;
   const rowIsCurrent = input.registryRow?.imageRef === imageRef;
-  const machineIsCurrent = input.providerMachineImageDigest === input.fleetImage.digest;
+
+  const machineIsCurrent =
+    input.providerMachineImageDigest === input.fleetImage.digest &&
+    input.providerMachineRegion === input.region;
 
   if (rowIsCurrent && input.providerAppExists && input.providerMachineExists && machineIsCurrent) {
     return [];

--- a/scripts/src/deploy/read-provider-app-state.ts
+++ b/scripts/src/deploy/read-provider-app-state.ts
@@ -38,6 +38,6 @@ export async function readProviderAppState(app: string): Promise<ProviderAppStat
     exists: true,
     hasMachine: machine !== undefined,
     machineID: machine?.id ?? null,
-    machineImageDigest: machine?.image_ref.digest ?? null,
+    machineImageDigest: machine?.image_ref?.digest ?? null,
   };
 }

--- a/scripts/src/deploy/read-provider-app-state.ts
+++ b/scripts/src/deploy/read-provider-app-state.ts
@@ -8,7 +8,11 @@ const appsSchema = z.array(appSchema);
 // image_ref can be absent while a machine is in a transient state (created, replacing); a missing
 // digest reads as not-current downstream, so the machine is replaced rather than the parse failing
 const machineSchema = z
-  .object({ id: z.string(), image_ref: z.object({ digest: z.string() }).readonly().optional() })
+  .object({
+    id: z.string(),
+    image_ref: z.object({ digest: z.string() }).readonly().optional(),
+    region: z.string(),
+  })
   .readonly();
 
 const machinesSchema = z.array(machineSchema);
@@ -27,7 +31,13 @@ export async function readProviderAppState(app: string): Promise<ProviderAppStat
   const exists = apps.some((candidate) => candidate.Name === app);
 
   if (!exists) {
-    return { exists: false, hasMachine: false, machineID: null, machineImageDigest: null };
+    return {
+      exists: false,
+      hasMachine: false,
+      machineID: null,
+      machineImageDigest: null,
+      machineRegion: null,
+    };
   }
 
   const machinesStdout = await runFlyctl(['machines', 'list', '--app', app, '--json']);
@@ -39,5 +49,6 @@ export async function readProviderAppState(app: string): Promise<ProviderAppStat
     hasMachine: machine !== undefined,
     machineID: machine?.id ?? null,
     machineImageDigest: machine?.image_ref?.digest ?? null,
+    machineRegion: machine?.region ?? null,
   };
 }

--- a/scripts/src/deploy/read-provider-app-state.ts
+++ b/scripts/src/deploy/read-provider-app-state.ts
@@ -4,13 +4,19 @@ import type { ProviderAppState } from './types';
 
 const appSchema = z.object({ Name: z.string() }).readonly();
 const appsSchema = z.array(appSchema);
-const machinesSchema = z.array(z.unknown());
+
+const machineSchema = z
+  .object({ id: z.string(), image_ref: z.object({ digest: z.string() }).readonly() })
+  .readonly();
+
+const machinesSchema = z.array(machineSchema);
 
 /**
  * Reads what exists of a per-version provider app: whether the app itself is
  * present in the org, and whether it still holds at least one machine — the
  * planner provisions a fresh machine for an app that lost its machine, not
- * just for a missing app.
+ * just for a missing app. The first machine's id and image digest are
+ * returned so the planner can detect a machine running a stale image.
  */
 export async function readProviderAppState(app: string): Promise<ProviderAppState> {
   const appsStdout = await runFlyctl(['apps', 'list', '--json']);
@@ -19,12 +25,17 @@ export async function readProviderAppState(app: string): Promise<ProviderAppStat
   const exists = apps.some((candidate) => candidate.Name === app);
 
   if (!exists) {
-    return { exists: false, hasMachine: false };
+    return { exists: false, hasMachine: false, machineID: null, machineImageDigest: null };
   }
 
   const machinesStdout = await runFlyctl(['machines', 'list', '--app', app, '--json']);
 
-  const machines = machinesSchema.parse(JSON.parse(machinesStdout));
+  const [machine] = machinesSchema.parse(JSON.parse(machinesStdout));
 
-  return { exists: true, hasMachine: machines.length > 0 };
+  return {
+    exists: true,
+    hasMachine: machine !== undefined,
+    machineID: machine?.id ?? null,
+    machineImageDigest: machine?.image_ref.digest ?? null,
+  };
 }

--- a/scripts/src/deploy/read-provider-app-state.ts
+++ b/scripts/src/deploy/read-provider-app-state.ts
@@ -5,8 +5,10 @@ import type { ProviderAppState } from './types';
 const appSchema = z.object({ Name: z.string() }).readonly();
 const appsSchema = z.array(appSchema);
 
+// image_ref can be absent while a machine is in a transient state (created, replacing); a missing
+// digest reads as not-current downstream, so the machine is replaced rather than the parse failing
 const machineSchema = z
-  .object({ id: z.string(), image_ref: z.object({ digest: z.string() }).readonly() })
+  .object({ id: z.string(), image_ref: z.object({ digest: z.string() }).readonly().optional() })
   .readonly();
 
 const machinesSchema = z.array(machineSchema);

--- a/scripts/src/deploy/types.ts
+++ b/scripts/src/deploy/types.ts
@@ -20,9 +20,10 @@ export interface DeployTarget {
   /**
    * Marks the target whose deploy the sim-version reconcile runs after —
    * provisioning a per-version provider app and upserting the `sim_versions`
-   * registry row for the engine hash baked into its image.
+   * registry row for the engine hash baked into its image. `region` is the
+   * Fly region a provider machine launches into.
    */
-  readonly simVersionProvider?: boolean;
+  readonly simVersionProvider?: { readonly region: string };
 }
 
 /**
@@ -111,6 +112,9 @@ export interface SimVersionActionInput {
   readonly fleetImage: FleetImage | null;
   readonly providerAppExists: boolean;
   readonly providerMachineExists: boolean;
+  readonly providerMachineID: string | null;
+  readonly providerMachineImageDigest: string | null;
+  readonly region: string;
   readonly registryRow: SimVersionRow | undefined;
 }
 
@@ -118,11 +122,14 @@ export interface SimVersionActionInput {
  * What already exists of a per-version provider app. `hasMachine` is false
  * whenever `exists` is — an app can outlive its machine (a partial provision
  * or a manual destroy), and a registry row must never point at one that has
- * nothing to wake.
+ * nothing to wake. `machineID`/`machineImageDigest` are null whenever
+ * `hasMachine` is.
  */
 export interface ProviderAppState {
   readonly exists: boolean;
   readonly hasMachine: boolean;
+  readonly machineID: string | null;
+  readonly machineImageDigest: string | null;
 }
 
 interface CreateProviderAppAction {
@@ -139,6 +146,20 @@ interface RunProviderMachineAction {
   readonly kind: 'run-provider-machine';
   readonly app: string;
   readonly image: string;
+  readonly region: string;
+}
+
+/**
+ * Replaces a provider machine whose image has drifted from the fleet's
+ * resolved digest — `image` is always the fleet's tag ref, never its digest
+ * ref, matching `RunProviderMachineAction`.
+ */
+interface ReplaceProviderMachineAction {
+  readonly kind: 'replace-provider-machine';
+  readonly app: string;
+  readonly machineID: string;
+  readonly image: string;
+  readonly region: string;
 }
 
 interface UpsertRegistryRowAction {
@@ -150,6 +171,7 @@ export type SimVersionAction =
   | CreateProviderAppAction
   | AllocateFlycastIPAction
   | RunProviderMachineAction
+  | ReplaceProviderMachineAction
   | UpsertRegistryRowAction;
 
 /**

--- a/scripts/src/deploy/types.ts
+++ b/scripts/src/deploy/types.ts
@@ -114,6 +114,7 @@ export interface SimVersionActionInput {
   readonly providerMachineExists: boolean;
   readonly providerMachineID: string | null;
   readonly providerMachineImageDigest: string | null;
+  readonly providerMachineRegion: string | null;
   readonly region: string;
   readonly registryRow: SimVersionRow | undefined;
 }
@@ -122,14 +123,15 @@ export interface SimVersionActionInput {
  * What already exists of a per-version provider app. `hasMachine` is false
  * whenever `exists` is — an app can outlive its machine (a partial provision
  * or a manual destroy), and a registry row must never point at one that has
- * nothing to wake. `machineID`/`machineImageDigest` are null whenever
- * `hasMachine` is.
+ * nothing to wake. `machineID`/`machineImageDigest`/`machineRegion` are null
+ * whenever `hasMachine` is.
  */
 export interface ProviderAppState {
   readonly exists: boolean;
   readonly hasMachine: boolean;
   readonly machineID: string | null;
   readonly machineImageDigest: string | null;
+  readonly machineRegion: string | null;
 }
 
 interface CreateProviderAppAction {
@@ -151,8 +153,9 @@ interface RunProviderMachineAction {
 
 /**
  * Replaces a provider machine whose image has drifted from the fleet's
- * resolved digest — `image` is always the fleet's tag ref, never its digest
- * ref, matching `RunProviderMachineAction`.
+ * resolved digest or whose region has drifted from the declared one —
+ * `image` is always the fleet's tag ref, never its digest ref, matching
+ * `RunProviderMachineAction`.
  */
 interface ReplaceProviderMachineAction {
   readonly kind: 'replace-provider-machine';

--- a/services/replay/Dockerfile
+++ b/services/replay/Dockerfile
@@ -48,13 +48,20 @@ RUN bun build src/serve.ts --compile --target=bun-linux-x64-musl \
   --define "process.env.SIM_ENGINE_HASH='$SIM_ENGINE_HASH'" \
   --outfile /tmp/server
 
-# --- runtime: just the binary on alpine (busybox shell kept for `fly ssh console`) ---
+# the provider binary: only `replaySegment`, on a narrowed env shape with no database, keys
+# service, or signing key — per-version provider apps run this instead of `server`
+RUN bun build src/serve-provider.ts --compile --target=bun-linux-x64-musl \
+  --define "process.env.SIM_ENGINE_HASH='$SIM_ENGINE_HASH'" \
+  --outfile /tmp/provider
+
+# --- runtime: both binaries on alpine (busybox shell kept for `fly ssh console`) ---
 FROM alpine:3.21
 
-# bun's musl binary links against libgcc and libstdc++
+# bun's musl binaries link against libgcc and libstdc++
 RUN apk add --no-cache libgcc libstdc++
 
 COPY --from=builder /tmp/server /usr/local/bin/server
+COPY --from=builder /tmp/provider /usr/local/bin/provider
 
 ENV NODE_ENV="production"
 

--- a/services/replay/src/build-provider-router.test.ts
+++ b/services/replay/src/build-provider-router.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from 'bun:test';
+import { replayContract } from '@vers/contract-replay';
+import { createAnonymousViewer } from '@vers/service-test-utils/bun';
+import { collectConformanceCases } from '@vers/test-utils';
+import { createReplayProvider } from './create-replay-provider';
+
+test('it passes every conformance case collected from its narrowed contract', async () => {
+  const service = await createReplayProvider();
+  const viewer = await createAnonymousViewer({ audience: 'service-replay-provider' });
+
+  const cases = collectConformanceCases(
+    { replaySegment: replayContract.replaySegment },
+    { anonymousHeaders: { authorization: `Bearer ${viewer.token}` } },
+  );
+
+  for (const conformanceCase of cases) {
+    await expect(conformanceCase.run(service.app)).toResolve();
+  }
+});

--- a/services/replay/src/build-provider-router.ts
+++ b/services/replay/src/build-provider-router.ts
@@ -1,0 +1,25 @@
+import { implement } from '@orpc/server';
+import { replayContract } from '@vers/contract-replay';
+import type { ServiceContext } from '@vers/service-runtime';
+import { replaySegment } from './handlers/replay-segment';
+
+interface BuildProviderRouterDeps {
+  readonly simVersion: string;
+}
+
+/**
+ * Assembles the provider-mode router: only `replaySegment`, closing over the baked engine hash
+ * this deploy serves. No `wake` route — a provider machine never claims or drains a chain, and an
+ * unmatched path 404s at the transport.
+ */
+export function buildProviderRouter(deps: Readonly<BuildProviderRouterDeps>) {
+  const os = implement({ replaySegment: replayContract.replaySegment }).$context<ServiceContext>();
+
+  return {
+    replaySegment: os.replaySegment.handler((opts) =>
+      replaySegment({ simVersion: deps.simVersion }, opts),
+    ),
+  };
+}
+
+export type ProviderRouter = ReturnType<typeof buildProviderRouter>;

--- a/services/replay/src/create-replay-provider.test.ts
+++ b/services/replay/src/create-replay-provider.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from 'bun:test';
+import { createReplayProvider } from './create-replay-provider';
+
+test('it boots from env.SIM_ENGINE_HASH', async () => {
+  const service = await createReplayProvider();
+
+  expect(service.env.SIM_ENGINE_HASH).toBe('test-engine-hash');
+});

--- a/services/replay/src/create-replay-provider.ts
+++ b/services/replay/src/create-replay-provider.ts
@@ -1,0 +1,19 @@
+import { createService } from '@vers/service-runtime';
+import type { Service } from '@vers/service-runtime';
+import { buildProviderRouter } from './build-provider-router';
+import { providerEnvShape } from './provider-env-shape';
+
+export type ReplayProvider = Service<typeof providerEnvShape>;
+
+/**
+ * Boots the provider-mode replay service; the provider entrypoint is the one caller. No database
+ * pool, no worker deps, no signing key — the narrowed env shape has nothing for them to resolve
+ * from.
+ */
+export function createReplayProvider(): Promise<ReplayProvider> {
+  return createService({
+    buildRouter: (runtime) => buildProviderRouter({ simVersion: runtime.env.SIM_ENGINE_HASH }),
+    envShape: providerEnvShape,
+    name: 'service-replay-provider',
+  });
+}

--- a/services/replay/src/index.ts
+++ b/services/replay/src/index.ts
@@ -1,4 +1,5 @@
 export { applyVerifiedSegment } from './apply/apply-verified-segment';
+export type { ProviderRouter } from './build-provider-router';
 export type { ReplayRouter } from './build-router';
 export { parkActivity } from './dispatch/park-activity';
 export type { RunReplaySegmentDeps, RunReplaySegmentOutcome } from './dispatch/run-replay-segment';

--- a/services/replay/src/provider-env-shape.ts
+++ b/services/replay/src/provider-env-shape.ts
@@ -1,0 +1,14 @@
+import * as z from 'zod';
+
+/**
+ * Environment the provider entrypoint needs beyond the base service env: only the engine hash its
+ * build baked in. No database, keys service, or signing key — a provider machine serves
+ * `replaySegment` in-process against its own baked engine and never claims a chain or dispatches
+ * cross-version.
+ */
+export const providerEnvShape = {
+  SIM_ENGINE_HASH: z
+    .string()
+    .min(1)
+    .describe('Engine hash baked at build; the provider answers replay only for this version'),
+};

--- a/services/replay/src/serve-provider.test.ts
+++ b/services/replay/src/serve-provider.test.ts
@@ -1,0 +1,128 @@
+import { expect, onTestFinished, test } from 'bun:test';
+import path from 'node:path';
+import { createMockReplaySegmentInput } from '@vers/contract-replay/test-utils';
+import { createServiceToken, getTestServiceKeyPair } from '@vers/service-test-utils/bun';
+import { waitFor } from '@vers/test-utils';
+
+const SERVE_PROVIDER_PATH = path.resolve(import.meta.dirname, 'serve-provider.ts');
+const REPLAY_DIR = path.resolve(import.meta.dirname, '..');
+let nextPort = 41_100;
+
+/**
+ * Starts the real `serve-provider.ts` entrypoint in a subprocess on only base env plus
+ * `SIM_ENGINE_HASH` — no `DATABASE_URL`, `KEYS_SERVICE_URL`, or `SERVICE_AUTH_PRIVATE_KEY` — the
+ * exact env a per-version provider machine boots on, and the regression this entrypoint exists to
+ * fix: the in-process test client shares this suite's full ambient env, which would mask a missing
+ * env-wiring bug this real process cannot. Kills the subprocess once the calling test finishes.
+ */
+async function startProviderProcess(): Promise<string> {
+  const keyPair = await getTestServiceKeyPair();
+
+  const port = nextPort;
+
+  nextPort += 1;
+
+  const url = `http://127.0.0.1:${port}`;
+
+  const proc = Bun.spawn([process.execPath, SERVE_PROVIDER_PATH], {
+    cwd: REPLAY_DIR,
+    env: {
+      PORT: String(port),
+      SERVICE_AUTH_JWKS: keyPair.jwksJSON,
+      SIM_ENGINE_HASH: 'test-engine-hash',
+    },
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+
+  onTestFinished(() => {
+    proc.kill();
+  });
+
+  await waitFor(
+    async () => {
+      const response = await fetch(`${url}/health`);
+
+      if (!response.ok) {
+        throw new Error(`provider health check returned ${String(response.status)}`);
+      }
+    },
+    { timeoutMs: 5000 },
+  );
+
+  return url;
+}
+
+/**
+ * Sends a signed RPC call to a booted provider process over the network — a real socket round
+ * trip, not the in-process `app.handle` test client.
+ */
+function sendRPC(url: string, procedure: string, token: string, input: unknown): Promise<Response> {
+  return fetch(`${url}/rpc/${procedure}`, {
+    body: JSON.stringify({ json: input }),
+    headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+    method: 'POST',
+  });
+}
+
+test('it serves /health with no database, keys service, or signing key configured', async () => {
+  const url = await startProviderProcess();
+  const response = await fetch(`${url}/health`);
+  const body = await response.json();
+
+  expect(response.status).toBe(200);
+  expect(body).toStrictEqual({ service: 'service-replay-provider', status: 'ok' });
+});
+
+test('it round-trips an authed replaySegment call', async () => {
+  const url = await startProviderProcess();
+  const keyPair = await getTestServiceKeyPair();
+
+  const token = await createServiceToken({
+    audience: 'service-replay-provider',
+    privateKey: keyPair.privateKey,
+  });
+
+  const input = createMockReplaySegmentInput({ simVersion: 'test-engine-hash' });
+
+  const response = await sendRPC(url, 'replaySegment', token, input);
+  const body = await response.json();
+
+  expect(response.status).toBe(200);
+  expect(body).toMatchObject({ json: { elapsed: input.duration } });
+});
+
+test('it rejects a stamp that does not match the baked engine hash with SIM_VERSION_MISMATCH', async () => {
+  const url = await startProviderProcess();
+  const keyPair = await getTestServiceKeyPair();
+
+  const token = await createServiceToken({
+    audience: 'service-replay-provider',
+    privateKey: keyPair.privateKey,
+  });
+
+  const input = createMockReplaySegmentInput({ simVersion: 'some-other-engine-hash' });
+
+  const response = await sendRPC(url, 'replaySegment', token, input);
+  const body = await response.json();
+
+  expect(response.status).toBe(409);
+
+  expect(body).toMatchObject({
+    json: { code: 'SIM_VERSION_MISMATCH', data: { providerSimVersion: 'test-engine-hash' } },
+  });
+});
+
+test('it 404s on /rpc/wake — a provider serves no drain route', async () => {
+  const url = await startProviderProcess();
+  const keyPair = await getTestServiceKeyPair();
+
+  const token = await createServiceToken({
+    audience: 'service-replay-provider',
+    privateKey: keyPair.privateKey,
+  });
+
+  const response = await sendRPC(url, 'wake', token, {});
+
+  expect(response.status).toBe(404);
+});

--- a/services/replay/src/serve-provider.ts
+++ b/services/replay/src/serve-provider.ts
@@ -1,0 +1,55 @@
+import { flushErrorReports, reportUnexpectedError } from '@vers/service-runtime';
+import { withTraceContext } from '@vers/service-utils';
+import { createTraceContext } from '@vers/trace';
+import { createReplayProvider } from './create-replay-provider';
+import { getBakedEngineHash } from './get-baked-engine-hash';
+
+// Env validation reads the process env object dynamically, which a compile-time define never
+// rewrites — the baked hash must be seeded back into the environment before the service boots.
+const bakedEngineHash = getBakedEngineHash();
+const engineHashKey = 'SIM_ENGINE_HASH';
+
+if (bakedEngineHash !== undefined) {
+  process.env[engineHashKey] = bakedEngineHash;
+}
+
+const service = await createReplayProvider();
+
+service.listen();
+
+process.on('SIGTERM', () => {
+  void handleSIGTERM();
+});
+
+async function handleSIGTERM(): Promise<void> {
+  // the try/catch lives inside the trace scope so a shutdown report still carries its trace id
+  await withTraceContext(createTraceContext(), async () => {
+    try {
+      await stopGracefully();
+    } catch (error) {
+      service.logger.error({ err: error }, 'graceful shutdown failed');
+
+      reportUnexpectedError(error);
+
+      const flushed = await flushErrorReports();
+
+      if (!flushed) {
+        service.logger.warn('error reports were still queued when the flush timed out');
+      }
+
+      process.exit(1);
+    }
+  });
+}
+
+/**
+ * Stops accepting HTTP, then flushes telemetry while the process is still alive. Each step runs
+ * even if an earlier one rejects, so a failure never strands telemetry timers live.
+ */
+async function stopGracefully(): Promise<void> {
+  try {
+    await service.app.stop();
+  } finally {
+    await service.stopTelemetry();
+  }
+}


### PR DESCRIPTION
## Description

Closes #773

Adds a provider-mode entrypoint to `services/replay` that serves only `replaySegment` on a narrowed env, and fixes the deploy tooling that provisions its per-version machines.

- New `provider-env-shape.ts`, `build-provider-router.ts`, `create-replay-provider.ts`, `serve-provider.ts` boot the provider service with no database, worker, or signing-key deps
- Dockerfile now compiles a second `provider` binary; the fleet's `CMD` stays `server`
- `simVersionProvider` is now `{ region }` instead of `boolean`, so `deploy.ts`'s reconcile gate actually runs and a provider machine launches into the right Fly region
- `read-provider-app-state.ts` parses the real machine id and image digest instead of `z.unknown()`
- `plan-sim-version-actions.ts` adds a replace-provider-machine action when a running machine's digest drifts from the fleet's resolved digest, and tightens the no-op short-circuit to require a digest match
- `apply-sim-version-actions.ts` runs the provider machine with `--region` and a `provider` command replacing the image's `CMD`, and destroys+relaunches on replace

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality

## Context

_None._
