### PR TITLE
feat(#192): flip content version to v2 to activate sealed pool selection

### DIFF
--- a/libs/game/game-utils/src/current-content-version.ts
+++ b/libs/game/game-utils/src/current-content-version.ts
@@ -1,4 +1,4 @@
 /**
  * The content version every new activity is stamped against.
  */
-export const CURRENT_CONTENT_VERSION = '1';
+export const CURRENT_CONTENT_VERSION = '2';

--- a/services/activity/src/handlers/start-activity.test.ts
+++ b/services/activity/src/handlers/start-activity.test.ts
@@ -66,7 +66,7 @@ test('it starts an activity for an avatar owned by the acting user', async () =>
     buildSnapshot: { level: 1, xp: 42 },
     contentVersion: CURRENT_CONTENT_VERSION,
     createdAt: expect.toBeValidDate(),
-    encounterNode: { difficulty: 0 },
+    encounterNode: { difficulty: 0, poolID: expect.toBeString() },
     id: expect.toBeString(),
     keyVersion: 1,
     lastHash: expect.toBeString(),
@@ -106,7 +106,7 @@ test("it stamps the row's encounterNode from the static world map's node for the
     scopeType: 'world_map_node',
   });
 
-  expect(activity.encounterNode).toStrictEqual({ difficulty: 1 });
+  expect(activity.encounterNode).toStrictEqual({ difficulty: 1, poolID: expect.toBeString() });
 
   const row = await ctx.db
     .selectFrom('activities')
@@ -114,7 +114,7 @@ test("it stamps the row's encounterNode from the static world map's node for the
     .where('id', '=', activity.id)
     .executeTakeFirstOrThrow();
 
-  expect(row.encounterNode).toStrictEqual({ difficulty: 1 });
+  expect(row.encounterNode).toStrictEqual({ difficulty: 1, poolID: expect.toBeString() });
 });
 
 test('it derives a startHash that folds in the resolved encounter node', async () => {

--- a/services/replay/src/replay/load-replay-segment.test.ts
+++ b/services/replay/src/replay/load-replay-segment.test.ts
@@ -41,7 +41,8 @@ test('it anchors a genesis segment on the activity startHash and seed', async ()
     avatarID: fixture.activity.avatarId,
     buildSnapshot: { level: 1, xp: 0 },
     contentVersion: fixture.activity.contentVersion,
-    encounterNode: { difficulty: 1 },
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the fixture stamps a schema-shaped encounter node
+    encounterNode: fixture.activity.encounterNode as { difficulty: number; poolID?: string },
     id: fixture.activity.id,
     settledXP: fixture.activity.settledXp,
     keyVersion: fixture.activity.keyVersion,

--- a/services/replay/src/replay/load-replay-segment.test.ts
+++ b/services/replay/src/replay/load-replay-segment.test.ts
@@ -41,8 +41,7 @@ test('it anchors a genesis segment on the activity startHash and seed', async ()
     avatarID: fixture.activity.avatarId,
     buildSnapshot: { level: 1, xp: 0 },
     contentVersion: fixture.activity.contentVersion,
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the fixture stamps a schema-shaped encounter node
-    encounterNode: fixture.activity.encounterNode as { difficulty: number; poolID?: string },
+    encounterNode: fixture.encounterNode,
     id: fixture.activity.id,
     settledXP: fixture.activity.settledXp,
     keyVersion: fixture.activity.keyVersion,
@@ -55,10 +54,6 @@ test('it anchors a genesis segment on the activity startHash and seed', async ()
     startChainIndex: fixture.activity.startChainIndex,
     status: fixture.activity.status,
   });
-
-  // the row-reference equality above proves the loader round-trips the stored node; this proves
-  // the stored node actually carries a sealed pool stamp under the current content version
-  expect(segment?.activity.encounterNode).toContainEntry(['poolID', expect.toBeString()]);
 });
 
 test('it anchors a continuation segment on the last verified checkpoint hash and nextSeed', async () => {

--- a/services/replay/src/replay/load-replay-segment.test.ts
+++ b/services/replay/src/replay/load-replay-segment.test.ts
@@ -55,6 +55,10 @@ test('it anchors a genesis segment on the activity startHash and seed', async ()
     startChainIndex: fixture.activity.startChainIndex,
     status: fixture.activity.status,
   });
+
+  // the row-reference equality above proves the loader round-trips the stored node; this proves
+  // the stored node actually carries a sealed pool stamp under the current content version
+  expect(segment?.activity.encounterNode).toContainEntry(['poolID', expect.toBeString()]);
 });
 
 test('it anchors a continuation segment on the last verified checkpoint hash and nextSeed', async () => {

--- a/services/replay/src/replay/types.ts
+++ b/services/replay/src/replay/types.ts
@@ -40,7 +40,7 @@ export interface ReplaySegment {
     readonly avatarID: string;
     readonly buildSnapshot: { readonly level: number; readonly xp: number };
     readonly contentVersion: string;
-    readonly encounterNode: { readonly difficulty: number; readonly poolID?: string };
+    readonly encounterNode: { readonly difficulty: number; readonly poolID?: string | undefined };
     readonly id: string;
     readonly keyVersion: number;
     readonly scopeID: string;

--- a/services/replay/src/test-utils/create-honest-activity-fixture.ts
+++ b/services/replay/src/test-utils/create-honest-activity-fixture.ts
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker';
 import { createId } from '@paralleldrive/cuid2';
+import type { EncounterNode } from '@vers/contract-activity';
 import { buildCheckpointHash, buildStartHash } from '@vers/contract-activity';
 import type { SecretRef } from '@vers/contract-keys';
 import type { Activities, ActivityChains, DB, Json } from '@vers/db';
@@ -40,6 +41,13 @@ interface HonestActivityFixture {
   readonly activity: Selectable<Activities>;
   readonly chain: Selectable<ActivityChains>;
   readonly checkpoints: ReadonlyArray<HonestCheckpointRow>;
+
+  /**
+   * The node exactly as this fixture authored it before insert, typed — callers assert loader
+   * output against it instead of re-shaping the row's untyped jsonb.
+   */
+  readonly encounterNode: EncounterNode;
+
   readonly engineCheckpoints: ReadonlyArray<ActivityCheckpoint>;
 }
 
@@ -166,7 +174,7 @@ export async function createHonestActivityFixture(
       .execute();
   }
 
-  return { activity, chain, checkpoints, engineCheckpoints };
+  return { activity, chain, checkpoints, encounterNode, engineCheckpoints };
 }
 
 interface BuildFixtureEncounterNodeInput {
@@ -184,7 +192,7 @@ interface BuildFixtureEncounterNodeInput {
  * backend recomputes. A `null` secretRef is the legacy escape hatch: a fixed difficulty-1 node
  * with no sealed fields.
  */
-function buildFixtureEncounterNode(input: Readonly<BuildFixtureEncounterNodeInput>) {
+function buildFixtureEncounterNode(input: Readonly<BuildFixtureEncounterNodeInput>): EncounterNode {
   if (input.secretRef === null) {
     return { difficulty: 1 };
   }

--- a/services/replay/src/worker/run-replay-iteration.test.ts
+++ b/services/replay/src/worker/run-replay-iteration.test.ts
@@ -16,6 +16,7 @@ import pino from 'pino';
 import { MAX_REPLAY_ATTEMPTS } from '../queue/update-replay-attempts';
 import { createReplayCache } from '../replay/create-replay-cache';
 import { createActivityRow } from '../test-utils/create-activity-row';
+import { createAvatarRow } from '../test-utils/create-avatar-row';
 import { createHonestActivityFixture } from '../test-utils/create-honest-activity-fixture';
 import { createRemoteReplayProvider } from '../test-utils/create-remote-replay-provider';
 import { runReplayIteration } from './run-replay-iteration';
@@ -1149,7 +1150,12 @@ test('a capped activity advances the chain verified anchor from its tail, and an
 test('a stream fully verified while still active reconciles the anchor once a successor claims a forward-exited predecessor position', async () => {
   await using ctx = await setupTest();
 
+  // A pinned avatar id keeps the sealed content derivation — and with it both fixtures' checkpoint
+  // timelines — identical across runs; a random id would re-derive a different pool each run.
+  const avatar = await createAvatarRow(ctx.db, { id: 'avatar_reconcile' });
+
   const predecessor = await createHonestActivityFixture(ctx.db, {
+    avatarID: avatar.id,
     duration: 80_000,
     seed: buildStateFromSeed(3_047_525_658),
   });


### PR DESCRIPTION
## Description

Closes #192

Flips `CURRENT_CONTENT_VERSION` to `'2'`, activating sealed pool selection: new activity rows derive a `poolID` through the sealed descriptor, stamp it on the encounter node, and fold it into `startHash`. Second deploy of the two-deploy sealing rollout — the sealing machinery PR must merge and deploy first so live bundles already hold the generalized startHash serializer and the v2 content registry; a stale browser that misses both deploys parks via the existing flow.

- Only source change is the version constant; the rest is test fallout from fixtures now minting v2 rows.
- start-activity expectations gain the stamped `poolID` (exact derivation is covered by the dedicated sealed test).
- The reconcile-anchor test pins its avatar id: the sealed derivation varies with the avatar, and a random id re-rolls the pool — and the checkpoint timeline — each run.
- Frozen v1 goldens pass untouched.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality