### PR TITLE
fix(#797): end a run on its checkpoint type, not its parsed reward xp

### DIFF
--- a/services/activity/src/handlers/track-activity-progress.test.ts
+++ b/services/activity/src/handlers/track-activity-progress.test.ts
@@ -568,6 +568,85 @@ test('it advances the chain anchor to the terminal checkpoint on a failed batch'
   expect(chain.appendedChainIndex).toBe(terminal.payload.chainIndex);
 });
 
+test('it ends a run whose last checkpoint carries no rewards payload', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'a9lp75',
+    scopeType: 'world_map_node',
+  });
+
+  const batch = createMockCheckpointBatch({
+    finalPayloadOverrides: { type: 'completed' },
+    startPrevHash: started.startHash,
+    startVersion: 1,
+  });
+
+  await client.trackActivityProgress({
+    activityID: started.id,
+    checkpoints: batch,
+    expectedHead: 0,
+  });
+
+  const activity = await ctx.db
+    .selectFrom('activities')
+    .selectAll()
+    .where('id', '=', started.id)
+    .executeTakeFirstOrThrow();
+
+  const chain = await ctx.db
+    .selectFrom('activityChains')
+    .selectAll()
+    .where('avatarId', '=', avatar.id)
+    .where('scopeType', '=', 'world_map_node')
+    .where('scopeId', '=', 'a9lp75')
+    .executeTakeFirstOrThrow();
+
+  expect(activity.status).toBe('stopped');
+  expect(chain.appendedChainIndex).toBe(batch[0]!.payload.chainIndex);
+});
+
+test('it ends a run whose last checkpoint carries rewards without an xp figure', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'a9lp75',
+    scopeType: 'world_map_node',
+  });
+
+  const batch = createMockCheckpointBatch({
+    finalPayloadOverrides: { rewards: {}, type: 'failed' },
+    startPrevHash: started.startHash,
+    startVersion: 1,
+  });
+
+  await client.trackActivityProgress({
+    activityID: started.id,
+    checkpoints: batch,
+    expectedHead: 0,
+  });
+
+  const activity = await ctx.db
+    .selectFrom('activities')
+    .selectAll()
+    .where('id', '=', started.id)
+    .executeTakeFirstOrThrow();
+
+  expect(activity.status).toBe('stopped');
+});
+
 test('it advances the chain anchor when the terminal segment consumed no entropy', async () => {
   await using ctx = await setupTest();
 

--- a/services/activity/src/handlers/track-activity-progress.ts
+++ b/services/activity/src/handlers/track-activity-progress.ts
@@ -8,7 +8,6 @@ import type { Kysely } from 'kysely';
 import invariant from 'tiny-invariant';
 import * as z from 'zod';
 import { recordTerminalTransition } from '../metrics/record-terminal-transition';
-import { parseTerminalCheckpointXP } from '../parse-terminal-checkpoint-xp';
 import type {
   CappedPayload,
   CheckpointInvalidPayload,
@@ -136,7 +135,12 @@ export async function trackActivityProgress(
   const newLastHash = lastCheckpoint?.hash ?? head.lastHash;
   const newTimeMs = lastCheckpoint?.payload.time ?? appendedTimeMs;
   const timeDelta = newTimeMs - appendedTimeMs;
-  const terminalRewardsXP = lastCheckpoint && parseTerminalCheckpointXP(lastCheckpoint.payload);
+
+  // The type alone decides, matching the rule a verifier replays against. `rewards` is outside the
+  // hash and the settled figure comes from the replayed checkpoint, so a run that ends still ends
+  // however its client wrote that field.
+  const isTerminalBatch =
+    lastCheckpoint !== undefined && isTerminalCheckpointType(lastCheckpoint.payload.type);
 
   // The budget decision is only meaningful against the head the batch claims to extend; a stale
   // batch falls through to the transaction's guarded update and resolves as CONFLICT.
@@ -205,7 +209,7 @@ export async function trackActivityProgress(
   const appendOutcome = await db.transaction().execute(async (trx) => {
     // Only a terminal batch advances the chain anchor; a batch that never touches the chain row
     // takes part in no lock ordering. When both rows are taken, the chain row comes first.
-    if (terminalRewardsXP !== undefined) {
+    if (isTerminalBatch) {
       await trx
         .selectFrom('activityChains')
         .select('appendedChainIndex')
@@ -224,7 +228,7 @@ export async function trackActivityProgress(
         appendedTimeMs: Math.floor(newTimeMs),
         lastHash: newLastHash,
         ...(actingSessionID !== null && { writerSessionId: actingSessionID }),
-        ...(terminalRewardsXP !== undefined && {
+        ...(isTerminalBatch && {
           status: 'stopped' as const,
           stoppedAt: sql`now()`,
         }),
@@ -260,7 +264,7 @@ export async function trackActivityProgress(
         .execute();
     }
 
-    if (terminalRewardsXP !== undefined && lastCheckpoint !== undefined) {
+    if (isTerminalBatch) {
       await updateAppendedAnchorFromTail(trx, {
         activityId: opts.input.activityID,
         appendedHead: newHead,
@@ -294,8 +298,7 @@ export async function trackActivityProgress(
 
     return {
       appendedHead: updated.appendedHead,
-      kind:
-        terminalRewardsXP !== undefined && lastCheckpoint !== undefined ? 'stopped' : 'appended',
+      kind: isTerminalBatch ? 'stopped' : 'appended',
     } as const;
   });
 


### PR DESCRIPTION
## Description

Closes #797

The terminal transition was claimed only when the last checkpoint carried a numeric `rewards.xp`. Nothing validates `rewards` and it sits outside the hash, so a `completed` or `failed` checkpoint with a missing or malformed one appended cleanly, claimed no transition, and left the activity `active` holding a run-ending checkpoint with the chain anchor stuck behind it.

- Decides terminality from the checkpoint type, the rule the replay service already replays against — the two services no longer disagree about what ends a run.
- Takes an untrusted, unvalidated payload field out of a control-flow decision; the handler only ever read the parsed figure as a boolean.
- Keeps `parseTerminalCheckpointXP` for `buildUnsettledXP`, which needs the figure rather than the verdict.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality

Both new tests were confirmed to fail against the unfixed handler.