### PR TITLE
fix: clear the nanoid and js-yaml bun audit advisories

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1189,6 +1189,8 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "fast-uri": "3.1.5",
+    "js-yaml": "4.3.1",
+    "nanoid": "3.3.17",
   },
   "catalog": {
     "@ark-ui/react": "5.37.2",
@@ -3569,7 +3571,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
+    "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
@@ -3897,7 +3899,7 @@
 
     "nan": ["nan@2.28.0", "", {}, "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ=="],
 
-    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+    "nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
 
     "native-duplexpair": ["native-duplexpair@1.0.0", "", {}, "sha512-E7QQoM+3jvNtlmyfqRZ0/U75VFgCls+fSkbml2MpgWkWyz3ox8Y58gNhfuziuQYGNNQAbFZJQck55LHCnCK6CA=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -10,10 +10,9 @@ minimumReleaseAge = 604800
 
 # an exclude lives only as long as its pinned version is younger than the gate —
 # once the version ages past it, the entry is dead weight; remove it
-# brace-expansion 2.1.4 (published 2026-07-30, patches GHSA-mh99-v99m-4gvg + GHSA-rgw5-rvv9-x895) ages past the gate ~2026-08-06 — remove then (#735)
-# fast-uri 3.1.5 (published 2026-07-31, patches GHSA-7p8r-x3mc-p8w7) ages past the gate ~2026-08-07 — remove then (#765)
 # hono 4.13.0 (published 2026-08-03, patches GHSA-8j4g-w8fx-2239) ages past the gate ~2026-08-10 — remove then (#837)
-minimumReleaseAgeExcludes = ["brace-expansion", "fast-uri", "hono"]
+# nanoid 3.3.17 (published 2026-08-03, patches GHSA-2v37-7h3g-55p8) ages past the gate ~2026-08-10 — remove then (#839)
+minimumReleaseAgeExcludes = ["hono", "nanoid"]
 
 [test]
 # registers jest-extended matchers for any root-invoked `bun test`; each

--- a/package.json
+++ b/package.json
@@ -223,7 +223,9 @@
     "@pulumi/pulumi": "3.253.0",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
-    "fast-uri": "3.1.5"
+    "fast-uri": "3.1.5",
+    "js-yaml": "4.3.1",
+    "nanoid": "3.3.17"
   },
   "packageManager": "bun@1.3.10",
   "patchedDependencies": {


### PR DESCRIPTION
Clears the two `bun audit` advisories that surfaced since #838 and are currently red on every open PR, and tidies the release-age exclude list.

- Override `nanoid` → 3.3.17 (GHSA-2v37-7h3g-55p8, zero-size infinite loop, via postcss).
- Override `js-yaml` → 4.3.1 (GHSA-5p4m-2wfm-xmqj, quadratic CPU in `!!omap`, via pulumi/kysely-codegen/commitlint/tanstack).
- Exclude `nanoid` from the 7-day release-age gate until it matures (~2026-08-10, tracked in #839); js-yaml's fix already aged in.
- Drop the matured `brace-expansion` and `fast-uri` excludes now both have aged past the gate.

Closes #735
Closes #765

## Testing

- [x] `bun run audit` → no vulnerabilities
- [x] `bun run typecheck`, `bun run lint`, `bun run format:check` pass

## Context

Unblocks the #191 worldmap PR stack (#832, #833) whose merges are gated on `bun audit`.