### PR TITLE
feat(#778): tighten progression polling and net the overlay at mount

### DIFF
--- a/apps/web/src/lib/activity/build-avatar-progression-query-options.test.ts
+++ b/apps/web/src/lib/activity/build-avatar-progression-query-options.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from 'bun:test';
+import { buildAvatarProgressionQueryOptions } from './build-avatar-progression-query-options';
+
+test('it polls on the relaxed interval when nothing is waiting to settle', () => {
+  const options = buildAvatarProgressionQueryOptions('avatar_1');
+
+  expect(options.refetchInterval({ state: { data: { pending: [] } } })).toBe(10_000);
+});
+
+test('it tightens the poll while an entry is waiting to settle', () => {
+  const options = buildAvatarProgressionQueryOptions('avatar_1');
+
+  expect(
+    options.refetchInterval({
+      state: { data: { pending: [{ activityID: 'act_1', xpDelta: 40 }] } },
+    }),
+  ).toBe(2000);
+});
+
+test('it polls on the relaxed interval before the first response lands', () => {
+  const options = buildAvatarProgressionQueryOptions('avatar_1');
+
+  expect(options.refetchInterval({ state: {} })).toBe(10_000);
+});
+
+test('it polls on the relaxed interval for an avatar the caller does not own', () => {
+  const options = buildAvatarProgressionQueryOptions('avatar_1');
+
+  expect(options.refetchInterval({ state: { data: null } })).toBe(10_000);
+});

--- a/apps/web/src/lib/activity/build-avatar-progression-query-options.ts
+++ b/apps/web/src/lib/activity/build-avatar-progression-query-options.ts
@@ -1,14 +1,36 @@
 import { orpc } from '../rpc/orpc';
 
+const IDLE_REFETCH_INTERVAL_MS = 10_000;
+
+/**
+ * The cadence while an entry is still waiting on the verifier — short enough that a settled total
+ * lands close behind the run that earned it.
+ */
+const SETTLING_REFETCH_INTERVAL_MS = 2000;
+
+/**
+ * The one field the refetch cadence reads off a progression response.
+ */
+interface ProgressionRefetchQuery {
+  readonly state: {
+    readonly data?: { readonly pending: ReadonlyArray<unknown> } | null | undefined;
+  };
+}
+
 /**
  * Query options for an avatar's settled xp/level plus its pending terminal-but-unsettled xp
- * deltas, or `null` when the avatar doesn't exist or isn't owned by the caller. Refetched on a
- * modest interval: settlement lands server-side with no client signal, so polling is what lets a
- * pending delta quietly firm up into the settled row.
+ * deltas, or `null` when the avatar doesn't exist or isn't owned by the caller. Settlement lands
+ * server-side with no client signal, so polling is what firms a pending delta up into the settled
+ * row: the interval tightens while any entry is outstanding and relaxes once none is. A run in
+ * flight needs no tightening of its own — its live overlay and the settled total that overlay nets
+ * against advance together, so the figure on screen holds steady however far behind the read lags.
  */
 export function buildAvatarProgressionQueryOptions(avatarID: string) {
   return {
     ...orpc.activity.getAvatarProgression.queryOptions({ input: { avatarID } }),
-    refetchInterval: 10_000,
+    refetchInterval: (query: ProgressionRefetchQuery) =>
+      (query.state.data?.pending.length ?? 0) > 0
+        ? SETTLING_REFETCH_INTERVAL_MS
+        : IDLE_REFETCH_INTERVAL_MS,
   };
 }

--- a/apps/web/src/routes/-avatar/avatar-progression.test.tsx
+++ b/apps/web/src/routes/-avatar/avatar-progression.test.tsx
@@ -2,7 +2,9 @@ import { expect, test } from 'bun:test';
 import { waitFor } from '@testing-library/react';
 import { ActivityFailureAction } from '@vers/idle-core';
 import { createMockActivitySnapshot, createMockAvatarSnapshot } from '@vers/idle-core/test-utils';
+import { mockActivityService } from '@vers/mock-services/activity';
 import * as db from '@vers/mock-services/db';
+import { server } from '../../mocks/node';
 import { createActiveAvatar } from '../../test-utils/create-active-avatar';
 import { createSignedInUser } from '../../test-utils/create-signed-in-user';
 import { render } from '../../test-utils/render';
@@ -101,5 +103,40 @@ test('it shows the optimistic sim overlay and the settling marker while an activ
     });
 
     expect(rendered.getByTestId('avatar-progression-settling')).toBeInTheDocument();
+  });
+});
+
+test('it withholds the live overlay until the settled read lands', async () => {
+  const signedIn = await createSignedInUser();
+  const avatar = await createActiveAvatar({ level: 3, userID: signedIn.userID, xp: 450 });
+
+  const activity = await db.activityCollection.create({
+    avatarID: avatar.id,
+    status: 'active',
+  });
+
+  setIdleWorkerHandle({
+    activity: createMockActivitySnapshot({ id: activity.id, rewards: { xp: 25 } }),
+    avatar: createMockAvatarSnapshot({ level: 3 }),
+    client: undefined,
+    failureAction: ActivityFailureAction.Retry,
+    initialized: true,
+    writerAbortSignal: new AbortController().signal,
+  });
+
+  // the read never lands, holding the screen in the window where no per-activity settled total is
+  // available for the overlay to net against
+  server.use(mockActivityService.getAvatarProgression.handler(() => new Promise<never>(() => {})));
+
+  await withRequestContext({ cookies: signedIn.cookies }, async () => {
+    const rendered = render(<AvatarProgression />);
+
+    const xp = await rendered.findByTestId('avatar-xp');
+
+    await waitFor(() => {
+      expect(xp).toHaveTextContent('XP: 450');
+    });
+
+    expect(rendered.queryByTestId('avatar-progression-settling')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/routes/-avatar/avatar-progression.tsx
+++ b/apps/web/src/routes/-avatar/avatar-progression.tsx
@@ -24,13 +24,16 @@ export function AvatarProgression() {
     return null;
   }
 
-  // Settled row from the query once it resolves; the avatar row alone with no pending entries
-  // while it's still loading, so the screen shows a total immediately rather than nothing.
-  const settled = progressionQuery.data ?? { level: avatar.level, pending: [], xp: avatar.xp };
+  const settled = progressionQuery.data;
 
   const progression = buildOptimisticProgression({
-    progression: settled,
-    simActivity: idleWorkerHandle.activity,
+    // the avatar row alone while the read is still in flight, so the screen shows a total
+    // immediately rather than nothing
+    progression: settled ?? { level: avatar.level, pending: [], xp: avatar.xp },
+    // that row carries no per-activity settled total for the live overlay to net against, so
+    // projecting the sim on top of it would count the banked part twice and then correct downward
+    // once the read lands
+    simActivity: settled ? idleWorkerHandle.activity : undefined,
   });
 
   return (


### PR DESCRIPTION
## Description

Closes #778

Two fixes to how the avatar screen reads progression, now that the simulation records xp per kill.

- The poll ran at a flat 10s, so a pending entry took up to that long to firm up into the settled row. It now tightens to 2s while any entry is outstanding and relaxes once none is.
- Deliberately not tightened for a run merely being active: the live overlay and the settled total it nets against advance together, so the figure on screen holds steady however far behind the read lags. Polling every 2s for a whole run would multiply load on a lateral-join query that also pokes the replay waker, for nothing visible.
- The loading fallback carried no per-activity settled total, so the overlay was projected onto it unnetted — counting the banked part of the run twice, then correcting downward once the read landed. The overlay now waits for the settled read.

The live per-kill bar itself needed no change; it followed from #796.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality