### PR TITLE
fix: roll out backend services with bluegreen

### DIFF
--- a/docs/architecture/platform/deployment.md
+++ b/docs/architecture/platform/deployment.md
@@ -196,11 +196,12 @@ the app's service machines.
 
 ### Rollout strategies
 
-`app-web` rolls out `bluegreen` — a full parallel fleet passes `/health` before traffic cuts over —
-because it is the user-facing app. Services use `rolling` with `max_unavailable = 1`: a broken boot
-fails the health gate with the old machine still up. Deploy jobs queue rather than cancel — killing
-flyctl mid-bluegreen strands the green machines and fails every later deploy with "found multiple
-image versions".
+Every app and service rolls out `bluegreen`: Fly boots a parallel fleet, gates it on `/health`, cuts
+traffic over, then retires the old machines. A broken boot fails the gate before cutover, and the
+old machines serve every request until it passes — an in-place `rolling` swap of a scale-to-zero
+service's single machine drops its internal callers with 503s for the length of the restart. Deploy
+jobs queue rather than cancel — killing flyctl mid-deploy strands the green machines and fails every
+later deploy with "found multiple image versions".
 
 A rollout can fail on transient `syd` host-capacity refusals ("could not reserve resource"); Fly
 rolls back cleanly, so re-run the failed job.

--- a/services/activity/fly.toml
+++ b/services/activity/fly.toml
@@ -35,5 +35,4 @@ cpu_kind = 'shared'
 cpus = 1
 
 [deploy]
-strategy = 'rolling'
-max_unavailable = 1
+strategy = 'bluegreen'

--- a/services/avatar/fly.toml
+++ b/services/avatar/fly.toml
@@ -32,5 +32,4 @@ cpu_kind = 'shared'
 cpus = 1
 
 [deploy]
-strategy = 'rolling'
-max_unavailable = 1
+strategy = 'bluegreen'

--- a/services/email/fly.toml
+++ b/services/email/fly.toml
@@ -34,5 +34,4 @@ cpu_kind = 'shared'
 cpus = 1
 
 [deploy]
-strategy = 'rolling'
-max_unavailable = 1
+strategy = 'bluegreen'

--- a/services/keys/fly.toml
+++ b/services/keys/fly.toml
@@ -32,5 +32,4 @@ cpu_kind = 'shared'
 cpus = 1
 
 [deploy]
-strategy = 'rolling'
-max_unavailable = 1
+strategy = 'bluegreen'

--- a/services/replay/fly.toml
+++ b/services/replay/fly.toml
@@ -35,5 +35,4 @@ cpu_kind = 'shared'
 cpus = 1
 
 [deploy]
-strategy = 'rolling'
-max_unavailable = 1
+strategy = 'bluegreen'

--- a/services/session/fly.toml
+++ b/services/session/fly.toml
@@ -32,5 +32,4 @@ cpu_kind = 'shared'
 cpus = 1
 
 [deploy]
-strategy = 'rolling'
-max_unavailable = 1
+strategy = 'bluegreen'

--- a/services/user/fly.toml
+++ b/services/user/fly.toml
@@ -32,5 +32,4 @@ cpu_kind = 'shared'
 cpus = 1
 
 [deploy]
-strategy = 'rolling'
-max_unavailable = 1
+strategy = 'bluegreen'

--- a/services/verification/fly.toml
+++ b/services/verification/fly.toml
@@ -32,5 +32,4 @@ cpu_kind = 'shared'
 cpus = 1
 
 [deploy]
-strategy = 'rolling'
-max_unavailable = 1
+strategy = 'bluegreen'


### PR DESCRIPTION
## Description

Switch all eight backend services from `rolling` to `bluegreen`. A scale-to-zero service runs one machine, so a rolling deploy replaces it in place and drops internal callers with 503s for the length of the restart — the source of recurring replay-poke exhaustion alarms and stalled checkpoint-flush errors on every deploy. Bluegreen boots a parallel machine, gates it on `/health`, and cuts over with the old machine still serving.

- Drops `max_unavailable` (rolling-only) from each service `fly.toml`.
- Matches the strategy app-web already uses; the deploy-jobs-queue rule that guards bluegreen is already in place.
- Updates the rollout-strategies runbook to the single strategy and its rationale.

## Testing

- [x] No code changed — config and docs only; CI format/lint/typecheck cover it.