### PR TITLE
fix(#818): retry never-applied outbound failures for any method

### DIFF
--- a/apps/web/src/lib/rpc/build-service-link.ts
+++ b/apps/web/src/lib/rpc/build-service-link.ts
@@ -15,10 +15,11 @@ import type { ServiceLinkContext } from './types';
 
 /**
  * Builds one service's server-branch `RPCLink`: mints and attaches a short-lived s2s token for the
- * target service, bounds each outbound attempt to a single timeout, and retries the contract's
- * declared idempotent procedures on a transient failure. Callers invoke this only from inside a
- * `createIsomorphicFn().server()` branch — the contract reference, and everything it pulls in, must
- * never reach the browser bundle.
+ * target service, bounds each outbound attempt to a single timeout, and retries on a transient
+ * failure — a never-reached (transport) failure retries for any method since nothing applied, while
+ * a timeout or a 5xx retries only for the contract's idempotent procedures. Callers invoke this only
+ * from inside a `createIsomorphicFn().server()` branch — the contract reference, and everything it
+ * pulls in, must never reach the browser bundle.
  */
 export function buildServiceLink(
   service: ServiceName,

--- a/apps/web/src/lib/rpc/make-bounded-fetch.test.ts
+++ b/apps/web/src/lib/rpc/make-bounded-fetch.test.ts
@@ -3,7 +3,7 @@ import { HttpResponse, delay, http } from 'msw';
 import { server } from '../../mocks/node';
 import { makeBoundedFetch } from './make-bounded-fetch';
 
-test('it aborts a hung upstream at its bound and surfaces SERVICE_UNAVAILABLE', () => {
+test('it aborts a hung upstream at its bound and tags the failure as a timeout', () => {
   server.use(
     http.post('http://bounded.test/rpc/proc', async () => {
       await delay('infinite');
@@ -22,7 +22,29 @@ test('it aborts a hung upstream at its bound and surfaces SERVICE_UNAVAILABLE', 
     undefined,
   );
 
-  expect(promise).rejects.toMatchObject({ code: 'SERVICE_UNAVAILABLE' });
+  expect(promise).rejects.toMatchObject({
+    code: 'SERVICE_UNAVAILABLE',
+    data: { failureMode: 'timeout' },
+  });
+});
+
+test('it converts an immediate transport failure and tags it as never-applied', () => {
+  server.use(http.post('http://bounded.test/rpc/proc', () => HttpResponse.error()));
+
+  const boundedFetch = makeBoundedFetch({ service: 'avatar' });
+
+  const promise = boundedFetch(
+    new Request('http://bounded.test/rpc/proc', { method: 'POST' }),
+    {},
+    { context: {} },
+    ['proc'],
+    undefined,
+  );
+
+  expect(promise).rejects.toMatchObject({
+    code: 'SERVICE_UNAVAILABLE',
+    data: { failureMode: 'transport' },
+  });
 });
 
 test("it rethrows a caller's own abort instead of converting it to SERVICE_UNAVAILABLE", () => {

--- a/apps/web/src/lib/rpc/make-bounded-fetch.ts
+++ b/apps/web/src/lib/rpc/make-bounded-fetch.ts
@@ -2,6 +2,7 @@ import type { ClientContext } from '@orpc/client';
 import { ORPCError } from '@orpc/client';
 import type { LinkFetchClientOptions } from '@orpc/client/fetch';
 import type { ServiceName } from '@vers/service-auth';
+import type { OutboundFailureMode } from '@vers/service-utils/orpc';
 import { recordServiceCallFailure } from '../metrics/record-service-call-failure';
 import { serviceDispatcher } from './service-dispatcher';
 import type { ServiceFetchInit } from './types';
@@ -19,10 +20,12 @@ export const DEFAULT_ATTEMPT_TIMEOUTS_MS: ReadonlyArray<number> = [2000, 6000];
  * Builds an `RPCLink` `fetch` that bounds a single outbound attempt to a timeout instead of
  * undici's multi-minute default — a request against a Fly machine whose autosuspend-era keep-alive
  * socket the pool still holds fails fast instead of hanging out that stale connection's idle
- * window. A timeout or transport failure converts to a thrown `ORPCError('SERVICE_UNAVAILABLE')`; a
+ * window. A timeout or transport failure converts to a thrown `ORPCError('SERVICE_UNAVAILABLE')`
+ * tagged with its `data.failureMode` — `'transport'` when the request never reached the server,
+ * `'timeout'` when the attempt's own bound fired instead — so the retry interceptor one layer up
+ * can tell a request that never applied from one the server may have already processed. A
  * caller-driven abort (the request's own signal, not the attempt timeout) always rethrows
- * unconverted — that's the caller's decision, not a transport failure. Retry for idempotent
- * procedures lives one layer up, in `buildRetryInterceptor`.
+ * unconverted — that's the caller's decision, not a transport failure.
  */
 export function makeBoundedFetch(options: MakeBoundedFetchOptions): BoundFetch {
   const attemptTimeoutMs = options.attemptTimeoutMs ?? Math.max(...DEFAULT_ATTEMPT_TIMEOUTS_MS);
@@ -56,10 +59,10 @@ export function makeBoundedFetch(options: MakeBoundedFetchOptions): BoundFetch {
         throw error;
       }
 
-      const reason = boundFired ? 'timeout' : 'transport';
+      const reason: OutboundFailureMode = boundFired ? 'timeout' : 'transport';
 
       recordServiceCallFailure(options.service, reason);
-      throw new ORPCError('SERVICE_UNAVAILABLE', { cause: error });
+      throw new ORPCError('SERVICE_UNAVAILABLE', { cause: error, data: { failureMode: reason } });
     }
   };
 }

--- a/libs/service/service-utils/src/orpc/build-retry-interceptor.test.ts
+++ b/libs/service/service-utils/src/orpc/build-retry-interceptor.test.ts
@@ -1,4 +1,5 @@
 import { expect, mock, test } from 'bun:test';
+import { ORPCError } from '@orpc/client';
 import type { StandardLazyResponse } from '@orpc/standard-server';
 import { buildRetryInterceptor } from './build-retry-interceptor';
 
@@ -279,4 +280,155 @@ test('it invokes onRetry once per retry', async () => {
 
   expect(response.status).toBe(200);
   expect(onRetry).toHaveBeenCalledTimes(2);
+});
+
+test('it retries a POST whose transport failure never reached the server', async () => {
+  let callCount = 0;
+
+  const next = mock((): Promise<StandardLazyResponse> => {
+    callCount += 1;
+
+    if (callCount === 1) {
+      throw new ORPCError('SERVICE_UNAVAILABLE', { data: { failureMode: 'transport' } });
+    }
+
+    return Promise.resolve({ body: () => Promise.resolve(undefined), headers: {}, status: 200 });
+  });
+
+  const interceptor = buildRetryInterceptor({ backoffMs: 1, isRetryable: () => false });
+
+  const response = await interceptor({
+    context: {},
+    input: undefined,
+    next,
+    path: ['auth', 'refreshTokens'],
+    request: {
+      body: undefined,
+      headers: {},
+      method: 'POST',
+      signal: undefined,
+      url: new URL('http://test.local/rpc'),
+    },
+  });
+
+  expect(response.status).toBe(200);
+  expect(next).toHaveBeenCalledTimes(2);
+});
+
+test('it does not retry a POST timeout since the request may have already reached the server', async () => {
+  const next = mock((): Promise<StandardLazyResponse> => {
+    throw new ORPCError('SERVICE_UNAVAILABLE', { data: { failureMode: 'timeout' } });
+  });
+
+  const interceptor = buildRetryInterceptor({ backoffMs: 1, isRetryable: () => false });
+
+  const pending = interceptor({
+    context: {},
+    input: undefined,
+    next,
+    path: ['auth', 'refreshTokens'],
+    request: {
+      body: undefined,
+      headers: {},
+      method: 'POST',
+      signal: undefined,
+      url: new URL('http://test.local/rpc'),
+    },
+  });
+
+  await expect(pending).toReject();
+
+  expect(next).toHaveBeenCalledOnce();
+});
+
+test('it does not retry a POST 5xx response since the server already processed it', async () => {
+  const next = mock(
+    (): Promise<StandardLazyResponse> =>
+      Promise.resolve({ body: () => Promise.resolve(undefined), headers: {}, status: 503 }),
+  );
+
+  const interceptor = buildRetryInterceptor({ backoffMs: 1, isRetryable: () => false });
+
+  const response = await interceptor({
+    context: {},
+    input: undefined,
+    next,
+    path: ['auth', 'refreshTokens'],
+    request: {
+      body: undefined,
+      headers: {},
+      method: 'POST',
+      signal: undefined,
+      url: new URL('http://test.local/rpc'),
+    },
+  });
+
+  expect(response.status).toBe(503);
+  expect(next).toHaveBeenCalledOnce();
+});
+
+test('it retries a GET timeout for an idempotent path', async () => {
+  let callCount = 0;
+
+  const next = mock((): Promise<StandardLazyResponse> => {
+    callCount += 1;
+
+    if (callCount === 1) {
+      throw new ORPCError('SERVICE_UNAVAILABLE', { data: { failureMode: 'timeout' } });
+    }
+
+    return Promise.resolve({ body: () => Promise.resolve(undefined), headers: {}, status: 200 });
+  });
+
+  const interceptor = buildRetryInterceptor({ backoffMs: 1, isRetryable: () => true });
+
+  const response = await interceptor({
+    context: {},
+    input: undefined,
+    next,
+    path: ['activity', 'getLatestActivityProgress'],
+    request: {
+      body: undefined,
+      headers: {},
+      method: 'GET',
+      signal: undefined,
+      url: new URL('http://test.local/rpc'),
+    },
+  });
+
+  expect(response.status).toBe(200);
+  expect(next).toHaveBeenCalledTimes(2);
+});
+
+test('it retries a GET transport failure for an idempotent path', async () => {
+  let callCount = 0;
+
+  const next = mock((): Promise<StandardLazyResponse> => {
+    callCount += 1;
+
+    if (callCount === 1) {
+      throw new ORPCError('SERVICE_UNAVAILABLE', { data: { failureMode: 'transport' } });
+    }
+
+    return Promise.resolve({ body: () => Promise.resolve(undefined), headers: {}, status: 200 });
+  });
+
+  const interceptor = buildRetryInterceptor({ backoffMs: 1, isRetryable: () => true });
+
+  const response = await interceptor({
+    context: {},
+    input: undefined,
+    next,
+    path: ['activity', 'getLatestActivityProgress'],
+    request: {
+      body: undefined,
+      headers: {},
+      method: 'GET',
+      signal: undefined,
+      url: new URL('http://test.local/rpc'),
+    },
+  });
+
+  expect(response.status).toBe(200);
+  expect(next).toHaveBeenCalledTimes(2);
 });

--- a/libs/service/service-utils/src/orpc/build-retry-interceptor.ts
+++ b/libs/service/service-utils/src/orpc/build-retry-interceptor.ts
@@ -3,6 +3,7 @@ import type { StandardLinkClientInterceptorOptions } from '@orpc/client/standard
 import type { Interceptor } from '@orpc/shared';
 import type { StandardLazyResponse } from '@orpc/standard-server';
 import invariant from 'tiny-invariant';
+import { isNeverAppliedFailure } from './is-never-applied-failure';
 
 export interface RetryInterceptorOptions {
   /**
@@ -27,12 +28,14 @@ const DEFAULT_MAX_RETRIES = 2;
 const DEFAULT_BACKOFF_MS = 250;
 
 /**
- * Builds an `RPCLink` `clientInterceptors` entry that retries a contract's idempotent procedures
- * on a transient failure — a 5xx response or a thrown transport error — with a growing linear
- * backoff between attempts. A non-retryable path (`isRetryable` reads GET/HEAD off the contract,
- * since only those can't double-apply) passes through unchanged after a single attempt. The
- * caller's own abort always ends the loop immediately, mid-attempt or mid-backoff, rather than
- * spending the remaining retry budget on a call nobody wants anymore.
+ * Builds an `RPCLink` `clientInterceptors` entry that retries a transient failure with a growing
+ * linear backoff between attempts. A 5xx response retries only an idempotent path (`isRetryable`
+ * reads GET/HEAD off the contract, since only those can't double-apply); a thrown never-applied
+ * failure (`isNeverAppliedFailure` — the outbound request never reached the server) retries
+ * regardless of method, since nothing applied and nothing can double-apply. Any other thrown error
+ * still falls back to the idempotent-path check. The caller's own abort always ends the loop
+ * immediately, mid-attempt or mid-backoff, rather than spending the remaining retry budget on a
+ * call nobody wants anymore.
  */
 export function buildRetryInterceptor<T extends ClientContext = ClientContext>(
   options: Readonly<RetryInterceptorOptions>,
@@ -51,10 +54,6 @@ export function buildRetryInterceptor<T extends ClientContext = ClientContext>(
   );
 
   return async (interceptorOptions) => {
-    if (!options.isRetryable(interceptorOptions.path)) {
-      return interceptorOptions.next();
-    }
-
     const signal = interceptorOptions.request.signal;
 
     for (let attempt = 0; ; attempt += 1) {
@@ -63,11 +62,18 @@ export function buildRetryInterceptor<T extends ClientContext = ClientContext>(
       try {
         const response = await interceptorOptions.next();
 
-        if (response.status < 500 || isLastAttempt) {
+        if (
+          response.status < 500 ||
+          isLastAttempt ||
+          !options.isRetryable(interceptorOptions.path)
+        ) {
           return response;
         }
       } catch (error) {
-        if (signal?.aborted === true || isLastAttempt) {
+        const canRetry =
+          isNeverAppliedFailure(error) || options.isRetryable(interceptorOptions.path);
+
+        if (signal?.aborted === true || isLastAttempt || !canRetry) {
           throw error;
         }
       }

--- a/libs/service/service-utils/src/orpc/index.ts
+++ b/libs/service/service-utils/src/orpc/index.ts
@@ -1,3 +1,5 @@
 export { buildRetryInterceptor } from './build-retry-interceptor';
 export { buildTracingInterceptor } from './build-tracing-interceptor';
+export { isNeverAppliedFailure } from './is-never-applied-failure';
 export { makeIsRetryable } from './make-is-retryable';
+export type { OutboundFailureMode } from './types';

--- a/libs/service/service-utils/src/orpc/is-never-applied-failure.ts
+++ b/libs/service/service-utils/src/orpc/is-never-applied-failure.ts
@@ -1,10 +1,6 @@
 import { ORPCError } from '@orpc/client';
 import type { OutboundFailureMode } from './types';
 
-interface ServiceUnavailableErrorData {
-  readonly failureMode?: OutboundFailureMode;
-}
-
 /**
  * Reports whether `error` is a bounded-fetch `SERVICE_UNAVAILABLE` tagged with the `'transport'`
  * failure mode — the outbound request never reached the server, so nothing applied and retrying is
@@ -18,6 +14,10 @@ export function isNeverAppliedFailure(error: unknown): boolean {
   const data: unknown = error.data;
 
   return isServiceUnavailableErrorData(data) && data.failureMode === 'transport';
+}
+
+interface ServiceUnavailableErrorData {
+  readonly failureMode?: OutboundFailureMode;
 }
 
 function isServiceUnavailableErrorData(value: unknown): value is ServiceUnavailableErrorData {

--- a/libs/service/service-utils/src/orpc/is-never-applied-failure.ts
+++ b/libs/service/service-utils/src/orpc/is-never-applied-failure.ts
@@ -1,0 +1,25 @@
+import { ORPCError } from '@orpc/client';
+import type { OutboundFailureMode } from './types';
+
+interface ServiceUnavailableErrorData {
+  readonly failureMode?: OutboundFailureMode;
+}
+
+/**
+ * Reports whether `error` is a bounded-fetch `SERVICE_UNAVAILABLE` tagged with the `'transport'`
+ * failure mode — the outbound request never reached the server, so nothing applied and retrying is
+ * safe regardless of the procedure's HTTP method.
+ */
+export function isNeverAppliedFailure(error: unknown): boolean {
+  if (!(error instanceof ORPCError)) {
+    return false;
+  }
+
+  const data: unknown = error.data;
+
+  return isServiceUnavailableErrorData(data) && data.failureMode === 'transport';
+}
+
+function isServiceUnavailableErrorData(value: unknown): value is ServiceUnavailableErrorData {
+  return typeof value === 'object' && value !== null;
+}

--- a/libs/service/service-utils/src/orpc/types.ts
+++ b/libs/service/service-utils/src/orpc/types.ts
@@ -1,0 +1,7 @@
+/**
+ * Why a bounded fetch attempt failed before a response arrived: `'transport'` means the request
+ * never reached the server, so nothing applied and retrying is safe for any method; `'timeout'`
+ * means the attempt's own bound fired, so the server may already have received and processed the
+ * request.
+ */
+export type OutboundFailureMode = 'timeout' | 'transport';


### PR DESCRIPTION
## Description

Closes #818

A transport failure means the outbound request never reached the server, so retrying is safe for any HTTP method; a timeout or 5xx means the server may already have it, so those stay gated to idempotent GET/HEAD paths. This preserves that distinction end to end instead of collapsing it into a single `SERVICE_UNAVAILABLE`.

- `makeBoundedFetch` tags its thrown `ORPCError('SERVICE_UNAVAILABLE')` with `data.failureMode: 'timeout' | 'transport'`
- New `OutboundFailureMode` type and `isNeverAppliedFailure` predicate in `@vers/service-utils`'s `orpc` module, transport-agnostic (no app-web import)
- `buildRetryInterceptor`'s thrown-error branch retries when the caller hasn't aborted, it's not the last attempt, and either the failure never applied or the path is idempotent — a POST like `refreshTokens` now retries on a transport failure but not on a timeout or 5xx
- Response-status retry rule is unchanged in effect, just moved inside the loop alongside the new branch

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
