### PR TITLE
fix: widen the replay provider boot test timeouts

### DIFF
--- a/services/replay/src/serve-provider.test.ts
+++ b/services/replay/src/serve-provider.test.ts
@@ -19,31 +19,36 @@ let proc: Bun.Subprocess;
  * by `build-provider-router.test.ts`; this file only proves the real entrypoint boots and serves
  * over a socket, so one shared process serves every case.
  */
-beforeAll(async () => {
-  const keyPair = await getTestServiceKeyPair();
+beforeAll(
+  async () => {
+    const keyPair = await getTestServiceKeyPair();
 
-  proc = Bun.spawn([process.execPath, SERVE_PROVIDER_PATH], {
-    cwd: REPLAY_DIR,
-    env: {
-      PORT: String(PORT),
-      SERVICE_AUTH_JWKS: keyPair.jwksJSON,
-      SIM_ENGINE_HASH: 'test-engine-hash',
-    },
-    stderr: 'pipe',
-    stdout: 'pipe',
-  });
+    proc = Bun.spawn([process.execPath, SERVE_PROVIDER_PATH], {
+      cwd: REPLAY_DIR,
+      env: {
+        PORT: String(PORT),
+        SERVICE_AUTH_JWKS: keyPair.jwksJSON,
+        SIM_ENGINE_HASH: 'test-engine-hash',
+      },
+      stderr: 'pipe',
+      stdout: 'pipe',
+    });
 
-  await waitFor(
-    async () => {
-      const response = await fetch(`${URL}/health`);
+    // a cold CI runner can take longer than bun's default 5s hook timeout to
+    // spawn and boot the process, so both the poll and the hook get headroom
+    await waitFor(
+      async () => {
+        const response = await fetch(`${URL}/health`);
 
-      if (!response.ok) {
-        throw new Error(`provider health check returned ${String(response.status)}`);
-      }
-    },
-    { timeoutMs: 5000 },
-  );
-});
+        if (!response.ok) {
+          throw new Error(`provider health check returned ${String(response.status)}`);
+        }
+      },
+      { timeoutMs: 15_000 },
+    );
+  },
+  { timeout: 20_000 },
+);
 
 afterAll(() => {
   proc?.kill();


### PR DESCRIPTION
## Description

The serve-provider suite boots the real entrypoint as a subprocess and polled /health for at most 5s, inside bun's default 5s hook timeout — a cold runner intermittently exceeded both and failed `@vers/service-replay#test` on main. Raise the poll to 15s and the hook timeout to 20s.

- The failure showed as an unnamed test at 5006ms: the beforeAll hook hit bun's default timeout at the same moment the poll hit its own.
- Passing runs stay fast — the poll returns as soon as /health answers (~650ms locally).

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality