### PR TITLE
feat(#820): add slow-request warn log and Axiom duration monitor

### DIFF
--- a/docs/architecture/platform/observability.md
+++ b/docs/architecture/platform/observability.md
@@ -220,10 +220,11 @@ exporter. It is the explicit signal that the replay queue may go undrained despi
 appending unverified work.
 
 The `vers slow requests` threshold monitor watches `vers-traces` for any non-probe server span past
-a fixed 30s duration ceiling and notifies `vers alarms`. Health-probe routes are excluded because
-their latency tracks scale-to-zero machine wake rather than request handling. It is the immediate,
-fleet-wide alarm for a hung or pathologically slow request, independent of the per-request
-slow-request warn log a service's own `slowRequestMs` threshold decides.
+a fixed 30s duration ceiling and notifies `vers alarms`, evaluated on its own schedule rather than
+at span close. Health-probe routes are excluded because their latency tracks scale-to-zero machine
+wake rather than request handling. It is the fleet-wide alarm for a hung or pathologically slow
+request, independent of the per-request slow-request warn log a service's own `slowRequestMs`
+threshold decides.
 
 ## Alarms channel
 

--- a/docs/architecture/platform/observability.md
+++ b/docs/architecture/platform/observability.md
@@ -219,10 +219,11 @@ when a wake delivery exhausts its retries, so a quiet dataset is the healthy def
 exporter. It is the explicit signal that the replay queue may go undrained despite an activity
 appending unverified work.
 
-The `vers slow requests` threshold monitor watches `vers-traces` for any server span past a fixed
-10s duration ceiling and notifies `vers alarms`. It is the immediate, fleet-wide alarm for a hung or
-pathologically slow request, independent of the per-request slow-request warn log a service's own
-`slowRequestMs` threshold decides.
+The `vers slow requests` threshold monitor watches `vers-traces` for any non-probe server span past
+a fixed 30s duration ceiling and notifies `vers alarms`. Health-probe routes are excluded because
+their latency tracks scale-to-zero machine wake rather than request handling. It is the immediate,
+fleet-wide alarm for a hung or pathologically slow request, independent of the per-request
+slow-request warn log a service's own `slowRequestMs` threshold decides.
 
 ## Alarms channel
 

--- a/docs/architecture/platform/observability.md
+++ b/docs/architecture/platform/observability.md
@@ -105,6 +105,10 @@ line-level conventions:
   GET-mapped procedure inputs. The service scaffold emits the line for every `/rpc` request and
   leaves `/health` unlogged, so platform probes don't dominate volume. app-web's middleware emits it
   for every request, at `debug` for a served static asset (a pathname with a file extension).
+- A request past its slow-request threshold logs at `warn` instead, with `slow: true` and
+  `thresholdMs` added onto the completion line, unless its status is already a server error. The
+  threshold defaults to 2s (`slowRequestMs`, a `createService` config option) and is overridable per
+  pathname through `slowRequestOverridesMs`.
 - Presentation is the transport's job: dev consoles pretty-print through `pino-pretty`, and call
   sites never embed color codes or decoration in the message.
 
@@ -214,6 +218,11 @@ notifies `vers alarms`. It alerts on the threshold alone, never on no data — t
 when a wake delivery exhausts its retries, so a quiet dataset is the healthy default, not a down
 exporter. It is the explicit signal that the replay queue may go undrained despite an activity
 appending unverified work.
+
+The `vers slow requests` threshold monitor watches `vers-traces` for any server span past a fixed
+10s duration ceiling and notifies `vers alarms`. It is the immediate, fleet-wide alarm for a hung or
+pathologically slow request, independent of the per-request slow-request warn log a service's own
+`slowRequestMs` threshold decides.
 
 ## Alarms channel
 

--- a/infra/axiom.ts
+++ b/infra/axiom.ts
@@ -129,7 +129,9 @@ const serverErrorsMonitor = new axiom.Monitor(
 /**
  * Catches a hung or pathologically slow request the moment its span closes, independent of the
  * per-request warn log `createService` emits against its own configurable threshold — this alarm
- * fires on any server span past a fixed ceiling regardless of which service or route it came from.
+ * fires on any non-probe server span past a fixed ceiling regardless of which service or route it
+ * came from. Health-probe routes are excluded: their latency tracks scale-to-zero machine wake, not
+ * request handling, so they would fire the alarm continuously without indicating a real fault.
  */
 const slowRequestsMonitor = new axiom.Monitor(
   'vers-slow-requests',
@@ -137,9 +139,9 @@ const slowRequestsMonitor = new axiom.Monitor(
     name: 'vers slow requests',
     type: 'Threshold',
     description:
-      'Fires when a vers service or app-web server span exceeds a 10s duration ceiling — the explicit alarm for a hung or pathologically slow request.',
+      'Fires when a vers service or app-web server span other than a health probe exceeds a 30s duration ceiling — the explicit alarm for a hung or pathologically slow request.',
     aplQuery:
-      "['vers-traces'] | where kind == 'server' and duration > 10s | summarize count() by bin(_time, 5m)",
+      "['vers-traces'] | where kind == 'server' and duration > 30s and not (name endswith '/health') | summarize count() by bin(_time, 5m)",
     intervalMinutes: 5,
     rangeMinutes: 10,
     operator: 'AboveOrEqual',

--- a/infra/axiom.ts
+++ b/infra/axiom.ts
@@ -127,11 +127,12 @@ const serverErrorsMonitor = new axiom.Monitor(
 );
 
 /**
- * Catches a hung or pathologically slow request the moment its span closes, independent of the
- * per-request warn log `createService` emits against its own configurable threshold — this alarm
- * fires on any non-probe server span past a fixed ceiling regardless of which service or route it
- * came from. Health-probe routes are excluded: their latency tracks scale-to-zero machine wake, not
- * request handling, so they would fire the alarm continuously without indicating a real fault.
+ * Fleet-wide alarm for a hung or pathologically slow request, evaluated on the monitor's own
+ * schedule rather than at span close, and independent of the per-request slow-request warn log a
+ * service emits against its own configurable threshold. It fires on any non-probe server span past
+ * a fixed ceiling regardless of which service or route it came from. Health-probe routes are
+ * excluded: their latency tracks scale-to-zero machine wake, not request handling, so they would
+ * fire the alarm continuously without indicating a real fault.
  */
 const slowRequestsMonitor = new axiom.Monitor(
   'vers-slow-requests',

--- a/infra/axiom.ts
+++ b/infra/axiom.ts
@@ -127,6 +127,30 @@ const serverErrorsMonitor = new axiom.Monitor(
 );
 
 /**
+ * Catches a hung or pathologically slow request the moment its span closes, independent of the
+ * per-request warn log `createService` emits against its own configurable threshold — this alarm
+ * fires on any server span past a fixed ceiling regardless of which service or route it came from.
+ */
+const slowRequestsMonitor = new axiom.Monitor(
+  'vers-slow-requests',
+  {
+    name: 'vers slow requests',
+    type: 'Threshold',
+    description:
+      'Fires when a vers service or app-web server span exceeds a 10s duration ceiling — the explicit alarm for a hung or pathologically slow request.',
+    aplQuery:
+      "['vers-traces'] | where kind == 'server' and duration > 10s | summarize count() by bin(_time, 5m)",
+    intervalMinutes: 5,
+    rangeMinutes: 10,
+    operator: 'AboveOrEqual',
+    threshold: 1,
+    triggerFromNRuns: 1,
+    notifierIds: [alarmsNotifier.id],
+  },
+  { provider: axiomProvider },
+);
+
+/**
  * alertOnNoData stays false: the counter emits only when a wake delivery
  * exhausts its retries, so a quiet dataset is the healthy default, never a
  * down exporter. The metric is an OTLP cumulative counter (the exporter sets no
@@ -226,6 +250,7 @@ export const ingestTokenName = ingestToken.name;
 export const mcpTokenName = mcpToken.name;
 export const alarmsNotifierName = alarmsNotifier.name;
 export const serverErrorsMonitorName = serverErrorsMonitor.name;
+export const slowRequestsMonitorName = slowRequestsMonitor.name;
 export const replayPokeFailedMonitorName = replayPokeFailedMonitor.name;
 export const baselineDashboardUID = baselineDashboard.uid;
 

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -10,6 +10,7 @@ export {
   metricsDatasetName,
   replayPokeFailedMonitorName,
   serverErrorsMonitorName,
+  slowRequestsMonitorName,
   tracesDatasetName,
 } from './axiom.ts';
 

--- a/libs/service/service-runtime/src/create-service.test.ts
+++ b/libs/service/service-runtime/src/create-service.test.ts
@@ -22,6 +22,7 @@ function buildTestContract() {
       .input(z.object({ id: z.string() }))
       .output(z.object({ id: z.string() })),
     ping: publicRoute.output(z.object({ pong: z.boolean() })),
+    sleep: publicRoute.input(z.object({ ms: z.number() })).output(z.object({ slept: z.boolean() })),
     throwPlainError: publicRoute.output(z.object({})),
   };
 }
@@ -55,6 +56,11 @@ function buildTestRouter(contract: ReturnType<typeof buildTestContract>) {
       return { id: opts.input.id };
     }),
     ping: os.ping.handler(() => ({ pong: true })),
+    sleep: os.sleep.handler(async (opts) => {
+      await Bun.sleep(opts.input.ms);
+
+      return { slept: true };
+    }),
     throwPlainError: os.throwPlainError.handler(() => {
       throw new Error('a secret internal detail');
     }),
@@ -761,4 +767,123 @@ test('it serves /health without logging a request line', async () => {
   await service.app.handle(new Request('http://test.local/health'));
 
   expect(infoSpy).not.toHaveBeenCalled();
+});
+
+test('it logs a request past its slow-request threshold at warn with slow and thresholdMs', async () => {
+  const keyPair = await getTestServiceKeyPair();
+
+  updateEnv('SERVICE_AUTH_JWKS', keyPair.jwksJSON);
+
+  const contract = buildTestContract();
+
+  const service = await createService({
+    buildRouter: () => buildTestRouter(contract),
+    envShape: {},
+    name: 'test-service',
+    slowRequestMs: 10,
+  });
+
+  const warnSpy = spyOn(service.logger, 'warn');
+
+  const token = await createServiceToken({
+    audience: 'test-service',
+    privateKey: keyPair.privateKey,
+  });
+
+  const client = buildRPCTestClient<ReturnType<typeof buildTestContract>>(service.app, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+
+  await client.sleep({ ms: 30 });
+
+  expect(warnSpy).toHaveBeenCalledExactlyOnceWith(
+    {
+      durationMs: expect.toBeNumber(),
+      method: 'POST',
+      path: '/rpc/sleep',
+      slow: true,
+      status: 200,
+      thresholdMs: 10,
+    },
+    'request completed',
+  );
+});
+
+test('it keeps a request under its slow-request threshold at its status-derived level with no slow flag', async () => {
+  const keyPair = await getTestServiceKeyPair();
+
+  updateEnv('SERVICE_AUTH_JWKS', keyPair.jwksJSON);
+
+  const contract = buildTestContract();
+
+  const service = await createService({
+    buildRouter: () => buildTestRouter(contract),
+    envShape: {},
+    name: 'test-service',
+    slowRequestMs: 1000,
+  });
+
+  const infoSpy = spyOn(service.logger, 'info');
+
+  const token = await createServiceToken({
+    audience: 'test-service',
+    privateKey: keyPair.privateKey,
+  });
+
+  const client = buildRPCTestClient<ReturnType<typeof buildTestContract>>(service.app, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+
+  await client.sleep({ ms: 5 });
+
+  expect(infoSpy).toHaveBeenCalledExactlyOnceWith(
+    {
+      durationMs: expect.toBeNumber(),
+      method: 'POST',
+      path: '/rpc/sleep',
+      status: 200,
+    },
+    'request completed',
+  );
+});
+
+test('it honors a per-path slow-request override over the default threshold', async () => {
+  const keyPair = await getTestServiceKeyPair();
+
+  updateEnv('SERVICE_AUTH_JWKS', keyPair.jwksJSON);
+
+  const contract = buildTestContract();
+
+  const service = await createService({
+    buildRouter: () => buildTestRouter(contract),
+    envShape: {},
+    name: 'test-service',
+    slowRequestMs: 10_000,
+    slowRequestOverridesMs: { '/rpc/sleep': 10 },
+  });
+
+  const warnSpy = spyOn(service.logger, 'warn');
+
+  const token = await createServiceToken({
+    audience: 'test-service',
+    privateKey: keyPair.privateKey,
+  });
+
+  const client = buildRPCTestClient<ReturnType<typeof buildTestContract>>(service.app, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+
+  await client.sleep({ ms: 30 });
+
+  expect(warnSpy).toHaveBeenCalledExactlyOnceWith(
+    {
+      durationMs: expect.toBeNumber(),
+      method: 'POST',
+      path: '/rpc/sleep',
+      slow: true,
+      status: 200,
+      thresholdMs: 10,
+    },
+    'request completed',
+  );
 });

--- a/libs/service/service-runtime/src/create-service.test.ts
+++ b/libs/service/service-runtime/src/create-service.test.ts
@@ -809,6 +809,44 @@ test('it logs a request past its slow-request threshold at warn with slow and th
   );
 });
 
+test('it keeps a slow 5xx at error severity without the slow flag', async () => {
+  const keyPair = await getTestServiceKeyPair();
+
+  updateEnv('SERVICE_AUTH_JWKS', keyPair.jwksJSON);
+
+  const contract = buildTestContract();
+
+  const service = await createService({
+    buildRouter: () => buildTestRouter(contract),
+    envShape: {},
+    name: 'test-service',
+    slowRequestMs: 0,
+  });
+
+  const errorSpy = spyOn(service.logger, 'error');
+
+  const token = await createServiceToken({
+    audience: 'test-service',
+    privateKey: keyPair.privateKey,
+  });
+
+  const client = buildRPCTestClient<ReturnType<typeof buildTestContract>>(service.app, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+
+  await expect(client.throwPlainError({})).toReject();
+
+  expect(errorSpy).toHaveBeenCalledWith(
+    {
+      durationMs: expect.toBeNumber(),
+      method: 'POST',
+      path: '/rpc/throwPlainError',
+      status: 500,
+    },
+    'request completed',
+  );
+});
+
 test('it keeps a request under its slow-request threshold at its status-derived level with no slow flag', async () => {
   const keyPair = await getTestServiceKeyPair();
 

--- a/libs/service/service-runtime/src/create-service.ts
+++ b/libs/service/service-runtime/src/create-service.ts
@@ -298,9 +298,10 @@ function registerORPCHandler(
 
         finalResponse.headers.set('x-trace-id', trace.traceID);
 
-        const durationMs = toDurationMs(performance.now() - start);
+        const elapsedMs = performance.now() - start;
+        const durationMs = toDurationMs(elapsedMs);
         const thresholdMs = deps.slowRequestOverridesMs?.[path] ?? deps.slowRequestMs;
-        const isSlow = durationMs > thresholdMs && finalResponse.status < 500;
+        const isSlow = elapsedMs > thresholdMs && finalResponse.status < 500;
 
         deps.logger[isSlow ? 'warn' : pickRequestLogLevel(finalResponse.status)](
           {

--- a/libs/service/service-runtime/src/create-service.ts
+++ b/libs/service/service-runtime/src/create-service.ts
@@ -25,10 +25,16 @@ interface ServiceRuntime<TEnvShape extends z.ZodRawShape> {
   readonly logger: pino.Logger;
 }
 
+/**
+ * `slowRequestMs` defaults to 2000 when unset. `slowRequestOverridesMs` keys a per-pathname
+ * threshold that wins over `slowRequestMs` for a matching request.
+ */
 export interface ServiceConfig<TEnvShape extends z.ZodRawShape> {
   readonly buildRouter: (runtime: ServiceRuntime<TEnvShape>) => AnyRouter | Promise<AnyRouter>;
   readonly envShape: TEnvShape;
   readonly name: string;
+  readonly slowRequestMs?: number;
+  readonly slowRequestOverridesMs?: Readonly<Record<string, number>>;
 }
 
 export interface Service<TEnvShape extends z.ZodRawShape> {
@@ -38,6 +44,8 @@ export interface Service<TEnvShape extends z.ZodRawShape> {
   logger: pino.Logger;
   stopTelemetry: () => Promise<void>;
 }
+
+const DEFAULT_SLOW_REQUEST_MS = 2000;
 
 /**
  * Boots the Elysia shell every service composes: env validation, s2s token verification ahead of
@@ -126,6 +134,10 @@ export async function createService<TEnvShape extends z.ZodRawShape = Record<nev
     keySet,
     logger,
     serviceName: config.name,
+    slowRequestMs: config.slowRequestMs ?? DEFAULT_SLOW_REQUEST_MS,
+    ...(config.slowRequestOverridesMs !== undefined && {
+      slowRequestOverridesMs: config.slowRequestOverridesMs,
+    }),
   });
 
   return {
@@ -201,6 +213,8 @@ interface RegisterORPCHandlerDeps {
   readonly keySet: ServiceKeySet;
   readonly logger: pino.Logger;
   readonly serviceName: string;
+  readonly slowRequestMs: number;
+  readonly slowRequestOverridesMs?: Readonly<Record<string, number>>;
 }
 
 /**
@@ -209,7 +223,9 @@ interface RegisterORPCHandlerDeps {
  * split. Every response — including that 401 — carries the request's trace id
  * in `x-trace-id`, and the whole request runs inside its trace-context scope so logs correlate.
  * Every request logs one structured line on completion (method, path, status, duration), severity
- * following the response status; a trust-boundary rejection's line carries the rejection reason.
+ * following the response status; a trust-boundary rejection's line carries the rejection reason. A
+ * completed request past its slow-request threshold logs at `warn` with `slow: true` and
+ * `thresholdMs` instead, unless its status is already a server error.
  */
 function registerORPCHandler(
   // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- elysia app is a live framework instance with mutable routing state; no readonly form
@@ -282,12 +298,17 @@ function registerORPCHandler(
 
         finalResponse.headers.set('x-trace-id', trace.traceID);
 
-        deps.logger[pickRequestLogLevel(finalResponse.status)](
+        const durationMs = toDurationMs(performance.now() - start);
+        const thresholdMs = deps.slowRequestOverridesMs?.[path] ?? deps.slowRequestMs;
+        const isSlow = durationMs > thresholdMs && finalResponse.status < 500;
+
+        deps.logger[isSlow ? 'warn' : pickRequestLogLevel(finalResponse.status)](
           {
-            durationMs: toDurationMs(performance.now() - start),
+            durationMs,
             method,
             path,
             status: finalResponse.status,
+            ...(isSlow && { slow: true, thresholdMs }),
           },
           'request completed',
         );


### PR DESCRIPTION
## Description

Closes #820

Warn-logs requests that exceed a slow-request threshold, and adds an Axiom monitor that alarms on any pathologically slow server span fleet-wide.

- `createService` gains `slowRequestMs` (default 2s) and `slowRequestOverridesMs` (per-pathname override); a request over its threshold logs the completion line at `warn` with `slow: true` and `thresholdMs`, unless the status is already a server error.
- New `vers-slow-requests` Axiom threshold monitor watches `vers-traces` for any server span past a fixed 10s ceiling and notifies `vers alarms`, independent of each service's own configurable threshold.
- `slowRequestsMonitorName` exported from `infra/axiom.ts` and re-exported from `infra/index.ts` alongside the existing monitor names.
- Documented both the warn-log behavior and the new monitor in `docs/architecture/platform/observability.md`.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
