### PR TITLE
fix(#825): exclude /health from tracing

### DIFF
--- a/libs/service/service-runtime/src/create-service.ts
+++ b/libs/service/service-runtime/src/create-service.ts
@@ -14,6 +14,7 @@ import * as z from 'zod';
 import { baseEnvSchema } from './base-env-schema';
 import { createLogger } from './create-logger';
 import { reportUnexpectedError } from './report-unexpected-error';
+import { shouldTraceRequest } from './should-trace-request';
 import { startErrorReporting } from './start-error-reporting';
 import type { ServiceContext } from './types';
 
@@ -80,6 +81,7 @@ export async function createService<TEnvShape extends z.ZodRawShape = Record<nev
     // and shared plus per-signal headers (backend auth, dataset routing) merge from env
     app.use(
       opentelemetry({
+        checkIfShouldTrace: shouldTraceRequest,
         resource: buildTelemetryResource({ serviceName: config.name }),
         serviceName: config.name,
         traceExporter: new OTLPTraceExporter(),

--- a/libs/service/service-runtime/src/should-trace-request.test.ts
+++ b/libs/service/service-runtime/src/should-trace-request.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from 'bun:test';
+import { shouldTraceRequest } from './should-trace-request';
+
+test('it excludes the health path from tracing', () => {
+  expect(shouldTraceRequest(new Request('http://svc.local/health'))).toBeFalse();
+});
+
+test('it traces an rpc path', () => {
+  expect(shouldTraceRequest(new Request('http://svc.local/rpc/ping'))).toBeTrue();
+});
+
+test('it keys on the path alone, ignoring the query string', () => {
+  expect(shouldTraceRequest(new Request('http://svc.local/health?probe=fly'))).toBeFalse();
+});
+
+test('it traces a path that merely contains the health segment', () => {
+  expect(shouldTraceRequest(new Request('http://svc.local/health/deep'))).toBeTrue();
+});

--- a/libs/service/service-runtime/src/should-trace-request.ts
+++ b/libs/service/service-runtime/src/should-trace-request.ts
@@ -1,0 +1,14 @@
+/**
+ * Paths kept out of tracing. Fly probes `/health` every few seconds, and its `suspend` autostop
+ * freezes the process mid-span: on resume the server span reports the whole sleep gap as its own
+ * duration, so an idle machine's health checks read as multi-second event-loop stalls that never
+ * happened.
+ */
+const UNTRACED_PATHS = new Set(['/health']);
+
+/**
+ * Decides whether the OTel plugin opens a span for a request, keyed on the request path.
+ */
+export function shouldTraceRequest(request: Request): boolean {
+  return !UNTRACED_PATHS.has(new URL(request.url).pathname);
+}


### PR DESCRIPTION
## Description

Closes #825. The reported service-activity "event-loop stalls" are a telemetry artifact, not real blocking: Fly's `suspend` autostop freezes the process mid-span, so on resume the `/health` server span reports the whole sleep gap (20-51s) as its duration.

- Traces show the handler runs in ~0ms and real RPCs complete in ms during the "stall" window — nothing is blocked; the inflated health spans co-terminate at the resume instant.
- The OTel plugin gains a `checkIfShouldTrace` predicate that skips `/health`, dropping the false signal for every service (shared scaffold).
- Request handling is unchanged; `/health` still serves, just untraced.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality