### PR TITLE
fix(#792): reset mock db collections between tests

### DIFF
--- a/apps/web/test-setup.ts
+++ b/apps/web/test-setup.ts
@@ -3,6 +3,7 @@ import { afterEach, expect } from 'bun:test';
 import { faker } from '@faker-js/faker';
 import * as jestDOMMatchers from '@testing-library/jest-dom/matchers';
 import { registerZustandReset } from '@vers/client-test-utils';
+import { registerMockDBReset } from '@vers/mock-services/bun';
 import {
   registerBunTestCleanup,
   registerHappyDOM,
@@ -39,6 +40,7 @@ expect.extend(jestDOMMatchers);
 // package's stores (worldmap selection, idle sync state) reset between tests
 registerZustandReset();
 registerMSWLifecycle(server);
+registerMockDBReset();
 registerRequestContextMock();
 registerIdleWorkerHandleMock();
 registerGameCanvasMock();

--- a/libs/game/idle-client/test-setup.ts
+++ b/libs/game/idle-client/test-setup.ts
@@ -3,6 +3,7 @@ import { afterEach, expect, mock } from 'bun:test';
 import { GlobalRegistrator } from '@happy-dom/global-registrator';
 import * as jestDOMMatchers from '@testing-library/jest-dom/matchers';
 import { registerZustandReset } from '@vers/client-test-utils';
+import { registerMockDBReset } from '@vers/mock-services/bun';
 import { registerMSWLifecycle } from '@vers/test-utils/bun';
 import { server } from './src/mocks/node';
 import { CHECKPOINT_QUEUE_STORE_NAME, PREFERENCES_STORE_NAME } from './src/submission/constants';
@@ -23,6 +24,7 @@ expect.extend(jestDOMMatchers);
 // files
 registerZustandReset();
 registerMSWLifecycle(server);
+registerMockDBReset();
 
 // dynamic import: RTL reads `document` at import time, so it must load after registration
 const reactTestingLibrary = await import('@testing-library/react');

--- a/libs/testing/mock-services/package.json
+++ b/libs/testing/mock-services/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./bun": "./src/bun/index.ts",
     "./db": "./src/db/index.ts",
     "./user": "./src/user/index.ts",
     "./session": "./src/session/index.ts",

--- a/libs/testing/mock-services/src/bun/index.ts
+++ b/libs/testing/mock-services/src/bun/index.ts
@@ -1,0 +1,1 @@
+export { registerMockDBReset } from './register-mock-db-reset';

--- a/libs/testing/mock-services/src/bun/register-mock-db-reset.ts
+++ b/libs/testing/mock-services/src/bun/register-mock-db-reset.ts
@@ -1,0 +1,13 @@
+import { afterEach } from 'bun:test';
+import { resetMockDB } from '../db/reset-mock-db';
+
+/**
+ * Wires the `@msw/data` store's reset into the current bun-test run: clears every db collection
+ * after each test. Call once from a package's preload — `bun test` runs every file in one process,
+ * so a row one test writes otherwise stays visible to every later test.
+ */
+export function registerMockDBReset(): void {
+  afterEach(() => {
+    resetMockDB();
+  });
+}

--- a/libs/testing/mock-services/src/db/reset-mock-db.test.ts
+++ b/libs/testing/mock-services/src/db/reset-mock-db.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'bun:test';
 import { avatarCollection, userCollection } from './index';
 import { resetMockDB } from './reset-mock-db';
 
-test('it clears every collection in the db barrel', async () => {
+test('it clears the collections it creates from the db barrel', async () => {
   await userCollection.create({});
   await avatarCollection.create({});
 

--- a/libs/testing/mock-services/src/db/reset-mock-db.test.ts
+++ b/libs/testing/mock-services/src/db/reset-mock-db.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from 'bun:test';
+import { avatarCollection, userCollection } from './index';
+import { resetMockDB } from './reset-mock-db';
+
+test('it clears every collection in the db barrel', async () => {
+  await userCollection.create({});
+  await avatarCollection.create({});
+
+  resetMockDB();
+
+  expect(userCollection.all()).toBeEmpty();
+  expect(avatarCollection.all()).toBeEmpty();
+});

--- a/libs/testing/mock-services/src/db/reset-mock-db.ts
+++ b/libs/testing/mock-services/src/db/reset-mock-db.ts
@@ -1,0 +1,15 @@
+import { Collection } from '@msw/data';
+import * as db from './index';
+
+/**
+ * Clears every `@msw/data` collection exported from the db barrel, discarding rows any test wrote.
+ * Derives the collection set from the barrel's own exports rather than a hand-maintained list, so a
+ * collection added later is swept without a corresponding edit here.
+ */
+export function resetMockDB(): void {
+  for (const value of Object.values(db)) {
+    if (value instanceof Collection) {
+      value.clear();
+    }
+  }
+}

--- a/libs/testing/mock-services/test-setup.ts
+++ b/libs/testing/mock-services/test-setup.ts
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker';
 import { registerBunTestCleanup } from '@vers/test-utils/bun';
+import { registerMockDBReset } from './src/bun';
 
 // a throwaway dev-only Ed25519 PKCS8 key, so mock access tokens can be signed under `bun test`
 process.env['SERVICE_AUTH_PRIVATE_KEY'] = `-----BEGIN PRIVATE KEY-----
@@ -10,3 +11,4 @@ MC4CAQAwBQYDK2VwBCIEIBMom57erggdVdDCIdRWS+NKMykK+I5BUKpuHziAq+0W
 faker.seed(1);
 
 registerBunTestCleanup();
+registerMockDBReset();


### PR DESCRIPTION
## Description

Closes #792

The `@msw/data` collections exported by `@vers/mock-services/db` are module-level singletons shared across every `bun test` file, and nothing cleared them — rows one test wrote stayed visible to later tests, and one test could pass off another file's leftovers.

- `resetMockDB` clears every collection in the db barrel, derived at runtime by filtering the barrel's exports to `Collection` instances rather than a hand-maintained list
- `registerMockDBReset` (new `@vers/mock-services/bun` subpath, mirroring `@vers/test-utils/bun`) wires the reset into an `afterEach`, wired into the three preloads that seed the store: `apps/web`, `libs/game/idle-client`, `libs/testing/mock-services`
- `apps/web-e2e/src/serve-mock-services.ts` imports the db collections at runtime with no bunfig, so `bun:test` stays reachable only through the new `./bun` subpath, never `./db`

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality

## Context

`apps/web/src/routes/-avatar-create/run-avatar-create.test.ts` relied on the avatar name `Karnak` being free; that now holds because of the reset, with no rename needed.
