### PR TITLE
fix(#783): refuse a run whose build snapshot borrowed rejected xp

### DIFF
--- a/contracts/activity/src/build-snapshot-schema.ts
+++ b/contracts/activity/src/build-snapshot-schema.ts
@@ -3,6 +3,13 @@ import * as z from 'zod';
 /**
  * Server-side truth an activity is played against, captured at start time so a later avatar
  * change can't retroactively alter a stream already in flight.
+ *
+ * Every field here is stamped from totals that may include what unverified runs earned, and the
+ * verifier replays against the stamped value rather than re-deriving it. A field added here widens
+ * what a new activity can borrow ahead of verification, so the provenance recorded at start widens
+ * with it: a borrowed quantity whose lending runs go unrecorded verifies clean against progress the
+ * avatar never proved. Level and xp are the borrowable quantities — an item mints only for a
+ * verified segment, so an unverified run has none to lend.
  */
 export const BuildSnapshotSchema = z.object({
   level: z.int(),

--- a/docs/architecture/game/seed-chain.md
+++ b/docs/architecture/game/seed-chain.md
@@ -104,27 +104,20 @@ immediately starts another builds against what they just earned. A held run is e
 and `quarantined` reach verification only by operator action, so counting one would stamp xp that
 never settles into this run's snapshot and every later one.
 
-Borrowing unsettled xp records where it came from. A new activity's snapshot provenance is the set
-of unverified runs whose remainders it counted, stored per activity at start, and it makes the
-borrowed total answerable to what verification later proves. Chains are scoped per `(avatar, scope)`
-while identity is avatar-global, so provenance is what orders an avatar's chains against each other:
-a chain whose replay frontier borrowed xp is unclaimable until every run it borrowed from has no
-appends left past its own verified cursor. Provenance points at runs that had already ended when the
-borrower started, so the ordering it imposes is acyclic, and it applies transitively — a borrower is
-adjudicated only after its sources, which were themselves adjudicated only after theirs.
+A borrowed remainder records where it came from. An activity's snapshot provenance is the set of
+unverified runs it counted, stored at start. Identity is avatar-global while chains are per-scope,
+so a borrow crosses chains, and provenance is what orders them against each other:
 
-Adjudicating a borrower begins by checking that foundation. A source that rejected leaves the
-borrower playing a level and life the avatar never proved it had, so the borrower is rejected
-outright, without replaying its stream — there is no total left to replay against and no divergence
-to confirm. Every activity that borrowed from the borrower fails the same check when its own turn
-comes, so one rejection reaches the whole dependency graph through the single-chain rejection path,
-with no writer reaching across chains. A source under an operator hold keeps its borrowers waiting
-rather than releasing them: a hold that later rejects would otherwise leave the same unproven total
-in place. Progress on a borrowing chain therefore stalls for as long as the hold lasts.
-
-An activity whose source rejects while it is still running is refused at its next adjudication
-rather than the moment the source falls, since a chain is only ever inspected when it has appends to
-verify.
+- A chain is unclaimable while its replay frontier has a source with appends past its own verified
+  cursor. Provenance points at runs that had already ended when the borrower started, so the
+  ordering is acyclic and holds transitively.
+- A frontier whose source rejected is refused without replaying its stream, there being no proven
+  total left to replay against. Its own borrowers fail the same check in turn, so one rejection
+  reaches every dependent through the single-chain rejection path.
+- A source under an operator hold keeps its borrowers waiting, since a hold that later rejects would
+  leave the same unproven total in place. The borrowing chain stalls until the hold clears.
+- A borrower still running when its source falls is refused at its next adjudication, since a chain
+  is inspected only when it has appends to verify.
 
 `getAvatarProgression` reads the settled row, its pending projection, and the live run's
 settled-so-far in a single statement, so a client display is never torn between them. The pending
@@ -137,9 +130,8 @@ pending projection is display-only.
 
 - The verifier serializes a chain's activities on the chain row, adjudicating one at a time in
   order, so a continuation never confirms against a predecessor that later rejects.
-- A chain is claimable only once every run its replay frontier borrowed xp from has been adjudicated
-  to completion, which orders an avatar's chains against each other without any writer holding more
-  than the one chain row it claimed.
+- A chain waits on the runs its replay frontier borrowed xp from, ordering an avatar's chains
+  against each other while no writer holds more than the one chain row it claimed.
 - The request-path forward-advance and the verifier both acquire the chain row before the activity
   row, a single ordering that admits no cycle.
 - The rejection rewind reads the verified columns inline in its update statement, never through a

--- a/docs/architecture/game/seed-chain.md
+++ b/docs/architecture/game/seed-chain.md
@@ -102,9 +102,29 @@ A consequential read — a new activity's `buildSnapshot`, a future point spend,
 new run — includes an ended run's unsettled remainder, so a player who finishes one run and
 immediately starts another builds against what they just earned. A held run is excluded: `parked`
 and `quarantined` reach verification only by operator action, so counting one would stamp xp that
-never settles into this run's snapshot and every later one. Chains are scoped per `(avatar, scope)`
-while identity is avatar-global, and a rejection's cascade follows chain membership: a run on
-another scope keeps the snapshot it built from the rejected run's unsettled xp.
+never settles into this run's snapshot and every later one.
+
+Borrowing unsettled xp records where it came from. A new activity's snapshot provenance is the set
+of unverified runs whose remainders it counted, stored per activity at start, and it makes the
+borrowed total answerable to what verification later proves. Chains are scoped per `(avatar, scope)`
+while identity is avatar-global, so provenance is what orders an avatar's chains against each other:
+a chain whose replay frontier borrowed xp is unclaimable until every run it borrowed from has no
+appends left past its own verified cursor. Provenance points at runs that had already ended when the
+borrower started, so the ordering it imposes is acyclic, and it applies transitively — a borrower is
+adjudicated only after its sources, which were themselves adjudicated only after theirs.
+
+Adjudicating a borrower begins by checking that foundation. A source that rejected leaves the
+borrower playing a level and life the avatar never proved it had, so the borrower is rejected
+outright, without replaying its stream — there is no total left to replay against and no divergence
+to confirm. Every activity that borrowed from the borrower fails the same check when its own turn
+comes, so one rejection reaches the whole dependency graph through the single-chain rejection path,
+with no writer reaching across chains. A source under an operator hold keeps its borrowers waiting
+rather than releasing them: a hold that later rejects would otherwise leave the same unproven total
+in place. Progress on a borrowing chain therefore stalls for as long as the hold lasts.
+
+An activity whose source rejects while it is still running is refused at its next adjudication
+rather than the moment the source falls, since a chain is only ever inspected when it has appends to
+verify.
 
 `getAvatarProgression` reads the settled row, its pending projection, and the live run's
 settled-so-far in a single statement, so a client display is never torn between them. The pending
@@ -117,6 +137,9 @@ pending projection is display-only.
 
 - The verifier serializes a chain's activities on the chain row, adjudicating one at a time in
   order, so a continuation never confirms against a predecessor that later rejects.
+- A chain is claimable only once every run its replay frontier borrowed xp from has been adjudicated
+  to completion, which orders an avatar's chains against each other without any writer holding more
+  than the one chain row it claimed.
 - The request-path forward-advance and the verifier both acquire the chain row before the activity
   row, a single ordering that admits no cycle.
 - The rejection rewind reads the verified columns inline in its update statement, never through a

--- a/docs/architecture/game/seed-chain.md
+++ b/docs/architecture/game/seed-chain.md
@@ -105,8 +105,11 @@ and `quarantined` reach verification only by operator action, so counting one wo
 never settles into this run's snapshot and every later one.
 
 A borrowed remainder records where it came from. An activity's snapshot provenance is the set of
-unverified runs it counted, stored at start. Identity is avatar-global while chains are per-scope,
-so a borrow crosses chains, and provenance is what orders them against each other:
+unverified runs whose xp moved its total, stored at start; one that moved it by nothing lends
+nothing and is left out. Xp is the only quantity a snapshot borrows ahead of verification, an item
+minting only for a verified segment, so a quantity added to the snapshot widens what provenance
+records. Identity is avatar-global while chains are per-scope, so a borrow crosses chains, and
+provenance is what orders them against each other:
 
 - A chain is unclaimable while its replay frontier has a source with appends past its own verified
   cursor. Provenance points at runs that had already ended when the borrower started, so the

--- a/docs/architecture/platform/observability.md
+++ b/docs/architecture/platform/observability.md
@@ -171,6 +171,9 @@ timestamp to the moment the drain confirms it.
 - `provider-unavailable` — a cross-version dispatch's provider timed out, refused the connection, or
   answered with an undefined error; repeated occurrences distinguish a dead provider deploy from
   normal cold-boot latency.
+- `unbacked-snapshot` — the activity's build snapshot borrowed xp from a run that has since been
+  rejected, so the level and life it plays at were never proven; a rise tracks how far one rejection
+  propagates through an avatar's later runs.
 
 Each recording's log line carries the raw numbers behind it (heads, checkpoint counts, sim version).
 

--- a/libs/data/db/migrations/1784728873775_activity_snapshot_sources.ts
+++ b/libs/data/db/migrations/1784728873775_activity_snapshot_sources.ts
@@ -8,8 +8,9 @@ import type { Kysely } from 'kysely';
  * activity is unclaimable while a source still has appends past its verified cursor, and a source
  * that rejected invalidates it.
  *
- * Edges are only ever walked from the dependent to its sources, so the primary key's leading
- * column serves every read and no reverse index exists.
+ * Edges are only ever walked from the dependent to its sources, which the primary key's leading
+ * column serves. The index on `source_activity_id` carries no read: it keeps the cascade from
+ * scanning the whole table once per activity when an avatar is removed.
  */
 export async function up(db: Kysely<unknown>): Promise<void> {
   await db.schema
@@ -31,6 +32,12 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       ['id'],
       (fk) => fk.onDelete('cascade').onUpdate('cascade'),
     )
+    .execute();
+
+  await db.schema
+    .createIndex('activity_snapshot_sources_source_activity_id_idx')
+    .on('activity_snapshot_sources')
+    .column('source_activity_id')
     .execute();
 }
 

--- a/libs/data/db/migrations/1784728873775_activity_snapshot_sources.ts
+++ b/libs/data/db/migrations/1784728873775_activity_snapshot_sources.ts
@@ -1,0 +1,39 @@
+import type { Kysely } from 'kysely';
+
+/**
+ * Creates `activity_snapshot_sources`, one row per unverified run whose unsettled xp fed an
+ * activity's `build_snapshot`. The verifier reads the stored snapshot as its simulation input
+ * rather than re-deriving it, so a snapshot built from a run that later rejects would otherwise
+ * verify clean against xp that never existed. The edges make that dependency queryable: an
+ * activity is unclaimable while a source still has appends past its verified cursor, and a source
+ * that rejected invalidates it.
+ *
+ * Edges are only ever walked from the dependent to its sources, so the primary key's leading
+ * column serves every read and no reverse index exists.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable('activity_snapshot_sources')
+    .addColumn('activity_id', 'text', (col) => col.notNull())
+    .addColumn('source_activity_id', 'text', (col) => col.notNull())
+    .addPrimaryKeyConstraint('activity_snapshot_sources_pk', ['activity_id', 'source_activity_id'])
+    .addForeignKeyConstraint(
+      'activity_snapshot_sources_activity_id_activities_id_fk',
+      ['activity_id'],
+      'activities',
+      ['id'],
+      (fk) => fk.onDelete('cascade').onUpdate('cascade'),
+    )
+    .addForeignKeyConstraint(
+      'activity_snapshot_sources_source_activity_id_activities_id_fk',
+      ['source_activity_id'],
+      'activities',
+      ['id'],
+      (fk) => fk.onDelete('cascade').onUpdate('cascade'),
+    )
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable('activity_snapshot_sources').execute();
+}

--- a/libs/data/db/src/index.ts
+++ b/libs/data/db/src/index.ts
@@ -5,6 +5,7 @@ export type {
   Activities,
   ActivityChains,
   ActivityCheckpoints,
+  ActivitySnapshotSources,
   ActivityStatus,
   AvatarGrants,
   AvatarItems,

--- a/libs/data/db/src/schema.generated.ts
+++ b/libs/data/db/src/schema.generated.ts
@@ -88,6 +88,11 @@ export interface ActivityCheckpoints {
   version: number;
 }
 
+export interface ActivitySnapshotSources {
+  activityId: string;
+  sourceActivityId: string;
+}
+
 export interface AvatarGrants {
   avatarId: string;
   createdAt: Generated<Timestamp>;
@@ -206,6 +211,7 @@ export interface DB {
   activities: Activities;
   activityChains: ActivityChains;
   activityCheckpoints: ActivityCheckpoints;
+  activitySnapshotSources: ActivitySnapshotSources;
   avatarGrants: AvatarGrants;
   avatarItems: AvatarItems;
   avatars: Avatars;

--- a/services/activity/src/handlers/start-activity.test.ts
+++ b/services/activity/src/handlers/start-activity.test.ts
@@ -976,6 +976,86 @@ test('it records the unverified run a new build snapshot borrowed its xp from', 
   expect(sources).toStrictEqual([{ sourceActivityId: first.id }]);
 });
 
+test('it records no borrowed run for an unsettled run that moved the total by nothing', async () => {
+  await using ctx = await setupTest();
+
+  await createSimVersionRow(ctx.db);
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { level: 1, userId: viewer.user.id, xp: 0 });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const first = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'a9lp75',
+    scopeType: 'world_map_node',
+  });
+
+  const batch = createMockCheckpointBatch({
+    finalPayloadOverrides: { rewards: { xp: 0 }, type: 'completed' },
+    startPrevHash: first.startHash,
+    startVersion: 1,
+  });
+
+  await client.trackActivityProgress({ activityID: first.id, checkpoints: batch, expectedHead: 0 });
+
+  const second = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'esaxrt',
+    scopeType: 'world_map_node',
+  });
+
+  const sources = await ctx.db
+    .selectFrom('activitySnapshotSources')
+    .select('sourceActivityId')
+    .where('activityId', '=', second.id)
+    .execute();
+
+  expect(sources).toBeEmpty();
+  expect(second.buildSnapshot).toStrictEqual({ level: 1, xp: 0 });
+});
+
+test('it records a borrowed run whose death penalty lowered the total', async () => {
+  await using ctx = await setupTest();
+
+  await createSimVersionRow(ctx.db);
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { level: 2, userId: viewer.user.id, xp: 200 });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const first = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'a9lp75',
+    scopeType: 'world_map_node',
+  });
+
+  const batch = createMockCheckpointBatch({
+    finalPayloadOverrides: { rewards: { xp: -50 }, type: 'failed' },
+    startPrevHash: first.startHash,
+    startVersion: 1,
+  });
+
+  await client.trackActivityProgress({ activityID: first.id, checkpoints: batch, expectedHead: 0 });
+
+  const second = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'esaxrt',
+    scopeType: 'world_map_node',
+  });
+
+  const sources = await ctx.db
+    .selectFrom('activitySnapshotSources')
+    .select('sourceActivityId')
+    .where('activityId', '=', second.id)
+    .execute();
+
+  expect(sources).toStrictEqual([{ sourceActivityId: first.id }]);
+  expect(second.buildSnapshot).toStrictEqual({ level: 2, xp: 150 });
+});
+
 test('it records no borrowed run when the avatar carries no pending work', async () => {
   await using ctx = await setupTest();
 

--- a/services/activity/src/handlers/start-activity.test.ts
+++ b/services/activity/src/handlers/start-activity.test.ts
@@ -936,3 +936,112 @@ test('it stamps the build snapshot from settled xp/level alone when the avatar c
 
   expect(activity.buildSnapshot).toStrictEqual({ level: 3, xp: 500 });
 });
+
+test('it records the unverified run a new build snapshot borrowed its xp from', async () => {
+  await using ctx = await setupTest();
+
+  await createSimVersionRow(ctx.db);
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { level: 1, userId: viewer.user.id, xp: 0 });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const first = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'a9lp75',
+    scopeType: 'world_map_node',
+  });
+
+  const batch = createMockCheckpointBatch({
+    finalPayloadOverrides: { rewards: { xp: 150 }, type: 'completed' },
+    startPrevHash: first.startHash,
+    startVersion: 1,
+  });
+
+  await client.trackActivityProgress({ activityID: first.id, checkpoints: batch, expectedHead: 0 });
+
+  const second = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'esaxrt',
+    scopeType: 'world_map_node',
+  });
+
+  const sources = await ctx.db
+    .selectFrom('activitySnapshotSources')
+    .select('sourceActivityId')
+    .where('activityId', '=', second.id)
+    .execute();
+
+  expect(sources).toStrictEqual([{ sourceActivityId: first.id }]);
+});
+
+test('it records no borrowed run when the avatar carries no pending work', async () => {
+  await using ctx = await setupTest();
+
+  await createSimVersionRow(ctx.db);
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { level: 3, userId: viewer.user.id, xp: 500 });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const activity = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'a9lp75',
+    scopeType: 'world_map_node',
+  });
+
+  const sources = await ctx.db
+    .selectFrom('activitySnapshotSources')
+    .select('sourceActivityId')
+    .where('activityId', '=', activity.id)
+    .execute();
+
+  expect(sources).toBeEmpty();
+});
+
+test('it records no borrowed run for a parked activity left out of the build snapshot', async () => {
+  await using ctx = await setupTest();
+
+  await createSimVersionRow(ctx.db);
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { level: 1, userId: viewer.user.id, xp: 0 });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const first = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'a9lp75',
+    scopeType: 'world_map_node',
+  });
+
+  const batch = createMockCheckpointBatch({
+    finalPayloadOverrides: { rewards: { xp: 150 }, type: 'completed' },
+    startPrevHash: first.startHash,
+    startVersion: 1,
+  });
+
+  await client.trackActivityProgress({ activityID: first.id, checkpoints: batch, expectedHead: 0 });
+
+  await ctx.db
+    .updateTable('activities')
+    .set({ parkedFrom: 'stopped', status: 'parked' })
+    .where('id', '=', first.id)
+    .execute();
+
+  const second = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'esaxrt',
+    scopeType: 'world_map_node',
+  });
+
+  const sources = await ctx.db
+    .selectFrom('activitySnapshotSources')
+    .select('sourceActivityId')
+    .where('activityId', '=', second.id)
+    .execute();
+
+  expect(sources).toBeEmpty();
+});

--- a/services/activity/src/handlers/start-activity.ts
+++ b/services/activity/src/handlers/start-activity.ts
@@ -139,9 +139,12 @@ export async function startActivity(
 
       const seed = chain.appendedNextSeed;
 
-      const totalXP = await getOptimisticXP(trx, opts.input.avatarID);
+      const optimistic = await getOptimisticBuild(trx, opts.input.avatarID);
 
-      const buildSnapshot: BuildSnapshot = { level: buildLevelFromXP(totalXP), xp: totalXP };
+      const buildSnapshot: BuildSnapshot = {
+        level: buildLevelFromXP(optimistic.totalXP),
+        xp: optimistic.totalXP,
+      };
 
       const startHash = buildStartHash({
         activityID: id,
@@ -152,7 +155,7 @@ export async function startActivity(
         simVersion,
       });
 
-      return trx
+      const inserted = await trx
         .insertInto('activities')
         .values({
           avatarId: opts.input.avatarID,
@@ -173,6 +176,20 @@ export async function startActivity(
         })
         .returningAll()
         .executeTakeFirstOrThrow();
+
+      if (optimistic.sourceIDs.length > 0) {
+        await trx
+          .insertInto('activitySnapshotSources')
+          .values(
+            optimistic.sourceIDs.map((sourceID) => ({
+              activityId: id,
+              sourceActivityId: sourceID,
+            })),
+          )
+          .execute();
+      }
+
+      return inserted;
     });
 
     return toActivityData(row);
@@ -256,15 +273,25 @@ async function resolveSimVersionStamp(
   throw errors.SIM_VERSION_EXPIRED({ data: { currentSimVersion } });
 }
 
+interface OptimisticBuild {
+  /**
+   * The unverified runs `totalXP` borrows from. Recording them is what lets the verifier refuse a
+   * run whose snapshot counted xp that a later rejection proved never existed.
+   */
+  readonly sourceIDs: ReadonlyArray<string>;
+
+  readonly totalXP: number;
+}
+
 /**
- * Sums an avatar's settled xp with the unsettled xp of every activity that ended and is still
- * awaiting its verifier — the total a new run's build snapshot is stamped with. A `parked` or
- * `quarantined` activity is left out: both are holds with no path back to verification on their
- * own, so counting them would stamp xp that never settles into this run's snapshot and every later
- * one's. The settled row and the unsettled set are read in one statement, so a concurrent verifier
- * commit can't land its delta in the gap between two separate reads.
+ * An avatar's settled xp plus the unsettled xp of every activity that ended and is still awaiting
+ * its verifier — what a new run's build snapshot is stamped with — beside the runs that xp came
+ * from. A `parked` or `quarantined` activity is left out: both are holds with no path back to
+ * verification on their own, so counting them would stamp xp that never settles into this run's
+ * snapshot and every later one's. The settled row and the unsettled set are read in one statement,
+ * so a concurrent verifier commit can't land its delta in the gap between two separate reads.
  */
-async function getOptimisticXP(trx: Kysely<DB>, avatarID: string): Promise<number> {
+async function getOptimisticBuild(trx: Kysely<DB>, avatarID: string): Promise<OptimisticBuild> {
   const rows = await trx
     .selectFrom('avatars')
     .leftJoin('activities', (join) =>
@@ -309,18 +336,26 @@ async function getOptimisticXP(trx: Kysely<DB>, avatarID: string): Promise<numbe
     'avatar must still exist inside the transaction that starts its activity',
   );
 
-  return rows.reduce(
-    (total, row) =>
-      row.id === null
-        ? total
-        : total +
-          buildUnsettledXP({
-            settledXP: row.settledXp ?? 0,
-            tailPayload: row.payload,
-            unverifiedDeltaSum: row.deltaSum ?? 0,
-          }),
-    settled.xp,
-  );
+  const sourceIDs: Array<string> = [];
+  let totalXP = settled.xp;
+
+  // The left join yields one all-null activity row for an avatar with nothing unsettled, so a null
+  // id marks the absence of a source rather than a source without one.
+  for (const row of rows) {
+    if (row.id === null) {
+      continue;
+    }
+
+    sourceIDs.push(row.id);
+
+    totalXP += buildUnsettledXP({
+      settledXP: row.settledXp ?? 0,
+      tailPayload: row.payload,
+      unverifiedDeltaSum: row.deltaSum ?? 0,
+    });
+  }
+
+  return { sourceIDs, totalXP };
 }
 
 /**

--- a/services/activity/src/handlers/start-activity.ts
+++ b/services/activity/src/handlers/start-activity.ts
@@ -275,8 +275,9 @@ async function resolveSimVersionStamp(
 
 interface OptimisticBuild {
   /**
-   * The unverified runs `totalXP` borrows from. Recording them is what lets the verifier refuse a
-   * run whose snapshot counted xp that a later rejection proved never existed.
+   * The unverified runs `totalXP` borrows from, holding only those that moved it. Recording them
+   * is what lets the verifier refuse a run whose snapshot counted xp that a later rejection proved
+   * never existed.
    */
   readonly sourceIDs: ReadonlyArray<string>;
 
@@ -346,13 +347,23 @@ async function getOptimisticBuild(trx: Kysely<DB>, avatarID: string): Promise<Op
       continue;
     }
 
-    sourceIDs.push(row.id);
-
-    totalXP += buildUnsettledXP({
+    const unsettledXP = buildUnsettledXP({
       settledXP: row.settledXp ?? 0,
       tailPayload: row.payload,
       unverifiedDeltaSum: row.deltaSum ?? 0,
     });
+
+    // A run that moved the total by nothing is not a dependency: the snapshot is the same value
+    // whether or not it exists, so its later rejection has no bearing on this run's honesty. A
+    // negative contribution still counts — a death penalty lowered the total, which is a borrow
+    // like any other.
+    if (unsettledXP === 0) {
+      continue;
+    }
+
+    sourceIDs.push(row.id);
+
+    totalXP += unsettledXP;
   }
 
   return { sourceIDs, totalXP };

--- a/services/replay/src/metrics/record-rejection.ts
+++ b/services/replay/src/metrics/record-rejection.ts
@@ -4,14 +4,16 @@ export type RejectionReason =
   | 'elapsed-time'
   | 'integrity-mismatch'
   | 'provider-unavailable'
+  | 'unbacked-snapshot'
   | 'version-park';
 
 /**
  * Counts one adjudication that refused or held a stream, split by reason: `integrity-mismatch`
  * covers confirmed divergence and seed validation, `version-park` covers version-registry holds
- * (unknown or retention-expired sim versions), `elapsed-time` covers duration-cap trips, and
+ * (unknown or retention-expired sim versions), `elapsed-time` covers duration-cap trips,
  * `provider-unavailable` covers a cross-version dispatch whose provider timed out, refused the
- * connection, or answered with an undefined error. The counter is resolved through the global
+ * connection, or answered with an undefined error, and `unbacked-snapshot` covers a build snapshot
+ * that borrowed xp from a run since rejected. The counter is resolved through the global
  * metrics API on every call — the SDK returns the same instrument for an identical registration,
  * and resolving late keeps the counter bound to whichever meter provider the process registered at
  * boot; without one it is the API's no-op.

--- a/services/replay/src/queue/claim-next-chain.test.ts
+++ b/services/replay/src/queue/claim-next-chain.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'bun:test';
 import { createTestDB } from '@vers/service-test-utils/bun';
 import { createActivityRow } from '../test-utils/create-activity-row';
 import { createChainRow } from '../test-utils/create-chain-row';
+import { createSnapshotSourceRow } from '../test-utils/create-snapshot-source-row';
 import { claimNextChain } from './claim-next-chain';
 
 /**
@@ -191,6 +192,132 @@ test('it skips a chain whose replay frontier is parked', async () => {
     avatarId: chain.avatarId,
     scopeId: chain.scopeId,
     startChainIndex: 3,
+  });
+
+  const claimed = await ctx.db.transaction().execute((trx) => claimNextChain(trx));
+
+  expect(claimed).toBeUndefined();
+});
+
+test('it skips a chain whose frontier borrowed xp from a run still awaiting its verifier', async () => {
+  await using ctx = await setupTest();
+
+  const chain = await createChainRow(ctx.db);
+
+  const source = await createActivityRow(ctx.db, {
+    appendedHead: 4,
+    avatarId: chain.avatarId,
+    scopeId: 'scope_lender',
+    status: 'stopped',
+    verifiedHead: 1,
+  });
+
+  const borrower = await createActivityRow(ctx.db, {
+    appendedHead: 3,
+    avatarId: chain.avatarId,
+    scopeId: chain.scopeId,
+  });
+
+  await createSnapshotSourceRow(ctx.db, {
+    activityID: borrower.id,
+    sourceActivityID: source.id,
+  });
+
+  const claimed = await ctx.db.transaction().execute((trx) => claimNextChain(trx));
+
+  expect(claimed).toBeUndefined();
+});
+
+test('it claims a chain whose frontier borrowed xp from a fully verified run', async () => {
+  await using ctx = await setupTest();
+
+  const chain = await createChainRow(ctx.db);
+
+  const source = await createActivityRow(ctx.db, {
+    appendedHead: 4,
+    avatarId: chain.avatarId,
+    scopeId: 'scope_lender',
+    status: 'stopped',
+    verifiedHead: 4,
+  });
+
+  const borrower = await createActivityRow(ctx.db, {
+    appendedHead: 3,
+    avatarId: chain.avatarId,
+    scopeId: chain.scopeId,
+  });
+
+  await createSnapshotSourceRow(ctx.db, {
+    activityID: borrower.id,
+    sourceActivityID: source.id,
+  });
+
+  const claimed = await ctx.db.transaction().execute((trx) => claimNextChain(trx));
+
+  expect(claimed).toStrictEqual({
+    avatarID: chain.avatarId,
+    priority: 0,
+    scopeID: chain.scopeId,
+    scopeType: chain.scopeType,
+  });
+});
+
+test('it claims a chain whose frontier borrowed xp from a rejected run, so the refusal can be applied', async () => {
+  await using ctx = await setupTest();
+
+  const chain = await createChainRow(ctx.db);
+
+  const source = await createActivityRow(ctx.db, {
+    appendedHead: 4,
+    avatarId: chain.avatarId,
+    scopeId: 'scope_lender',
+    status: 'rejected',
+    verifiedHead: 1,
+  });
+
+  const borrower = await createActivityRow(ctx.db, {
+    appendedHead: 3,
+    avatarId: chain.avatarId,
+    scopeId: chain.scopeId,
+  });
+
+  await createSnapshotSourceRow(ctx.db, {
+    activityID: borrower.id,
+    sourceActivityID: source.id,
+  });
+
+  const claimed = await ctx.db.transaction().execute((trx) => claimNextChain(trx));
+
+  expect(claimed).toStrictEqual({
+    avatarID: chain.avatarId,
+    priority: 0,
+    scopeID: chain.scopeId,
+    scopeType: chain.scopeType,
+  });
+});
+
+test('it skips a chain whose frontier borrowed xp from a run an operator parked', async () => {
+  await using ctx = await setupTest();
+
+  const chain = await createChainRow(ctx.db);
+
+  const source = await createActivityRow(ctx.db, {
+    appendedHead: 4,
+    avatarId: chain.avatarId,
+    scopeId: 'scope_lender',
+    status: 'parked',
+    verifiedHead: 1,
+  });
+
+  const borrower = await createActivityRow(ctx.db, {
+    appendedHead: 3,
+    avatarId: chain.avatarId,
+    scopeId: chain.scopeId,
+  });
+
+  await createSnapshotSourceRow(ctx.db, {
+    activityID: borrower.id,
+    sourceActivityID: source.id,
   });
 
   const claimed = await ctx.db.transaction().execute((trx) => claimNextChain(trx));

--- a/services/replay/src/queue/claim-next-chain.ts
+++ b/services/replay/src/queue/claim-next-chain.ts
@@ -20,6 +20,8 @@ import type { ClaimedChain } from '../types';
  * other: adjudicating a borrower before its source would settle xp and mint items against a total
  * the source's own rejection could still erase. A source held under an operator park keeps its
  * borrowers waiting, since a hold that later rejects would leave the same unbacked total in place.
+ * A rejected source is deliberately not a barrier, whatever its cursors read: its borrowers must be
+ * claimed to be refused, and blocking them would strand them unadjudicated forever.
  */
 export async function claimNextChain(trx: Transaction<DB>): Promise<ClaimedChain | undefined> {
   const row = await trx

--- a/services/replay/src/queue/claim-next-chain.ts
+++ b/services/replay/src/queue/claim-next-chain.ts
@@ -13,6 +13,13 @@ import type { ClaimedChain } from '../types';
  * transaction — the claim is the row lock, and it releases on commit or rollback. The lock only
  * prevents duplicated effort: exactly-once application is the verified-cursor guard's job, not
  * this lock's.
+ *
+ * A frontier whose build snapshot borrowed unsettled xp is unclaimable until every run it borrowed
+ * from has no appends left past its own verified cursor. Chains are scoped per (avatar, scope)
+ * while identity is avatar-global, so that wait is what orders an avatar's chains against each
+ * other: adjudicating a borrower before its source would settle xp and mint items against a total
+ * the source's own rejection could still erase. A source held under an operator park keeps its
+ * borrowers waiting, since a hold that later rejects would leave the same unbacked total in place.
  */
 export async function claimNextChain(trx: Transaction<DB>): Promise<ClaimedChain | undefined> {
   const row = await trx
@@ -21,7 +28,7 @@ export async function claimNextChain(trx: Transaction<DB>): Promise<ClaimedChain
       (eb) =>
         eb
           .selectFrom('activities')
-          .select('activities.status')
+          .select(['activities.id', 'activities.status'])
           .whereRef('activities.avatarId', '=', 'chain.avatarId')
           .whereRef('activities.scopeType', '=', 'chain.scopeType')
           .whereRef('activities.scopeId', '=', 'chain.scopeId')
@@ -34,6 +41,19 @@ export async function claimNextChain(trx: Transaction<DB>): Promise<ClaimedChain
     )
     .select(['chain.avatarId', 'chain.priority', 'chain.scopeId', 'chain.scopeType'])
     .where('frontier.status', 'not in', ['quarantined', 'parked'])
+    .where((eb) =>
+      eb.not(
+        eb.exists(
+          eb
+            .selectFrom('activitySnapshotSources as edge')
+            .innerJoin('activities as source', 'source.id', 'edge.sourceActivityId')
+            .select('edge.sourceActivityId')
+            .whereRef('edge.activityId', '=', 'frontier.id')
+            .where('source.status', '!=', 'rejected')
+            .whereRef('source.verifiedHead', '<', 'source.appendedHead'),
+        ),
+      ),
+    )
     .orderBy('chain.priority', 'desc')
     .orderBy('chain.createdAt')
     .limit(1)

--- a/services/replay/src/queue/has-rejected-snapshot-source.test.ts
+++ b/services/replay/src/queue/has-rejected-snapshot-source.test.ts
@@ -1,0 +1,79 @@
+import { expect, test } from 'bun:test';
+import { createTestDB } from '@vers/service-test-utils/bun';
+import { createActivityRow } from '../test-utils/create-activity-row';
+import { createSnapshotSourceRow } from '../test-utils/create-snapshot-source-row';
+import { hasRejectedSnapshotSource } from './has-rejected-snapshot-source';
+
+async function setupTest() {
+  const db = await createTestDB();
+
+  return { db: db.db, [Symbol.asyncDispose]: db[Symbol.asyncDispose] };
+}
+
+test('it reports a snapshot that borrowed xp from a rejected run', async () => {
+  await using ctx = await setupTest();
+
+  const source = await createActivityRow(ctx.db, { status: 'rejected' });
+  const borrower = await createActivityRow(ctx.db, { avatarId: source.avatarId });
+
+  await createSnapshotSourceRow(ctx.db, {
+    activityID: borrower.id,
+    sourceActivityID: source.id,
+  });
+
+  const unbacked = await hasRejectedSnapshotSource(ctx.db, borrower.id);
+
+  expect(unbacked).toBeTrue();
+});
+
+test('it reports nothing for a snapshot that borrowed no xp', async () => {
+  await using ctx = await setupTest();
+
+  const activity = await createActivityRow(ctx.db);
+  const unbacked = await hasRejectedSnapshotSource(ctx.db, activity.id);
+
+  expect(unbacked).toBeFalse();
+});
+
+test('it reports nothing while every run the snapshot borrowed from stands', async () => {
+  await using ctx = await setupTest();
+
+  const source = await createActivityRow(ctx.db, { status: 'stopped', verifiedHead: 4 });
+  const borrower = await createActivityRow(ctx.db, { avatarId: source.avatarId });
+
+  await createSnapshotSourceRow(ctx.db, {
+    activityID: borrower.id,
+    sourceActivityID: source.id,
+  });
+
+  const unbacked = await hasRejectedSnapshotSource(ctx.db, borrower.id);
+
+  expect(unbacked).toBeFalse();
+});
+
+test('it reports a rejection among several runs the snapshot borrowed from', async () => {
+  await using ctx = await setupTest();
+
+  const honest = await createActivityRow(ctx.db, { status: 'stopped', verifiedHead: 4 });
+
+  const rejected = await createActivityRow(ctx.db, {
+    avatarId: honest.avatarId,
+    status: 'rejected',
+  });
+
+  const borrower = await createActivityRow(ctx.db, { avatarId: honest.avatarId });
+
+  await createSnapshotSourceRow(ctx.db, {
+    activityID: borrower.id,
+    sourceActivityID: honest.id,
+  });
+
+  await createSnapshotSourceRow(ctx.db, {
+    activityID: borrower.id,
+    sourceActivityID: rejected.id,
+  });
+
+  const unbacked = await hasRejectedSnapshotSource(ctx.db, borrower.id);
+
+  expect(unbacked).toBeTrue();
+});

--- a/services/replay/src/queue/has-rejected-snapshot-source.ts
+++ b/services/replay/src/queue/has-rejected-snapshot-source.ts
@@ -1,0 +1,27 @@
+import type { DB } from '@vers/db';
+import type { Kysely } from 'kysely';
+
+/**
+ * Whether a run whose unsettled xp fed this activity's build snapshot has since been rejected. The
+ * snapshot is stamped at start and replayed as the verifier's simulation input rather than
+ * re-derived, so a rejected source leaves the activity playing a level and life the avatar never
+ * proved it had, and no replay of it can be adjudicated on its merits.
+ *
+ * A source is only ever read once the claim has established it has no appends left past its
+ * verified cursor, so a false answer means every source verified rather than that one is still
+ * being adjudicated.
+ */
+export async function hasRejectedSnapshotSource(
+  db: Kysely<DB>,
+  activityID: string,
+): Promise<boolean> {
+  const rejected = await db
+    .selectFrom('activitySnapshotSources as edge')
+    .innerJoin('activities as source', 'source.id', 'edge.sourceActivityId')
+    .select('edge.sourceActivityId')
+    .where('edge.activityId', '=', activityID)
+    .where('source.status', '=', 'rejected')
+    .executeTakeFirst();
+
+  return rejected !== undefined;
+}

--- a/services/replay/src/test-utils/create-snapshot-source-row.ts
+++ b/services/replay/src/test-utils/create-snapshot-source-row.ts
@@ -1,0 +1,29 @@
+import type { ActivitySnapshotSources, DB } from '@vers/db';
+import type { Kysely, Selectable } from 'kysely';
+
+interface SnapshotSourceInput {
+  /**
+   * The activity whose build snapshot borrowed xp.
+   */
+  readonly activityID: string;
+
+  /**
+   * The unverified run it borrowed from.
+   */
+  readonly sourceActivityID: string;
+}
+
+/**
+ * Persists one snapshot-provenance edge. Both columns are foreign keys into activities the caller
+ * has already created, so there is nothing for a factory to default.
+ */
+export function createSnapshotSourceRow(
+  db: Kysely<DB>,
+  input: Readonly<SnapshotSourceInput>,
+): Promise<Selectable<ActivitySnapshotSources>> {
+  return db
+    .insertInto('activitySnapshotSources')
+    .values({ activityId: input.activityID, sourceActivityId: input.sourceActivityID })
+    .returningAll()
+    .executeTakeFirstOrThrow();
+}

--- a/services/replay/src/worker/run-frontier.test.ts
+++ b/services/replay/src/worker/run-frontier.test.ts
@@ -6,7 +6,9 @@ import { createTestDB, getTestServiceKeyPair } from '@vers/service-test-utils/bu
 import pino from 'pino';
 import invariant from 'tiny-invariant';
 import { createReplayCache } from '../replay/create-replay-cache';
+import { createActivityRow } from '../test-utils/create-activity-row';
 import { createHonestActivityFixture } from '../test-utils/create-honest-activity-fixture';
+import { createSnapshotSourceRow } from '../test-utils/create-snapshot-source-row';
 import { runFrontier } from './run-frontier';
 
 async function setupTest() {
@@ -356,4 +358,61 @@ test('it settles no additional xp when a stale duplicate frontier misses the alr
     .executeTakeFirstOrThrow();
 
   expect(afterSecond.xp).toBe(afterFirst.xp);
+});
+
+test('it refuses an activity whose build snapshot borrowed xp from a rejected run', async () => {
+  await using ctx = await setupTest();
+
+  const fixture = await createHonestActivityFixture(ctx.db, {
+    duration: 80_000,
+    seed: buildStateFromSeed(3_047_525_658),
+  });
+
+  const source = await createActivityRow(ctx.db, {
+    avatarId: fixture.activity.avatarId,
+    scopeId: 'scope_lender',
+    status: 'rejected',
+  });
+
+  await createSnapshotSourceRow(ctx.db, {
+    activityID: fixture.activity.id,
+    sourceActivityID: source.id,
+  });
+
+  const deps = {
+    db: ctx.db,
+    keysServiceURL: resolveServiceURL('keys'),
+    logger: pino({ enabled: false }),
+    privateKey: ctx.privateKey,
+    simVersion: 'test-engine-hash',
+  };
+
+  const outcome = await ctx.db.transaction().execute((trx) =>
+    runFrontier(trx, deps, createReplayCache(), {
+      activityID: fixture.activity.id,
+      appendedHead: fixture.activity.appendedHead,
+      replayAttempts: 0,
+      startChainIndex: fixture.activity.startChainIndex,
+      status: fixture.activity.status,
+      verifiedHead: 0,
+    }),
+  );
+
+  expect(outcome).toStrictEqual({ kind: 'rejected' });
+
+  const activity = await ctx.db
+    .selectFrom('activities')
+    .select(['status', 'verifiedHead'])
+    .where('id', '=', fixture.activity.id)
+    .executeTakeFirstOrThrow();
+
+  expect(activity).toStrictEqual({ status: 'rejected', verifiedHead: 0 });
+
+  const avatar = await ctx.db
+    .selectFrom('avatars')
+    .select('xp')
+    .where('id', '=', fixture.activity.avatarId)
+    .executeTakeFirstOrThrow();
+
+  expect(avatar.xp).toBe(0);
 });

--- a/services/replay/src/worker/run-frontier.ts
+++ b/services/replay/src/worker/run-frontier.ts
@@ -13,6 +13,7 @@ import type { RejectionReason } from '../metrics/record-rejection';
 import { recordSettledXP } from '../metrics/record-settled-xp';
 import { recordVerificationLag } from '../metrics/record-verification-lag';
 import { rollRewardItems } from '../mint/roll-reward-items';
+import { hasRejectedSnapshotSource } from '../queue/has-rejected-snapshot-source';
 import { updateReplayAttempts } from '../queue/update-replay-attempts';
 import { buildSegmentDuration } from '../replay/build-segment-duration';
 import { compareReplaySegment } from '../replay/compare-replay-segment';
@@ -28,12 +29,13 @@ import type { PendingCacheEffect, ReplayIterationOutcome, ReplayWorkerDeps } fro
 import { updateVerifiedAnchorFromPredecessor } from './update-verified-anchor-from-predecessor';
 
 /**
- * Adjudicates one claimed chain's replay frontier: loads its segment, catches the chain's verified
- * anchor up to a forward-exited predecessor it missed, re-derives the activity's seed on its first
- * verified batch, then dispatches by `simVersion` — the in-process incremental cache for this
- * deploy's own engine, the cross-version provider registry for everything else — and turns the
- * resulting verdict into a cursor-only apply, a confirmed rejection, or a park. Runs inside the
- * caller's transaction, alongside the chain claim it composes with.
+ * Adjudicates one claimed chain's replay frontier: loads its segment, refuses it outright when a
+ * run its build snapshot borrowed xp from has been rejected, catches the chain's verified anchor up
+ * to a forward-exited predecessor it missed, re-derives the activity's seed on its first verified
+ * batch, then dispatches by `simVersion` — the in-process incremental cache for this deploy's own
+ * engine, the cross-version provider registry for everything else — and turns the resulting verdict
+ * into a cursor-only apply, a confirmed rejection, or a park. Runs inside the caller's transaction,
+ * alongside the chain claim it composes with.
  */
 export async function runFrontier(
   trx: Transaction<DB>,
@@ -46,6 +48,12 @@ export async function runFrontier(
 
   if (loaded === undefined) {
     return { kind: 'idle' };
+  }
+
+  const unbackedSnapshot = await hasRejectedSnapshotSource(trx, loaded.activity.id);
+
+  if (unbackedSnapshot) {
+    return rejectUnbackedSnapshot(trx, deps, cache, loaded);
   }
 
   const reconciledAnchor = await updateVerifiedAnchorFromPredecessor(trx, loaded);
@@ -355,6 +363,45 @@ async function rejectSegment(
   );
 
   recordRejection('integrity-mismatch');
+
+  await rejectActivity(trx, {
+    activityID: segment.activity.id,
+    avatarID: segment.activity.avatarID,
+    scopeID: segment.activity.scopeID,
+    scopeType: segment.activity.scopeType,
+  });
+
+  cache.remove(segment.activity.id);
+
+  return { kind: 'rejected' };
+}
+
+/**
+ * Refuses an activity whose build snapshot borrowed xp from a run that has since been rejected.
+ * The borrowed total is gone, so there is nothing to replay the stream against and no divergence
+ * to confirm — the rejection follows from the snapshot's foundation rather than from anything the
+ * stream itself did. Rejecting through the same single-chain path voids this activity's own
+ * successors, and every activity that borrowed from this one fails this check in turn, so the
+ * refusal reaches the whole dependency graph without any writer reaching across chains.
+ */
+async function rejectUnbackedSnapshot(
+  trx: Transaction<DB>,
+  deps: Readonly<ReplayWorkerDeps>,
+  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- a mutable cache handle whose remove/get/set are its whole point; no readonly form is useful
+  cache: ReplayCache,
+  segment: Readonly<ReplaySegment>,
+): Promise<ReplayIterationOutcome> {
+  deps.logger.error(
+    {
+      activityID: segment.activity.id,
+      appendedHead: segment.activity.appendedHead,
+      buildSnapshotXP: segment.activity.buildSnapshot.xp,
+      verifiedHead: segment.verifiedHead,
+    },
+    'build snapshot borrowed xp from a rejected run; rejecting activity',
+  );
+
+  recordRejection('unbacked-snapshot');
 
   await rejectActivity(trx, {
     activityID: segment.activity.id,


### PR DESCRIPTION
## Description

Closes #783

A new activity's build snapshot counts the unsettled xp of runs awaiting their verifier, and the
verifier replays against that stored snapshot rather than re-deriving it — so a run that borrowed
from a later-rejected run kept an inflated level and earned real xp and loot from it.

- Records each activity's snapshot provenance at start, in a new `activity_snapshot_sources` table.
- Makes a chain unclaimable while its replay frontier has a source with appends past its own
  verified cursor, which orders an avatar's chains against each other.
- Refuses a frontier whose source rejected, through the existing single-chain rejection path;
  dependents fail the same check on their own turn, so one rejection reaches the whole graph with
  no writer reaching across chains and no change to the chain-row lock ordering.
- Chose that over cascading writes at rejection time: a cascade needs the chain rows of chains it
  discovers mid-transaction, which two concurrent rejections can deadlock on, and the retry path
  counts a lock abort toward quarantine.
- A parked source keeps its borrowers waiting, stalling that chain until the hold clears — a hold
  that later rejects would otherwise leave the same unproven total in place.
- A doomed activity is refused at its next adjudication, not the instant its source falls.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
