### PR TITLE
chore: drop stale otel-core audit ignore

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "clean": "./scripts/clean.sh",
     "build": "turbo run build",
     "build:agents": "bash scripts/build-agents-md.sh agents/shared.md agents/project.md AGENTS.md",
-    "audit": "bun audit --ignore=GHSA-8988-4f7v-96qf",
+    "audit": "bun audit",
     "boundaries": "turbo boundaries",
     "deadcode": "knip",
     "lint": "turbo run codegen typegen && oxlint --type-aware --type-check --report-unused-disable-directives-severity error",


### PR DESCRIPTION
## Description

Closes #445.

`@pulumi/pulumi` 3.253.0 moved off the `^0.57` OTLP exporter line — `@opentelemetry/core` now resolves to 2.9.0, above the <2.8.0 range of GHSA-8988-4f7v-96qf. The `--ignore` is dead weight and the dep-health stale-ignore check would flag it.

- Drops `--ignore=GHSA-8988-4f7v-96qf` from the root `audit` script.
- Raw `bun audit` reports no vulnerabilities with the ignore gone.

## Testing

- [x] `bun audit` clean without the ignore
- [ ] CI `audit` job passes