### PR TITLE
fix(#817): bound neon connect acquisition and span it

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -148,6 +148,12 @@
           { "from": "package", "name": "Page", "package": "playwright-core" },
           // a live kysely transaction handle: same mutable connection state as Kysely above
           { "from": "package", "name": "Transaction", "package": "kysely" },
+          // a driver's connection-pool handle: structurally a set of method signatures, same as
+          // KyselyTransactionLike below
+          { "from": "package", "name": "Driver", "package": "kysely" },
+          // a live kysely-postgres-js dialect handle: wraps a postgres.js Sql client, no readonly
+          // form
+          { "from": "package", "name": "PostgresJSDialect", "package": "kysely-postgres-js" },
           // a live pg-boss client handle: connection pool and event emitter state, no readonly form
           { "from": "package", "name": "PgBoss", "package": "pg-boss" },
           // structurally a single method signature, which the rule's default settings treat as

--- a/docs/architecture/platform/observability.md
+++ b/docs/architecture/platform/observability.md
@@ -48,11 +48,12 @@ carries no such plugin; `withRequestTrace` (`apps/web/src/server/with-request-tr
 same SERVER span itself, skipping a served static asset or the `/health` probe. Every `Kysely`
 client (`createDB`, `@vers/db`) emits a retroactively timed CLIENT span per compiled query from its
 `log` callback, named `db.<operation>` from the compiled query's root node kind and carrying the
-compiled SQL (never its parameters). Every service-to-service `RPCLink` carries
-`buildTracingInterceptor` (`@vers/service-utils/orpc`) in its `clientInterceptors`, minting a CLIENT
-span per call named by the procedure path. A worker iteration, a boot drain, a scheduled sweep, or a
-queued job — anything with no inbound request to continue — opens its own root span through
-`withRootSpan` (`@vers/service-utils`).
+compiled SQL (never its parameters). A `db.connect` CLIENT span wraps each connection acquired from
+the driver's pool, covering the phase neither the query span nor a session timeout observes. Every
+service-to-service `RPCLink` carries `buildTracingInterceptor` (`@vers/service-utils/orpc`) in its
+`clientInterceptors`, minting a CLIENT span per call named by the procedure path. A worker
+iteration, a boot drain, a scheduled sweep, or a queued job — anything with no inbound request to
+continue — opens its own root span through `withRootSpan` (`@vers/service-utils`).
 
 Boundary span sites — the server plugins and outbound clients — inject or extract `traceparent`
 through the OpenTelemetry API's global propagator, never `@vers/trace` directly: outbound calls

--- a/libs/data/db/src/create-db.test.ts
+++ b/libs/data/db/src/create-db.test.ts
@@ -160,6 +160,53 @@ test('it emits a db.connect client span around a successful connection acquisiti
   expect(connectSpans[0]?.attributes['db.system']).toBe('postgresql');
 });
 
+test('it forwards savepoint, rollbackToSavepoint, and releaseSavepoint to the wrapped driver', async () => {
+  await using handle = await createTestDB();
+
+  const trx = await handle.db.startTransaction().execute();
+
+  try {
+    await trx
+      .insertInto('users')
+      .values({
+        email: 'before-savepoint@test.com',
+        id: 'usr_before_savepoint',
+        name: 'Before Savepoint User',
+        username: 'before_savepoint_user',
+      })
+      .execute();
+
+    const trxAfterSavepoint = await trx.savepoint('after_insert').execute();
+
+    await trxAfterSavepoint
+      .insertInto('users')
+      .values({
+        email: 'after-savepoint@test.com',
+        id: 'usr_after_savepoint',
+        name: 'After Savepoint User',
+        username: 'after_savepoint_user',
+      })
+      .execute();
+
+    const trxAfterRollback = await trxAfterSavepoint.rollbackToSavepoint('after_insert').execute();
+
+    await trxAfterRollback.releaseSavepoint('after_insert').execute();
+    await trxAfterRollback.commit().execute();
+  } catch (error) {
+    await trx.rollback().execute();
+
+    throw error;
+  }
+
+  const users = await handle.db
+    .selectFrom('users')
+    .select('id')
+    .where('id', 'in', ['usr_before_savepoint', 'usr_after_savepoint'])
+    .execute();
+
+  expect(users.map((user) => user.id)).toEqual(['usr_before_savepoint']);
+});
+
 test('it marks the db.connect span failed and records the exception when the connection never opens', async () => {
   const ctx = setupTest();
   const db = createDB({ databaseURL: 'postgres://user:pass@127.0.0.1:1/db' });

--- a/libs/data/db/src/create-db.test.ts
+++ b/libs/data/db/src/create-db.test.ts
@@ -6,6 +6,7 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-node';
 import invariant from 'tiny-invariant';
+import { buildPostgresOptions, createDB } from './create-db';
 import { createTestDB } from './test-support/create-test-db';
 
 function setupTest() {
@@ -60,7 +61,7 @@ test('it emits a db.select client span carrying the compiled sql with placeholde
 
   await handle.db.selectFrom('users').selectAll().where('email', '=', 'redaction-probe').execute();
 
-  const [span] = ctx.exporter.getFinishedSpans();
+  const span = ctx.exporter.getFinishedSpans().find((candidate) => candidate.name === 'db.select');
 
   invariant(span, 'expected the query span to be exported');
 
@@ -87,7 +88,7 @@ test('it names the span from the compiled query kind', async () => {
     })
     .execute();
 
-  const [span] = ctx.exporter.getFinishedSpans();
+  const span = ctx.exporter.getFinishedSpans().find((candidate) => candidate.name === 'db.insert');
 
   expect(span?.name).toBe('db.insert');
 });
@@ -105,7 +106,7 @@ test('it marks the span failed for a query that errors', async () => {
       .execute(),
   ).toReject();
 
-  const [span] = ctx.exporter.getFinishedSpans();
+  const span = ctx.exporter.getFinishedSpans().find((candidate) => candidate.name === 'db.select');
 
   expect(span?.status.code).toBe(SpanStatusCode.ERROR);
 });
@@ -123,7 +124,9 @@ test('it parents the query span to the active context', async () => {
     parentSpan.end();
   });
 
-  const [querySpan, parentSpan] = ctx.exporter.getFinishedSpans();
+  const spans = ctx.exporter.getFinishedSpans();
+  const querySpan = spans.find((candidate) => candidate.name === 'db.select');
+  const parentSpan = spans.find((candidate) => candidate.name === 'parent');
 
   invariant(querySpan, 'expected the query span to be exported');
   invariant(parentSpan, 'expected the parent span to be exported');
@@ -135,4 +138,40 @@ test('it stays inert without a registered tracer provider', async () => {
   await using handle = await createTestDB();
 
   await expect(handle.db.selectFrom('users').selectAll().execute()).toResolve();
+});
+
+test('it bounds connection acquisition with a 10s connect_timeout', () => {
+  const options = buildPostgresOptions({ databaseURL: 'postgres://user:pass@localhost:5432/db' });
+
+  expect(options.connect_timeout).toBe(10);
+});
+
+test('it emits a db.connect client span around a successful connection acquisition', async () => {
+  const ctx = setupTest();
+
+  await using handle = await createTestDB();
+
+  await handle.db.selectFrom('users').selectAll().execute();
+
+  const connectSpans = ctx.exporter.getFinishedSpans().filter((span) => span.name === 'db.connect');
+
+  expect(connectSpans).toHaveLength(1);
+  expect(connectSpans[0]?.kind).toBe(SpanKind.CLIENT);
+  expect(connectSpans[0]?.attributes['db.system']).toBe('postgresql');
+});
+
+test('it marks the db.connect span failed and records the exception when the connection never opens', async () => {
+  const ctx = setupTest();
+  const db = createDB({ databaseURL: 'postgres://user:pass@127.0.0.1:1/db' });
+
+  onTestFinished(() => db.destroy());
+
+  await expect(db.selectFrom('users').selectAll().execute()).toReject();
+
+  const connectSpan = ctx.exporter.getFinishedSpans().find((span) => span.name === 'db.connect');
+
+  invariant(connectSpan, 'expected a db.connect span to be exported');
+
+  expect(connectSpan.status.code).toBe(SpanStatusCode.ERROR);
+  expect(connectSpan.events[0]?.name).toBe('exception');
 });

--- a/libs/data/db/src/create-db.ts
+++ b/libs/data/db/src/create-db.ts
@@ -1,6 +1,6 @@
 import { SpanKind, SpanStatusCode, context, trace } from '@opentelemetry/api';
 import { CamelCasePlugin, Kysely } from 'kysely';
-import type { LogEvent } from 'kysely';
+import type { Dialect, Driver, LogEvent } from 'kysely';
 import { PostgresJSDialect } from 'kysely-postgres-js';
 import postgres from 'postgres';
 import type { DB } from './schema.generated';
@@ -26,22 +26,95 @@ interface CreateDBConfig {
  * it the pool hands a caller a connection the endpoint already closed, and the
  * first write fails with CONNECTION_CLOSED; the value stays under the
  * endpoint's suspend timeout so the client always closes first.
+ *
+ * `connect_timeout` (also seconds) bounds connection acquisition itself, a
+ * phase neither `statement_timeout` nor `idle_timeout` covers: a suspended
+ * managed Postgres endpoint that stalls on wake fails in 10s instead of
+ * hanging for minutes, while 10s leaves headroom for a normal cold wake
+ * (roughly 1-5s).
  */
 export function createDB(config: CreateDBConfig): Kysely<DB> {
+  const sql = postgres(config.databaseURL, buildPostgresOptions(config));
+
   return new Kysely<DB>({
-    dialect: new PostgresJSDialect({
-      postgres: postgres(config.databaseURL, {
-        connection: {
-          idle_in_transaction_session_timeout: 30_000,
-          statement_timeout: 30_000,
-          ...(config.searchPath === undefined ? {} : { search_path: config.searchPath }),
-        },
-        idle_timeout: 240,
-      }),
-    }),
+    dialect: buildTracedDialect(new PostgresJSDialect({ postgres: sql })),
     log: recordQuerySpan,
     plugins: [new CamelCasePlugin()],
   });
+}
+
+/**
+ * Builds the postgres.js connection options `createDB` passes to `postgres(...)`, split out from
+ * the dialect construction so tests can assert on the options object without opening a real
+ * connection.
+ */
+export function buildPostgresOptions(config: CreateDBConfig) {
+  return {
+    connect_timeout: 10,
+    connection: {
+      idle_in_transaction_session_timeout: 30_000,
+      statement_timeout: 30_000,
+      ...(config.searchPath === undefined ? {} : { search_path: config.searchPath }),
+    },
+    idle_timeout: 240,
+  };
+}
+
+/**
+ * Wraps a `PostgresJSDialect` so the driver it creates emits a `db.connect` span around connection
+ * acquisition, delegating every other dialect method straight through.
+ */
+function buildTracedDialect(dialect: PostgresJSDialect): Dialect {
+  return {
+    createAdapter: () => dialect.createAdapter(),
+    createDriver: () => buildTracedDriver(dialect.createDriver()),
+    createIntrospector: (db) => dialect.createIntrospector(db),
+    createQueryCompiler: () => dialect.createQueryCompiler(),
+  };
+}
+
+/**
+ * Wraps a `Driver` so `acquireConnection` runs inside a `db.connect` span, delegating every other
+ * method to the inner driver unchanged.
+ */
+function buildTracedDriver(driver: Driver): Driver {
+  return {
+    acquireConnection: (options) => withConnectSpan(() => driver.acquireConnection(options)),
+    beginTransaction: (connection, settings) => driver.beginTransaction(connection, settings),
+    commitTransaction: (connection) => driver.commitTransaction(connection),
+    destroy: (options) => driver.destroy(options),
+    init: (options) => driver.init(options),
+    releaseConnection: (connection, options) => driver.releaseConnection(connection, options),
+    rollbackTransaction: (connection) => driver.rollbackTransaction(connection),
+  };
+}
+
+/**
+ * Runs a driver's `acquireConnection` call inside a `db.connect` CLIENT span, parented to
+ * `context.active()` so it nests under whatever request or worker span is active; a no-op span
+ * without a registered tracer provider. Marks the span failed and records the exception on a
+ * stalled or refused connect.
+ */
+async function withConnectSpan<T>(acquireConnection: () => Promise<T>): Promise<T> {
+  const tracer = trace.getTracer('@vers/db');
+
+  const span = tracer.startSpan(
+    'db.connect',
+    { attributes: { 'db.system': 'postgresql' }, kind: SpanKind.CLIENT },
+    context.active(),
+  );
+
+  try {
+    return await acquireConnection();
+  } catch (error) {
+    const exception = error instanceof Error ? error : String(error);
+
+    span.recordException(exception);
+    span.setStatus({ code: SpanStatusCode.ERROR });
+    throw error;
+  } finally {
+    span.end();
+  }
 }
 
 /**

--- a/libs/data/db/src/create-db.ts
+++ b/libs/data/db/src/create-db.ts
@@ -1,6 +1,6 @@
 import { SpanKind, SpanStatusCode, context, trace } from '@opentelemetry/api';
 import { CamelCasePlugin, Kysely } from 'kysely';
-import type { Dialect, Driver, LogEvent } from 'kysely';
+import type { AbortableOperationOptions, Dialect, Driver, LogEvent } from 'kysely';
 import { PostgresJSDialect } from 'kysely-postgres-js';
 import postgres from 'postgres';
 import type { DB } from './schema.generated';
@@ -75,18 +75,29 @@ function buildTracedDialect(dialect: PostgresJSDialect): Dialect {
 
 /**
  * Wraps a `Driver` so `acquireConnection` runs inside a `db.connect` span, delegating every other
- * method to the inner driver unchanged.
+ * method — including the optional savepoint methods — to the inner driver unchanged. Delegates
+ * through a `Proxy` rather than a hand-listed method map, so a `Driver` method this file doesn't
+ * name still reaches the inner driver instead of silently becoming a no-op.
  */
 function buildTracedDriver(driver: Driver): Driver {
-  return {
-    acquireConnection: (options) => withConnectSpan(() => driver.acquireConnection(options)),
-    beginTransaction: (connection, settings) => driver.beginTransaction(connection, settings),
-    commitTransaction: (connection) => driver.commitTransaction(connection),
-    destroy: (options) => driver.destroy(options),
-    init: (options) => driver.init(options),
-    releaseConnection: (connection, options) => driver.releaseConnection(connection, options),
-    rollbackTransaction: (connection) => driver.rollbackTransaction(connection),
-  };
+  return new Proxy(driver, {
+    get: (target, property, receiver) => {
+      if (property === 'acquireConnection') {
+        return (options?: AbortableOperationOptions) =>
+          withConnectSpan(() => target.acquireConnection(options));
+      }
+
+      const value: unknown = Reflect.get(target, property, receiver);
+
+      if (typeof value !== 'function') {
+        return value;
+      }
+
+      const boundValue: unknown = value.bind(target);
+
+      return boundValue;
+    },
+  });
 }
 
 /**


### PR DESCRIPTION
Closes #817

## Description

`createDB` had no bound on connection acquisition itself, so a suspended managed Postgres endpoint that stalled on wake could hang the caller for minutes instead of failing fast. This adds a `connect_timeout` and traces the acquisition phase so it shows up in spans.

- add `connect_timeout: 10` to the postgres.js options, extracted into an exported `buildPostgresOptions` for direct unit testing
- wrap `PostgresJSDialect`'s driver in a `Proxy` so `acquireConnection` runs inside a `db.connect` CLIENT span (mirrors `recordQuerySpan`'s tracer/attributes/no-op/exception conventions), every other `Driver`/`Dialect` method delegates through unchanged
- allow-list `Driver` and `PostgresJSDialect` in `prefer-readonly-parameter-types` alongside the existing kysely/pg-boss handle entries
- document the `db.connect` span in the observability registry

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
