### PR TITLE
feat: record an activity's settled xp and net the live overlay

### DIFF
--- a/apps/web/src/lib/activity/build-optimistic-progression.test.ts
+++ b/apps/web/src/lib/activity/build-optimistic-progression.test.ts
@@ -123,3 +123,17 @@ test('it overlays a live run whole when the settled entry belongs to another act
 
   expect(result).toStrictEqual({ isSettling: true, level: buildLevelFromXP(425), xp: 425 });
 });
+
+test('it adds nothing once the settled row carries the whole live run', () => {
+  const result = buildOptimisticProgression({
+    progression: {
+      active: { activityID: 'activity_1', settledXP: 150 },
+      level: 3,
+      pending: [],
+      xp: 550,
+    },
+    simActivity: { id: 'activity_1', rewards: { xp: 120 } },
+  });
+
+  expect(result).toStrictEqual({ isSettling: true, level: buildLevelFromXP(550), xp: 550 });
+});

--- a/apps/web/src/lib/activity/build-optimistic-progression.test.ts
+++ b/apps/web/src/lib/activity/build-optimistic-progression.test.ts
@@ -110,7 +110,7 @@ test('it leaves the display xp unchanged as the settled row absorbs more of the 
   expect(afterSettlement.xp).toBe(beforeSettlement.xp);
 });
 
-test('it overlays a live run whole when the settled entry belongs to another activity', () => {
+test('it ignores a sim overlay for a run displaced by a different live activity', () => {
   const result = buildOptimisticProgression({
     progression: {
       active: { activityID: 'activity_2', settledXP: 90 },
@@ -118,6 +118,15 @@ test('it overlays a live run whole when the settled entry belongs to another act
       pending: [],
       xp: 400,
     },
+    simActivity: { id: 'activity_1', rewards: { xp: 25 } },
+  });
+
+  expect(result).toStrictEqual({ isSettling: false, level: 3, xp: 400 });
+});
+
+test('it keeps overlaying a just-terminal run while no activity is live', () => {
+  const result = buildOptimisticProgression({
+    progression: { active: null, level: 3, pending: [], xp: 400 },
     simActivity: { id: 'activity_1', rewards: { xp: 25 } },
   });
 

--- a/apps/web/src/lib/activity/build-optimistic-progression.test.ts
+++ b/apps/web/src/lib/activity/build-optimistic-progression.test.ts
@@ -71,3 +71,55 @@ test('it leaves the display xp unchanged when a delta moves from pending into th
 
   expect(afterSettlement.xp).toBe(beforeSettlement.xp);
 });
+
+test('it overlays only the part of the live run the settled row does not already carry', () => {
+  const result = buildOptimisticProgression({
+    progression: {
+      active: { activityID: 'activity_1', settledXP: 90 },
+      level: 3,
+      pending: [],
+      xp: 490,
+    },
+    simActivity: { id: 'activity_1', rewards: { xp: 120 } },
+  });
+
+  expect(result).toStrictEqual({ isSettling: true, level: buildLevelFromXP(520), xp: 520 });
+});
+
+test('it leaves the display xp unchanged as the settled row absorbs more of the live run', () => {
+  const beforeSettlement = buildOptimisticProgression({
+    progression: {
+      active: { activityID: 'activity_1', settledXP: 0 },
+      level: 3,
+      pending: [],
+      xp: 400,
+    },
+    simActivity: { id: 'activity_1', rewards: { xp: 120 } },
+  });
+
+  const afterSettlement = buildOptimisticProgression({
+    progression: {
+      active: { activityID: 'activity_1', settledXP: 90 },
+      level: 3,
+      pending: [],
+      xp: 490,
+    },
+    simActivity: { id: 'activity_1', rewards: { xp: 120 } },
+  });
+
+  expect(afterSettlement.xp).toBe(beforeSettlement.xp);
+});
+
+test('it overlays a live run whole when the settled entry belongs to another activity', () => {
+  const result = buildOptimisticProgression({
+    progression: {
+      active: { activityID: 'activity_2', settledXP: 90 },
+      level: 3,
+      pending: [],
+      xp: 400,
+    },
+    simActivity: { id: 'activity_1', rewards: { xp: 25 } },
+  });
+
+  expect(result).toStrictEqual({ isSettling: true, level: buildLevelFromXP(425), xp: 425 });
+});

--- a/apps/web/src/lib/activity/build-optimistic-progression.ts
+++ b/apps/web/src/lib/activity/build-optimistic-progression.ts
@@ -57,12 +57,16 @@ export function buildOptimisticProgression(
     (entry) => entry.activityID === input.simActivity?.id,
   );
 
-  const overlayApplies = input.simActivity !== undefined && !simIsPending;
+  const liveActivityID = input.progression.active?.activityID;
+  const simIsLive = liveActivityID === input.simActivity?.id;
 
-  const settledForSim =
-    input.progression.active?.activityID === input.simActivity?.id
-      ? (input.progression.active?.settledXP ?? 0)
-      : 0;
+  // A run other than the sim's is live, so the sim is a stale worker snapshot of a run that has
+  // already been displaced — its total belongs to nothing the settled row is still tracking. No
+  // live run at all leaves the overlay standing, covering the window between a terminal append
+  // and the pending entry that replaces it.
+  const simIsStale = liveActivityID !== undefined && !simIsLive;
+  const overlayApplies = input.simActivity !== undefined && !simIsPending && !simIsStale;
+  const settledForSim = simIsLive ? (input.progression.active?.settledXP ?? 0) : 0;
 
   const overlayXP = overlayApplies
     ? Math.max(0, (input.simActivity?.rewards.xp ?? 0) - settledForSim)

--- a/apps/web/src/lib/activity/build-optimistic-progression.ts
+++ b/apps/web/src/lib/activity/build-optimistic-progression.ts
@@ -5,7 +5,13 @@ interface PendingXPEntry {
   readonly xpDelta: number;
 }
 
+interface ActiveXPEntry {
+  readonly activityID: string;
+  readonly settledXP: number;
+}
+
 interface OptimisticProgressionRead {
+  readonly active?: ActiveXPEntry | null | undefined;
   readonly level: number;
   readonly pending: ReadonlyArray<PendingXPEntry>;
   readonly xp: number;
@@ -35,10 +41,12 @@ interface OptimisticProgression {
  * Derives the level/xp a screen renders from the settled progression read: the settled total plus
  * every pending entry's delta, plus the live sim's own running delta on top — deduped by activity
  * id against the pending list so a just-terminal run's own entry, once its refetch lands, is never
- * counted twice. The level is recomputed from the resulting total whenever anything is projected —
- * a pending entry can carry xp from a run the live sim never drove, so only the aggregate total
- * derives a trustworthy level; the settled row's own level is exact only once nothing projects on
- * top of it.
+ * counted twice. The live overlay is net of whatever the settled total already carries for that
+ * same run, so a settled row that tracks a run in flight never double-counts its verified part;
+ * checkpoints still queued client-side only widen that remainder, never invert it. The level is
+ * recomputed from the resulting total whenever anything is projected — a pending entry can carry
+ * xp from a run the live sim never drove, so only the aggregate total derives a trustworthy level;
+ * the settled row's own level is exact only once nothing projects on top of it.
  */
 export function buildOptimisticProgression(
   input: Readonly<BuildOptimisticProgressionInput>,
@@ -50,7 +58,16 @@ export function buildOptimisticProgression(
   );
 
   const overlayApplies = input.simActivity !== undefined && !simIsPending;
-  const overlayXP = overlayApplies ? (input.simActivity?.rewards.xp ?? 0) : 0;
+
+  const settledForSim =
+    input.progression.active?.activityID === input.simActivity?.id
+      ? (input.progression.active?.settledXP ?? 0)
+      : 0;
+
+  const overlayXP = overlayApplies
+    ? Math.max(0, (input.simActivity?.rewards.xp ?? 0) - settledForSim)
+    : 0;
+
   const displayXP = input.progression.xp + pendingXP + overlayXP;
   const isSettling = input.progression.pending.length > 0 || overlayApplies;
 

--- a/contracts/activity/src/activity-contract.ts
+++ b/contracts/activity/src/activity-contract.ts
@@ -34,7 +34,15 @@ const RevealedRewardSchema = z.object({
 
 const PendingXPEntrySchema = z.object({ activityID: z.string(), xpDelta: z.number() });
 
+/**
+ * The live activity's xp already on the settled row, so a client overlaying that run's own running
+ * total subtracts what it would otherwise count twice. Absent while no activity is live, and from
+ * a service deployed before the field existed — both read as nothing settled yet.
+ */
+const ActiveXPEntrySchema = z.object({ activityID: z.string(), settledXP: z.int() });
+
 const AvatarProgressionSchema = z.object({
+  active: ActiveXPEntrySchema.nullish(),
   level: z.int(),
   pending: z.array(PendingXPEntrySchema),
   xp: z.int(),

--- a/libs/data/db/migrations/1784723149793_activities_settled_xp.ts
+++ b/libs/data/db/migrations/1784723149793_activities_settled_xp.ts
@@ -1,0 +1,38 @@
+import type { Kysely } from 'kysely';
+import { sql } from 'kysely';
+
+/**
+ * Adds `settled_xp` to `activities` — the xp an activity has already contributed to its avatar's
+ * settled row, advanced by the same guarded update that moves `verified_head`. It is an intent
+ * ledger: the identity write floors at zero, so a debit larger than the avatar's settled total
+ * lands smaller than the amount recorded here. Signed and unconstrained, because a failed run's
+ * total is its accrued xp minus a death penalty computed against the avatar's lifetime progress,
+ * which is routinely the larger of the two.
+ *
+ * The default of zero is what makes a run that is mid-flight at deploy come out whole: its
+ * verified prefix settled nothing under the previous rule, and its terminal contributes the run
+ * total minus this column, so the prefix is paid exactly once at the terminal. A row already
+ * settled by a terminal checkpoint has no terminal left to true it up, so it is backfilled with
+ * what it was paid — without that, re-verifying one would pay its total a second time.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable('activities')
+    .addColumn('settled_xp', 'integer', (col) => col.notNull().defaultTo(0))
+    .execute();
+
+  await sql`
+    UPDATE activities
+    SET settled_xp = (checkpoint.payload -> 'rewards' ->> 'xp')::integer
+    FROM activity_checkpoints AS checkpoint
+    WHERE checkpoint.activity_id = activities.id
+      AND checkpoint.version = activities.appended_head
+      AND activities.verified_head = activities.appended_head
+      AND checkpoint.payload ->> 'type' IN ('completed', 'failed')
+      AND jsonb_typeof(checkpoint.payload -> 'rewards' -> 'xp') = 'number'
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.alterTable('activities').dropColumn('settled_xp').execute();
+}

--- a/libs/data/db/src/schema.generated.ts
+++ b/libs/data/db/src/schema.generated.ts
@@ -52,6 +52,7 @@ export interface Activities {
   scopeId: string;
   scopeType: string;
   seed: string;
+  settledXp: Generated<number>;
   simVersion: string;
   startChainIndex: Generated<number>;
   startedAt: Generated<Timestamp>;

--- a/libs/testing/mock-services/src/activity/get-avatar-progression.ts
+++ b/libs/testing/mock-services/src/activity/get-avatar-progression.ts
@@ -16,8 +16,11 @@ const TerminalCheckpointPayloadSchema = z.object({
 /**
  * Returns the avatar's settled xp/level plus one pending entry per terminal-but-unsettled activity
  * — a non-active, non-rejected activity whose `verifiedHead` hasn't caught up to its `appendedHead`
- * — sourced from that activity's tail checkpoint. Seed `checkpointCollection` to assert on a
- * pending entry's `xpDelta`.
+ * — sourced from that activity's tail checkpoint, and an identity entry for the live activity when
+ * one is active. Seed `checkpointCollection` to assert on a pending entry's `xpDelta`. The live
+ * entry always reports nothing settled: the stored row mirrors the public activity shape, which
+ * carries no settled-xp field, so the net a client overlays is asserted against the client's own
+ * projection rather than through this handler.
  */
 export const getAvatarProgression = os.getAvatarProgression.handler((opts) => {
   const actingUserId = opts.context.actingUserId;
@@ -61,5 +64,11 @@ export const getAvatarProgression = os.getAvatarProgression.handler((opts) => {
       return [{ activityID: activity.id, xpDelta: parsed.data.rewards.xp }];
     });
 
-  return { level: avatar.level, pending, xp: avatar.xp };
+  const live = db.activityCollection.findFirst((q) =>
+    q.where({ avatarID: opts.input.avatarID, status: 'active' }),
+  );
+
+  const active = live === undefined ? null : { activityID: live.id, settledXP: 0 };
+
+  return { active, level: avatar.level, pending, xp: avatar.xp };
 });

--- a/services/activity/src/handlers/get-avatar-progression.test.ts
+++ b/services/activity/src/handlers/get-avatar-progression.test.ts
@@ -34,7 +34,7 @@ test('it returns the settled xp and level with no pending entries for an avatar 
 
   const result = await client.getAvatarProgression({ avatarID: avatar.id });
 
-  expect(result).toStrictEqual({ level: 3, pending: [], xp: 450 });
+  expect(result).toStrictEqual({ active: null, level: 3, pending: [], xp: 450 });
 });
 
 test("it includes a pending entry carrying the terminal checkpoint's rewards.xp for an unverified terminal activity", async () => {
@@ -66,6 +66,7 @@ test("it includes a pending entry carrying the terminal checkpoint's rewards.xp 
   const result = await client.getAvatarProgression({ avatarID: avatar.id });
 
   expect(result).toStrictEqual({
+    active: null,
     level: 1,
     pending: [{ activityID: started.id, xpDelta: 150 }],
     xp: 0,
@@ -106,7 +107,7 @@ test('it excludes a verified activity from pending', async () => {
 
   const result = await client.getAvatarProgression({ avatarID: avatar.id });
 
-  expect(result).toStrictEqual({ level: 1, pending: [], xp: 0 });
+  expect(result).toStrictEqual({ active: null, level: 1, pending: [], xp: 0 });
 });
 
 test('it excludes a rejected activity from pending', async () => {
@@ -143,7 +144,7 @@ test('it excludes a rejected activity from pending', async () => {
 
   const result = await client.getAvatarProgression({ avatarID: avatar.id });
 
-  expect(result).toStrictEqual({ level: 1, pending: [], xp: 0 });
+  expect(result).toStrictEqual({ active: null, level: 1, pending: [], xp: 0 });
 });
 
 test('it excludes an active activity from pending', async () => {
@@ -170,7 +171,42 @@ test('it excludes an active activity from pending', async () => {
 
   const result = await client.getAvatarProgression({ avatarID: avatar.id });
 
-  expect(result).toStrictEqual({ level: 1, pending: [], xp: 0 });
+  expect(result).toStrictEqual({
+    active: { activityID: started.id, settledXP: 0 },
+    level: 1,
+    pending: [],
+    xp: 0,
+  });
+});
+
+test('it reports how much of the live run the settled total already carries', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id, xp: 90 });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'a9lp75',
+    scopeType: 'world_map_node',
+  });
+
+  await ctx.db
+    .updateTable('activities')
+    .set({ settledXp: 90 })
+    .where('id', '=', started.id)
+    .execute();
+
+  const result = await client.getAvatarProgression({ avatarID: avatar.id });
+
+  expect(result).toStrictEqual({
+    active: { activityID: started.id, settledXP: 90 },
+    level: 1,
+    pending: [],
+    xp: 90,
+  });
 });
 
 test('it skips a pending entry whose tail checkpoint carries no terminal rewards payload', async () => {
@@ -201,7 +237,7 @@ test('it skips a pending entry whose tail checkpoint carries no terminal rewards
 
   const result = await client.getAvatarProgression({ avatarID: avatar.id });
 
-  expect(result).toStrictEqual({ level: 1, pending: [], xp: 0 });
+  expect(result).toStrictEqual({ active: null, level: 1, pending: [], xp: 0 });
 });
 
 test('it returns null for an avatar owned by another caller', async () => {

--- a/services/activity/src/handlers/get-avatar-progression.ts
+++ b/services/activity/src/handlers/get-avatar-progression.ts
@@ -24,7 +24,13 @@ interface PendingXPEntry {
   readonly xpDelta: number;
 }
 
+interface ActiveXPEntry {
+  readonly activityID: string;
+  readonly settledXP: number;
+}
+
 interface AvatarProgression {
+  readonly active: ActiveXPEntry | null;
   readonly level: number;
   readonly pending: Array<PendingXPEntry>;
   readonly xp: number;
@@ -33,11 +39,13 @@ interface AvatarProgression {
 /**
  * Returns an avatar's settled xp/level plus one pending entry per terminal-but-unsettled activity
  * — a stopped, capped, quarantined, or parked activity whose verified anchor hasn't caught up to
- * its appended tail. The settled row and the pending set are read in one statement, so a single
- * read always sees the same constant sum a verifier apply moves a delta across: settlement never
- * visibly jumps. A non-empty pending set pokes the replay service, so a client polling this while
- * showing "Settling…" is itself the retry trigger for a poke a crash or deploy lost. Returns null
- * when the avatar doesn't exist or isn't owned by the acting user.
+ * its appended tail — and, while a run is live, how much of that run's xp the settled total
+ * already carries, so a client overlaying the run's own running total never counts the settled
+ * part twice. All three are read in one statement, so a single read always sees the same constant
+ * sum a verifier apply moves a delta across: settlement never visibly jumps. A non-empty pending
+ * set pokes the replay service, so a client polling this while showing "Settling…" is itself the
+ * retry trigger for a poke a crash or deploy lost. Returns null when the avatar doesn't exist or
+ * isn't owned by the acting user.
  */
 export async function getAvatarProgression(
   deps: GetAvatarProgressionDeps,
@@ -61,7 +69,19 @@ export async function getAvatarProgression(
         .onRef('activityCheckpoints.activityId', '=', 'activities.id')
         .onRef('activityCheckpoints.version', '=', 'activities.appendedHead'),
     )
-    .select(['avatars.level', 'avatars.xp', 'activities.id', 'activityCheckpoints.payload'])
+    .leftJoin('activities as liveActivity', (join) =>
+      join
+        .onRef('liveActivity.avatarId', '=', 'avatars.id')
+        .on('liveActivity.status', '=', 'active'),
+    )
+    .select([
+      'avatars.level',
+      'avatars.xp',
+      'activities.id',
+      'activityCheckpoints.payload',
+      'liveActivity.id as liveActivityId',
+      'liveActivity.settledXp as liveSettledXp',
+    ])
     .where('avatars.id', '=', opts.input.avatarID)
     .where('avatars.userId', '=', opts.context.actingUserId)
     .execute();
@@ -78,7 +98,12 @@ export async function getAvatarProgression(
     deps.sendReplayWake();
   }
 
-  return { level: settled.level, pending, xp: settled.xp };
+  const active =
+    settled.liveActivityId === null
+      ? null
+      : { activityID: settled.liveActivityId, settledXP: settled.liveSettledXp ?? 0 };
+
+  return { active, level: settled.level, pending, xp: settled.xp };
 }
 
 interface PendingCandidateRow {


### PR DESCRIPTION
## Description

Part of #777.

Adds `settled_xp` to activities — how much of a run's xp the avatar's settled row already carries —
and reports the live run's value through the progression read, so a client nets that run's own
running total instead of counting the settled part twice.

- Inert on its own: nothing advances the column, so every value is zero and the displayed total is unchanged.
- The wire field is optional, so a client deployed ahead of the service degrades to today's math.
- Default zero is required, not incidental: a run mid-flight at deploy settled nothing for its verified prefix, so its terminal contributes the run total minus this column and pays that prefix once.
- Rows already settled by a terminal have no terminal left to true them up, so the migration backfills what they were paid — without it, re-verifying one would pay twice.
- The column is signed and unconstrained: a failed run's total is accrued xp minus a death penalty computed against lifetime progress, routinely the larger.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality

## Context

Second of three PRs for #777. The settlement flip follows and must land after this, so both
progression readers are already deployed when the writer changes.
