### PR TITLE
fix: issue the honeypot valid-from timestamp from the server

### DIFF
--- a/apps/web/src/lib/auth/check-honeypot.test.ts
+++ b/apps/web/src/lib/auth/check-honeypot.test.ts
@@ -91,6 +91,52 @@ test('it logs a timing spam flag with its reason outside test mode', () => {
   );
 });
 
+test('it distinguishes an absent valid-from field from a too-early submission', () => {
+  const warnSpy = spyOn(logger, 'warn');
+  const previousNodeEnv = process.env.NODE_ENV;
+
+  onTestFinished(() => {
+    if (previousNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = previousNodeEnv;
+    }
+  });
+
+  process.env.NODE_ENV = 'production';
+
+  expect(() => {
+    checkHoneypot(new FormData());
+  }).toThrow();
+
+  expect(warnSpy).toHaveBeenCalledExactlyOnceWith(
+    { reason: 'missing-valid-from' },
+    'form submission flagged as spam',
+  );
+});
+
+test('it passes a submission whose valid-from timestamp has already elapsed outside test mode', () => {
+  const formData = new FormData();
+
+  formData.set(HONEYPOT_VALID_FROM_FIELD_NAME, String(Date.now() - 60_000));
+
+  const previousNodeEnv = process.env.NODE_ENV;
+
+  onTestFinished(() => {
+    if (previousNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = previousNodeEnv;
+    }
+  });
+
+  process.env.NODE_ENV = 'production';
+
+  expect(() => {
+    checkHoneypot(formData);
+  }).not.toThrow();
+});
+
 test('it flags a submission arriving before its form-render valid-from timestamp outside test mode', () => {
   const formData = new FormData();
 

--- a/apps/web/src/lib/auth/check-honeypot.test.ts
+++ b/apps/web/src/lib/auth/check-honeypot.test.ts
@@ -1,4 +1,5 @@
-import { expect, onTestFinished, spyOn, test } from 'bun:test';
+import { expect, spyOn, test } from 'bun:test';
+import { updateEnv } from '@vers/test-utils/bun';
 import { logger } from '../../server/logger';
 import { checkHoneypot } from './check-honeypot';
 import { HONEYPOT_FIELD_NAME, HONEYPOT_VALID_FROM_FIELD_NAME } from './honeypot-field-names';
@@ -45,21 +46,11 @@ test('it flags a submission whose valid-from field is an empty string outside te
 
   formData.set(HONEYPOT_VALID_FROM_FIELD_NAME, '');
 
-  const previousNodeEnv = process.env.NODE_ENV;
+  updateEnv('NODE_ENV', 'production');
 
-  process.env.NODE_ENV = 'production';
-
-  try {
-    expect(() => {
-      checkHoneypot(formData);
-    }).toThrowWithMessage(Error, 'Form not submitted properly');
-  } finally {
-    if (previousNodeEnv === undefined) {
-      delete process.env.NODE_ENV;
-    } else {
-      process.env.NODE_ENV = previousNodeEnv;
-    }
-  }
+  expect(() => {
+    checkHoneypot(formData);
+  }).toThrowWithMessage(Error, 'Form not submitted properly');
 });
 
 test('it logs a timing spam flag with its reason outside test mode', () => {
@@ -69,17 +60,7 @@ test('it logs a timing spam flag with its reason outside test mode', () => {
 
   formData.set(HONEYPOT_VALID_FROM_FIELD_NAME, String(Date.now() + 60_000));
 
-  const previousNodeEnv = process.env.NODE_ENV;
-
-  onTestFinished(() => {
-    if (previousNodeEnv === undefined) {
-      delete process.env.NODE_ENV;
-    } else {
-      process.env.NODE_ENV = previousNodeEnv;
-    }
-  });
-
-  process.env.NODE_ENV = 'production';
+  updateEnv('NODE_ENV', 'production');
 
   expect(() => {
     checkHoneypot(formData);
@@ -93,17 +74,8 @@ test('it logs a timing spam flag with its reason outside test mode', () => {
 
 test('it distinguishes an absent valid-from field from a too-early submission', () => {
   const warnSpy = spyOn(logger, 'warn');
-  const previousNodeEnv = process.env.NODE_ENV;
 
-  onTestFinished(() => {
-    if (previousNodeEnv === undefined) {
-      delete process.env.NODE_ENV;
-    } else {
-      process.env.NODE_ENV = previousNodeEnv;
-    }
-  });
-
-  process.env.NODE_ENV = 'production';
+  updateEnv('NODE_ENV', 'production');
 
   expect(() => {
     checkHoneypot(new FormData());
@@ -120,17 +92,7 @@ test('it passes a submission whose valid-from timestamp has already elapsed outs
 
   formData.set(HONEYPOT_VALID_FROM_FIELD_NAME, String(Date.now() - 60_000));
 
-  const previousNodeEnv = process.env.NODE_ENV;
-
-  onTestFinished(() => {
-    if (previousNodeEnv === undefined) {
-      delete process.env.NODE_ENV;
-    } else {
-      process.env.NODE_ENV = previousNodeEnv;
-    }
-  });
-
-  process.env.NODE_ENV = 'production';
+  updateEnv('NODE_ENV', 'production');
 
   expect(() => {
     checkHoneypot(formData);
@@ -142,19 +104,9 @@ test('it flags a submission arriving before its form-render valid-from timestamp
 
   formData.set(HONEYPOT_VALID_FROM_FIELD_NAME, String(Date.now() + 60_000));
 
-  const previousNodeEnv = process.env.NODE_ENV;
+  updateEnv('NODE_ENV', 'production');
 
-  process.env.NODE_ENV = 'production';
-
-  try {
-    expect(() => {
-      checkHoneypot(formData);
-    }).toThrowWithMessage(Error, 'Form not submitted properly');
-  } finally {
-    if (previousNodeEnv === undefined) {
-      delete process.env.NODE_ENV;
-    } else {
-      process.env.NODE_ENV = previousNodeEnv;
-    }
-  }
+  expect(() => {
+    checkHoneypot(formData);
+  }).toThrowWithMessage(Error, 'Form not submitted properly');
 });

--- a/apps/web/src/lib/auth/check-honeypot.ts
+++ b/apps/web/src/lib/auth/check-honeypot.ts
@@ -23,7 +23,12 @@ export function checkHoneypot(formData: FormData): void {
   const validFrom = formData.get(HONEYPOT_VALID_FROM_FIELD_NAME);
   const validFromMs = typeof validFrom === 'string' ? Number(validFrom) : Number.NaN;
 
-  if (!Number.isFinite(validFromMs) || validFromMs <= 0 || Date.now() < validFromMs) {
+  if (!Number.isFinite(validFromMs) || validFromMs <= 0) {
+    logger.warn({ reason: 'missing-valid-from' }, 'form submission flagged as spam');
+    throw new SpamError('Form not submitted properly');
+  }
+
+  if (Date.now() < validFromMs) {
     logger.warn({ reason: 'timing' }, 'form submission flagged as spam');
     throw new SpamError('Form not submitted properly');
   }

--- a/apps/web/src/lib/auth/get-honeypot-valid-from.ts
+++ b/apps/web/src/lib/auth/get-honeypot-valid-from.ts
@@ -1,0 +1,13 @@
+import { createServerFn } from '@tanstack/react-start';
+import { buildHoneypotValidFrom } from './build-honeypot-valid-from';
+
+/**
+ * Issues a form's `valid-from` timestamp from the server, so the value a route ships and the value
+ * the submission check compares it against are read from the same clock. Routes call this in their
+ * loader and pass the result down as loader data: computing it while rendering would let hydration
+ * recompute it against the browser's clock, and a caller whose device clock runs ahead of the
+ * server would then be rejected as a bot on every auth form.
+ */
+export const getHoneypotValidFrom = createServerFn({ method: 'GET' }).handler(() =>
+  buildHoneypotValidFrom(),
+);

--- a/apps/web/src/lib/auth/honeypot-inputs.test.tsx
+++ b/apps/web/src/lib/auth/honeypot-inputs.test.tsx
@@ -1,0 +1,34 @@
+import { expect, test } from 'bun:test';
+import invariant from 'tiny-invariant';
+import { render } from '../../test-utils/render';
+import { HoneypotInputs } from './honeypot-inputs';
+
+test('it carries the given valid-from timestamp verbatim', () => {
+  const rendered = render(<HoneypotInputs validFrom="1700000000000" />);
+  const validFrom = rendered.container.querySelector('input[name="from__confirm"]');
+
+  invariant(validFrom, 'expected the valid-from field to render');
+
+  expect(validFrom).toHaveValue('1700000000000');
+});
+
+test('it re-renders without restamping the valid-from timestamp', () => {
+  const rendered = render(<HoneypotInputs validFrom="1700000000000" />);
+
+  rendered.refresh();
+
+  const validFrom = rendered.container.querySelector('input[name="from__confirm"]');
+
+  invariant(validFrom, 'expected the valid-from field to render');
+
+  expect(validFrom).toHaveValue('1700000000000');
+});
+
+test('it renders the honeypot field empty', () => {
+  const rendered = render(<HoneypotInputs validFrom="1700000000000" />);
+  const honeypot = rendered.container.querySelector('input[name="name__confirm"]');
+
+  invariant(honeypot, 'expected the honeypot field to render');
+
+  expect(honeypot).toHaveValue('');
+});

--- a/apps/web/src/lib/auth/honeypot-inputs.tsx
+++ b/apps/web/src/lib/auth/honeypot-inputs.tsx
@@ -1,12 +1,20 @@
-import { buildHoneypotValidFrom } from './build-honeypot-valid-from';
 import { HONEYPOT_FIELD_NAME, HONEYPOT_VALID_FROM_FIELD_NAME } from './honeypot-field-names';
 
+interface HoneypotInputsProps {
+  /**
+   * Epoch-ms timestamp the submission must arrive after. Callers pass a server-issued value from
+   * loader data rather than computing one here: a value built while rendering is rebuilt again
+   * during hydration, against the browser's clock instead of the server's.
+   */
+  readonly validFrom: string;
+}
+
 /**
- * Renders a form-bearing route's hidden anti-spam fields. Server-rendered, so `valid-from` reads
- * the serving time — a submission arriving before that moment, or with the honeypot field
- * non-empty, is treated as spam by the server-side check these fields feed.
+ * Renders a form-bearing route's hidden anti-spam fields. A submission arriving before `validFrom`,
+ * or carrying a non-empty honeypot field, is treated as spam by the server-side check these fields
+ * feed.
  */
-export function HoneypotInputs() {
+export function HoneypotInputs(props: Readonly<HoneypotInputsProps>) {
   return (
     <div aria-hidden="true" style={{ display: 'none' }}>
       <label htmlFor={HONEYPOT_FIELD_NAME}>Please leave this field blank</label>
@@ -17,7 +25,7 @@ export function HoneypotInputs() {
         tabIndex={-1}
         type="text"
       />
-      <input name={HONEYPOT_VALID_FROM_FIELD_NAME} type="hidden" value={buildHoneypotValidFrom()} />
+      <input name={HONEYPOT_VALID_FROM_FIELD_NAME} type="hidden" value={props.validFrom} />
     </div>
   );
 }

--- a/apps/web/src/routes/-forgot-password/forgot-password-form.test.tsx
+++ b/apps/web/src/routes/-forgot-password/forgot-password-form.test.tsx
@@ -14,6 +14,7 @@ test('it shows the error for the email field', async () => {
   await withRequestContext({}, async () => {
     renderWithRouter(
       <ForgotPasswordForm
+        honeypotValidFrom="1700000000000"
         lastResult={{ error: { email: ['Email is invalid'] }, status: 'error' }}
       />,
     );
@@ -28,7 +29,9 @@ test('it shows a generic failure message when the server rejects the submission'
   const user = userEvent.setup();
 
   await withRequestContext({}, async () => {
-    renderWithRouter(<ForgotPasswordForm action={rejectWithResponse} />);
+    renderWithRouter(
+      <ForgotPasswordForm action={rejectWithResponse} honeypotValidFrom="1700000000000" />,
+    );
 
     const emailInput = await screen.findByLabelText('Email');
 
@@ -49,7 +52,7 @@ test('it disables the submit button while the request is pending', async () => {
   const gatedAction = mock(() => deferred.promise);
 
   await withRequestContext({}, async () => {
-    renderWithRouter(<ForgotPasswordForm action={gatedAction} />);
+    renderWithRouter(<ForgotPasswordForm action={gatedAction} honeypotValidFrom="1700000000000" />);
 
     const emailInput = await screen.findByLabelText('Email');
 

--- a/apps/web/src/routes/-forgot-password/forgot-password-form.tsx
+++ b/apps/web/src/routes/-forgot-password/forgot-password-form.tsx
@@ -13,6 +13,7 @@ import { ForgotPasswordFormSchema } from './forgot-password-form-schema';
 
 interface ForgotPasswordFormProps {
   readonly action?: FormAction;
+  readonly honeypotValidFrom: string;
   readonly lastResult?: SubmissionResult;
 }
 
@@ -45,7 +46,7 @@ export function ForgotPasswordForm(props: ForgotPasswordFormProps) {
         <Text>No worries, we&apos;ll send you reset instructions to your email address.</Text>
       </section>
       <form {...getFormProps(form)} className={formStyles} method="post">
-        <HoneypotInputs />
+        <HoneypotInputs validFrom={props.honeypotValidFrom} />
         <Field
           errors={fields.email.errors ?? []}
           inputProps={{

--- a/apps/web/src/routes/-login/login-form.test.tsx
+++ b/apps/web/src/routes/-login/login-form.test.tsx
@@ -13,7 +13,10 @@ function rejectWithResponse(): Promise<Response> {
 test('it shows a form-level error message', async () => {
   await withRequestContext({}, async () => {
     renderWithRouter(
-      <LoginForm lastResult={{ error: { '': ['Invalid email or password'] }, status: 'error' }} />,
+      <LoginForm
+        honeypotValidFrom="1700000000000"
+        lastResult={{ error: { '': ['Invalid email or password'] }, status: 'error' }}
+      />,
     );
 
     const alert = await screen.findByRole('alert');
@@ -26,6 +29,7 @@ test('it shows the error for each invalid field', async () => {
   await withRequestContext({}, async () => {
     renderWithRouter(
       <LoginForm
+        honeypotValidFrom="1700000000000"
         lastResult={{
           error: { email: ['Email is invalid'], password: ['Password must be 8+ characters'] },
           status: 'error',
@@ -44,7 +48,7 @@ test('it shows a generic failure message when the server rejects the submission'
   const user = userEvent.setup();
 
   await withRequestContext({}, async () => {
-    renderWithRouter(<LoginForm action={rejectWithResponse} />);
+    renderWithRouter(<LoginForm action={rejectWithResponse} honeypotValidFrom="1700000000000" />);
 
     const emailInput = await screen.findByLabelText('Email');
 
@@ -66,7 +70,7 @@ test('it disables the submit button while the login request is pending', async (
   const gatedAction = mock(() => deferred.promise);
 
   await withRequestContext({}, async () => {
-    renderWithRouter(<LoginForm action={gatedAction} />);
+    renderWithRouter(<LoginForm action={gatedAction} honeypotValidFrom="1700000000000" />);
 
     const emailInput = await screen.findByLabelText('Email');
 
@@ -84,7 +88,7 @@ test('it disables the submit button while the login request is pending', async (
 
 test('it links to signup and forgot password', async () => {
   await withRequestContext({}, async () => {
-    renderWithRouter(<LoginForm />);
+    renderWithRouter(<LoginForm honeypotValidFrom="1700000000000" />);
 
     const signupLink = await screen.findByRole('link', { name: 'Create an account' });
 
@@ -99,7 +103,7 @@ test('it links to signup and forgot password', async () => {
 
 test('it renders the redirect target as a hidden field', async () => {
   await withRequestContext({}, async () => {
-    renderWithRouter(<LoginForm redirectTo="/nexus" />);
+    renderWithRouter(<LoginForm honeypotValidFrom="1700000000000" redirectTo="/nexus" />);
 
     const hiddenInput = await waitFor(() => {
       const input = document.querySelector<HTMLInputElement>('input[name="redirectTo"]');
@@ -117,7 +121,7 @@ test('it renders the redirect target as a hidden field', async () => {
 
 test('it declares a POST submit so a pre-hydration fallback never puts credentials in the URL', async () => {
   await withRequestContext({}, async () => {
-    renderWithRouter(<LoginForm />);
+    renderWithRouter(<LoginForm honeypotValidFrom="1700000000000" />);
 
     const form = await waitFor(() => {
       const element = document.querySelector('form');

--- a/apps/web/src/routes/-login/login-form.tsx
+++ b/apps/web/src/routes/-login/login-form.tsx
@@ -13,6 +13,7 @@ import { LoginFormSchema } from './login-form-schema';
 
 interface LoginFormProps {
   readonly action?: FormAction;
+  readonly honeypotValidFrom: string;
   readonly lastResult?: SubmissionResult;
   readonly redirectTo?: string | undefined;
 }
@@ -65,7 +66,7 @@ export function LoginForm(props: LoginFormProps) {
         <Text>Please enter your details to login</Text>
       </section>
       <form {...getFormProps(form)} className={formStyles} method="post">
-        <HoneypotInputs />
+        <HoneypotInputs validFrom={props.honeypotValidFrom} />
         <Field
           errors={fields.email.errors ?? []}
           inputProps={{

--- a/apps/web/src/routes/-onboarding/onboarding-form.test.tsx
+++ b/apps/web/src/routes/-onboarding/onboarding-form.test.tsx
@@ -14,7 +14,7 @@ test('it renders every field the account-creation form collects', async () => {
   await withRequestContext(
     { cookies: { en_verification: { 'onboarding#email': 'onboarding-form@vers.test' } } },
     async () => {
-      renderWithRouter(<OnboardingForm />);
+      renderWithRouter(<OnboardingForm honeypotValidFrom="1700000000000" />);
 
       const usernameField = await screen.findByLabelText('Username');
 
@@ -34,6 +34,7 @@ test('it shows the error for the username field', async () => {
     async () => {
       renderWithRouter(
         <OnboardingForm
+          honeypotValidFrom="1700000000000"
           lastResult={{
             error: { username: ['A user with that username already exists'] },
             status: 'error',
@@ -54,6 +55,7 @@ test('it shows the error for the confirm-password field', async () => {
     async () => {
       renderWithRouter(
         <OnboardingForm
+          honeypotValidFrom="1700000000000"
           lastResult={{ error: { confirmPassword: ['The passwords must match'] }, status: 'error' }}
         />,
       );
@@ -71,7 +73,9 @@ test('it shows a generic failure message when the server rejects the submission'
   await withRequestContext(
     { cookies: { en_verification: { 'onboarding#email': 'onboarding-form-honeypot@vers.test' } } },
     async () => {
-      renderWithRouter(<OnboardingForm action={rejectWithResponse} />);
+      renderWithRouter(
+        <OnboardingForm action={rejectWithResponse} honeypotValidFrom="1700000000000" />,
+      );
 
       const usernameField = await screen.findByLabelText('Username');
 
@@ -99,7 +103,7 @@ test('it disables the submit button while the account-creation request is pendin
   await withRequestContext(
     { cookies: { en_verification: { 'onboarding#email': 'onboarding-form-pending@vers.test' } } },
     async () => {
-      renderWithRouter(<OnboardingForm action={gatedAction} />);
+      renderWithRouter(<OnboardingForm action={gatedAction} honeypotValidFrom="1700000000000" />);
 
       const usernameField = await screen.findByLabelText('Username');
 

--- a/apps/web/src/routes/-onboarding/onboarding-form.tsx
+++ b/apps/web/src/routes/-onboarding/onboarding-form.tsx
@@ -14,6 +14,7 @@ import { OnboardingFormSchema } from './onboarding-form-schema';
 
 interface OnboardingFormProps {
   readonly action?: FormAction;
+  readonly honeypotValidFrom: string;
   readonly lastResult?: SubmissionResult;
 }
 
@@ -77,7 +78,7 @@ export function OnboardingForm(props: OnboardingFormProps) {
         <Text>Please enter your details to create an account</Text>
       </section>
       <form {...getFormProps(form)} className={formStyles} method="post">
-        <HoneypotInputs />
+        <HoneypotInputs validFrom={props.honeypotValidFrom} />
         <Field
           errors={fields.username.errors ?? []}
           inputProps={{

--- a/apps/web/src/routes/-reset-password/reset-password-form.test.tsx
+++ b/apps/web/src/routes/-reset-password/reset-password-form.test.tsx
@@ -12,7 +12,13 @@ function rejectWithResponse(): Promise<Response> {
 
 test('it renders the hidden email and reset-token fields', async () => {
   await withRequestContext({}, async () => {
-    renderWithRouter(<ResetPasswordForm email="reset-form@vers.test" resetToken="a-token" />);
+    renderWithRouter(
+      <ResetPasswordForm
+        email="reset-form@vers.test"
+        honeypotValidFrom="1700000000000"
+        resetToken="a-token"
+      />,
+    );
 
     const emailField = await waitFor(() => {
       const field = document.querySelector<HTMLInputElement>('input[name="email"]');
@@ -37,6 +43,7 @@ test('it shows a form-level error message', async () => {
     renderWithRouter(
       <ResetPasswordForm
         email="reset-form@vers.test"
+        honeypotValidFrom="1700000000000"
         lastResult={{
           error: { '': ['This reset link is invalid or has expired.'] },
           status: 'error',
@@ -56,6 +63,7 @@ test('it shows the error for the confirm-password field', async () => {
     renderWithRouter(
       <ResetPasswordForm
         email="reset-form@vers.test"
+        honeypotValidFrom="1700000000000"
         lastResult={{ error: { confirmPassword: ['The passwords must match'] }, status: 'error' }}
         resetToken="a-token"
       />,
@@ -75,6 +83,7 @@ test('it shows a generic failure message when the server rejects the submission'
       <ResetPasswordForm
         action={rejectWithResponse}
         email="reset-form-honeypot@vers.test"
+        honeypotValidFrom="1700000000000"
         resetToken="tok"
       />,
     );
@@ -103,6 +112,7 @@ test('it disables the submit button while the reset request is pending', async (
       <ResetPasswordForm
         action={gatedAction}
         email="reset-form-pending@vers.test"
+        honeypotValidFrom="1700000000000"
         resetToken="tok"
       />,
     );

--- a/apps/web/src/routes/-reset-password/reset-password-form.tsx
+++ b/apps/web/src/routes/-reset-password/reset-password-form.tsx
@@ -14,6 +14,7 @@ import { ResetPasswordFormSchema } from './reset-password-form-schema';
 interface ResetPasswordFormProps {
   readonly action?: FormAction;
   readonly email: string;
+  readonly honeypotValidFrom: string;
   readonly lastResult?: SubmissionResult;
   readonly resetToken: string;
 }
@@ -63,7 +64,7 @@ export function ResetPasswordForm(props: ResetPasswordFormProps) {
         <Text>Please enter your new password</Text>
       </section>
       <form {...getFormProps(form)} className={formStyles} method="post">
-        <HoneypotInputs />
+        <HoneypotInputs validFrom={props.honeypotValidFrom} />
         <input name="email" type="hidden" value={props.email} />
         <input name="resetToken" type="hidden" value={props.resetToken} />
         <Field

--- a/apps/web/src/routes/-signup/signup-form.test.tsx
+++ b/apps/web/src/routes/-signup/signup-form.test.tsx
@@ -13,7 +13,10 @@ function rejectWithResponse(): Promise<Response> {
 test('it shows the error for the email field', async () => {
   await withRequestContext({}, async () => {
     renderWithRouter(
-      <SignupForm lastResult={{ error: { email: ['Email is invalid'] }, status: 'error' }} />,
+      <SignupForm
+        honeypotValidFrom="1700000000000"
+        lastResult={{ error: { email: ['Email is invalid'] }, status: 'error' }}
+      />,
     );
 
     const emailError = await screen.findByText('Email is invalid');
@@ -26,7 +29,7 @@ test('it shows a generic failure message when the server rejects the submission'
   const user = userEvent.setup();
 
   await withRequestContext({}, async () => {
-    renderWithRouter(<SignupForm action={rejectWithResponse} />);
+    renderWithRouter(<SignupForm action={rejectWithResponse} honeypotValidFrom="1700000000000" />);
 
     const emailInput = await screen.findByLabelText('Email');
 
@@ -47,7 +50,7 @@ test('it disables the submit button while the signup request is pending', async 
   const gatedAction = mock(() => deferred.promise);
 
   await withRequestContext({}, async () => {
-    renderWithRouter(<SignupForm action={gatedAction} />);
+    renderWithRouter(<SignupForm action={gatedAction} honeypotValidFrom="1700000000000" />);
 
     const emailInput = await screen.findByLabelText('Email');
 

--- a/apps/web/src/routes/-signup/signup-form.tsx
+++ b/apps/web/src/routes/-signup/signup-form.tsx
@@ -14,6 +14,7 @@ import { SignupFormSchema } from './signup-form-schema';
 
 interface SignupFormProps {
   readonly action?: FormAction;
+  readonly honeypotValidFrom: string;
   readonly lastResult?: SubmissionResult;
 }
 
@@ -60,7 +61,7 @@ export function SignupForm(props: SignupFormProps) {
         <Text>Please enter your details to create an account</Text>
       </section>
       <form {...getFormProps(form)} className={formStyles} method="post">
-        <HoneypotInputs />
+        <HoneypotInputs validFrom={props.honeypotValidFrom} />
         <Field
           errors={fields.email.errors ?? []}
           inputProps={{

--- a/apps/web/src/routes/-verify-otp/verify-otp-form.test.tsx
+++ b/apps/web/src/routes/-verify-otp/verify-otp-form.test.tsx
@@ -14,7 +14,9 @@ function rejectWithResponse(): Promise<Response> {
 
 test('it shows the 2FA heading and instructions for a login verification', async () => {
   await withRequestContext({}, async () => {
-    renderWithRouter(<VerifyOTPForm target="user_1" type="2fa" />);
+    renderWithRouter(
+      <VerifyOTPForm honeypotValidFrom="1700000000000" target="user_1" type="2fa" />,
+    );
 
     const heading = await screen.findByText('Two-factor authentication');
 
@@ -28,7 +30,13 @@ test('it shows the 2FA heading and instructions for a login verification', async
 
 test('it shows the check-your-email heading and instructions for onboarding', async () => {
   await withRequestContext({}, async () => {
-    renderWithRouter(<VerifyOTPForm target="new-user@vers.test" type="onboarding" />);
+    renderWithRouter(
+      <VerifyOTPForm
+        honeypotValidFrom="1700000000000"
+        target="new-user@vers.test"
+        type="onboarding"
+      />,
+    );
 
     const heading = await screen.findByText('Check your email');
 
@@ -46,6 +54,7 @@ test('it shows a form-level error on the code field', async () => {
   await withRequestContext({}, async () => {
     renderWithRouter(
       <VerifyOTPForm
+        honeypotValidFrom="1700000000000"
         lastResult={{ error: { '': ['Invalid or expired code'] }, status: 'error' }}
         target="user_1"
         type="2fa"
@@ -62,7 +71,14 @@ test('it shows a generic failure message for a rejected submission', async () =>
   const user = userEvent.setup();
 
   await withRequestContext({}, async () => {
-    renderWithRouter(<VerifyOTPForm action={rejectWithResponse} target="user_1" type="2fa" />);
+    renderWithRouter(
+      <VerifyOTPForm
+        action={rejectWithResponse}
+        honeypotValidFrom="1700000000000"
+        target="user_1"
+        type="2fa"
+      />,
+    );
 
     const otpInput = await screen.findByTestId('otp-input');
 
@@ -82,7 +98,14 @@ test('it disables the submit button while the verify request is pending', async 
   const gatedAction = mock(() => deferred.promise);
 
   await withRequestContext({}, async () => {
-    renderWithRouter(<VerifyOTPForm action={gatedAction} target="user_1" type="2fa" />);
+    renderWithRouter(
+      <VerifyOTPForm
+        action={gatedAction}
+        honeypotValidFrom="1700000000000"
+        target="user_1"
+        type="2fa"
+      />,
+    );
 
     const otpInput = await screen.findByTestId('otp-input');
 
@@ -103,7 +126,13 @@ test('it pre-fills the OTP field from the code prop', async () => {
     const action = mock<FormAction>(() => Promise.resolve(undefined));
 
     renderWithRouter(
-      <VerifyOTPForm action={action} code="TMMPD7" target="new-user@vers.test" type="onboarding" />,
+      <VerifyOTPForm
+        action={action}
+        code="TMMPD7"
+        honeypotValidFrom="1700000000000"
+        target="new-user@vers.test"
+        type="onboarding"
+      />,
     );
 
     await screen.findByTestId('otp-input');
@@ -117,7 +146,13 @@ test('it auto-submits once when a valid code arrives with the emailed link', asy
     const action = mock<FormAction>(() => Promise.resolve(undefined));
 
     renderWithRouter(
-      <VerifyOTPForm action={action} code="TMMPD7" target="new-user@vers.test" type="onboarding" />,
+      <VerifyOTPForm
+        action={action}
+        code="TMMPD7"
+        honeypotValidFrom="1700000000000"
+        target="new-user@vers.test"
+        type="onboarding"
+      />,
     );
 
     await waitFor(() => {
@@ -137,7 +172,13 @@ test('it auto-submits a rejected code only once instead of looping', async () =>
     const action = mock<FormAction>(() => Promise.resolve(new Response(null, { status: 400 })));
 
     renderWithRouter(
-      <VerifyOTPForm action={action} code="TMMPD7" target="new-user@vers.test" type="onboarding" />,
+      <VerifyOTPForm
+        action={action}
+        code="TMMPD7"
+        honeypotValidFrom="1700000000000"
+        target="new-user@vers.test"
+        type="onboarding"
+      />,
     );
 
     await waitFor(() => {
@@ -152,7 +193,14 @@ test('it does not auto-submit when the link carries no code', async () => {
   await withRequestContext({}, async () => {
     const action = mock<FormAction>(() => Promise.resolve(undefined));
 
-    renderWithRouter(<VerifyOTPForm action={action} target="user_1" type="2fa" />);
+    renderWithRouter(
+      <VerifyOTPForm
+        action={action}
+        honeypotValidFrom="1700000000000"
+        target="user_1"
+        type="2fa"
+      />,
+    );
 
     await screen.findByTestId('otp-input');
 
@@ -165,7 +213,13 @@ test('it pre-fills without auto-submitting when the code is the wrong length', a
     const action = mock<FormAction>(() => Promise.resolve(undefined));
 
     renderWithRouter(
-      <VerifyOTPForm action={action} code="ABC" target="new-user@vers.test" type="onboarding" />,
+      <VerifyOTPForm
+        action={action}
+        code="ABC"
+        honeypotValidFrom="1700000000000"
+        target="new-user@vers.test"
+        type="onboarding"
+      />,
     );
 
     await screen.findByTestId('otp-input');

--- a/apps/web/src/routes/-verify-otp/verify-otp-form.tsx
+++ b/apps/web/src/routes/-verify-otp/verify-otp-form.tsx
@@ -16,6 +16,7 @@ import { VerifyOTPFormSchema } from './verify-otp-form-schema';
 interface VerifyOTPFormProps {
   readonly action?: FormAction;
   readonly code?: string | undefined;
+  readonly honeypotValidFrom: string;
   readonly lastResult?: SubmissionResult;
   readonly redirectTo?: string | undefined;
   readonly target: string;
@@ -120,7 +121,7 @@ export function VerifyOTPForm(props: VerifyOTPFormProps) {
         <Text>{INSTRUCTION_BY_TYPE[props.type]}</Text>
       </section>
       <form {...getFormProps(form)} className={formStyles} method="post" ref={formRef}>
-        <HoneypotInputs />
+        <HoneypotInputs validFrom={props.honeypotValidFrom} />
         <OTPField
           className={otpField}
           errors={codeErrors}

--- a/apps/web/src/routes/forgot-password.tsx
+++ b/apps/web/src/routes/forgot-password.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
 import { AuthLayout } from '../components/auth-layout';
+import { getHoneypotValidFrom } from '../lib/auth/get-honeypot-valid-from';
 import { requireAnonymous } from '../lib/auth/require-anonymous';
 import { ForgotPasswordForm } from './-forgot-password/forgot-password-form';
 
@@ -9,13 +10,19 @@ const requireAnonymousFn = createServerFn({ method: 'GET' }).handler(() => requi
 export const Route = createFileRoute('/forgot-password')({
   component: ForgotPasswordPage,
   head: () => ({ meta: [{ title: 'vers | Forgot Password' }] }),
-  loader: () => requireAnonymousFn(),
+  loader: async () => {
+    await requireAnonymousFn();
+
+    return { honeypotValidFrom: await getHoneypotValidFrom() };
+  },
 });
 
 function ForgotPasswordPage() {
+  const loaderData = Route.useLoaderData();
+
   return (
     <AuthLayout>
-      <ForgotPasswordForm />
+      <ForgotPasswordForm honeypotValidFrom={loaderData.honeypotValidFrom} />
     </AuthLayout>
   );
 }

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
 import { AuthLayout } from '../components/auth-layout';
+import { getHoneypotValidFrom } from '../lib/auth/get-honeypot-valid-from';
 import { requireAnonymous } from '../lib/auth/require-anonymous';
 import { LoginForm } from './-login/login-form';
 import { LoginSearchSchema } from './-login/login-search-schema';
@@ -10,16 +11,21 @@ const requireAnonymousFn = createServerFn({ method: 'GET' }).handler(() => requi
 export const Route = createFileRoute('/login')({
   component: LoginPage,
   head: () => ({ meta: [{ title: 'vers | Login' }] }),
-  loader: () => requireAnonymousFn(),
+  loader: async () => {
+    await requireAnonymousFn();
+
+    return { honeypotValidFrom: await getHoneypotValidFrom() };
+  },
   validateSearch: (search) => LoginSearchSchema.parse(search),
 });
 
 function LoginPage() {
+  const loaderData = Route.useLoaderData();
   const search = Route.useSearch();
 
   return (
     <AuthLayout>
-      <LoginForm redirectTo={search.redirect} />
+      <LoginForm honeypotValidFrom={loaderData.honeypotValidFrom} redirectTo={search.redirect} />
     </AuthLayout>
   );
 }

--- a/apps/web/src/routes/onboarding.tsx
+++ b/apps/web/src/routes/onboarding.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
 import { AuthLayout } from '../components/auth-layout';
+import { getHoneypotValidFrom } from '../lib/auth/get-honeypot-valid-from';
 import { OnboardingForm } from './-onboarding/onboarding-form';
 import { requireOnboardingSession } from './-onboarding/require-onboarding-session';
 
@@ -11,13 +12,19 @@ const requireOnboardingSessionFn = createServerFn({ method: 'GET' }).handler(() 
 export const Route = createFileRoute('/onboarding')({
   component: OnboardingPage,
   head: () => ({ meta: [{ title: 'vers | Onboarding' }] }),
-  loader: () => requireOnboardingSessionFn(),
+  loader: async () => {
+    await requireOnboardingSessionFn();
+
+    return { honeypotValidFrom: await getHoneypotValidFrom() };
+  },
 });
 
 function OnboardingPage() {
+  const loaderData = Route.useLoaderData();
+
   return (
     <AuthLayout>
-      <OnboardingForm />
+      <OnboardingForm honeypotValidFrom={loaderData.honeypotValidFrom} />
     </AuthLayout>
   );
 }

--- a/apps/web/src/routes/reset-password.tsx
+++ b/apps/web/src/routes/reset-password.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
 import * as z from 'zod';
 import { AuthLayout } from '../components/auth-layout';
+import { getHoneypotValidFrom } from '../lib/auth/get-honeypot-valid-from';
 import { requireResetPasswordAccess } from './-reset-password/require-reset-password-access';
 import { ResetPasswordForm } from './-reset-password/reset-password-form';
 
@@ -17,7 +18,11 @@ const ResetPasswordSearchSchema = z.object({
 export const Route = createFileRoute('/reset-password')({
   component: ResetPasswordPage,
   head: () => ({ meta: [{ title: 'vers | Reset Password' }] }),
-  loader: (opts) => requireResetPasswordAccessFn({ data: opts.location.search }),
+  loader: async (opts) => {
+    const access = await requireResetPasswordAccessFn({ data: opts.location.search });
+
+    return { ...access, honeypotValidFrom: await getHoneypotValidFrom() };
+  },
   validateSearch: (search) => ResetPasswordSearchSchema.parse(search),
 });
 
@@ -26,7 +31,11 @@ function ResetPasswordPage() {
 
   return (
     <AuthLayout>
-      <ResetPasswordForm email={loaderData.email} resetToken={loaderData.resetToken} />
+      <ResetPasswordForm
+        email={loaderData.email}
+        honeypotValidFrom={loaderData.honeypotValidFrom}
+        resetToken={loaderData.resetToken}
+      />
     </AuthLayout>
   );
 }

--- a/apps/web/src/routes/signup.tsx
+++ b/apps/web/src/routes/signup.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
 import { AuthLayout } from '../components/auth-layout';
+import { getHoneypotValidFrom } from '../lib/auth/get-honeypot-valid-from';
 import { requireAnonymous } from '../lib/auth/require-anonymous';
 import { SignupForm } from './-signup/signup-form';
 
@@ -9,13 +10,19 @@ const requireAnonymousFn = createServerFn({ method: 'GET' }).handler(() => requi
 export const Route = createFileRoute('/signup')({
   component: SignupPage,
   head: () => ({ meta: [{ title: 'vers | Signup' }] }),
-  loader: () => requireAnonymousFn(),
+  loader: async () => {
+    await requireAnonymousFn();
+
+    return { honeypotValidFrom: await getHoneypotValidFrom() };
+  },
 });
 
 function SignupPage() {
+  const loaderData = Route.useLoaderData();
+
   return (
     <AuthLayout>
-      <SignupForm />
+      <SignupForm honeypotValidFrom={loaderData.honeypotValidFrom} />
     </AuthLayout>
   );
 }

--- a/apps/web/src/routes/verify-otp.tsx
+++ b/apps/web/src/routes/verify-otp.tsx
@@ -1,23 +1,27 @@
 import { createFileRoute, redirect } from '@tanstack/react-router';
 import { VerificationTypeSchema } from '@vers/contract-verification';
 import { AuthLayout } from '../components/auth-layout';
+import { getHoneypotValidFrom } from '../lib/auth/get-honeypot-valid-from';
 import { VerifyOTPForm } from './-verify-otp/verify-otp-form';
 import { VerifyOTPSearchSchema } from './-verify-otp/verify-otp-search-schema';
 
 export const Route = createFileRoute('/verify-otp')({
   component: VerifyOTPPage,
   head: () => ({ meta: [{ title: 'vers | Verify OTP' }] }),
-  loader: (opts) => {
+  loader: async (opts) => {
     const search = VerifyOTPSearchSchema.parse(opts.location.search);
 
     if (!VerificationTypeSchema.safeParse(search.type).success) {
       throw redirect({ href: '/' });
     }
+
+    return { honeypotValidFrom: await getHoneypotValidFrom() };
   },
   validateSearch: (search) => VerifyOTPSearchSchema.parse(search),
 });
 
 function VerifyOTPPage() {
+  const loaderData = Route.useLoaderData();
   const search = Route.useSearch();
   const type = VerificationTypeSchema.parse(search.type);
 
@@ -25,6 +29,7 @@ function VerifyOTPPage() {
     <AuthLayout>
       <VerifyOTPForm
         code={search.code}
+        honeypotValidFrom={loaderData.honeypotValidFrom}
         redirectTo={search.redirect}
         target={search.target ?? ''}
         type={type}

--- a/apps/web/test-setup.ts
+++ b/apps/web/test-setup.ts
@@ -1,9 +1,13 @@
 import '@zgeoff/bun-test-extended';
-import { afterEach, expect, mock } from 'bun:test';
+import { afterEach, expect } from 'bun:test';
 import { faker } from '@faker-js/faker';
 import * as jestDOMMatchers from '@testing-library/jest-dom/matchers';
 import { registerZustandReset } from '@vers/client-test-utils';
-import { registerHappyDOM, registerMSWLifecycle } from '@vers/test-utils/bun';
+import {
+  registerBunTestCleanup,
+  registerHappyDOM,
+  registerMSWLifecycle,
+} from '@vers/test-utils/bun';
 import { server } from './src/mocks/node';
 import { registerAvatarViewerMock } from './src/test-utils/register-avatar-viewer-mock';
 import { registerGameCanvasMock } from './src/test-utils/register-game-canvas-mock';
@@ -53,7 +57,4 @@ registerWorldMapNodeCodexSlotMock();
 const reactTestingLibrary = await import('@testing-library/react');
 
 afterEach(reactTestingLibrary.cleanup);
-
-afterEach(() => {
-  mock.restore();
-});
+registerBunTestCleanup();


### PR DESCRIPTION
## Description

Closes #779

`HoneypotInputs` built its valid-from stamp with `Date.now()` in the render body, so React recomputed it during hydration against the browser's clock while `checkHoneypot` compared it against the server's. Any caller whose device clock ran ahead of the server was rejected as a bot on every auth form until the skew elapsed — including password recovery.

- Routes issue the stamp through a server function and pass it as loader data, so one clock authors and checks it and hydration reuses the serialized string.
- Verified against a browser clock 60s ahead: the stamp landed 60063ms in the server's future before, and stays server-authored after.
- Splits the missing-or-unparseable valid-from case out of the timing rejection, so a dropped field no longer reports as a timing flag.
- The field stays unsigned, so the pacing gate is still spoofable by a bot that rewrites it — worth a follow-up, but out of scope for the outage.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality