### PR TITLE
fix(#774): park cross-version replay when the provider is unavailable

### DIFF
--- a/docs/architecture/platform/observability.md
+++ b/docs/architecture/platform/observability.md
@@ -164,6 +164,9 @@ timestamp to the moment the drain confirms it.
 - `version-park` — unknown or retention-expired sim version, a version-registry problem needing
   fleet action.
 - `elapsed-time` — replay duration cap tripped, a per-stream anomaly.
+- `provider-unavailable` — a cross-version dispatch's provider timed out, refused the connection, or
+  answered with an undefined error; repeated occurrences distinguish a dead provider deploy from
+  normal cold-boot latency.
 
 Each recording's log line carries the raw numbers behind it (heads, checkpoint counts, sim version).
 

--- a/services/replay/src/dispatch/run-replay-segment.test.ts
+++ b/services/replay/src/dispatch/run-replay-segment.test.ts
@@ -4,11 +4,9 @@ import { createMockReplaySegmentInput } from '@vers/contract-replay/test-utils';
 import { buildStateFromSeed } from '@vers/game-utils';
 import { createTestDB, getTestServiceKeyPair } from '@vers/service-test-utils/bun';
 import { createSimVersionRow } from '@vers/sim-registry/test-utils';
-import { updateEnv } from '@vers/test-utils/bun';
 import { http, passthrough } from 'msw';
-import { createReplayService } from '../create-replay-service';
-import type { ReplayService } from '../create-replay-service';
 import { server } from '../mocks/server';
+import { createRemoteReplayProvider } from '../test-utils/create-remote-replay-provider';
 import { runReplaySegment } from './run-replay-segment';
 
 const DETERMINISTIC_INPUT = createMockReplaySegmentInput({
@@ -165,30 +163,6 @@ async function setupTest() {
   };
 }
 
-/**
- * Boots a second replay instance baked with a different engine hash, listening on an ephemeral
- * port, so a remote dispatch has a real provider to round-trip against.
- */
-async function setupRemoteProvider(
-  engineHash: string,
-): Promise<{ provider: ReplayService; url: string }> {
-  updateEnv('SIM_ENGINE_HASH', engineHash);
-
-  const provider = await createReplayService();
-
-  provider.listen(0);
-
-  onTestFinished(() => provider.app.stop());
-
-  const port = provider.app.server?.port;
-
-  if (port === undefined) {
-    throw new Error('provider service did not bind a port');
-  }
-
-  return { provider, url: `http://localhost:${port}` };
-}
-
 test('it replays in-process when the job matches this deploy’s baked hash', async () => {
   await using ctx = await setupTest();
 
@@ -253,7 +227,7 @@ test('it reports expired for a registry row past its retention deadline', async 
 test('it round-trips a remote dispatch over real HTTP with real s2s auth', async () => {
   await using ctx = await setupTest();
 
-  const remote = await setupRemoteProvider(DETERMINISTIC_INPUT.simVersion);
+  const remote = await createRemoteReplayProvider(DETERMINISTIC_INPUT.simVersion);
 
   await createSimVersionRow(ctx.db, {
     engineHash: DETERMINISTIC_INPUT.simVersion,
@@ -275,7 +249,7 @@ test('it round-trips a remote dispatch over real HTTP with real s2s auth', async
 test('it attaches a traceparent to a remote dispatch', async () => {
   await using ctx = await setupTest();
 
-  const remote = await setupRemoteProvider(DETERMINISTIC_INPUT.simVersion);
+  const remote = await createRemoteReplayProvider(DETERMINISTIC_INPUT.simVersion);
 
   await createSimVersionRow(ctx.db, {
     engineHash: DETERMINISTIC_INPUT.simVersion,
@@ -308,10 +282,97 @@ test('it attaches a traceparent to a remote dispatch', async () => {
   expect(observedTraceparent).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-01$/u);
 });
 
+test('it reports providerUnavailable when the provider never responds', async () => {
+  await using ctx = await setupTest();
+
+  const providerServer = Bun.serve({
+    // Never resolves on its own; settles only once the client's own abort reaches the server, so
+    // `stop(true)` in teardown doesn't hang waiting on a handler stuck forever.
+    fetch: (request) =>
+      new Promise<Response>((resolve) => {
+        request.signal.addEventListener('abort', () => {
+          resolve(new Response(null, { status: 499 }));
+        });
+      }),
+    port: 0,
+  });
+
+  onTestFinished(async () => {
+    await providerServer.stop(true);
+  });
+
+  const job = createMockReplaySegmentInput({ simVersion: 'hung-provider-hash' });
+
+  await createSimVersionRow(ctx.db, {
+    engineHash: job.simVersion,
+    providerUrl: `http://localhost:${providerServer.port}`,
+    status: 'active',
+  });
+
+  const outcome = await runReplaySegment(
+    {
+      db: ctx.db,
+      privateKey: ctx.privateKey,
+      simVersion: 'this-dispatcher-hash',
+      timeoutMs: 50,
+    },
+    job,
+  );
+
+  expect(outcome).toStrictEqual({ kind: 'providerUnavailable' });
+});
+
+test('it reports providerUnavailable when the provider connection is refused', async () => {
+  await using ctx = await setupTest();
+
+  const job = createMockReplaySegmentInput({ simVersion: 'unreachable-provider-hash' });
+
+  await createSimVersionRow(ctx.db, {
+    engineHash: job.simVersion,
+    providerUrl: 'http://127.0.0.1:1',
+    status: 'active',
+  });
+
+  const outcome = await runReplaySegment(
+    { db: ctx.db, privateKey: ctx.privateKey, simVersion: 'this-dispatcher-hash' },
+    job,
+  );
+
+  expect(outcome).toStrictEqual({ kind: 'providerUnavailable' });
+});
+
+test('it reports providerUnavailable when the provider answers with a proxy-style 5xx', async () => {
+  await using ctx = await setupTest();
+
+  const providerServer = Bun.serve({
+    fetch: () => new Response('<html><body>502 Bad Gateway</body></html>', { status: 503 }),
+    port: 0,
+  });
+
+  onTestFinished(async () => {
+    await providerServer.stop(true);
+  });
+
+  const job = createMockReplaySegmentInput({ simVersion: 'half-booted-provider-hash' });
+
+  await createSimVersionRow(ctx.db, {
+    engineHash: job.simVersion,
+    providerUrl: `http://localhost:${providerServer.port}`,
+    status: 'active',
+  });
+
+  const outcome = await runReplaySegment(
+    { db: ctx.db, privateKey: ctx.privateKey, simVersion: 'this-dispatcher-hash' },
+    job,
+  );
+
+  expect(outcome).toStrictEqual({ kind: 'providerUnavailable' });
+});
+
 test('it lets a SIM_VERSION_MISMATCH from a resolved provider throw as a misroute', async () => {
   await using ctx = await setupTest();
 
-  const remote = await setupRemoteProvider('providers-actual-hash');
+  const remote = await createRemoteReplayProvider('providers-actual-hash');
 
   const job = createMockReplaySegmentInput({ simVersion: 'stamped-hash-the-provider-disowns' });
 

--- a/services/replay/src/dispatch/run-replay-segment.ts
+++ b/services/replay/src/dispatch/run-replay-segment.ts
@@ -14,15 +14,6 @@ import type { CryptoKey } from 'jose';
 import type { Kysely } from 'kysely';
 import { runReplaySimulation } from '../handlers/run-replay-simulation';
 
-/**
- * Bounds one provider dispatch, so a provider stuck mid-boot fails the call rather than holding
- * the caller's claim transaction forever. Applied fresh to each of the two dispatches a
- * cross-version segment can make (initial replay, fresh confirm) rather than a shared deadline
- * across both — worst case, a claim transaction that dispatches twice holds the lock for roughly
- * twice this bound.
- */
-const DEFAULT_PROVIDER_DISPATCH_TIMEOUT_MS = 15_000;
-
 export interface RunReplaySegmentDeps {
   readonly db: Kysely<DB>;
 
@@ -35,7 +26,7 @@ export interface RunReplaySegmentDeps {
   readonly simVersion: string;
 
   /**
-   * Overrides `DEFAULT_PROVIDER_DISPATCH_TIMEOUT_MS` for a remote provider dispatch.
+   * Bounds one remote provider dispatch, so tests can wait far less than production's default.
    */
   readonly timeoutMs?: number;
 }
@@ -87,6 +78,15 @@ export async function runReplaySegment(
     return { kind: 'providerUnavailable' };
   }
 }
+
+/**
+ * Bounds one provider dispatch, so a provider stuck mid-boot fails the call rather than holding
+ * the caller's claim transaction forever. Applied fresh to each of the two dispatches a
+ * cross-version segment can make (initial replay, fresh confirm) rather than a shared deadline
+ * across both — worst case, a claim transaction that dispatches twice holds the lock for roughly
+ * twice this bound.
+ */
+const DEFAULT_PROVIDER_DISPATCH_TIMEOUT_MS = 15_000;
 
 /**
  * Calls the registered provider's own `replaySegment` endpoint, minting a short-lived s2s token

--- a/services/replay/src/dispatch/run-replay-segment.ts
+++ b/services/replay/src/dispatch/run-replay-segment.ts
@@ -1,4 +1,4 @@
-import { createORPCClient } from '@orpc/client';
+import { createORPCClient, isDefinedError } from '@orpc/client';
 import { RPCLink } from '@orpc/client/fetch';
 import type { ContractRouterClient } from '@orpc/contract';
 import type {
@@ -14,6 +14,15 @@ import type { CryptoKey } from 'jose';
 import type { Kysely } from 'kysely';
 import { runReplaySimulation } from '../handlers/run-replay-simulation';
 
+/**
+ * Bounds one provider dispatch, so a provider stuck mid-boot fails the call rather than holding
+ * the caller's claim transaction forever. Applied fresh to each of the two dispatches a
+ * cross-version segment can make (initial replay, fresh confirm) rather than a shared deadline
+ * across both — worst case, a claim transaction that dispatches twice holds the lock for roughly
+ * twice this bound.
+ */
+const DEFAULT_PROVIDER_DISPATCH_TIMEOUT_MS = 15_000;
+
 export interface RunReplaySegmentDeps {
   readonly db: Kysely<DB>;
 
@@ -24,20 +33,28 @@ export interface RunReplaySegmentDeps {
   readonly privateKey: CryptoKey;
 
   readonly simVersion: string;
+
+  /**
+   * Overrides `DEFAULT_PROVIDER_DISPATCH_TIMEOUT_MS` for a remote provider dispatch.
+   */
+  readonly timeoutMs?: number;
 }
 
 export type RunReplaySegmentOutcome =
   | { readonly kind: 'expired' }
+  | { readonly kind: 'providerUnavailable' }
   | { readonly kind: 'replayed'; readonly output: ReplaySegmentOutput }
   | { readonly kind: 'unknownVersion' };
 
 /**
  * Routes one replay job to wherever its stamped `simVersion` can run: in-process when it matches
  * this deploy's own baked engine hash, or a remote call to the registry's provider otherwise.
- * `unknownVersion` (no registry row — a newer or unrecognized stamp) and `expired` (past retention)
- * are operational outcomes for the caller to act on — parking the activity or forcing a resync —
- * never thrown. A `SIM_VERSION_MISMATCH` rejection from a resolved provider means dispatch routed
- * to the wrong deploy; that is a bug, not an operational outcome, and is left to throw.
+ * `unknownVersion` (no registry row — a newer or unrecognized stamp), `expired` (past retention),
+ * and `providerUnavailable` (the remote dispatch timed out, couldn't connect, or the provider
+ * answered with an undefined error such as a proxy 5xx) are operational outcomes for the caller to
+ * act on — parking the activity or forcing a resync — never thrown. A `SIM_VERSION_MISMATCH`
+ * rejection from a resolved provider means dispatch routed to the wrong deploy; that is a bug, not
+ * an operational outcome, and is left to throw.
  */
 export async function runReplaySegment(
   deps: Readonly<RunReplaySegmentDeps>,
@@ -58,15 +75,24 @@ export async function runReplaySegment(
     return { kind: 'expired' };
   }
 
-  return {
-    kind: 'replayed',
-    output: await sendProviderReplaySegment(deps, version.providerUrl, job),
-  };
+  try {
+    const output = await sendProviderReplaySegment(deps, version.providerUrl, job);
+
+    return { kind: 'replayed', output };
+  } catch (error) {
+    if (isDefinedError(error)) {
+      throw error;
+    }
+
+    return { kind: 'providerUnavailable' };
+  }
 }
 
 /**
  * Calls the registered provider's own `replaySegment` endpoint, minting a short-lived s2s token
- * scoped to the replay audience.
+ * scoped to the replay audience. A defined contract error (a genuine misroute) and an undefined
+ * one (timeout, connection failure, or a proxy answering for a provider that isn't up yet) both
+ * reach the caller as a thrown error — the caller distinguishes them.
  */
 async function sendProviderReplaySegment(
   deps: Readonly<RunReplaySegmentDeps>,
@@ -88,5 +114,7 @@ async function sendProviderReplaySegment(
     }),
   );
 
-  return client.replaySegment(job);
+  return client.replaySegment(job, {
+    signal: AbortSignal.timeout(deps.timeoutMs ?? DEFAULT_PROVIDER_DISPATCH_TIMEOUT_MS),
+  });
 }

--- a/services/replay/src/metrics/record-rejection.test.ts
+++ b/services/replay/src/metrics/record-rejection.test.ts
@@ -33,6 +33,7 @@ test('it counts adjudications by reason', async () => {
   recordRejection('integrity-mismatch');
   recordRejection('version-park');
   recordRejection('elapsed-time');
+  recordRejection('provider-unavailable');
 
   await ctx.provider.forceFlush();
 
@@ -51,6 +52,7 @@ test('it counts adjudications by reason', async () => {
     { reason: 'integrity-mismatch', value: 2 },
     { reason: 'version-park', value: 1 },
     { reason: 'elapsed-time', value: 1 },
+    { reason: 'provider-unavailable', value: 1 },
   ]);
 });
 

--- a/services/replay/src/metrics/record-rejection.ts
+++ b/services/replay/src/metrics/record-rejection.ts
@@ -1,14 +1,20 @@
 import { metrics } from '@opentelemetry/api';
 
-export type RejectionReason = 'elapsed-time' | 'integrity-mismatch' | 'version-park';
+export type RejectionReason =
+  | 'elapsed-time'
+  | 'integrity-mismatch'
+  | 'provider-unavailable'
+  | 'version-park';
 
 /**
  * Counts one adjudication that refused or held a stream, split by reason: `integrity-mismatch`
  * covers confirmed divergence and seed validation, `version-park` covers version-registry holds
- * (unknown or retention-expired sim versions), and `elapsed-time` covers duration-cap trips. The
- * counter is resolved through the global metrics API on every call — the SDK returns the same
- * instrument for an identical registration, and resolving late keeps the counter bound to
- * whichever meter provider the process registered at boot; without one it is the API's no-op.
+ * (unknown or retention-expired sim versions), `elapsed-time` covers duration-cap trips, and
+ * `provider-unavailable` covers a cross-version dispatch whose provider timed out, refused the
+ * connection, or answered with an undefined error. The counter is resolved through the global
+ * metrics API on every call — the SDK returns the same instrument for an identical registration,
+ * and resolving late keeps the counter bound to whichever meter provider the process registered at
+ * boot; without one it is the API's no-op.
  */
 export function recordRejection(reason: RejectionReason): void {
   const counter = metrics

--- a/services/replay/src/test-utils/create-remote-replay-provider.ts
+++ b/services/replay/src/test-utils/create-remote-replay-provider.ts
@@ -23,7 +23,11 @@ export async function createRemoteReplayProvider(
 
   provider.listen(0);
 
-  onTestFinished(() => provider.app.stop());
+  onTestFinished(async () => {
+    await provider.app.stop();
+    await provider.stopTelemetry();
+    await provider.stopDB();
+  });
 
   const port = provider.app.server?.port;
 

--- a/services/replay/src/test-utils/create-remote-replay-provider.ts
+++ b/services/replay/src/test-utils/create-remote-replay-provider.ts
@@ -1,0 +1,33 @@
+import { onTestFinished } from 'bun:test';
+import { updateEnv } from '@vers/test-utils/bun';
+import invariant from 'tiny-invariant';
+import { createReplayService } from '../create-replay-service';
+import type { ReplayService } from '../create-replay-service';
+
+interface RemoteReplayProvider {
+  readonly provider: ReplayService;
+  readonly url: string;
+}
+
+/**
+ * Boots a second replay instance baked with a given engine hash, listening on an ephemeral port,
+ * so a cross-version dispatch test has a real provider to round-trip against; stopped via
+ * `onTestFinished`.
+ */
+export async function createRemoteReplayProvider(
+  engineHash: string,
+): Promise<RemoteReplayProvider> {
+  updateEnv('SIM_ENGINE_HASH', engineHash);
+
+  const provider = await createReplayService();
+
+  provider.listen(0);
+
+  onTestFinished(() => provider.app.stop());
+
+  const port = provider.app.server?.port;
+
+  invariant(port !== undefined, 'provider service did not bind a port');
+
+  return { provider, url: `http://localhost:${port}` };
+}

--- a/services/replay/src/worker/run-frontier.ts
+++ b/services/replay/src/worker/run-frontier.ts
@@ -9,6 +9,7 @@ import { parkActivity } from '../dispatch/park-activity';
 import { runReplaySegment } from '../dispatch/run-replay-segment';
 import { recordIterationFailure } from '../metrics/record-iteration-failure';
 import { recordRejection } from '../metrics/record-rejection';
+import type { RejectionReason } from '../metrics/record-rejection';
 import { recordVerificationLag } from '../metrics/record-verification-lag';
 import { rollRewardItems } from '../mint/roll-reward-items';
 import { updateReplayAttempts } from '../queue/update-replay-attempts';
@@ -386,7 +387,7 @@ async function parkFrontier(
   // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- a mutable cache handle whose remove/get/set are its whole point; no readonly form is useful
   cache: ReplayCache,
   segment: Readonly<ReplaySegment>,
-  reason: 'durationCapExceeded' | 'expired' | 'unknownVersion',
+  reason: 'durationCapExceeded' | 'expired' | 'providerUnavailable' | 'unknownVersion',
 ): Promise<ReplayIterationOutcome> {
   const message = pickParkMessage(reason);
 
@@ -403,9 +404,7 @@ async function parkFrontier(
     message,
   );
 
-  const rejectionReason = reason === 'durationCapExceeded' ? 'elapsed-time' : 'version-park';
-
-  recordRejection(rejectionReason);
+  recordRejection(pickParkRejectionReason(reason));
 
   await parkActivity(trx, segment.activity.id);
 
@@ -414,7 +413,9 @@ async function parkFrontier(
   return { kind: 'parked', reason };
 }
 
-function pickParkMessage(reason: 'durationCapExceeded' | 'expired' | 'unknownVersion'): string {
+function pickParkMessage(
+  reason: 'durationCapExceeded' | 'expired' | 'providerUnavailable' | 'unknownVersion',
+): string {
   if (reason === 'expired') {
     return 'sim version retention expired; parking activity for operator resolution';
   }
@@ -423,7 +424,25 @@ function pickParkMessage(reason: 'durationCapExceeded' | 'expired' | 'unknownVer
     return 'sim version unrecognized; parking activity';
   }
 
+  if (reason === 'providerUnavailable') {
+    return 'sim version provider unavailable; parking activity until the registry sweep retries it';
+  }
+
   return 'replay duration cap exhausted before the expected checkpoint count; parking activity for operator resolution';
+}
+
+function pickParkRejectionReason(
+  reason: 'durationCapExceeded' | 'expired' | 'providerUnavailable' | 'unknownVersion',
+): RejectionReason {
+  if (reason === 'durationCapExceeded') {
+    return 'elapsed-time';
+  }
+
+  if (reason === 'providerUnavailable') {
+    return 'provider-unavailable';
+  }
+
+  return 'version-park';
 }
 
 function buildFreshDriver(segment: Readonly<ReplaySegment>): SimulationDriver {

--- a/services/replay/src/worker/run-replay-iteration.test.ts
+++ b/services/replay/src/worker/run-replay-iteration.test.ts
@@ -17,6 +17,7 @@ import { MAX_REPLAY_ATTEMPTS } from '../queue/update-replay-attempts';
 import { createReplayCache } from '../replay/create-replay-cache';
 import { createActivityRow } from '../test-utils/create-activity-row';
 import { createHonestActivityFixture } from '../test-utils/create-honest-activity-fixture';
+import { createRemoteReplayProvider } from '../test-utils/create-remote-replay-provider';
 import { runReplayIteration } from './run-replay-iteration';
 
 /**
@@ -669,6 +670,51 @@ test('it parks rather than rejects when the duration cap trips before the expect
   expect(updated.status).toBe('parked');
 });
 
+test('it parks an activity without incrementing its attempt count when the provider is unavailable', async () => {
+  await using ctx = await setupTest();
+
+  const fixture = await createHonestActivityFixture(ctx.db, {
+    duration: 80_000,
+    seed: buildStateFromSeed(3_047_525_658),
+  });
+
+  await ctx.db
+    .updateTable('activities')
+    .set({ simVersion: 'unreachable-provider-hash' })
+    .where('id', '=', fixture.activity.id)
+    .execute();
+
+  await createSimVersionRow(ctx.db, {
+    engineHash: 'unreachable-provider-hash',
+    providerUrl: 'http://127.0.0.1:1',
+    retainedUntil: new Date(Date.now() + 86_400_000),
+    status: 'active',
+  });
+
+  const deps = {
+    db: ctx.db,
+    keysServiceURL: resolveServiceURL('keys'),
+    logger: buildSilentLogger(),
+    privateKey: ctx.privateKey,
+    simVersion: 'test-engine-hash',
+  };
+
+  const cache = createReplayCache();
+
+  const outcome = await runReplayIteration(deps, cache);
+
+  expect(outcome).toStrictEqual({ kind: 'parked', reason: 'providerUnavailable' });
+
+  const updated = await ctx.db
+    .selectFrom('activities')
+    .select(['replayAttempts', 'status'])
+    .where('id', '=', fixture.activity.id)
+    .executeTakeFirstOrThrow();
+
+  expect(updated.status).toBe('parked');
+  expect(updated.replayAttempts).toBe(0);
+});
+
 test('it evicts and rebuilds from Started when the cached driver no longer matches the loaded segment', async () => {
   await using ctx = await setupTest();
 
@@ -742,15 +788,17 @@ test('it counts a replay error as a failed attempt and quarantines at the attemp
     seed: buildStateFromSeed(3_047_525_658),
   });
 
+  const remote = await createRemoteReplayProvider('providers-actual-hash');
+
   await ctx.db
     .updateTable('activities')
-    .set({ simVersion: 'unreachable-provider-hash' })
+    .set({ simVersion: 'stamped-hash-the-provider-disowns' })
     .where('id', '=', fixture.activity.id)
     .execute();
 
   await createSimVersionRow(ctx.db, {
-    engineHash: 'unreachable-provider-hash',
-    providerUrl: 'http://127.0.0.1:1',
+    engineHash: 'stamped-hash-the-provider-disowns',
+    providerUrl: remote.url,
     retainedUntil: new Date(Date.now() + 86_400_000),
     status: 'active',
   });
@@ -793,15 +841,17 @@ test('it reports an iteration failure exactly once when a frontier was claimed',
     seed: buildStateFromSeed(3_047_525_658),
   });
 
+  const remote = await createRemoteReplayProvider('providers-actual-hash');
+
   await ctx.db
     .updateTable('activities')
-    .set({ simVersion: 'unreachable-provider-hash' })
+    .set({ simVersion: 'stamped-hash-the-provider-disowns' })
     .where('id', '=', fixture.activity.id)
     .execute();
 
   await createSimVersionRow(ctx.db, {
-    engineHash: 'unreachable-provider-hash',
-    providerUrl: 'http://127.0.0.1:1',
+    engineHash: 'stamped-hash-the-provider-disowns',
+    providerUrl: remote.url,
     retainedUntil: new Date(Date.now() + 86_400_000),
     status: 'active',
   });

--- a/services/replay/src/worker/types.ts
+++ b/services/replay/src/worker/types.ts
@@ -32,7 +32,7 @@ export type ReplayIterationOutcome =
     }
   | {
       readonly kind: 'parked';
-      readonly reason: 'durationCapExceeded' | 'expired' | 'unknownVersion';
+      readonly reason: 'durationCapExceeded' | 'expired' | 'providerUnavailable' | 'unknownVersion';
     }
   | { readonly kind: 'quarantined' }
   | { readonly kind: 'rejected' }


### PR DESCRIPTION
## Description

Closes #774

A cross-version provider dispatch that hangs, refuses the connection, or answers with an undefined error (e.g. a proxy 5xx) now parks the replay frontier instead of hanging the claim transaction or feeding attempt-counter quarantine.

- `runReplaySegment` bounds each remote dispatch with a 15s default (`timeoutMs` override for tests), applied fresh per dispatch rather than shared across a segment's two calls
- classifies the failure via `isDefinedError`: a defined `SIM_VERSION_MISMATCH` still rethrows as a misroute bug; everything else resolves to a new `providerUnavailable` outcome
- `run-frontier` parks on `providerUnavailable` with its own operator message and a new `provider-unavailable` rejection reason, via a `pickParkRejectionReason` lookup replacing the old two-way ternary
- `recordRejection`'s `RejectionReason` and the observability registry doc gain the fourth reason

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality

New coverage: a never-responding provider (real `Bun.serve`, short `timeoutMs`), a refused connection, and a proxy-style 503 all assert `providerUnavailable`; a park test asserts the frontier outcome and unchanged `replayAttempts`; the quarantine/report tests that previously rode the connection-refused throw path now exercise a genuine `SIM_VERSION_MISMATCH` rethrow via a second replay service baked with a mismatched engine hash. `setupRemoteProvider` is promoted to a shared `create-remote-replay-provider.ts` test util.
