### PR TITLE
feat(#191): render the world map from the local generator

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,7 +39,6 @@
     "@vers/contract-session": "workspace:*",
     "@vers/contract-user": "workspace:*",
     "@vers/contract-verification": "workspace:*",
-    "@vers/data": "workspace:*",
     "@vers/design-system": "workspace:*",
     "@vers/flags": "workspace:*",
     "@vers/game-rendering": "workspace:*",

--- a/apps/web/src/routes/-explore-node/explore-node-focus.test.tsx
+++ b/apps/web/src/routes/-explore-node/explore-node-focus.test.tsx
@@ -1,8 +1,8 @@
 import { expect, test } from 'bun:test';
 import { render, renderHook } from '@testing-library/react';
 import { setSelectedNode, setWorldGraph, useSelectedNode } from '@vers/worldmap-client';
+import type { WorldGraph } from '@vers/worldmap-client';
 import { createMockWorldMapNode } from '@vers/worldmap-client/test-utils';
-import type { WorldGraph } from '@vers/worldmap-core';
 import { ExploreNodeFocus } from './explore-node-focus';
 
 test('it selects the graph node matching the route param', () => {

--- a/apps/web/src/routes/-game/game-world.tsx
+++ b/apps/web/src/routes/-game/game-world.tsx
@@ -1,6 +1,7 @@
 import { GameCanvas } from '@vers/game-rendering';
 import { buildRegionGraph, setSelectedNode, setWorldGraph } from '@vers/worldmap-client';
 import { toNodeID } from '@vers/worldmap-core';
+import invariant from 'tiny-invariant';
 import { SceneRoot } from './scene-root';
 
 /**
@@ -14,10 +15,9 @@ const WORLD_SEED = 0;
  */
 const REGION_RADIUS = 24;
 const worldGraph = buildRegionGraph(WORLD_SEED, REGION_RADIUS);
+const originNode = worldGraph.nodes[toNodeID(0, 0)];
 
-// oxlint-disable-next-line typescript/no-non-null-assertion -- the region always contains its origin cell
-const originNode = worldGraph.nodes[toNodeID(0, 0)]!;
-
+invariant(originNode, 'the generated region always contains its origin cell');
 setWorldGraph(worldGraph);
 setSelectedNode(originNode, null);
 

--- a/apps/web/src/routes/-game/game-world.tsx
+++ b/apps/web/src/routes/-game/game-world.tsx
@@ -1,22 +1,29 @@
-import { worldMapNodes } from '@vers/data';
 import { GameCanvas } from '@vers/game-rendering';
-import { setSelectedNode, setWorldGraph } from '@vers/worldmap-client';
-import type { CompressedWorldMapNode } from '@vers/worldmap-core';
-import { decompressWorldGraph } from '@vers/worldmap-core';
+import { buildRegionGraph, setSelectedNode, setWorldGraph } from '@vers/worldmap-client';
+import { toNodeID } from '@vers/worldmap-core';
 import { SceneRoot } from './scene-root';
 
-// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the world graph ships as plain JSON with no way to encode the branded CompressedWorldMapNode type at that boundary
-const worldGraph = decompressWorldGraph(worldMapNodes as Array<CompressedWorldMapNode>);
+/**
+ * Seed the geometry generator draws from until the avatar's own seed is wired through; zero renders
+ * a stable placeholder region.
+ */
+const WORLD_SEED = 0;
 
-// oxlint-disable-next-line typescript/no-non-null-assertion -- the world graph ships with at least one node
-const firstNode = Object.values(worldGraph.nodes)[0]!;
+/**
+ * Ring radius of the lattice region generated for the initial render.
+ */
+const REGION_RADIUS = 24;
+const worldGraph = buildRegionGraph(WORLD_SEED, REGION_RADIUS);
+
+// oxlint-disable-next-line typescript/no-non-null-assertion -- the region always contains its origin cell
+const originNode = worldGraph.nodes[toNodeID(0, 0)]!;
 
 setWorldGraph(worldGraph);
-setSelectedNode(firstNode, null);
+setSelectedNode(originNode, null);
 
 /**
  * The persistent canvas's world content: dynamically imported through `GameCanvasMount`'s
- * code-split boundary so three.js and the world graph payload never land in the initial bundle.
+ * code-split boundary so three.js and the generated region never land in the initial bundle.
  */
 export function GameWorld() {
   return (

--- a/bun.lock
+++ b/bun.lock
@@ -64,7 +64,6 @@
         "@vers/contract-session": "workspace:*",
         "@vers/contract-user": "workspace:*",
         "@vers/contract-verification": "workspace:*",
-        "@vers/data": "workspace:*",
         "@vers/design-system": "workspace:*",
         "@vers/flags": "workspace:*",
         "@vers/game-rendering": "workspace:*",

--- a/bun.lock
+++ b/bun.lock
@@ -660,6 +660,7 @@
         "react": "catalog:",
         "react-dom": "catalog:",
         "three": "catalog:",
+        "tiny-invariant": "catalog:",
         "zustand": "catalog:",
       },
       "devDependencies": {

--- a/libs/game/worldmap-client/package.json
+++ b/libs/game/worldmap-client/package.json
@@ -24,6 +24,7 @@
     "react": "catalog:",
     "react-dom": "catalog:",
     "three": "catalog:",
+    "tiny-invariant": "catalog:",
     "zustand": "catalog:"
   },
   "devDependencies": {

--- a/libs/game/worldmap-client/src/build-region-graph.test.ts
+++ b/libs/game/worldmap-client/src/build-region-graph.test.ts
@@ -42,3 +42,15 @@ test('it connects the origin to at least one neighbour', () => {
 test('it is deterministic for a seed and radius', () => {
   expect(buildRegionGraph(SEED, 2)).toStrictEqual(buildRegionGraph(SEED, 2));
 });
+
+test('it lays nodes out differently under a different seed', () => {
+  const id = toNodeID(1, 0);
+
+  expect(buildRegionGraph(SEED, 2).nodes[id]?.position).not.toStrictEqual(
+    buildRegionGraph(SEED + 1, 2).nodes[id]?.position,
+  );
+});
+
+test('it rejects a non-integer radius', () => {
+  expect(() => buildRegionGraph(SEED, 2.5)).toThrow('non-negative integer');
+});

--- a/libs/game/worldmap-client/src/build-region-graph.test.ts
+++ b/libs/game/worldmap-client/src/build-region-graph.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from 'bun:test';
+import { toNodeID } from '@vers/worldmap-core';
+import { buildRegionGraph } from './build-region-graph';
+
+const SEED = 7;
+
+test('it carries every cell within the radius as a node', () => {
+  const graph = buildRegionGraph(SEED, 2);
+
+  // a hex disc of radius r holds 1 + 3r(r+1) cells
+  expect(Object.keys(graph.nodes)).toHaveLength(1 + 3 * 2 * 3);
+});
+
+test('it includes the origin node', () => {
+  const graph = buildRegionGraph(SEED, 2);
+
+  expect(graph.nodes[toNodeID(0, 0)]).toBeDefined();
+});
+
+test('it lands every edge on two rendered nodes', () => {
+  const graph = buildRegionGraph(SEED, 3);
+
+  for (const edge of Object.values(graph.edges)) {
+    const [aID = '', bID = ''] = edge.id.split('|');
+
+    expect(graph.nodes[aID]).toBeDefined();
+    expect(graph.nodes[bID]).toBeDefined();
+  }
+});
+
+test('it connects the origin to at least one neighbour', () => {
+  const graph = buildRegionGraph(SEED, 3);
+  const originID = toNodeID(0, 0);
+
+  const incident = Object.values(graph.edges).filter((edge) =>
+    edge.id.split('|').includes(originID),
+  );
+
+  expect(incident.length).toBeGreaterThan(0);
+});
+
+test('it is deterministic for a seed and radius', () => {
+  expect(buildRegionGraph(SEED, 2)).toStrictEqual(buildRegionGraph(SEED, 2));
+});

--- a/libs/game/worldmap-client/src/build-region-graph.ts
+++ b/libs/game/worldmap-client/src/build-region-graph.ts
@@ -1,5 +1,6 @@
 import { buildCellNode, collectNodeEdges } from '@vers/worldmap-core';
 import type { LatticeEdge, LatticeNode } from '@vers/worldmap-core';
+import invariant from 'tiny-invariant';
 import type { WorldGraph } from './types';
 
 /**
@@ -8,6 +9,11 @@ import type { WorldGraph } from './types';
  * rendered edge lands on a rendered node.
  */
 export function buildRegionGraph(userSeed: number, radius: number): WorldGraph {
+  invariant(
+    Number.isSafeInteger(radius) && radius >= 0,
+    'buildRegionGraph radius must be a non-negative integer',
+  );
+
   const nodes: Record<string, LatticeNode> = {};
 
   for (let cx = -radius; cx <= radius; cx++) {

--- a/libs/game/worldmap-client/src/build-region-graph.ts
+++ b/libs/game/worldmap-client/src/build-region-graph.ts
@@ -1,0 +1,37 @@
+import { buildCellNode, collectNodeEdges } from '@vers/worldmap-core';
+import type { LatticeEdge, LatticeNode } from '@vers/worldmap-core';
+import type { WorldGraph } from './types';
+
+/**
+ * Assembles a bounded slice of the lattice around the origin: every cell within `radius` rings, its
+ * nodes and their edges keyed by id. An edge to a cell beyond the slice is dropped, so every
+ * rendered edge lands on a rendered node.
+ */
+export function buildRegionGraph(userSeed: number, radius: number): WorldGraph {
+  const nodes: Record<string, LatticeNode> = {};
+
+  for (let cx = -radius; cx <= radius; cx++) {
+    const lowCy = Math.max(-radius, -cx - radius);
+    const highCy = Math.min(radius, -cx + radius);
+
+    for (let cy = lowCy; cy <= highCy; cy++) {
+      const node = buildCellNode(userSeed, cx, cy);
+
+      nodes[node.id] = node;
+    }
+  }
+
+  const edges: Record<string, LatticeEdge> = {};
+
+  for (const node of Object.values(nodes)) {
+    for (const edge of collectNodeEdges(userSeed, node.coord[0], node.coord[1])) {
+      const [aID = '', bID = ''] = edge.id.split('|');
+
+      if (nodes[aID] && nodes[bID]) {
+        edges[edge.id] = edge;
+      }
+    }
+  }
+
+  return { edges, nodes };
+}

--- a/libs/game/worldmap-client/src/components-three/world-edges.tsx
+++ b/libs/game/worldmap-client/src/components-three/world-edges.tsx
@@ -1,6 +1,6 @@
 import { extend } from '@react-three/fiber';
 import { sceneColors } from '@vers/design-system';
-import type { WorldEdge } from '@vers/worldmap-core';
+import type { LatticeEdge } from '@vers/worldmap-core';
 import { useLayoutEffect, useRef } from 'react';
 import type { BufferGeometry } from 'three';
 import { BufferAttribute } from 'three';
@@ -8,7 +8,7 @@ import { LineBasicNodeMaterial } from 'three/webgpu';
 import { getScenePosition } from '../utils/get-scene-position';
 
 interface WorldEdgesProps {
-  readonly edges: ReadonlyArray<WorldEdge>;
+  readonly edges: ReadonlyArray<LatticeEdge>;
 }
 
 const COLOR = sceneColors.worldmapEdge;

--- a/libs/game/worldmap-client/src/components-three/world-map-nodes.test.tsx
+++ b/libs/game/worldmap-client/src/components-three/world-map-nodes.test.tsx
@@ -1,19 +1,19 @@
 import { expect, test } from 'bun:test';
 import ReactThreeTestRenderer from '@react-three/test-renderer';
-import type { WorldMapNode } from '@vers/worldmap-core';
+import type { LatticeNode } from '@vers/worldmap-core';
 import { useWorldmapStore } from '../state/use-worldmap-store';
 import { createMockWorldMapNode } from '../test-utils/factories/create-mock-world-map-node';
 import { WorldMapNodes } from './world-map-nodes';
 
-async function setupTest(nodes: ReadonlyArray<WorldMapNode>) {
+async function setupTest(nodes: ReadonlyArray<LatticeNode>) {
   const renderer = await ReactThreeTestRenderer.create(<WorldMapNodes nodes={[...nodes]} />);
 
   return renderer;
 }
 
 test('it sets the hovered node when the pointer enters a node instance', async () => {
-  const nodeA = createMockWorldMapNode({ id: 'nodeA', index: 0 });
-  const nodeB = createMockWorldMapNode({ id: 'nodeB', index: 1 });
+  const nodeA = createMockWorldMapNode({ id: 'nodeA' });
+  const nodeB = createMockWorldMapNode({ id: 'nodeB' });
 
   const renderer = await setupTest([nodeA, nodeB]);
 
@@ -25,8 +25,8 @@ test('it sets the hovered node when the pointer enters a node instance', async (
 });
 
 test('it unsets the hovered node when the pointer leaves the instanced mesh', async () => {
-  const nodeA = createMockWorldMapNode({ id: 'nodeA', index: 0 });
-  const nodeB = createMockWorldMapNode({ id: 'nodeB', index: 1 });
+  const nodeA = createMockWorldMapNode({ id: 'nodeA' });
+  const nodeB = createMockWorldMapNode({ id: 'nodeB' });
 
   const renderer = await setupTest([nodeA, nodeB]);
 
@@ -39,8 +39,8 @@ test('it unsets the hovered node when the pointer leaves the instanced mesh', as
 });
 
 test('it sets the selected node when a node instance is clicked', async () => {
-  const nodeA = createMockWorldMapNode({ id: 'nodeA', index: 0 });
-  const nodeB = createMockWorldMapNode({ id: 'nodeB', index: 1 });
+  const nodeA = createMockWorldMapNode({ id: 'nodeA' });
+  const nodeB = createMockWorldMapNode({ id: 'nodeB' });
 
   const renderer = await setupTest([nodeA, nodeB]);
 

--- a/libs/game/worldmap-client/src/components-three/world-map-nodes.tsx
+++ b/libs/game/worldmap-client/src/components-three/world-map-nodes.tsx
@@ -1,7 +1,7 @@
 import { extend, useFrame } from '@react-three/fiber';
 import type { ThreeEvent } from '@react-three/fiber';
 import { sceneColors } from '@vers/design-system';
-import type { WorldMapNode } from '@vers/worldmap-core';
+import type { LatticeNode } from '@vers/worldmap-core';
 import { useLayoutEffect, useRef } from 'react';
 import type { InstancedMesh } from 'three';
 import { Color, Matrix4 } from 'three';
@@ -12,7 +12,7 @@ import { useWorldmapStore } from '../state/use-worldmap-store';
 import { getScenePosition } from '../utils/get-scene-position';
 
 interface WorldMapNodesProps {
-  readonly nodes: ReadonlyArray<WorldMapNode>;
+  readonly nodes: ReadonlyArray<LatticeNode>;
 }
 
 const RADIUS = 0.8;

--- a/libs/game/worldmap-client/src/components-ui/node-tooltip.test.tsx
+++ b/libs/game/worldmap-client/src/components-ui/node-tooltip.test.tsx
@@ -7,7 +7,6 @@ import { NodeTooltip } from './node-tooltip';
 
 test('it displays information about the hovered node', () => {
   const node = createMockWorldMapNode({
-    connections: ['conn1', null, 'conn2', null],
     difficulty: 2,
     id: 'node123',
     position: [1.2345, 6.789],

--- a/libs/game/worldmap-client/src/index.ts
+++ b/libs/game/worldmap-client/src/index.ts
@@ -1,3 +1,4 @@
+export { buildRegionGraph } from './build-region-graph';
 export { Scene } from './components-three/scene';
 export { DevTools } from './components-ui/dev-tools';
 export { NodeTooltip } from './components-ui/node-tooltip';
@@ -5,3 +6,4 @@ export { setWorldGraph } from './state/set-world-graph';
 export { setSelectedNode } from './state/set-selected-node';
 export { useWorldGraph } from './state/use-world-graph';
 export { useSelectedNode } from './state/use-selected-node';
+export type { WorldGraph } from './types';

--- a/libs/game/worldmap-client/src/state/create-graph-slice.ts
+++ b/libs/game/worldmap-client/src/state/create-graph-slice.ts
@@ -1,4 +1,4 @@
-import type { WorldGraph } from '@vers/worldmap-core';
+import type { WorldGraph } from '../types';
 
 export interface GraphSlice {
   worldGraph: WorldGraph;

--- a/libs/game/worldmap-client/src/state/create-interaction-slice.ts
+++ b/libs/game/worldmap-client/src/state/create-interaction-slice.ts
@@ -1,9 +1,9 @@
-import type { WorldMapNode } from '@vers/worldmap-core';
+import type { LatticeNode } from '@vers/worldmap-core';
 import type { Object3D } from 'three';
 
 export interface InteractionSlice {
-  hoveredNode: WorldMapNode | null;
-  selectedNode: WorldMapNode | null;
+  hoveredNode: LatticeNode | null;
+  selectedNode: LatticeNode | null;
   selectedObject3D: null | Object3D;
 }
 

--- a/libs/game/worldmap-client/src/state/set-hovered-node.ts
+++ b/libs/game/worldmap-client/src/state/set-hovered-node.ts
@@ -1,6 +1,6 @@
-import type { WorldMapNode } from '@vers/worldmap-core';
+import type { LatticeNode } from '@vers/worldmap-core';
 import { useWorldmapStore } from './use-worldmap-store';
 
-export function setHoveredNode(node: WorldMapNode | null) {
+export function setHoveredNode(node: LatticeNode | null) {
   useWorldmapStore.setState({ hoveredNode: node });
 }

--- a/libs/game/worldmap-client/src/state/set-selected-node.ts
+++ b/libs/game/worldmap-client/src/state/set-selected-node.ts
@@ -1,7 +1,7 @@
-import type { WorldMapNode } from '@vers/worldmap-core';
+import type { LatticeNode } from '@vers/worldmap-core';
 import type { Object3D } from 'three';
 import { useWorldmapStore } from './use-worldmap-store';
 
-export function setSelectedNode(node: WorldMapNode | null, object3D?: null | Object3D) {
+export function setSelectedNode(node: LatticeNode | null, object3D?: null | Object3D) {
   useWorldmapStore.setState({ selectedNode: node, selectedObject3D: object3D ?? null });
 }

--- a/libs/game/worldmap-client/src/state/set-world-graph.test.ts
+++ b/libs/game/worldmap-client/src/state/set-world-graph.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from 'bun:test';
 import { renderHook } from '@testing-library/react';
-import type { WorldGraph } from '@vers/worldmap-core';
 import { createMockWorldMapEdge } from '../test-utils/factories/create-mock-world-map-edge';
 import { createMockWorldMapNode } from '../test-utils/factories/create-mock-world-map-node';
+import type { WorldGraph } from '../types';
 import { setWorldGraph } from './set-world-graph';
 import { useWorldmapStore } from './use-worldmap-store';
 

--- a/libs/game/worldmap-client/src/state/set-world-graph.ts
+++ b/libs/game/worldmap-client/src/state/set-world-graph.ts
@@ -1,4 +1,4 @@
-import type { WorldGraph } from '@vers/worldmap-core';
+import type { WorldGraph } from '../types';
 import { useWorldmapStore } from './use-worldmap-store';
 
 export function setWorldGraph(graph: WorldGraph) {

--- a/libs/game/worldmap-client/src/state/use-selected-node.test.ts
+++ b/libs/game/worldmap-client/src/state/use-selected-node.test.ts
@@ -22,7 +22,7 @@ test('it returns the current selected node and object3D', () => {
 });
 
 test('it derives an object3D positioned at the node when none was provided', () => {
-  const node = createMockWorldMapNode({ id: 'node2', index: 1, position: [3, 5] });
+  const node = createMockWorldMapNode({ id: 'node2', position: [3, 5] });
 
   setSelectedNode(node);
 

--- a/libs/game/worldmap-client/src/state/use-world-graph.test.ts
+++ b/libs/game/worldmap-client/src/state/use-world-graph.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from 'bun:test';
 import { renderHook } from '@testing-library/react';
-import type { WorldGraph } from '@vers/worldmap-core';
 import { createMockWorldMapEdge } from '../test-utils/factories/create-mock-world-map-edge';
 import { createMockWorldMapNode } from '../test-utils/factories/create-mock-world-map-node';
+import type { WorldGraph } from '../types';
 import { setWorldGraph } from './set-world-graph';
 import { useWorldGraph } from './use-world-graph';
 

--- a/libs/game/worldmap-client/src/test-utils/factories/create-mock-world-map-edge.ts
+++ b/libs/game/worldmap-client/src/test-utils/factories/create-mock-world-map-edge.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
-import type { WorldEdge } from '@vers/worldmap-core';
+import type { LatticeEdge } from '@vers/worldmap-core';
 
-export function createMockWorldMapEdge(overrides: Partial<WorldEdge> = {}): WorldEdge {
+export function createMockWorldMapEdge(overrides: Partial<LatticeEdge> = {}): LatticeEdge {
   return {
     end: [faker.number.int({ max: 100, min: -100 }), faker.number.int({ max: 100, min: -100 })],
     id: faker.string.alphanumeric({ casing: 'lower', length: 24 }),

--- a/libs/game/worldmap-client/src/test-utils/factories/create-mock-world-map-node.test.ts
+++ b/libs/game/worldmap-client/src/test-utils/factories/create-mock-world-map-node.test.ts
@@ -4,26 +4,21 @@ import { createMockWorldMapNode } from './create-mock-world-map-node';
 test('it creates a world map node with default properties', () => {
   const node = createMockWorldMapNode();
 
-  expect(node).toContainAllKeys(['connections', 'difficulty', 'id', 'index', 'position', 'seed']);
-  expect(node.connections).toStrictEqual([null, null, null, null]);
+  expect(node).toContainAllKeys(['coord', 'difficulty', 'id', 'position']);
 });
 
 test('it creates a world map node with custom properties', () => {
   const node = createMockWorldMapNode({
-    connections: ['edge1', null, null, null],
+    coord: [3, 5],
     difficulty: 5,
     id: 'node1',
-    index: 2,
     position: [3, 5],
-    seed: 12_345,
   });
 
   expect(node).toStrictEqual({
-    connections: ['edge1', null, null, null],
+    coord: [3, 5],
     difficulty: 5,
     id: 'node1',
-    index: 2,
     position: [3, 5],
-    seed: 12_345,
   });
 });

--- a/libs/game/worldmap-client/src/test-utils/factories/create-mock-world-map-node.ts
+++ b/libs/game/worldmap-client/src/test-utils/factories/create-mock-world-map-node.ts
@@ -1,17 +1,16 @@
 import { faker } from '@faker-js/faker';
-import type { WorldMapNode } from '@vers/worldmap-core';
+import type { LatticeNode } from '@vers/worldmap-core';
+import { toNodeID } from '@vers/worldmap-core';
 
-export function createMockWorldMapNode(overrides: Partial<WorldMapNode> = {}): WorldMapNode {
+export function createMockWorldMapNode(overrides: Partial<LatticeNode> = {}): LatticeNode {
+  const cx = faker.number.int({ max: 100, min: -100 });
+  const cy = faker.number.int({ max: 100, min: -100 });
+
   return {
-    connections: [null, null, null, null],
+    coord: [cx, cy],
     difficulty: faker.number.int({ max: 10, min: 0 }),
-    id: faker.string.alphanumeric({ casing: 'lower', length: 24 }),
-    index: faker.number.int({ max: 100, min: 0 }),
-    position: [
-      faker.number.int({ max: 100, min: -100 }),
-      faker.number.int({ max: 100, min: -100 }),
-    ],
-    seed: faker.number.int(),
+    id: toNodeID(cx, cy),
+    position: [cx, cy],
     ...overrides,
   };
 }

--- a/libs/game/worldmap-client/src/types.ts
+++ b/libs/game/worldmap-client/src/types.ts
@@ -1,1 +1,12 @@
+import type { LatticeEdge, LatticeNode } from '@vers/worldmap-core';
+
 export type VectorTuple = [number, number, number];
+
+/**
+ * A rendered region of the lattice: nodes and edges keyed by id. Assembled from the generator for a
+ * bounded area around a center, so the client holds a finite slice of the infinite map.
+ */
+export interface WorldGraph {
+  readonly edges: Readonly<Record<string, LatticeEdge>>;
+  readonly nodes: Readonly<Record<string, LatticeNode>>;
+}

--- a/libs/game/worldmap-client/src/utils/build-nearby-graph.test.ts
+++ b/libs/game/worldmap-client/src/utils/build-nearby-graph.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from 'bun:test';
-import type { WorldGraph } from '@vers/worldmap-core';
 import { Object3D } from 'three';
 import { createMockWorldMapEdge } from '../test-utils/factories/create-mock-world-map-edge';
 import { createMockWorldMapNode } from '../test-utils/factories/create-mock-world-map-node';
+import type { WorldGraph } from '../types';
 import { buildNearbyGraph } from './build-nearby-graph';
 
 test('it filters nodes beyond the maximum distance', () => {

--- a/libs/game/worldmap-client/src/utils/build-nearby-graph.ts
+++ b/libs/game/worldmap-client/src/utils/build-nearby-graph.ts
@@ -1,6 +1,7 @@
-import type { WorldEdge, WorldGraph, WorldMapNode } from '@vers/worldmap-core';
+import type { LatticeEdge, LatticeNode } from '@vers/worldmap-core';
 import type { Object3D } from 'three';
 import { Vector3 } from 'three';
+import type { WorldGraph } from '../types';
 import { getScenePosition } from './get-scene-position';
 
 /**
@@ -14,7 +15,7 @@ const MAX_DISTANCE = 160;
  */
 export function buildNearbyGraph(selectedNode: null | Object3D, graphData: WorldGraph): WorldGraph {
   const position = selectedNode?.position ?? new Vector3();
-  const nodes: Record<string, WorldMapNode> = {};
+  const nodes: Record<string, LatticeNode> = {};
 
   for (const [id, node] of Object.entries(graphData.nodes)) {
     const nodePosition = new Vector3(...getScenePosition(node.position));
@@ -26,7 +27,7 @@ export function buildNearbyGraph(selectedNode: null | Object3D, graphData: World
     }
   }
 
-  const edges: Record<string, WorldEdge> = {};
+  const edges: Record<string, LatticeEdge> = {};
 
   for (const [id, edge] of Object.entries(graphData.edges)) {
     const start = new Vector3(...getScenePosition(edge.start));


### PR DESCRIPTION
Third of the #191 stack (stacked on #830). Cuts app-web's world map from the baked 3.1MB graph to the hex-lattice generator.

- `buildRegionGraph` assembles a bounded lattice slice around the origin; app-web seeds the store with it at mount instead of decompressing baked JSON.
- The three.js render layer, Zustand store, and mock factories carry the generator's `LatticeNode`/`LatticeEdge`, keyed by canonical coordinate id (client-owned `WorldGraph`).
- Drops the `@vers/data` graph import from app-web.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes (worldmap-client + app-web affected)
- [x] `bun run lint` passes

## Context

Base is #830, not `main`. The region seed is a fixed placeholder (0); wiring the avatar's own seed and viewport streaming is later worldmap work (#115). The baked `world-map-nodes.json` and legacy generator delete in the next step of the stack.