### PR TITLE
fix(#799): reject a checkpoint whose xp reward is not an integer

### DIFF
--- a/services/activity/src/build-unsettled-xp.ts
+++ b/services/activity/src/build-unsettled-xp.ts
@@ -14,8 +14,9 @@ interface UnsettledXPInput {
   /**
    * Summed `rewards.xp` of every checkpoint past the verified cursor. A terminal tail's own total
    * must be excluded from this sum by the caller's query — it is a run total, not a delta. A
-   * caller summing in postgres casts the aggregate back to `integer`: a bigint sum arrives as a
-   * string and would concatenate here rather than add.
+   * caller summing in postgres leaves the aggregate at `bigint` — narrowing it to `integer` in SQL
+   * overflows once the total passes that ceiling — and converts it to a number here, since the
+   * driver hands a bigint over as a string that would concatenate rather than add.
    */
   readonly unverifiedDeltaSum: number;
 }

--- a/services/activity/src/handlers/get-avatar-progression.test.ts
+++ b/services/activity/src/handlers/get-avatar-progression.test.ts
@@ -248,6 +248,56 @@ test('it includes the unsettled xp of a run stopped before its encounter finishe
   });
 });
 
+test('it reports unsettled xp that sums past what a database integer holds', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id, xp: 0 });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'a9lp75',
+    scopeType: 'world_map_node',
+  });
+
+  const first = createMockCheckpointBatch({
+    finalPayloadOverrides: { rewards: { xp: 2_147_483_647 }, type: 'progress' },
+    startPrevHash: started.startHash,
+    startVersion: 1,
+  });
+
+  await client.trackActivityProgress({
+    activityID: started.id,
+    checkpoints: first,
+    expectedHead: 0,
+  });
+
+  const second = createMockCheckpointBatch({
+    finalPayloadOverrides: { rewards: { xp: 2_147_483_647 }, type: 'progress' },
+    startPrevHash: first[0]!.hash,
+    startVersion: 2,
+  });
+
+  await client.trackActivityProgress({
+    activityID: started.id,
+    checkpoints: second,
+    expectedHead: 1,
+  });
+
+  await client.stopActivity({ avatarID: avatar.id });
+
+  const result = await client.getAvatarProgression({ avatarID: avatar.id });
+
+  expect(result).toStrictEqual({
+    active: null,
+    level: 1,
+    pending: [{ activityID: started.id, xpDelta: 4_294_967_294 }],
+    xp: 0,
+  });
+});
+
 test('it skips a pending entry whose tail checkpoint carries no terminal rewards payload', async () => {
   await using ctx = await setupTest();
 

--- a/services/activity/src/handlers/get-avatar-progression.ts
+++ b/services/activity/src/handlers/get-avatar-progression.ts
@@ -80,7 +80,7 @@ export async function getAvatarProgression(
         eb
           .selectFrom('activityCheckpoints as unverified')
           .select(
-            sql<number>`coalesce(sum((unverified.payload -> 'rewards' ->> 'xp')::integer), 0)::integer`.as(
+            sql<string>`coalesce(sum((unverified.payload -> 'rewards' ->> 'xp')::integer), 0)`.as(
               'deltaSum',
             ),
           )
@@ -124,7 +124,7 @@ export async function getAvatarProgression(
 }
 
 interface PendingCandidateRow {
-  readonly deltaSum: null | number;
+  readonly deltaSum: null | string;
   readonly id: null | string;
   readonly payload: unknown;
   readonly settledXp: null | number;
@@ -142,7 +142,7 @@ function findPendingEntry(row: Readonly<PendingCandidateRow>): Array<PendingXPEn
   const xpDelta = buildUnsettledXP({
     settledXP: row.settledXp ?? 0,
     tailPayload: row.payload,
-    unverifiedDeltaSum: row.deltaSum ?? 0,
+    unverifiedDeltaSum: Number(row.deltaSum ?? 0),
   });
 
   if (xpDelta === 0) {

--- a/services/activity/src/handlers/start-activity.ts
+++ b/services/activity/src/handlers/start-activity.ts
@@ -311,7 +311,7 @@ async function getOptimisticBuild(trx: Kysely<DB>, avatarID: string): Promise<Op
         eb
           .selectFrom('activityCheckpoints as unverified')
           .select(
-            sql<number>`coalesce(sum((unverified.payload -> 'rewards' ->> 'xp')::integer), 0)::integer`.as(
+            sql<string>`coalesce(sum((unverified.payload -> 'rewards' ->> 'xp')::integer), 0)`.as(
               'deltaSum',
             ),
           )
@@ -350,7 +350,7 @@ async function getOptimisticBuild(trx: Kysely<DB>, avatarID: string): Promise<Op
     const unsettledXP = buildUnsettledXP({
       settledXP: row.settledXp ?? 0,
       tailPayload: row.payload,
-      unverifiedDeltaSum: row.deltaSum ?? 0,
+      unverifiedDeltaSum: Number(row.deltaSum ?? 0),
     });
 
     // A run that moved the total by nothing is not a dependency: the snapshot is the same value

--- a/services/activity/src/handlers/track-activity-progress.test.ts
+++ b/services/activity/src/handlers/track-activity-progress.test.ts
@@ -353,6 +353,91 @@ test('it rejects a batch whose reward slot ordinals are not contiguous from 0 wi
   });
 });
 
+test('it rejects a batch whose xp reward is fractional with CHECKPOINT_INVALID', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'a9lp75',
+    scopeType: 'world_map_node',
+  });
+
+  const batch = createMockCheckpointBatch({
+    finalPayloadOverrides: { rewards: { xp: 1.5 } },
+    startPrevHash: started.startHash,
+    startVersion: 1,
+  });
+
+  expect(
+    client.trackActivityProgress({ activityID: started.id, checkpoints: batch, expectedHead: 0 }),
+  ).rejects.toMatchObject({
+    code: 'CHECKPOINT_INVALID',
+    data: { reason: 'invalid-rewards' },
+  });
+});
+
+test('it rejects a batch whose xp reward is not a number with CHECKPOINT_INVALID', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'a9lp75',
+    scopeType: 'world_map_node',
+  });
+
+  const batch = createMockCheckpointBatch({
+    finalPayloadOverrides: { rewards: { xp: 'lots' } },
+    startPrevHash: started.startHash,
+    startVersion: 1,
+  });
+
+  expect(
+    client.trackActivityProgress({ activityID: started.id, checkpoints: batch, expectedHead: 0 }),
+  ).rejects.toMatchObject({
+    code: 'CHECKPOINT_INVALID',
+    data: { reason: 'invalid-rewards' },
+  });
+});
+
+test('it appends a batch whose rewards carry fields beside xp', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'a9lp75',
+    scopeType: 'world_map_node',
+  });
+
+  const batch = createMockCheckpointBatch({
+    finalPayloadOverrides: { rewards: { gold: 3, xp: 40 } },
+    startPrevHash: started.startHash,
+    startVersion: 1,
+  });
+
+  const result = await client.trackActivityProgress({
+    activityID: started.id,
+    checkpoints: batch,
+    expectedHead: 0,
+  });
+
+  expect(result).toStrictEqual({ appendedHead: 1 });
+});
+
 test('it rejects appending to a stopped activity with ACTIVITY_TERMINAL', async () => {
   await using ctx = await setupTest();
 

--- a/services/activity/src/handlers/track-activity-progress.test.ts
+++ b/services/activity/src/handlers/track-activity-progress.test.ts
@@ -409,6 +409,63 @@ test('it rejects a batch whose xp reward is not a number with CHECKPOINT_INVALID
   });
 });
 
+test('it rejects a batch whose xp reward exceeds what the database column holds with CHECKPOINT_INVALID', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'a9lp75',
+    scopeType: 'world_map_node',
+  });
+
+  const batch = createMockCheckpointBatch({
+    finalPayloadOverrides: { rewards: { xp: 2_147_483_648 } },
+    startPrevHash: started.startHash,
+    startVersion: 1,
+  });
+
+  expect(
+    client.trackActivityProgress({ activityID: started.id, checkpoints: batch, expectedHead: 0 }),
+  ).rejects.toMatchObject({
+    code: 'CHECKPOINT_INVALID',
+    data: { reason: 'invalid-rewards' },
+  });
+});
+
+test('it appends a batch whose xp reward sits at the largest value the database column holds', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const started = await client.startActivity({
+    avatarID: avatar.id,
+    scopeID: 'a9lp75',
+    scopeType: 'world_map_node',
+  });
+
+  const batch = createMockCheckpointBatch({
+    finalPayloadOverrides: { rewards: { xp: 2_147_483_647 } },
+    startPrevHash: started.startHash,
+    startVersion: 1,
+  });
+
+  const result = await client.trackActivityProgress({
+    activityID: started.id,
+    checkpoints: batch,
+    expectedHead: 0,
+  });
+
+  expect(result).toStrictEqual({ appendedHead: 1 });
+});
+
 test('it appends a batch whose rewards carry fields beside xp', async () => {
   await using ctx = await setupTest();
 

--- a/services/activity/src/handlers/track-activity-progress.ts
+++ b/services/activity/src/handlers/track-activity-progress.ts
@@ -441,6 +441,23 @@ function findRewardSlotsInvalidReason(payload: Readonly<CheckpointPayload>): str
   return isContiguous ? undefined : 'invalid-reward-slots';
 }
 
+const RewardsSchema = z.looseObject({ xp: z.int().optional() });
+
+/**
+ * A checkpoint's `rewards` field rides outside the hashed subset, so it's validated here rather
+ * than by the payload schema. Absent is valid — a checkpoint that earned nothing carries no key at
+ * all. Present, `xp` must be an integer: readers aggregate it in postgres with an `integer` cast
+ * that fails the whole statement on a fractional or non-numeric value, and the offending
+ * checkpoint would keep failing it on every later read.
+ */
+function findRewardsInvalidReason(payload: Readonly<CheckpointPayload>): string | undefined {
+  if (!('rewards' in payload)) {
+    return undefined;
+  }
+
+  return RewardsSchema.safeParse(payload['rewards']).success ? undefined : 'invalid-rewards';
+}
+
 interface CheckpointBatchInput {
   readonly checkpoints: ReadonlyArray<CheckpointBatchEntry>;
   readonly expectedHead: number;
@@ -460,7 +477,8 @@ interface TrackActivityProgressHead {
  * contiguity from `expectedHead + 1`, each entry's `chainIndex` continuity from
  * `head.startChainIndex`, no run-ending entry before the batch's last — only the last entry claims
  * the activity's terminal transition, so an interior one would store a terminal the settlement rule
- * never reads — each entry's optional `rewardSlots` shape and ordinal contiguity, each
+ * never reads — each entry's optional `rewardSlots` shape and ordinal contiguity, each entry's
+ * optional `rewards.xp` being an integer, each
  * entry's cumulative `time` never regressing — within the batch always, and from the head row's
  * accounted time only when `expectedHead` still matches the head row, since a stale batch predates
  * that value — each entry's hash against its own payload, each entry's chain link to the previous
@@ -494,6 +512,12 @@ function findInvalidReason(
 
     if (rewardSlotsReason !== undefined) {
       return rewardSlotsReason;
+    }
+
+    const rewardsReason = findRewardsInvalidReason(checkpoint.payload);
+
+    if (rewardsReason !== undefined) {
+      return rewardsReason;
     }
 
     // The negated >= also rejects a NaN time, which would otherwise slip through as a 0 delta.

--- a/services/activity/src/handlers/track-activity-progress.ts
+++ b/services/activity/src/handlers/track-activity-progress.ts
@@ -441,13 +441,13 @@ function findRewardSlotsInvalidReason(payload: Readonly<CheckpointPayload>): str
   return isContiguous ? undefined : 'invalid-reward-slots';
 }
 
-const RewardsSchema = z.looseObject({ xp: z.int().optional() });
+const RewardsSchema = z.looseObject({ xp: z.int32().optional() });
 
 /**
  * A checkpoint's `rewards` field rides outside the hashed subset, so it's validated here rather
  * than by the payload schema. Absent is valid — a checkpoint that earned nothing carries no key at
- * all. Present, `xp` must be an integer: readers aggregate it in postgres with an `integer` cast
- * that fails the whole statement on a fractional or non-numeric value, and the offending
+ * all. Present, `xp` must fit postgres `integer`: readers aggregate it with a cast that fails the
+ * whole statement on a fractional, non-numeric, or out-of-range value, and the offending
  * checkpoint would keep failing it on every later read.
  */
 function findRewardsInvalidReason(payload: Readonly<CheckpointPayload>): string | undefined {
@@ -478,7 +478,7 @@ interface TrackActivityProgressHead {
  * `head.startChainIndex`, no run-ending entry before the batch's last — only the last entry claims
  * the activity's terminal transition, so an interior one would store a terminal the settlement rule
  * never reads — each entry's optional `rewardSlots` shape and ordinal contiguity, each entry's
- * optional `rewards.xp` being an integer, each
+ * optional `rewards.xp` fitting postgres `integer`, each
  * entry's cumulative `time` never regressing — within the batch always, and from the head row's
  * accounted time only when `expectedHead` still matches the head row, since a stale batch predates
  * that value — each entry's hash against its own payload, each entry's chain link to the previous


### PR DESCRIPTION
## Description

Closes #799
Closes #803

`getAvatarProgression` and `startActivity` aggregate unverified xp in postgres, but neither end of that aggregate was safe: `rewards.xp` was never validated on the way in, and the sum was narrowed back to `integer` on the way out. Either could fail the whole statement, and since the checkpoints persist, both procedures would then throw for that avatar on every later call.

- Validates `rewards.xp` at the append path with `z.int32()` — integral and within postgres `integer` — rejecting with `CHECKPOINT_INVALID` / `invalid-rewards`. The field is untrusted client input, so the boundary is where it belongs.
- Leaves the aggregate at its natural `bigint` width and converts at the read site, matching how the bigint meter and time columns are already read. Two in-range checkpoints were enough to overflow the old `::integer`.
- Absent `rewards` stays valid, as do extra fields beside `xp`.
- Production holds no row either change would have rejected — all 186 checkpoints carry an integer `xp`.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality

This tightens a contract other packages write against, so `bun run test` was run across the whole workspace, not just the changed project. Every new test was confirmed to fail against the unfixed code first.