### PR TITLE
test: boot the replay provider fixture per test with event-driven readiness

### DIFF
--- a/libs/service/service-runtime/src/base-env-schema.ts
+++ b/libs/service/service-runtime/src/base-env-schema.ts
@@ -12,7 +12,12 @@ export const baseEnvSchema = z.object({
     .url()
     .optional()
     .describe('OTLP collector endpoint; unset leaves every instrument a no-op'),
-  PORT: z.coerce.number().int().positive().default(3000).describe('TCP port the HTTP server binds'),
+  PORT: z.coerce
+    .number()
+    .int()
+    .nonnegative()
+    .default(3000)
+    .describe('TCP port the HTTP server binds; 0 binds an OS-assigned port'),
   SENTRY_DSN: z.url().optional().describe('Bugsink project DSN; unset disables error reporting'),
   SERVICE_AUTH_JWKS: z
     .string()

--- a/services/replay/src/serve-provider.test.ts
+++ b/services/replay/src/serve-provider.test.ts
@@ -1,92 +1,47 @@
-import { afterAll, beforeAll, expect, test } from 'bun:test';
-import path from 'node:path';
+import { expect, test } from 'bun:test';
 import { createMockReplaySegmentInput } from '@vers/contract-replay/test-utils';
 import { createServiceToken, getTestServiceKeyPair } from '@vers/service-test-utils/bun';
-import { waitFor } from '@vers/test-utils';
+import { createProviderProcess } from './test-utils/create-provider-process';
 
-const SERVE_PROVIDER_PATH = path.resolve(import.meta.dirname, 'serve-provider.ts');
-const REPLAY_DIR = path.resolve(import.meta.dirname, '..');
-const PORT = 41_100;
-const URL = `http://127.0.0.1:${PORT}`;
-let proc: Bun.Subprocess;
+// each test boots its own subprocess, so the test budget covers a cold boot, not just assertions
+const BOOT_TIMEOUT_MS = 30_000;
 
-/**
- * Boots the real `serve-provider.ts` entrypoint once for the whole file, on only base env plus
- * `SIM_ENGINE_HASH` — no `DATABASE_URL`, `KEYS_SERVICE_URL`, or `SERVICE_AUTH_PRIVATE_KEY` — the
- * exact env a per-version provider machine boots on, and the regression this entrypoint exists to
- * catch: the in-process test client shares this suite's full ambient env, which would mask a
- * missing env-wiring bug this real process cannot. Provider routing behaviour is covered in-process
- * by `build-provider-router.test.ts`; this file only proves the real entrypoint boots and serves
- * over a socket, so one shared process serves every case.
- */
-beforeAll(
+test(
+  'it serves /health with no database, keys service, or signing key configured',
   async () => {
-    const keyPair = await getTestServiceKeyPair();
+    const ctx = await createProviderProcess('test-engine-hash');
+    const response = await fetch(`${ctx.url}/health`);
+    const body = await response.json();
 
-    proc = Bun.spawn([process.execPath, SERVE_PROVIDER_PATH], {
-      cwd: REPLAY_DIR,
-      env: {
-        PORT: String(PORT),
-        SERVICE_AUTH_JWKS: keyPair.jwksJSON,
-        SIM_ENGINE_HASH: 'test-engine-hash',
-      },
-      stderr: 'pipe',
-      stdout: 'pipe',
-    });
-
-    // a cold CI runner can take longer than bun's default 5s hook timeout to
-    // spawn and boot the process, so both the poll and the hook get headroom
-    await waitFor(
-      async () => {
-        const response = await fetch(`${URL}/health`);
-
-        if (!response.ok) {
-          throw new Error(`provider health check returned ${String(response.status)}`);
-        }
-      },
-      { timeoutMs: 15_000 },
-    );
+    expect(response.status).toBe(200);
+    expect(body).toStrictEqual({ service: 'service-replay-provider', status: 'ok' });
   },
-  { timeout: 20_000 },
+  BOOT_TIMEOUT_MS,
 );
 
-afterAll(() => {
-  proc?.kill();
-});
+test(
+  'it round-trips an authed replaySegment call over a real socket',
+  async () => {
+    const ctx = await createProviderProcess('test-engine-hash');
+    const keyPair = await getTestServiceKeyPair();
 
-/**
- * Sends a signed RPC call to the booted provider process over the network — a real socket round
- * trip, not the in-process `app.handle` test client.
- */
-function sendRPC(procedure: string, token: string, input: unknown): Promise<Response> {
-  return fetch(`${URL}/rpc/${procedure}`, {
-    body: JSON.stringify({ json: input }),
-    headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
-    method: 'POST',
-  });
-}
+    const token = await createServiceToken({
+      audience: 'service-replay-provider',
+      privateKey: keyPair.privateKey,
+    });
 
-test('it serves /health with no database, keys service, or signing key configured', async () => {
-  const response = await fetch(`${URL}/health`);
-  const body = await response.json();
+    const input = createMockReplaySegmentInput({ simVersion: 'test-engine-hash' });
 
-  expect(response.status).toBe(200);
-  expect(body).toStrictEqual({ service: 'service-replay-provider', status: 'ok' });
-});
+    const response = await fetch(`${ctx.url}/rpc/replaySegment`, {
+      body: JSON.stringify({ json: input }),
+      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      method: 'POST',
+    });
 
-test('it round-trips an authed replaySegment call', async () => {
-  const keyPair = await getTestServiceKeyPair();
+    const body = await response.json();
 
-  const token = await createServiceToken({
-    audience: 'service-replay-provider',
-    privateKey: keyPair.privateKey,
-  });
-
-  const input = createMockReplaySegmentInput({ simVersion: 'test-engine-hash' });
-
-  const response = await sendRPC('replaySegment', token, input);
-  const body = await response.json();
-
-  expect(response.status).toBe(200);
-  expect(body).toMatchObject({ json: { elapsed: input.duration } });
-});
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ json: { elapsed: input.duration } });
+  },
+  BOOT_TIMEOUT_MS,
+);

--- a/services/replay/src/test-utils/create-provider-process.ts
+++ b/services/replay/src/test-utils/create-provider-process.ts
@@ -1,0 +1,114 @@
+import { onTestFinished } from 'bun:test';
+import path from 'node:path';
+import { getTestServiceKeyPair } from '@vers/service-test-utils/bun';
+import { findListeningPort } from './find-listening-port';
+
+const SERVE_PROVIDER_PATH = path.resolve(import.meta.dirname, '..', 'serve-provider.ts');
+const REPLAY_DIR = path.resolve(import.meta.dirname, '..', '..');
+const BOOT_DEADLINE_MS = 20_000;
+
+interface ProviderProcess {
+  readonly url: string;
+}
+
+/**
+ * Boots the real `serve-provider.ts` entrypoint as a subprocess on only base env plus
+ * `SIM_ENGINE_HASH` — no `DATABASE_URL`, `KEYS_SERVICE_URL`, or `SERVICE_AUTH_PRIVATE_KEY` — the
+ * exact env a per-version provider machine boots on. An in-process boot would inherit the suite's
+ * full ambient env and mask a missing env-wiring bug, which is the regression this fixture exists
+ * to catch. `PORT=0` binds an OS-assigned port, read back from the boot log; the process is killed
+ * via `onTestFinished`.
+ *
+ * Readiness is event-driven, not polled: the boot resolves on the log's bound-port announcement,
+ * and a process that exits first rejects immediately with its captured output, so a crashing boot
+ * reports its real error instead of running out the clock. The deadline only catches a boot that
+ * hangs without exiting. stdout keeps draining after the port is found so a full pipe can never
+ * block the child.
+ */
+export async function createProviderProcess(engineHash: string): Promise<ProviderProcess> {
+  const keyPair = await getTestServiceKeyPair();
+
+  const proc = Bun.spawn([process.execPath, SERVE_PROVIDER_PATH], {
+    cwd: REPLAY_DIR,
+    env: {
+      PORT: '0',
+      SERVICE_AUTH_JWKS: keyPair.jwksJSON,
+      SIM_ENGINE_HASH: engineHash,
+    },
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+
+  onTestFinished(async () => {
+    proc.kill();
+
+    await proc.exited;
+  });
+
+  const collected: Array<string> = [];
+
+  // consumes stdout to exhaustion — never releasing it mid-run, which would close the pipe under
+  // the writing child — reporting the first bound-port announcement and collecting every chunk
+  // for failure diagnostics
+  const drainForPort = async (onPort: (port: number) => void): Promise<void> => {
+    const decoder = new TextDecoder();
+
+    let buffer = '';
+    let reported = false;
+
+    for await (const chunk of proc.stdout) {
+      const text = decoder.decode(chunk, { stream: true });
+
+      collected.push(text);
+
+      buffer += text;
+
+      const lines = buffer.split('\n');
+
+      buffer = lines.pop() ?? '';
+
+      for (const line of lines) {
+        const port = findListeningPort(line);
+
+        if (port !== undefined && !reported) {
+          reported = true;
+
+          onPort(port);
+        }
+      }
+    }
+  };
+
+  const port = await new Promise<number>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(
+        new Error(
+          `provider reported no listening port within ${String(BOOT_DEADLINE_MS)}ms\n${collected.join('')}`,
+        ),
+      );
+    }, BOOT_DEADLINE_MS);
+
+    drainForPort((foundPort) => {
+      clearTimeout(timer);
+      resolve(foundPort);
+    }).catch(() => {});
+
+    const reportExit = async (): Promise<void> => {
+      const code = await proc.exited;
+
+      const stderr = await new Response(proc.stderr).text();
+
+      clearTimeout(timer);
+
+      reject(
+        new Error(
+          `provider exited with code ${String(code)} before serving\n${collected.join('')}${stderr}`,
+        ),
+      );
+    };
+
+    reportExit().catch(() => {});
+  });
+
+  return { url: `http://127.0.0.1:${String(port)}` };
+}

--- a/services/replay/src/test-utils/create-provider-process.ts
+++ b/services/replay/src/test-utils/create-provider-process.ts
@@ -22,8 +22,8 @@ interface ProviderProcess {
  * Readiness is event-driven, not polled: the boot resolves on the log's bound-port announcement,
  * and a process that exits first rejects immediately with its captured output, so a crashing boot
  * reports its real error instead of running out the clock. The deadline only catches a boot that
- * hangs without exiting. stdout keeps draining after the port is found so a full pipe can never
- * block the child.
+ * hangs without exiting. Both pipes keep draining for the process's whole life so a full pipe can
+ * never block the child.
  */
 export async function createProviderProcess(engineHash: string): Promise<ProviderProcess> {
   const keyPair = await getTestServiceKeyPair();
@@ -46,10 +46,22 @@ export async function createProviderProcess(engineHash: string): Promise<Provide
   });
 
   const collected: Array<string> = [];
+  const stderrCollected: Array<string> = [];
 
-  // consumes stdout to exhaustion — never releasing it mid-run, which would close the pipe under
-  // the writing child — reporting the first bound-port announcement and collecting every chunk
-  // for failure diagnostics
+  // both pipes drain to exhaustion from the start — an unread pipe would block the child once its
+  // buffer fills, hanging the boot without ever reporting the real error
+  const drainStderr = async (): Promise<void> => {
+    const decoder = new TextDecoder();
+
+    for await (const chunk of proc.stderr) {
+      stderrCollected.push(decoder.decode(chunk, { stream: true }));
+    }
+  };
+
+  const stderrDrain = drainStderr();
+
+  // consumes stdout to exhaustion, reporting the first bound-port announcement and collecting
+  // every chunk for failure diagnostics
   const drainForPort = async (onPort: (port: number) => void): Promise<void> => {
     const decoder = new TextDecoder();
 
@@ -83,7 +95,7 @@ export async function createProviderProcess(engineHash: string): Promise<Provide
     const timer = setTimeout(() => {
       reject(
         new Error(
-          `provider reported no listening port within ${String(BOOT_DEADLINE_MS)}ms\n${collected.join('')}`,
+          `provider reported no listening port within ${String(BOOT_DEADLINE_MS)}ms\n${collected.join('')}${stderrCollected.join('')}`,
         ),
       );
     }, BOOT_DEADLINE_MS);
@@ -96,13 +108,14 @@ export async function createProviderProcess(engineHash: string): Promise<Provide
     const reportExit = async (): Promise<void> => {
       const code = await proc.exited;
 
-      const stderr = await new Response(proc.stderr).text();
+      // the drain ends when the pipe closes at process death, so the message carries all of stderr
+      await stderrDrain.catch(() => {});
 
       clearTimeout(timer);
 
       reject(
         new Error(
-          `provider exited with code ${String(code)} before serving\n${collected.join('')}${stderr}`,
+          `provider exited with code ${String(code)} before serving\n${collected.join('')}${stderrCollected.join('')}`,
         ),
       );
     };

--- a/services/replay/src/test-utils/find-listening-port.test.ts
+++ b/services/replay/src/test-utils/find-listening-port.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from 'bun:test';
+import { findListeningPort } from './find-listening-port';
+
+test('it reads the bound port from a boot log line', () => {
+  const line =
+    '{"level":30,"time":1,"pid":1,"hostname":"h","name":"service-replay-provider","msg":"service-replay-provider listening on port 41123"}';
+
+  expect(findListeningPort(line)).toBe(41_123);
+});
+
+test('it misses on a line without a port announcement', () => {
+  expect(findListeningPort('{"level":30,"msg":"request completed"}')).toBeUndefined();
+});

--- a/services/replay/src/test-utils/find-listening-port.ts
+++ b/services/replay/src/test-utils/find-listening-port.ts
@@ -1,0 +1,11 @@
+const LISTENING_PATTERN = /listening on port (?<port>\d+)/;
+
+/**
+ * Scans one line of a service process's stdout for the boot log's bound-port announcement — the
+ * only place a `PORT=0` OS-assigned port is reported back.
+ */
+export function findListeningPort(line: string): number | undefined {
+  const port = LISTENING_PATTERN.exec(line)?.groups?.['port'];
+
+  return port === undefined ? undefined : Number(port);
+}


### PR DESCRIPTION
## Description

The serve-provider suite booted one shared subprocess in a `beforeAll`, polled /health on a fixed port, and discarded the child's stderr — a crashing boot burned the whole timeout and reported nothing. Each test now boots its own process through a `createProviderProcess` test util with event-driven readiness.

- Readiness resolves on the boot log's bound-port announcement; a process that exits first rejects immediately with its captured stdout and stderr, so a crash reports its real error. The deadline only catches a hung boot.
- `PORT=0` binds an OS-assigned port (base env schema now allows 0), removing the fixed-port collision risk.
- No lifecycle hooks left in the test file; cleanup registers via `onTestFinished`, mirroring the package's other provider util.
- The port-line matcher is its own tested util.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality