### PR TITLE
test: boot one replay provider process per socket test file

### DIFF
--- a/services/replay/src/build-provider-router.test.ts
+++ b/services/replay/src/build-provider-router.test.ts
@@ -1,7 +1,8 @@
 import { expect, test } from 'bun:test';
 import { replayContract } from '@vers/contract-replay';
+import { createMockReplaySegmentInput } from '@vers/contract-replay/test-utils';
 import { createAnonymousViewer } from '@vers/service-test-utils/bun';
-import { collectConformanceCases } from '@vers/test-utils';
+import { buildRPCTestClient, collectConformanceCases } from '@vers/test-utils';
 import { createReplayProvider } from './create-replay-provider';
 
 test('it passes every conformance case collected from its narrowed contract', async () => {
@@ -16,4 +17,36 @@ test('it passes every conformance case collected from its narrowed contract', as
   for (const conformanceCase of cases) {
     await expect(conformanceCase.run(service.app)).toResolve();
   }
+});
+
+test('it rejects a stamp that does not match the baked engine hash with SIM_VERSION_MISMATCH', async () => {
+  const service = await createReplayProvider();
+  const viewer = await createAnonymousViewer({ audience: 'service-replay-provider' });
+
+  const client = buildRPCTestClient<{ replaySegment: typeof replayContract.replaySegment }>(
+    service.app,
+    { token: viewer.token },
+  );
+
+  const input = createMockReplaySegmentInput({ simVersion: 'some-other-engine-hash' });
+
+  expect(client.replaySegment(input)).rejects.toMatchObject({
+    code: 'SIM_VERSION_MISMATCH',
+    data: { providerSimVersion: 'test-engine-hash' },
+  });
+});
+
+test('it 404s on /rpc/wake — a provider serves no drain route', async () => {
+  const service = await createReplayProvider();
+  const viewer = await createAnonymousViewer({ audience: 'service-replay-provider' });
+
+  const response = await service.app.handle(
+    new Request('http://test.local/rpc/wake', {
+      body: JSON.stringify({ json: {} }),
+      headers: { authorization: `Bearer ${viewer.token}`, 'content-type': 'application/json' },
+      method: 'POST',
+    }),
+  );
+
+  expect(response.status).toBe(404);
 });

--- a/services/replay/src/serve-provider.test.ts
+++ b/services/replay/src/serve-provider.test.ts
@@ -46,7 +46,7 @@ beforeAll(async () => {
 });
 
 afterAll(() => {
-  proc.kill();
+  proc?.kill();
 });
 
 /**

--- a/services/replay/src/serve-provider.test.ts
+++ b/services/replay/src/serve-provider.test.ts
@@ -1,4 +1,4 @@
-import { expect, onTestFinished, test } from 'bun:test';
+import { afterAll, beforeAll, expect, test } from 'bun:test';
 import path from 'node:path';
 import { createMockReplaySegmentInput } from '@vers/contract-replay/test-utils';
 import { createServiceToken, getTestServiceKeyPair } from '@vers/service-test-utils/bun';
@@ -6,28 +6,26 @@ import { waitFor } from '@vers/test-utils';
 
 const SERVE_PROVIDER_PATH = path.resolve(import.meta.dirname, 'serve-provider.ts');
 const REPLAY_DIR = path.resolve(import.meta.dirname, '..');
-let nextPort = 41_100;
+const PORT = 41_100;
+const URL = `http://127.0.0.1:${PORT}`;
+let proc: Bun.Subprocess;
 
 /**
- * Starts the real `serve-provider.ts` entrypoint in a subprocess on only base env plus
+ * Boots the real `serve-provider.ts` entrypoint once for the whole file, on only base env plus
  * `SIM_ENGINE_HASH` — no `DATABASE_URL`, `KEYS_SERVICE_URL`, or `SERVICE_AUTH_PRIVATE_KEY` — the
  * exact env a per-version provider machine boots on, and the regression this entrypoint exists to
- * fix: the in-process test client shares this suite's full ambient env, which would mask a missing
- * env-wiring bug this real process cannot. Kills the subprocess once the calling test finishes.
+ * catch: the in-process test client shares this suite's full ambient env, which would mask a
+ * missing env-wiring bug this real process cannot. Provider routing behaviour is covered in-process
+ * by `build-provider-router.test.ts`; this file only proves the real entrypoint boots and serves
+ * over a socket, so one shared process serves every case.
  */
-async function startProviderProcess(): Promise<string> {
+beforeAll(async () => {
   const keyPair = await getTestServiceKeyPair();
 
-  const port = nextPort;
-
-  nextPort += 1;
-
-  const url = `http://127.0.0.1:${port}`;
-
-  const proc = Bun.spawn([process.execPath, SERVE_PROVIDER_PATH], {
+  proc = Bun.spawn([process.execPath, SERVE_PROVIDER_PATH], {
     cwd: REPLAY_DIR,
     env: {
-      PORT: String(port),
+      PORT: String(PORT),
       SERVICE_AUTH_JWKS: keyPair.jwksJSON,
       SIM_ENGINE_HASH: 'test-engine-hash',
     },
@@ -35,13 +33,9 @@ async function startProviderProcess(): Promise<string> {
     stdout: 'pipe',
   });
 
-  onTestFinished(() => {
-    proc.kill();
-  });
-
   await waitFor(
     async () => {
-      const response = await fetch(`${url}/health`);
+      const response = await fetch(`${URL}/health`);
 
       if (!response.ok) {
         throw new Error(`provider health check returned ${String(response.status)}`);
@@ -49,16 +43,18 @@ async function startProviderProcess(): Promise<string> {
     },
     { timeoutMs: 5000 },
   );
+});
 
-  return url;
-}
+afterAll(() => {
+  proc.kill();
+});
 
 /**
- * Sends a signed RPC call to a booted provider process over the network — a real socket round
+ * Sends a signed RPC call to the booted provider process over the network — a real socket round
  * trip, not the in-process `app.handle` test client.
  */
-function sendRPC(url: string, procedure: string, token: string, input: unknown): Promise<Response> {
-  return fetch(`${url}/rpc/${procedure}`, {
+function sendRPC(procedure: string, token: string, input: unknown): Promise<Response> {
+  return fetch(`${URL}/rpc/${procedure}`, {
     body: JSON.stringify({ json: input }),
     headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
     method: 'POST',
@@ -66,8 +62,7 @@ function sendRPC(url: string, procedure: string, token: string, input: unknown):
 }
 
 test('it serves /health with no database, keys service, or signing key configured', async () => {
-  const url = await startProviderProcess();
-  const response = await fetch(`${url}/health`);
+  const response = await fetch(`${URL}/health`);
   const body = await response.json();
 
   expect(response.status).toBe(200);
@@ -75,7 +70,6 @@ test('it serves /health with no database, keys service, or signing key configure
 });
 
 test('it round-trips an authed replaySegment call', async () => {
-  const url = await startProviderProcess();
   const keyPair = await getTestServiceKeyPair();
 
   const token = await createServiceToken({
@@ -85,44 +79,9 @@ test('it round-trips an authed replaySegment call', async () => {
 
   const input = createMockReplaySegmentInput({ simVersion: 'test-engine-hash' });
 
-  const response = await sendRPC(url, 'replaySegment', token, input);
+  const response = await sendRPC('replaySegment', token, input);
   const body = await response.json();
 
   expect(response.status).toBe(200);
   expect(body).toMatchObject({ json: { elapsed: input.duration } });
-});
-
-test('it rejects a stamp that does not match the baked engine hash with SIM_VERSION_MISMATCH', async () => {
-  const url = await startProviderProcess();
-  const keyPair = await getTestServiceKeyPair();
-
-  const token = await createServiceToken({
-    audience: 'service-replay-provider',
-    privateKey: keyPair.privateKey,
-  });
-
-  const input = createMockReplaySegmentInput({ simVersion: 'some-other-engine-hash' });
-
-  const response = await sendRPC(url, 'replaySegment', token, input);
-  const body = await response.json();
-
-  expect(response.status).toBe(409);
-
-  expect(body).toMatchObject({
-    json: { code: 'SIM_VERSION_MISMATCH', data: { providerSimVersion: 'test-engine-hash' } },
-  });
-});
-
-test('it 404s on /rpc/wake — a provider serves no drain route', async () => {
-  const url = await startProviderProcess();
-  const keyPair = await getTestServiceKeyPair();
-
-  const token = await createServiceToken({
-    audience: 'service-replay-provider',
-    privateKey: keyPair.privateKey,
-  });
-
-  const response = await sendRPC(url, 'wake', token, {});
-
-  expect(response.status).toBe(404);
 });


### PR DESCRIPTION
## Description

The replay `serve-provider` socket suite spawned a fresh Bun subprocess per test, racing each boot against a 5s health-check deadline; one boot exceeded it under CI load and timed out `main`. This reshapes the suite to boot once and moves socket-agnostic behaviour off the subprocess tier.

- Move `SIM_VERSION_MISMATCH` and `wake`-404 assertions to the in-process `build-provider-router` suite — they test router behaviour, not the socket.
- Boot a single shared provider process in `beforeAll` for the two tests that genuinely exercise the real entrypoint over a socket.
- Net: the file drops from four subprocess boots to one; the socket tier now proves only env-wiring and wire serialization.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality