### PR TITLE
ci: pin flyctl to 0.4.78

### DIFF
--- a/.github/actions/fly-deploy/action.yml
+++ b/.github/actions/fly-deploy/action.yml
@@ -12,8 +12,12 @@ inputs:
 runs:
   using: composite
   steps:
+    # pinned: 0.4.80's bluegreen health polling ignores configured check grace
+    # periods and aborts the whole rollout on a single transient machine read
     - name: Setup flyctl
       uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # 1.6
+      with:
+        version: 0.4.78
 
     - name: Setup Bun
       uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -187,8 +187,12 @@ jobs:
         with:
           persist-credentials: false
 
+      # pinned: 0.4.80's bluegreen health polling ignores configured check grace
+      # periods and aborts the whole rollout on a single transient machine read
       - name: Setup flyctl
         uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # 1.6
+        with:
+          version: 0.4.78
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -281,8 +285,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # pinned: 0.4.80's bluegreen health polling ignores configured check grace
+      # periods and aborts the whole rollout on a single transient machine read
       - name: Setup flyctl
         uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # 1.6
+        with:
+          version: 0.4.78
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0


### PR DESCRIPTION
## Description

flyctl 0.4.80 (superfly/flyctl#4952) made the bluegreen strategy poll green-machine health directly, and the new poll rolled back six of eight healthy service cutovers on the last main push. Pin the deploy pipeline to 0.4.78, the last version before the change.

- The poll starts after a 1s floor regardless of the configured check grace period, and one failed read of a just-created machine ("failed to get VM ...: machine not found") aborts the rollout with no retry.
- Pinned at all three setup sites in the deploy pipeline; bugsink-vacuum only runs `flyctl ssh console` and stays on latest.
- #841 tracks unpinning once upstream fixes the poll.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality