### PR TITLE
fix: park a stopped or capped activity, not just an active one

### DIFF
--- a/docs/architecture/platform/deployment.md
+++ b/docs/architecture/platform/deployment.md
@@ -265,7 +265,8 @@ is harmless — dispatch already reports it `expired` — while an app destroyed
 would leave an `active` row pointing at nothing. The sweep finishes by unparking every activity
 whose stamped hash the registry now carries as `active`, so an activity parked while its version was
 unregistered becomes replayable again once a later deploy provisions it, without waiting on the
-client to resync.
+client to resync. Each one returns to the status it parked from — a run that had already stopped or
+capped resumes as itself, never as an appendable `active` row.
 
 The sweep is idempotent: a repeat run tombstones nothing already `pruned`, destroys nothing already
 gone, and unparks nothing already `active`.

--- a/libs/data/db/migrations/1784715446972_activities_parked_from.ts
+++ b/libs/data/db/migrations/1784715446972_activities_parked_from.ts
@@ -1,0 +1,18 @@
+import type { Kysely } from 'kysely';
+import { sql } from 'kysely';
+
+/**
+ * Adds the nullable `parked_from` column to `activities` — the status a row held when it parked,
+ * so the unpark sweep restores that status rather than assuming `active`. Null on a row parked
+ * before this column existed, which only `active` rows could reach.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable('activities')
+    .addColumn('parked_from', sql`activity_status`)
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.alterTable('activities').dropColumn('parked_from').execute();
+}

--- a/libs/data/db/src/schema.generated.ts
+++ b/libs/data/db/src/schema.generated.ts
@@ -47,6 +47,7 @@ export interface Activities {
   id: string;
   keyVersion: Generated<number>;
   lastHash: string;
+  parkedFrom: ActivityStatus | null;
   replayAttempts: Generated<number>;
   scopeId: string;
   scopeType: string;

--- a/scripts/src/deploy/update-parked-activities.test.ts
+++ b/scripts/src/deploy/update-parked-activities.test.ts
@@ -55,6 +55,51 @@ test('it reactivates a parked activity whose stamped sim version is now active',
   expect(row.status).toBe('active');
 });
 
+test('it returns a parked activity to the status it parked from', async () => {
+  await using ctx = await setupTest();
+
+  const activeVersion = await createSimVersionRow(ctx.db, { status: 'active' });
+  const user = await createTestUser(ctx.db);
+
+  const avatar = await ctx.db
+    .insertInto('avatars')
+    .values({ id: 'avatar_restored', name: 'avatar-restored', userId: user.user.id })
+    .returningAll()
+    .executeTakeFirstOrThrow();
+
+  const activity = await ctx.db
+    .insertInto('activities')
+    .values({
+      avatarId: avatar.id,
+      buildSnapshot: { level: 1, xp: 0 },
+      contentVersion: '0.0.0-dev',
+      encounterNode: { difficulty: 1 },
+      id: 'act_restored',
+      lastHash: 'hash_last',
+      parkedFrom: 'stopped',
+      scopeId: 'node_1',
+      scopeType: 'world_map_node',
+      seed: 'seed_1',
+      simVersion: activeVersion.engineHash,
+      startHash: 'hash_start',
+      status: 'parked',
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
+
+  const reactivated = await updateParkedActivities(ctx.db);
+
+  expect(reactivated).toStrictEqual([{ id: activity.id }]);
+
+  const row = await ctx.db
+    .selectFrom('activities')
+    .select(['parkedFrom', 'status'])
+    .where('id', '=', activity.id)
+    .executeTakeFirstOrThrow();
+
+  expect(row).toStrictEqual({ parkedFrom: null, status: 'stopped' });
+});
+
 test('it leaves a parked activity untouched when no sim version is active for its hash', async () => {
   await using ctx = await setupTest();
 

--- a/scripts/src/deploy/update-parked-activities.test.ts
+++ b/scripts/src/deploy/update-parked-activities.test.ts
@@ -48,11 +48,11 @@ test('it reactivates a parked activity whose stamped sim version is now active',
 
   const row = await ctx.db
     .selectFrom('activities')
-    .select('status')
+    .select(['parkedFrom', 'status'])
     .where('id', '=', activity.id)
     .executeTakeFirstOrThrow();
 
-  expect(row.status).toBe('active');
+  expect(row).toStrictEqual({ parkedFrom: null, status: 'active' });
 });
 
 test('it returns a parked activity to the status it parked from', async () => {

--- a/scripts/src/deploy/update-parked-activities.ts
+++ b/scripts/src/deploy/update-parked-activities.ts
@@ -1,17 +1,24 @@
-import type { Activities, DB } from '@vers/db';
+import type { Activities, ActivityStatus, DB } from '@vers/db';
 import type { Kysely, Selectable } from 'kysely';
+import { sql } from 'kysely';
 
 /**
  * Unparks every activity parked for an unstamped sim version whose hash the registry now carries
  * as `active`, in a single statement — the same sweep run's tombstone update already excludes the
- * current version and any row it just pruned, so this never reactivates onto an expired hash.
+ * current version and any row it just pruned, so this never reactivates onto an expired hash. Each
+ * row returns to the status it parked from, so a stopped or capped run resumes as itself rather
+ * than becoming appendable again; a row parked before that status was recorded could only have been
+ * `active`.
  */
 export function updateParkedActivities(
   db: Kysely<DB>,
 ): Promise<Array<Pick<Selectable<Activities>, 'id'>>> {
   return db
     .updateTable('activities')
-    .set({ status: 'active' })
+    .set({
+      parkedFrom: null,
+      status: sql<ActivityStatus>`coalesce(parked_from, 'active'::activity_status)`,
+    })
     .where('status', '=', 'parked')
     .where('simVersion', 'in', (eb) =>
       eb.selectFrom('simVersions').select('engineHash').where('status', '=', 'active'),

--- a/services/replay/src/dispatch/park-activity.test.ts
+++ b/services/replay/src/dispatch/park-activity.test.ts
@@ -15,7 +15,25 @@ test('it parks an active activity', async () => {
   const activity = await createActivityRow(ctx.db, { status: 'active' });
   const parked = await parkActivity(ctx.db, activity.id);
 
-  expect(parked).toMatchObject({ id: activity.id, status: 'parked' });
+  expect(parked).toMatchObject({ id: activity.id, parkedFrom: 'active', status: 'parked' });
+});
+
+test('it parks a stopped activity, keeping the status it parked from', async () => {
+  await using ctx = await setupTest();
+
+  const activity = await createActivityRow(ctx.db, { status: 'stopped' });
+  const parked = await parkActivity(ctx.db, activity.id);
+
+  expect(parked).toMatchObject({ id: activity.id, parkedFrom: 'stopped', status: 'parked' });
+});
+
+test('it parks a capped activity, keeping the status it parked from', async () => {
+  await using ctx = await setupTest();
+
+  const activity = await createActivityRow(ctx.db, { status: 'capped' });
+  const parked = await parkActivity(ctx.db, activity.id);
+
+  expect(parked).toMatchObject({ id: activity.id, parkedFrom: 'capped', status: 'parked' });
 });
 
 test('it leaves a quarantined activity untouched', async () => {
@@ -28,26 +46,43 @@ test('it leaves a quarantined activity untouched', async () => {
 
   const row = await ctx.db
     .selectFrom('activities')
-    .select('status')
+    .select(['parkedFrom', 'status'])
     .where('id', '=', activity.id)
     .executeTakeFirstOrThrow();
 
-  expect(row.status).toBe('quarantined');
+  expect(row).toStrictEqual({ parkedFrom: null, status: 'quarantined' });
 });
 
-test('it leaves a stopped activity untouched', async () => {
+test('it leaves a rejected activity untouched', async () => {
   await using ctx = await setupTest();
 
-  const activity = await createActivityRow(ctx.db, { status: 'stopped' });
+  const activity = await createActivityRow(ctx.db, { status: 'rejected' });
   const parked = await parkActivity(ctx.db, activity.id);
 
   expect(parked).toBeUndefined();
 
   const row = await ctx.db
     .selectFrom('activities')
-    .select('status')
+    .select(['parkedFrom', 'status'])
     .where('id', '=', activity.id)
     .executeTakeFirstOrThrow();
 
-  expect(row.status).toBe('stopped');
+  expect(row).toStrictEqual({ parkedFrom: null, status: 'rejected' });
+});
+
+test('it keeps the first parked-from status when the activity is already parked', async () => {
+  await using ctx = await setupTest();
+
+  const activity = await createActivityRow(ctx.db, { parkedFrom: 'stopped', status: 'parked' });
+  const parked = await parkActivity(ctx.db, activity.id);
+
+  expect(parked).toBeUndefined();
+
+  const row = await ctx.db
+    .selectFrom('activities')
+    .select(['parkedFrom', 'status'])
+    .where('id', '=', activity.id)
+    .executeTakeFirstOrThrow();
+
+  expect(row).toStrictEqual({ parkedFrom: 'stopped', status: 'parked' });
 });

--- a/services/replay/src/dispatch/park-activity.ts
+++ b/services/replay/src/dispatch/park-activity.ts
@@ -2,9 +2,11 @@ import type { Activities, DB } from '@vers/db';
 import type { Kysely, Selectable } from 'kysely';
 
 /**
- * Parks an activity in a single statement, moving it out of the replay queue. Guarded to
- * `active` rows only, so a terminal or quarantined status is never overwritten; returns undefined
- * when the guard doesn't match.
+ * Parks an activity in a single statement, moving it out of the replay queue, and records the
+ * status it held so unparking restores that status rather than assuming `active`. Guarded to the
+ * statuses whose replay work an operator hold can still resolve — `active`, or a `stopped`/`capped`
+ * row whose appended tail is still unadjudicated — so a rejected, quarantined, or already-parked
+ * row is never overwritten; returns undefined when the guard doesn't match.
  */
 export function parkActivity(
   db: Kysely<DB>,
@@ -12,9 +14,9 @@ export function parkActivity(
 ): Promise<Selectable<Activities> | undefined> {
   return db
     .updateTable('activities')
-    .set({ status: 'parked' })
+    .set((eb) => ({ parkedFrom: eb.ref('status'), status: 'parked' as const }))
     .where('id', '=', activityID)
-    .where('status', '=', 'active')
+    .where('status', 'in', ['active', 'stopped', 'capped'])
     .returningAll()
     .executeTakeFirst();
 }

--- a/services/replay/src/worker/run-replay-iteration.test.ts
+++ b/services/replay/src/worker/run-replay-iteration.test.ts
@@ -599,6 +599,47 @@ test('it parks an activity stamped with an unknown sim version', async () => {
   expect(updated.status).toBe('parked');
 });
 
+test('it parks a stopped activity, leaving its chain claimable again', async () => {
+  await using ctx = await setupTest();
+
+  const fixture = await createHonestActivityFixture(ctx.db, {
+    duration: 80_000,
+    seed: buildStateFromSeed(3_047_525_658),
+  });
+
+  await ctx.db
+    .updateTable('activities')
+    .set({ simVersion: 'never-registered-hash', status: 'stopped' })
+    .where('id', '=', fixture.activity.id)
+    .execute();
+
+  const deps = {
+    db: ctx.db,
+    keysServiceURL: resolveServiceURL('keys'),
+    logger: buildSilentLogger(),
+    privateKey: ctx.privateKey,
+    simVersion: 'test-engine-hash',
+  };
+
+  const cache = createReplayCache();
+
+  const outcome = await runReplayIteration(deps, cache);
+
+  expect(outcome).toStrictEqual({ kind: 'parked', reason: 'unknownVersion' });
+
+  const updated = await ctx.db
+    .selectFrom('activities')
+    .select(['parkedFrom', 'status'])
+    .where('id', '=', fixture.activity.id)
+    .executeTakeFirstOrThrow();
+
+  expect(updated).toStrictEqual({ parkedFrom: 'stopped', status: 'parked' });
+
+  const next = await runReplayIteration(deps, cache);
+
+  expect(next).toStrictEqual({ kind: 'idle' });
+});
+
 test('it parks an activity stamped with a retention-expired sim version', async () => {
   await using ctx = await setupTest();
 


### PR DESCRIPTION
## Description

Closes #784

Parking guarded on `status = 'active'`, so a forward-exited activity never actually parked while
`parkFrontier` still reported success — the chain re-claimed the same frontier on every drain and
nothing behind it could be adjudicated.

- The guard admits `stopped` and `capped`; `rejected`, `quarantined`, and already-parked rows stay untouched.
- A parked row records the status it came from, so the deploy sweep restores that status.
- Without that record the sweep's unconditional `status = 'active'` would return a stopped run to service as an appendable live run, colliding with the one-active-row-per-avatar index.
- The new iteration test asserts the chain goes idle on the next drain rather than re-claiming.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality

## Context

First of three PRs for #777 — incremental xp settlement cannot settle a run whose chain is wedged
here, and that is the same stopped-run cohort #777 targets.
