### PR TITLE
feat(#191): add the hex-lattice geometry generator

### DIFF
--- a/libs/game/worldmap-core/src/__snapshots__/build-graph-nodes.test.ts.snap
+++ b/libs/game/worldmap-core/src/__snapshots__/build-graph-nodes.test.ts.snap
@@ -1,4 +1,4 @@
-// Bun Snapshot v1, https://bun.com/docs/test/snapshots
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`it generates a valid graph 1`] = `
 [

--- a/libs/game/worldmap-core/src/build-cell-node.test.ts
+++ b/libs/game/worldmap-core/src/build-cell-node.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from 'bun:test';
+import { buildCellNode } from './build-cell-node';
+import { JITTER } from './consts';
+import { toHexPosition } from './to-hex-position';
+
+const SEED = 12_345;
+
+test('it is deterministic for a seed and coordinate', () => {
+  expect(buildCellNode(SEED, 4, -2)).toStrictEqual(buildCellNode(SEED, 4, -2));
+});
+
+test('it identifies the node by its cell coordinate', () => {
+  const node = buildCellNode(SEED, 4, -2);
+
+  expect(node.id).toBe('4_-2');
+  expect(node.coord).toStrictEqual([4, -2]);
+});
+
+test('it keeps the jittered position within the jitter bound of the cell center', () => {
+  const [centerX, centerY] = toHexPosition(4, -2);
+  const node = buildCellNode(SEED, 4, -2);
+
+  expect(Math.abs(node.position[0] - centerX)).toBeLessThanOrEqual(JITTER);
+  expect(Math.abs(node.position[1] - centerY)).toBeLessThanOrEqual(JITTER);
+});
+
+test('it shifts the layout when the avatar seed changes', () => {
+  expect(buildCellNode(SEED, 4, -2).position).not.toStrictEqual(
+    buildCellNode(SEED + 1, 4, -2).position,
+  );
+});
+
+test('it builds a stable node', () => {
+  expect(buildCellNode(SEED, 1, 1)).toMatchInlineSnapshot(`
+    {
+      "coord": [
+        1,
+        1,
+      ],
+      "difficulty": 2,
+      "id": "1_1",
+      "position": [
+        2.4216949547357105,
+        1.3081833966076375,
+      ],
+    }
+  `);
+});

--- a/libs/game/worldmap-core/src/build-cell-node.ts
+++ b/libs/game/worldmap-core/src/build-cell-node.ts
@@ -1,0 +1,25 @@
+import { HASH_CHANNEL, buildCoordHashUnit } from './build-coord-hash';
+import { JITTER } from './consts';
+import { getDifficulty } from './get-difficulty';
+import { toHexPosition } from './to-hex-position';
+import { toNodeID } from './to-node-id';
+import type { LatticeNode } from './types';
+
+/**
+ * Builds the single node a cell carries: its canonical id, jittered scene position, and difficulty.
+ * Every cell holds a node — visible sparseness is a render choice, never an absence — so this never
+ * returns null. Jitter is a pure function of the avatar seed and coordinate, so client and server
+ * agree on the position without either storing it.
+ */
+export function buildCellNode(userSeed: number, cx: number, cy: number): LatticeNode {
+  const [centerX, centerY] = toHexPosition(cx, cy);
+  const offsetX = (buildCoordHashUnit(userSeed, cx, cy, HASH_CHANNEL.jitterX) - 0.5) * 2 * JITTER;
+  const offsetY = (buildCoordHashUnit(userSeed, cx, cy, HASH_CHANNEL.jitterY) - 0.5) * 2 * JITTER;
+
+  return {
+    coord: [cx, cy],
+    difficulty: getDifficulty(cx, cy),
+    id: toNodeID(cx, cy),
+    position: [centerX + offsetX, centerY + offsetY],
+  };
+}

--- a/libs/game/worldmap-core/src/build-chunk.test.ts
+++ b/libs/game/worldmap-core/src/build-chunk.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from 'bun:test';
+import { buildCellNode } from './build-cell-node';
+import { buildChunk } from './build-chunk';
+import { CHUNK_SIZE } from './consts';
+
+const SEED = 999;
+
+test('it carries a node for every cell in the chunk', () => {
+  expect(buildChunk(SEED, 0, 0)).toHaveLength(CHUNK_SIZE * CHUNK_SIZE);
+});
+
+test('it spans the chunk from its base cell to the far corner', () => {
+  const nodes = buildChunk(SEED, 1, -1);
+
+  expect(nodes[0]?.coord).toStrictEqual([CHUNK_SIZE, -CHUNK_SIZE]);
+  expect(nodes.at(-1)?.coord).toStrictEqual([2 * CHUNK_SIZE - 1, -1]);
+});
+
+test('it agrees with the single-cell builder', () => {
+  const nodes = buildChunk(SEED, 0, 0);
+
+  expect(nodes[0]).toStrictEqual(buildCellNode(SEED, 0, 0));
+});
+
+test('it holds no duplicate ids', () => {
+  const nodes = buildChunk(SEED, 0, 0);
+
+  const ids = new Set(nodes.map((node) => node.id));
+
+  expect(ids.size).toBe(nodes.length);
+});

--- a/libs/game/worldmap-core/src/build-chunk.ts
+++ b/libs/game/worldmap-core/src/build-chunk.ts
@@ -1,0 +1,21 @@
+import { buildCellNode } from './build-cell-node';
+import { CHUNK_SIZE } from './consts';
+import type { LatticeNode } from './types';
+
+/**
+ * Builds every node in a chunk — a `CHUNK_SIZE`×`CHUNK_SIZE` block of cells — straight from the
+ * chunk coordinate, touching no neighbouring chunk. Nodes come in row-major cell order.
+ */
+export function buildChunk(userSeed: number, chunkX: number, chunkY: number): Array<LatticeNode> {
+  const baseX = chunkX * CHUNK_SIZE;
+  const baseY = chunkY * CHUNK_SIZE;
+  const nodes: Array<LatticeNode> = [];
+
+  for (let row = 0; row < CHUNK_SIZE; row++) {
+    for (let col = 0; col < CHUNK_SIZE; col++) {
+      nodes.push(buildCellNode(userSeed, baseX + col, baseY + row));
+    }
+  }
+
+  return nodes;
+}

--- a/libs/game/worldmap-core/src/build-coord-hash.test.ts
+++ b/libs/game/worldmap-core/src/build-coord-hash.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from 'bun:test';
+import { HASH_CHANNEL, buildCoordHash, buildCoordHashUnit } from './build-coord-hash';
+
+test('it returns the same value for the same inputs', () => {
+  expect(buildCoordHash(42, 3, -7, HASH_CHANNEL.jitterX)).toBe(
+    buildCoordHash(42, 3, -7, HASH_CHANNEL.jitterX),
+  );
+});
+
+test('it stays within the uint32 range', () => {
+  for (let cx = -4; cx <= 4; cx++) {
+    for (let cy = -4; cy <= 4; cy++) {
+      const value = buildCoordHash(1, cx, cy, HASH_CHANNEL.jitterX);
+
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThanOrEqual(0xffffffff);
+      expect(Number.isInteger(value)).toBe(true);
+    }
+  }
+});
+
+test('it decorrelates the draw channels for one cell', () => {
+  expect(buildCoordHash(1, 2, 3, HASH_CHANNEL.jitterX)).not.toBe(
+    buildCoordHash(1, 2, 3, HASH_CHANNEL.jitterY),
+  );
+});
+
+test('it decorrelates neighbouring cells under one seed', () => {
+  expect(buildCoordHash(1, 0, 0, HASH_CHANNEL.jitterX)).not.toBe(
+    buildCoordHash(1, 1, 0, HASH_CHANNEL.jitterX),
+  );
+});
+
+test('it moves with the avatar seed', () => {
+  expect(buildCoordHash(1, 5, 5, HASH_CHANNEL.jitterX)).not.toBe(
+    buildCoordHash(2, 5, 5, HASH_CHANNEL.jitterX),
+  );
+});
+
+test('it maps to the half-open unit interval', () => {
+  const unit = buildCoordHashUnit(9, -3, 8, HASH_CHANNEL.jitterY);
+
+  expect(unit).toBeGreaterThanOrEqual(0);
+  expect(unit).toBeLessThan(1);
+});
+
+test('it draws a stable sequence for a fixed seed', () => {
+  const draws = [
+    buildCoordHash(7, 0, 0, HASH_CHANNEL.jitterX),
+    buildCoordHash(7, 0, 0, HASH_CHANNEL.jitterY),
+    buildCoordHash(7, 1, 0, HASH_CHANNEL.jitterX),
+    buildCoordHash(7, 0, 1, HASH_CHANNEL.jitterX),
+    buildCoordHash(7, -1, -1, HASH_CHANNEL.jitterY),
+  ];
+
+  expect(draws).toMatchInlineSnapshot(`
+    [
+      3589541006,
+      2630369547,
+      675780315,
+      2031336951,
+      2418359163,
+    ]
+  `);
+});

--- a/libs/game/worldmap-core/src/build-coord-hash.ts
+++ b/libs/game/worldmap-core/src/build-coord-hash.ts
@@ -1,0 +1,73 @@
+/**
+ * Distinct draw channels for a single cell, so independent decisions (x jitter, y jitter) read from
+ * uncorrelated streams rather than reusing one hash.
+ */
+export const HASH_CHANNEL = {
+  jitterX: 0,
+  jitterY: 1,
+} as const;
+
+/**
+ * Stateless Squirrel3-style integer hash of a cell coordinate and draw channel under an avatar's
+ * seed. Deterministic and neighbour-free: a cell's value computes straight from its coordinates, so
+ * regions generate in any order without touching each other. Returns a uint32.
+ */
+export function buildCoordHash(userSeed: number, cx: number, cy: number, channel: number): number {
+  const combined = toInt32(
+    cx + Math.imul(cy, COORD_PRIME_Y) + Math.imul(channel, COORD_PRIME_CHANNEL),
+  );
+
+  return buildSquirrelNoise(combined, toUint32(userSeed));
+}
+
+/**
+ * `buildCoordHash` mapped into the half-open unit interval `[0, 1)`, the form jitter and threshold
+ * draws consume.
+ */
+export function buildCoordHashUnit(
+  userSeed: number,
+  cx: number,
+  cy: number,
+  channel: number,
+): number {
+  return buildCoordHash(userSeed, cx, cy, channel) / UINT32_RANGE;
+}
+
+const COORD_PRIME_Y = 198_491_317;
+const COORD_PRIME_CHANNEL = 6_542_989;
+const UINT32_RANGE = 2 ** 32;
+const NOISE_1 = 0xb5297a4d;
+const NOISE_2 = 0x68e31da4;
+const NOISE_3 = 0x1b56c4e9;
+
+/**
+ * Squirrel3 bit-mixing avalanche: one 32-bit input plus a seed to a well-distributed uint32.
+ */
+function buildSquirrelNoise(n: number, seed: number): number {
+  let mixed = Math.imul(n, NOISE_1);
+
+  mixed = toInt32(mixed + seed);
+  mixed ^= mixed >>> 8;
+  mixed = toInt32(mixed + NOISE_2);
+  mixed ^= mixed << 8;
+  mixed = Math.imul(mixed, NOISE_3);
+  mixed ^= mixed >>> 8;
+
+  return toUint32(mixed);
+}
+
+/**
+ * Reinterprets a number as a signed 32-bit int, wrapping overflow the way the mixing steps rely on.
+ */
+function toInt32(n: number): number {
+  // oxlint-disable-next-line unicorn/prefer-math-trunc -- bitwise or wraps to a signed 32-bit int; Math.trunc only drops a fractional part, it never wraps
+  return n | 0;
+}
+
+/**
+ * Reinterprets a signed 32-bit int as its unsigned value.
+ */
+function toUint32(n: number): number {
+  // oxlint-disable-next-line unicorn/prefer-math-trunc -- unsigned shift reinterprets the sign bit as magnitude; Math.trunc cannot clear it
+  return n >>> 0;
+}

--- a/libs/game/worldmap-core/src/collect-node-edges.test.ts
+++ b/libs/game/worldmap-core/src/collect-node-edges.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from 'bun:test';
+import { collectNodeEdges } from './collect-node-edges';
+import { toCellCoord } from './to-cell-coord';
+import { toNodeID } from './to-node-id';
+
+const SEED = 2024;
+
+test('it connects the origin to at least one neighbour', () => {
+  expect(collectNodeEdges(SEED, 0, 0).length).toBeGreaterThan(0);
+});
+
+test('it is deterministic for a seed and cell', () => {
+  expect(collectNodeEdges(SEED, 2, 3)).toStrictEqual(collectNodeEdges(SEED, 2, 3));
+});
+
+test('it identifies every edge by its endpoints sorted ascending', () => {
+  for (const edge of collectNodeEdges(SEED, 2, 3)) {
+    const [low = '', high = ''] = edge.id.split('|');
+
+    expect(low < high).toBe(true);
+  }
+});
+
+test('it derives the same edge from both endpoints', () => {
+  const originID = toNodeID(0, 0);
+
+  for (const edge of collectNodeEdges(SEED, 0, 0)) {
+    const otherID = edge.id.split('|').find((endpoint) => endpoint !== originID) ?? originID;
+    const [ocx, ocy] = toCellCoord(otherID);
+    const mirrored = collectNodeEdges(SEED, ocx, ocy);
+
+    expect(mirrored.some((candidate) => candidate.id === edge.id)).toBe(true);
+  }
+});
+
+test('it leaves no cell in a patch isolated', () => {
+  for (let cx = -3; cx <= 3; cx++) {
+    for (let cy = -3; cy <= 3; cy++) {
+      expect(collectNodeEdges(SEED, cx, cy).length).toBeGreaterThan(0);
+    }
+  }
+});
+
+test('it collects a stable edge set for the origin', () => {
+  const ids = collectNodeEdges(SEED, 0, 0).map((edge) => edge.id);
+
+  expect(ids).toMatchInlineSnapshot(`
+    [
+      "-1_0|0_0",
+      "-1_1|0_0",
+      "0_-1|0_0",
+      "0_0|0_1",
+      "0_0|1_-1",
+      "0_0|1_0",
+    ]
+  `);
+});
+
+test('it collects a stable edge set for a cell far from the origin', () => {
+  const ids = collectNodeEdges(SEED, 12, -5).map((edge) => edge.id);
+
+  expect(ids).toMatchInlineSnapshot(`
+    [
+      "11_-5|12_-5",
+      "11_-4|12_-5",
+      "12_-5|12_-6",
+      "12_-4|12_-5",
+      "12_-5|13_-6",
+      "12_-5|13_-5",
+    ]
+  `);
+});

--- a/libs/game/worldmap-core/src/collect-node-edges.ts
+++ b/libs/game/worldmap-core/src/collect-node-edges.ts
@@ -1,0 +1,105 @@
+import { buildCellNode } from './build-cell-node';
+import { EDGE_DISTANCE_CAP } from './consts';
+import type { LatticeEdge, LatticeNode } from './types';
+
+/**
+ * Rings of cells scanned around a node. Two rings reach every cell whose node could fall inside the
+ * circle of a within-cap candidate pair, so the Gabriel test never misses a witness.
+ */
+const WITNESS_RING_RADIUS = 2;
+
+/**
+ * Collects every edge incident to the node at a cell under the distance-capped Gabriel rule: two
+ * nodes connect when they fall within the cap and no third node sits inside the circle whose
+ * diameter is the pair. Reading the surrounding cells (the halo) lets a border node see the same
+ * candidates its neighbour across a chunk boundary sees, so both derive the identical edge with no
+ * reconciliation pass. Returns all incident edges, both orientations; callers spanning many cells
+ * dedupe on `id`.
+ */
+export function collectNodeEdges(userSeed: number, cx: number, cy: number): Array<LatticeEdge> {
+  const source = buildCellNode(userSeed, cx, cy);
+  const pool = collectDiscNodes(userSeed, cx, cy, WITNESS_RING_RADIUS);
+  const capSquared = EDGE_DISTANCE_CAP * EDGE_DISTANCE_CAP;
+  const edges: Array<LatticeEdge> = [];
+
+  for (const candidate of pool) {
+    if (candidate.id === source.id) {
+      continue;
+    }
+
+    if (getDistanceSquared(source.position, candidate.position) > capSquared) {
+      continue;
+    }
+
+    if (hasWitnessInside(source, candidate, pool)) {
+      continue;
+    }
+
+    edges.push(buildEdge(source, candidate));
+  }
+
+  return edges;
+}
+
+/**
+ * Builds the nodes of every cell within `radius` rings of the center, the candidate-and-witness pool
+ * one Gabriel evaluation reads.
+ */
+function collectDiscNodes(
+  userSeed: number,
+  cx: number,
+  cy: number,
+  radius: number,
+): Array<LatticeNode> {
+  const nodes: Array<LatticeNode> = [];
+
+  for (let dq = -radius; dq <= radius; dq++) {
+    const lowDr = Math.max(-radius, -dq - radius);
+    const highDr = Math.min(radius, -dq + radius);
+
+    for (let dr = lowDr; dr <= highDr; dr++) {
+      nodes.push(buildCellNode(userSeed, cx + dq, cy + dr));
+    }
+  }
+
+  return nodes;
+}
+
+/**
+ * Gabriel witness test: true when some pool node other than the pair lies strictly inside the circle
+ * whose diameter is the pair, which forbids the edge.
+ */
+function hasWitnessInside(
+  a: LatticeNode,
+  b: LatticeNode,
+  pool: ReadonlyArray<LatticeNode>,
+): boolean {
+  const midX = (a.position[0] + b.position[0]) / 2;
+  const midY = (a.position[1] + b.position[1]) / 2;
+  const radiusSquared = getDistanceSquared(a.position, b.position) / 4;
+
+  return pool.some((witness) => {
+    if (witness.id === a.id || witness.id === b.id) {
+      return false;
+    }
+
+    return getDistanceSquared([midX, midY], witness.position) < radiusSquared;
+  });
+}
+
+/**
+ * Builds the undirected edge for a pair, its id the endpoint ids sorted ascending so either endpoint
+ * derives the same identity.
+ */
+function buildEdge(a: LatticeNode, b: LatticeNode): LatticeEdge {
+  const id = a.id < b.id ? `${a.id}|${b.id}` : `${b.id}|${a.id}`;
+
+  return { end: b.position, id, start: a.position };
+}
+
+function getDistanceSquared(a: readonly [number, number], b: readonly [number, number]): number {
+  const dx = a[0] - b[0];
+  const dy = a[1] - b[1];
+
+  return dx * dx + dy * dy;
+}

--- a/libs/game/worldmap-core/src/consts.ts
+++ b/libs/game/worldmap-core/src/consts.ts
@@ -1,0 +1,42 @@
+/**
+ * Cells per side of a generation chunk — the unit a chunk is generated in, and the block a cell maps
+ * back to.
+ */
+export const CHUNK_SIZE = 16;
+
+/**
+ * Pointy-top hex circumradius in scene units. One keeps the lattice at unit scale; downstream render
+ * layers apply their own scene multiplier.
+ */
+export const HEX_SIZE = 1;
+
+/**
+ * Maximum per-axis position offset applied to a cell's center. Bounded below half the nearest-cell
+ * spacing so a jittered node never leaves its own cell and the edge cap still clears every
+ * nearest-neighbour pair.
+ */
+export const JITTER = 0.2;
+
+/**
+ * Two nodes connect only when their jittered centers fall within this distance. Set above the
+ * maximum jittered nearest-neighbour distance so every minimum-spanning-tree edge survives, and
+ * below the nearest second-ring distance so only the six adjacent cells are ever candidates — the
+ * bound that keeps the Gabriel backbone connected.
+ */
+export const EDGE_DISTANCE_CAP = 2.35;
+
+/**
+ * Hex-distance span mapped to one difficulty step. Difficulty climbs one level every `DIFFICULTY_STEP`
+ * rings out from the origin.
+ */
+export const DIFFICULTY_STEP = 1;
+
+/**
+ * Difficulty plateau. Distance runs unbounded past it; horizontal variety carries the world beyond.
+ */
+export const MAX_DIFFICULTY = 100;
+
+/**
+ * The home cell every avatar starts from and difficulty measures distance against.
+ */
+export const ORIGIN_CELL: readonly [number, number] = [0, 0];

--- a/libs/game/worldmap-core/src/get-difficulty.test.ts
+++ b/libs/game/worldmap-core/src/get-difficulty.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from 'bun:test';
+import { MAX_DIFFICULTY } from './consts';
+import { getDifficulty } from './get-difficulty';
+
+test('it is zero at the origin', () => {
+  expect(getDifficulty(0, 0)).toBe(0);
+});
+
+test('it climbs one step per ring out from the origin', () => {
+  expect(getDifficulty(1, 0)).toBe(1);
+  expect(getDifficulty(3, 0)).toBe(3);
+  expect(getDifficulty(0, -4)).toBe(4);
+});
+
+test('it plateaus at the cap for a far cell', () => {
+  expect(getDifficulty(1000, 0)).toBe(MAX_DIFFICULTY);
+});
+
+test('it treats direction symmetrically', () => {
+  expect(getDifficulty(6, 0)).toBe(getDifficulty(-6, 0));
+});

--- a/libs/game/worldmap-core/src/get-difficulty.ts
+++ b/libs/game/worldmap-core/src/get-difficulty.ts
@@ -1,0 +1,12 @@
+import { DIFFICULTY_STEP, MAX_DIFFICULTY, ORIGIN_CELL } from './consts';
+import { getHexDistance } from './get-hex-distance';
+
+/**
+ * Difficulty of a cell: one step per `DIFFICULTY_STEP` rings from the origin, clamped to the
+ * plateau. O(1) and seed-independent, so the server recomputes it from the coordinate alone.
+ */
+export function getDifficulty(cx: number, cy: number): number {
+  const rings = Math.floor(getHexDistance([cx, cy], ORIGIN_CELL) / DIFFICULTY_STEP);
+
+  return Math.min(Math.max(rings, 0), MAX_DIFFICULTY);
+}

--- a/libs/game/worldmap-core/src/get-hex-distance.test.ts
+++ b/libs/game/worldmap-core/src/get-hex-distance.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from 'bun:test';
+import { getHexDistance } from './get-hex-distance';
+
+test('it is zero for a cell against itself', () => {
+  expect(getHexDistance([4, -2], [4, -2])).toBe(0);
+});
+
+test('it is one for every adjacent cell', () => {
+  const neighbours: Array<[number, number]> = [
+    [1, 0],
+    [1, -1],
+    [0, -1],
+    [-1, 0],
+    [-1, 1],
+    [0, 1],
+  ];
+
+  for (const neighbour of neighbours) {
+    expect(getHexDistance([0, 0], neighbour)).toBe(1);
+  }
+});
+
+test('it is symmetric', () => {
+  expect(getHexDistance([2, 3], [-1, 5])).toBe(getHexDistance([-1, 5], [2, 3]));
+});
+
+test('it counts rings straight out one axis', () => {
+  expect(getHexDistance([0, 0], [5, 0])).toBe(5);
+  expect(getHexDistance([0, 0], [0, -5])).toBe(5);
+});

--- a/libs/game/worldmap-core/src/get-hex-distance.ts
+++ b/libs/game/worldmap-core/src/get-hex-distance.ts
@@ -1,0 +1,10 @@
+/**
+ * Number of steps between two axial hex cells — the cube-coordinate distance, where the third axis
+ * is `-cx - cy`. This is the ring count difficulty measures against.
+ */
+export function getHexDistance(a: readonly [number, number], b: readonly [number, number]): number {
+  const dx = a[0] - b[0];
+  const dy = a[1] - b[1];
+
+  return (Math.abs(dx) + Math.abs(dy) + Math.abs(dx + dy)) / 2;
+}

--- a/libs/game/worldmap-core/src/index.ts
+++ b/libs/game/worldmap-core/src/index.ts
@@ -1,2 +1,11 @@
+export { buildCellNode } from './build-cell-node';
+export { buildChunk } from './build-chunk';
+export { collectNodeEdges } from './collect-node-edges';
 export { decompressWorldGraph } from './decompress-world-graph';
+export { getDifficulty } from './get-difficulty';
+export { getHexDistance } from './get-hex-distance';
+export { toCellCoord } from './to-cell-coord';
+export { toChunkCoord } from './to-chunk-coord';
+export { toHexPosition } from './to-hex-position';
+export { toNodeID } from './to-node-id';
 export type * from './types';

--- a/libs/game/worldmap-core/src/to-cell-coord.test.ts
+++ b/libs/game/worldmap-core/src/to-cell-coord.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from 'bun:test';
+import { toCellCoord } from './to-cell-coord';
+import { toNodeID } from './to-node-id';
+
+test('it recovers a coordinate from its id', () => {
+  expect(toCellCoord('3_7')).toStrictEqual([3, 7]);
+});
+
+test('it recovers negative coordinates', () => {
+  expect(toCellCoord('-4_-9')).toStrictEqual([-4, -9]);
+});
+
+test('it round-trips every id built by toNodeID', () => {
+  for (let cx = -3; cx <= 3; cx++) {
+    for (let cy = -3; cy <= 3; cy++) {
+      expect(toCellCoord(toNodeID(cx, cy))).toStrictEqual([cx, cy]);
+    }
+  }
+});
+
+test('it throws on a malformed id', () => {
+  expect(() => toCellCoord('not-an-id')).toThrow('malformed node id');
+});
+
+test('it throws on a fractional coordinate', () => {
+  expect(() => toCellCoord('1.5_2')).toThrow('malformed node id');
+});

--- a/libs/game/worldmap-core/src/to-cell-coord.ts
+++ b/libs/game/worldmap-core/src/to-cell-coord.ts
@@ -1,0 +1,15 @@
+import invariant from 'tiny-invariant';
+
+const ID_PATTERN = /^-?\d+_-?\d+$/;
+
+/**
+ * Reverses `toNodeID`, recovering the integer cell coordinate a canonical id encodes. Throws on any
+ * string that is not a well-formed id — a broken invariant, never ordinary input.
+ */
+export function toCellCoord(id: string): [number, number] {
+  invariant(ID_PATTERN.test(id), `malformed node id: ${id}`);
+
+  const [cx, cy] = id.split('_');
+
+  return [Number(cx), Number(cy)];
+}

--- a/libs/game/worldmap-core/src/to-chunk-coord.test.ts
+++ b/libs/game/worldmap-core/src/to-chunk-coord.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from 'bun:test';
+import { CHUNK_SIZE } from './consts';
+import { toChunkCoord } from './to-chunk-coord';
+
+test('it maps the origin cell to the origin chunk', () => {
+  expect(toChunkCoord(0, 0)).toStrictEqual([0, 0]);
+});
+
+test('it keeps a cell inside the first chunk', () => {
+  expect(toChunkCoord(CHUNK_SIZE - 1, CHUNK_SIZE - 1)).toStrictEqual([0, 0]);
+});
+
+test('it rolls over to the next chunk at the boundary', () => {
+  expect(toChunkCoord(CHUNK_SIZE, 0)).toStrictEqual([1, 0]);
+});
+
+test('it floors negative cells into the chunk below', () => {
+  expect(toChunkCoord(-1, -1)).toStrictEqual([-1, -1]);
+  expect(toChunkCoord(-CHUNK_SIZE, 0)).toStrictEqual([-1, 0]);
+});

--- a/libs/game/worldmap-core/src/to-chunk-coord.ts
+++ b/libs/game/worldmap-core/src/to-chunk-coord.ts
@@ -1,0 +1,9 @@
+import { CHUNK_SIZE } from './consts';
+
+/**
+ * Maps a cell coordinate to the coordinate of the chunk that owns it. Uses floor division so
+ * negative cells fall into the chunk below them rather than rounding toward zero.
+ */
+export function toChunkCoord(cx: number, cy: number): [number, number] {
+  return [Math.floor(cx / CHUNK_SIZE), Math.floor(cy / CHUNK_SIZE)];
+}

--- a/libs/game/worldmap-core/src/to-hex-position.test.ts
+++ b/libs/game/worldmap-core/src/to-hex-position.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from 'bun:test';
+import { toHexPosition } from './to-hex-position';
+
+test('it places the origin cell at the scene origin', () => {
+  expect(toHexPosition(0, 0)).toStrictEqual([0, 0]);
+});
+
+test('it spaces adjacent cells one row apart vertically', () => {
+  const [, y] = toHexPosition(0, 1);
+
+  expect(y).toBeCloseTo(1.5);
+});
+
+test('it produces stable lattice centers', () => {
+  const centers = [
+    toHexPosition(1, 0),
+    toHexPosition(0, 1),
+    toHexPosition(2, -1),
+    toHexPosition(-3, 2),
+  ];
+
+  expect(centers).toMatchInlineSnapshot(`
+    [
+      [
+        1.7320508075688772,
+        0,
+      ],
+      [
+        0.8660254037844386,
+        1.5,
+      ],
+      [
+        2.598076211353316,
+        -1.5,
+      ],
+      [
+        -3.4641016151377544,
+        3,
+      ],
+    ]
+  `);
+});

--- a/libs/game/worldmap-core/src/to-hex-position.ts
+++ b/libs/game/worldmap-core/src/to-hex-position.ts
@@ -1,0 +1,14 @@
+import { HEX_SIZE } from './consts';
+
+const SQRT_3 = Math.sqrt(3);
+
+/**
+ * Converts an axial cell coordinate to the scene-space center of its pointy-top hex. Jitter is
+ * applied separately; this is the exact lattice center.
+ */
+export function toHexPosition(cx: number, cy: number): [number, number] {
+  const x = HEX_SIZE * SQRT_3 * (cx + cy / 2);
+  const y = HEX_SIZE * (3 / 2) * cy;
+
+  return [x, y];
+}

--- a/libs/game/worldmap-core/src/to-node-id.test.ts
+++ b/libs/game/worldmap-core/src/to-node-id.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from 'bun:test';
+import { toNodeID } from './to-node-id';
+
+test('it encodes a coordinate as an underscore-joined id', () => {
+  expect(toNodeID(3, 7)).toBe('3_7');
+});
+
+test('it preserves negative coordinates', () => {
+  expect(toNodeID(-4, -9)).toBe('-4_-9');
+});
+
+test('it encodes the origin', () => {
+  expect(toNodeID(0, 0)).toBe('0_0');
+});

--- a/libs/game/worldmap-core/src/to-node-id.ts
+++ b/libs/game/worldmap-core/src/to-node-id.ts
@@ -1,0 +1,10 @@
+import type { CanonicalID } from './types';
+
+/**
+ * Encodes a cell coordinate as its canonical node id, `"cx_cy"`. Reversed by `toCellCoord`. The
+ * underscore separator keeps the id within the activity scope-identifier character set, so a node id
+ * is a valid activity scope with no escaping.
+ */
+export function toNodeID(cx: number, cy: number): CanonicalID {
+  return `${cx}_${cy}`;
+}

--- a/libs/game/worldmap-core/src/types.ts
+++ b/libs/game/worldmap-core/src/types.ts
@@ -30,3 +30,32 @@ export interface CompressedWorldMapNode {
   readonly p: readonly [number, number];
   readonly s: number;
 }
+
+/**
+ * A canonical cell-coordinate node id, `"cx,cy"`. Stable across regenerations and referenceable from
+ * the database — an avatar's seed varies what a cell holds and which edges leave it, never that the
+ * cell exists or what its id is.
+ */
+export type CanonicalID = string;
+
+/**
+ * A node on the hex lattice. Identity is its cell coordinate; `position` is the cell center after
+ * per-avatar jitter, in unit-hex scene coordinates. Content lives on the sealed server plane and is
+ * never carried here.
+ */
+export interface LatticeNode {
+  readonly coord: readonly [number, number];
+  readonly difficulty: number;
+  readonly id: CanonicalID;
+  readonly position: readonly [number, number];
+}
+
+/**
+ * An undirected connection between two lattice nodes. `id` is the two endpoint ids in ascending
+ * order joined by `|`, so the same edge derived from either endpoint carries one identity.
+ */
+export interface LatticeEdge {
+  readonly end: readonly [number, number];
+  readonly id: string;
+  readonly start: readonly [number, number];
+}


### PR DESCRIPTION
First of a stack rebuilding `@vers/worldmap-core` (#191). Adds the deterministic geometry generator; ships additive, leaving the baked-graph path in place for later steps to retire.

- Stateless `buildCoordHash` (Squirrel3-style) seeds every cell straight from its coordinate, so regions regenerate in any order without touching neighbours.
- `buildChunk` / `buildCellNode` place one jittered node per hex cell; identity is the canonical cell coordinate (`toNodeID` / `toCellCoord`), not a random id.
- `collectNodeEdges` derives distance-capped Gabriel edges from a one-chunk halo, so both sides of a chunk border agree with no reconciliation.
- `getDifficulty` is O(1) from hex distance; `getHexDistance`, `toHexPosition`, `toChunkCoord` round out the surface.
- New `LatticeNode` / `LatticeEdge` types sit alongside the legacy graph; naming converges when the legacy path is deleted.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality

## Context

Step 1 of 4 for #191: generator → server cutover → client render cutover → delete baked graph. Design contract: `docs/architecture/game/worldmap.md`.