### PR TITLE
fix(#793): reject a batch whose terminal is not its last entry

### DIFF
--- a/libs/game/idle-core/src/index.ts
+++ b/libs/game/idle-core/src/index.ts
@@ -10,3 +10,4 @@ export { runSimulation } from './core/run-simulation';
 export { SIMULATION_TIMESTEP_MS } from './core/simulation-timestep-ms';
 export * from './progression';
 export * from './types';
+export { isTerminalCheckpointType } from './utils/is-terminal-checkpoint-type';

--- a/libs/game/idle-core/src/utils/is-terminal-checkpoint-type.test.ts
+++ b/libs/game/idle-core/src/utils/is-terminal-checkpoint-type.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from 'bun:test';
+import { ActivityCheckpointType } from '../types';
+import { isTerminalCheckpointType } from './is-terminal-checkpoint-type';
+
+test('it identifies the types that end a run', () => {
+  expect(isTerminalCheckpointType(ActivityCheckpointType.Completed)).toBeTrue();
+  expect(isTerminalCheckpointType(ActivityCheckpointType.Failed)).toBeTrue();
+});
+
+test('it rejects every other checkpoint type', () => {
+  expect(isTerminalCheckpointType(ActivityCheckpointType.Started)).toBeFalse();
+  expect(isTerminalCheckpointType(ActivityCheckpointType.Progress)).toBeFalse();
+});
+
+test('it rejects a type the simulation never emits', () => {
+  expect(isTerminalCheckpointType('tick')).toBeFalse();
+});

--- a/libs/game/idle-core/src/utils/is-terminal-checkpoint-type.ts
+++ b/libs/game/idle-core/src/utils/is-terminal-checkpoint-type.ts
@@ -1,0 +1,14 @@
+import { ActivityCheckpointType } from '../types';
+
+const TERMINAL_CHECKPOINT_TYPES: ReadonlySet<string> = new Set([
+  ActivityCheckpointType.Completed,
+  ActivityCheckpointType.Failed,
+]);
+
+/**
+ * Reports whether a checkpoint type ends its run. Takes the raw type rather than a checkpoint, so a
+ * caller validating an untrusted payload tests it without narrowing to the enum first.
+ */
+export function isTerminalCheckpointType(type: string): boolean {
+  return TERMINAL_CHECKPOINT_TYPES.has(type);
+}

--- a/services/activity/src/handlers/track-activity-progress.test.ts
+++ b/services/activity/src/handlers/track-activity-progress.test.ts
@@ -759,6 +759,48 @@ test('it rejects a chainIndex that is not startChainIndex plus version with CHEC
   });
 });
 
+test('it rejects a batch that continues past a run-ending checkpoint with CHECKPOINT_INVALID', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'a9lp75',
+    scopeType: 'world_map_node',
+  });
+
+  const throughCompletion = createMockCheckpointBatch({
+    count: 2,
+    finalPayloadOverrides: { rewards: { xp: 40 }, type: 'completed' },
+    startPrevHash: started.startHash,
+    startVersion: 1,
+  });
+
+  const afterCompletion = createMockCheckpointBatch({
+    startPrevHash: throughCompletion[1]!.hash,
+    startVersion: 3,
+  });
+
+  expect(
+    client.trackActivityProgress({
+      activityID: started.id,
+      checkpoints: [...throughCompletion, ...afterCompletion],
+      expectedHead: 0,
+    }),
+  ).rejects.toMatchObject({
+    code: 'CHECKPOINT_INVALID',
+    data: { reason: 'terminal-not-last' },
+  });
+
+  const current = await client.getCurrentActivity({ avatarID: avatar.id });
+
+  expect(current).toMatchObject({ appendedHead: 0, status: 'active' });
+});
+
 test('it returns the settled head when a terminal batch is resubmitted unchanged', async () => {
   await using ctx = await setupTest();
 

--- a/services/activity/src/handlers/track-activity-progress.ts
+++ b/services/activity/src/handlers/track-activity-progress.ts
@@ -1,12 +1,12 @@
 import type { CheckpointBatchEntry, CheckpointPayload } from '@vers/contract-activity';
 import { RewardSlotSchema, buildCheckpointHash } from '@vers/contract-activity';
 import type { ActivityStatus, DB, Json } from '@vers/db';
+import { isTerminalCheckpointType } from '@vers/idle-core';
 import type { ServiceContext } from '@vers/service-runtime';
 import { sql } from 'kysely';
 import type { Kysely } from 'kysely';
 import invariant from 'tiny-invariant';
 import * as z from 'zod';
-import { isTerminalCheckpointType } from '../is-terminal-checkpoint-type';
 import { recordTerminalTransition } from '../metrics/record-terminal-transition';
 import { parseTerminalCheckpointXP } from '../parse-terminal-checkpoint-xp';
 import type {

--- a/services/activity/src/handlers/track-activity-progress.ts
+++ b/services/activity/src/handlers/track-activity-progress.ts
@@ -6,6 +6,7 @@ import { sql } from 'kysely';
 import type { Kysely } from 'kysely';
 import invariant from 'tiny-invariant';
 import * as z from 'zod';
+import { isTerminalCheckpointType } from '../is-terminal-checkpoint-type';
 import { recordTerminalTransition } from '../metrics/record-terminal-transition';
 import { parseTerminalCheckpointXP } from '../parse-terminal-checkpoint-xp';
 import type {
@@ -454,7 +455,9 @@ interface TrackActivityProgressHead {
 /**
  * Validates a checkpoint batch's internal shape ahead of the transactional head-row compare-and-swap: version
  * contiguity from `expectedHead + 1`, each entry's `chainIndex` continuity from
- * `head.startChainIndex`, each entry's optional `rewardSlots` shape and ordinal contiguity, each
+ * `head.startChainIndex`, no run-ending entry before the batch's last — only the last entry claims
+ * the activity's terminal transition, so an interior one would store a terminal the settlement rule
+ * never reads — each entry's optional `rewardSlots` shape and ordinal contiguity, each
  * entry's cumulative `time` never regressing — within the batch always, and from the head row's
  * accounted time only when `expectedHead` still matches the head row, since a stale batch predates
  * that value — each entry's hash against its own payload, each entry's chain link to the previous
@@ -476,6 +479,12 @@ function findInvalidReason(
 
     if (checkpoint.payload.chainIndex !== head.startChainIndex + checkpoint.version) {
       return 'non-contiguous-chain-index';
+    }
+
+    const isLast = index === input.checkpoints.length - 1;
+
+    if (!isLast && isTerminalCheckpointType(checkpoint.payload.type)) {
+      return 'terminal-not-last';
     }
 
     const rewardSlotsReason = findRewardSlotsInvalidReason(checkpoint.payload);

--- a/services/activity/src/is-terminal-checkpoint-type.test.ts
+++ b/services/activity/src/is-terminal-checkpoint-type.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from 'bun:test';
+import { isTerminalCheckpointType } from './is-terminal-checkpoint-type';
+
+test('it reports a completed checkpoint as ending its run', () => {
+  expect(isTerminalCheckpointType('completed')).toBe(true);
+});
+
+test('it reports a failed checkpoint as ending its run', () => {
+  expect(isTerminalCheckpointType('failed')).toBe(true);
+});
+
+test('it reports an ordinary tick as not ending its run', () => {
+  expect(isTerminalCheckpointType('tick')).toBe(false);
+});

--- a/services/activity/src/is-terminal-checkpoint-type.ts
+++ b/services/activity/src/is-terminal-checkpoint-type.ts
@@ -1,0 +1,8 @@
+/**
+ * Reports whether a checkpoint type ends its run. A terminal checkpoint claims the activity's
+ * terminal transition and carries the run's final earned xp rather than one checkpoint's delta, so
+ * a stored stream holds at most one of them, at its head.
+ */
+export function isTerminalCheckpointType(type: string): boolean {
+  return type === 'completed' || type === 'failed';
+}

--- a/services/activity/src/parse-terminal-checkpoint-xp.ts
+++ b/services/activity/src/parse-terminal-checkpoint-xp.ts
@@ -1,5 +1,5 @@
+import { isTerminalCheckpointType } from '@vers/idle-core';
 import * as z from 'zod';
-import { isTerminalCheckpointType } from './is-terminal-checkpoint-type';
 
 const TerminalCheckpointPayloadSchema = z.object({
   rewards: z.object({ xp: z.number() }),

--- a/services/activity/src/parse-terminal-checkpoint-xp.ts
+++ b/services/activity/src/parse-terminal-checkpoint-xp.ts
@@ -1,10 +1,5 @@
 import * as z from 'zod';
-
-/**
- * Checkpoint types whose `rewards.xp` is a run's final earned total rather than one checkpoint's
- * own delta.
- */
-const TERMINAL_CHECKPOINT_TYPES = new Set(['completed', 'failed']);
+import { isTerminalCheckpointType } from './is-terminal-checkpoint-type';
 
 const TerminalCheckpointPayloadSchema = z.object({
   rewards: z.object({ xp: z.number() }),
@@ -20,7 +15,7 @@ const TerminalCheckpointPayloadSchema = z.object({
 export function parseTerminalCheckpointXP(payload: unknown): number | undefined {
   const parsed = TerminalCheckpointPayloadSchema.safeParse(payload);
 
-  if (!parsed.success || !TERMINAL_CHECKPOINT_TYPES.has(parsed.data.type)) {
+  if (!parsed.success || !isTerminalCheckpointType(parsed.data.type)) {
     return undefined;
   }
 


### PR DESCRIPTION
## Description

Closes #793

`findInvalidReason` never checked where a terminal checkpoint sits in a batch, while the terminal transition only inspects the last entry — so `[progress, completed, progress]` was accepted whole, storing an interior terminal and leaving the activity `active`.

- Rejects any run-ending entry before the batch's last with `CHECKPOINT_INVALID` / `terminal-not-last`.
- Checks the type alone, not the parsed terminal xp: an entry is positionally wrong whether or not its `rewards` payload is well formed.
- Adds `isTerminalCheckpointType` to `@vers/idle-core`, beside the `ActivityCheckpointType` enum and the existing `is*Checkpoint` family, so the position check and the xp parser read one definition. #797 tracks collapsing the remaining hand-rolled copies onto it.
- Replay already rejected such a stream, so this closes no inflation path — it makes settlement's one-attempt-per-row assumption hold at the append path instead of resting on the unrelated time-regression guard.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality