### PR TITLE
fix(#809): close idle neon sockets before autosuspend drops them

### DIFF
--- a/libs/data/db/src/create-db.ts
+++ b/libs/data/db/src/create-db.ts
@@ -19,6 +19,13 @@ interface CreateDBConfig {
  * idle-in-transaction connection can hold a lock: no future code path that
  * opens a transaction can leave orphaned transaction state alive past 30s,
  * even across a serverless process kill.
+ *
+ * `idle_timeout` (seconds, unlike the millisecond session timeouts) closes a
+ * pooled connection from the client side before the managed Postgres endpoint
+ * suspends on its own idle timeout and drops the socket server-side. Without
+ * it the pool hands a caller a connection the endpoint already closed, and the
+ * first write fails with CONNECTION_CLOSED; the value stays under the
+ * endpoint's suspend timeout so the client always closes first.
  */
 export function createDB(config: CreateDBConfig): Kysely<DB> {
   return new Kysely<DB>({
@@ -29,6 +36,7 @@ export function createDB(config: CreateDBConfig): Kysely<DB> {
           statement_timeout: 30_000,
           ...(config.searchPath === undefined ? {} : { search_path: config.searchPath }),
         },
+        idle_timeout: 240,
       }),
     }),
     log: recordQuerySpan,


### PR DESCRIPTION
## Description

Closes #809

The postgres.js pool held idle connections open indefinitely, so Neon's 300s scale-to-zero closed them server-side and the next write failed with `CONNECTION_CLOSED` — the first request to any domain service after an idle stretch. Sets `idle_timeout` below the suspend window so the client always closes first and reconnects transparently.

- Mirrors the Fly outbound-socket fix (#790) on the Neon connection pool.
- Leaves autosuspend on by design; the cold-resume path (`CONNECT_TIMEOUT` / `Authentication timed out`) is out of scope, to be masked with a retry if it recurs.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes (`@vers/db`)
- [x] `bun run lint` passes
- [ ] New tests added for new functionality
