### PR TITLE
refactor(#852): retire jsonb-boundary casts for parse or authored values

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,10 +266,10 @@ trigger is ordinary control flow, not an invariant.
 
 ## Untyped column boundaries
 
-An untyped jsonb or text column value re-enters typed code through its contract schema's `.parse`
-— a malformed row fails loudly at the read — or by threading the typed value its author already
-holds; never through a bare `as` cast. A write TypeScript cannot prove assignable to the column's
-`Json` type goes through the one documented converter (`toJSON`, `@vers/db`).
+An untyped jsonb or text column value re-enters typed code through its contract schema's `.parse` —
+a malformed row fails loudly at the read — or by threading the typed value its author already holds;
+never through a bare `as` cast. A write TypeScript cannot prove assignable to the column's `Json`
+type goes through the one documented converter (`toJSON`, `@vers/db`).
 
 ## Third-party packages
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,6 +264,13 @@ Express a true invariant — a condition only a bug can break — with `tiny-inv
 (`invariant(value, 'message')`) rather than a hand-rolled `if`/`throw`. A condition real input can
 trigger is ordinary control flow, not an invariant.
 
+## Untyped column boundaries
+
+An untyped jsonb or text column value re-enters typed code through its contract schema's `.parse`
+— a malformed row fails loudly at the read — or by threading the typed value its author already
+holds; never through a bare `as` cast. A write TypeScript cannot prove assignable to the column's
+`Json` type goes through the one documented converter (`toJSON`, `@vers/db`).
+
 ## Third-party packages
 
 Prefer an established, narrowly scoped third-party package over hand-rolling the same logic —

--- a/agents/project.md
+++ b/agents/project.md
@@ -102,6 +102,13 @@ Express a true invariant — a condition only a bug can break — with `tiny-inv
 (`invariant(value, 'message')`) rather than a hand-rolled `if`/`throw`. A condition real input can
 trigger is ordinary control flow, not an invariant.
 
+## Untyped column boundaries
+
+An untyped jsonb or text column value re-enters typed code through its contract schema's `.parse` —
+a malformed row fails loudly at the read — or by threading the typed value its author already holds;
+never through a bare `as` cast. A write TypeScript cannot prove assignable to the column's `Json`
+type goes through the one documented converter (`toJSON`, `@vers/db`).
+
 ## Third-party packages
 
 Prefer an established, narrowly scoped third-party package over hand-rolling the same logic —

--- a/bun.lock
+++ b/bun.lock
@@ -158,6 +158,7 @@
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
         "@zgeoff/bun-test-extended": "catalog:",
+        "tiny-invariant": "catalog:",
         "typescript": "catalog:",
       },
     },

--- a/contracts/activity/package.json
+++ b/contracts/activity/package.json
@@ -26,6 +26,7 @@
     "@types/bun": "catalog:",
     "@types/node": "catalog:",
     "@zgeoff/bun-test-extended": "catalog:",
+    "tiny-invariant": "catalog:",
     "typescript": "catalog:"
   }
 }

--- a/contracts/activity/src/activity-contract.ts
+++ b/contracts/activity/src/activity-contract.ts
@@ -7,6 +7,7 @@ import { CatchUpContinuationSchema } from './catch-up-continuation-schema';
 import { CheckpointBatchEntrySchema } from './checkpoint-batch-entry-schema';
 import { CheckpointSchema } from './checkpoint-schema';
 import { MAX_CATCH_UP_BATCH_CHECKPOINTS } from './max-catch-up-batch-checkpoints';
+import { RewardItemAffixSchema } from './reward-item-affix-schema';
 import { ScopeIdentifierSchema } from './scope-identifier-schema';
 
 const AvatarNotActiveDataSchema = z.object({
@@ -27,12 +28,6 @@ const TerminalStatusDataSchema = z.object({ appendedHead: z.int(), status: Activ
 const AdvanceBailDataSchema = z.object({ activityID: z.string(), appendedHead: z.int() });
 const AdvanceCheckpointInvalidDataSchema = AdvanceBailDataSchema.extend({ reason: z.string() });
 const AdvanceTerminalDataSchema = AdvanceBailDataSchema.extend({ status: ActivityStatusSchema });
-
-const RewardItemAffixSchema = z.object({
-  affixID: z.string(),
-  groupID: z.string(),
-  value: z.number(),
-});
 
 const RewardItemSchema = z.object({
   affixes: z.array(RewardItemAffixSchema),

--- a/contracts/activity/src/encounter-node-schema.test.ts
+++ b/contracts/activity/src/encounter-node-schema.test.ts
@@ -28,3 +28,17 @@ test('it accepts an encounter node without a poolID', () => {
 
   expect(result.success).toBeTrue();
 });
+
+test('it keeps a sealed scalar field it does not declare', () => {
+  const result = EncounterNodeSchema.safeParse({ difficulty: 3, juiceSalt: 7 });
+
+  expect(result.success).toBeTrue();
+  expect(result.data).toStrictEqual({ difficulty: 3, juiceSalt: 7 });
+});
+
+test('it rejects a sealed field that is not a string or number', () => {
+  const result = EncounterNodeSchema.safeParse({ difficulty: 3, modifiers: { fire: 2 } });
+
+  expect(result.success).toBeFalse();
+  expect(result.error?.issues).toPartiallyContain(expect.objectContaining({ path: ['modifiers'] }));
+});

--- a/contracts/activity/src/encounter-node-schema.test.ts
+++ b/contracts/activity/src/encounter-node-schema.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'bun:test';
+import invariant from 'tiny-invariant';
 import { EncounterNodeSchema } from './encounter-node-schema';
 
 test('it accepts a well-formed encounter node', () => {
@@ -32,13 +33,19 @@ test('it accepts an encounter node without a poolID', () => {
 test('it keeps a sealed scalar field it does not declare', () => {
   const result = EncounterNodeSchema.safeParse({ difficulty: 3, juiceSalt: 7 });
 
-  expect(result.success).toBeTrue();
+  invariant(result.success, 'a sealed scalar field must parse');
+
   expect(result.data).toStrictEqual({ difficulty: 3, juiceSalt: 7 });
 });
 
 test('it rejects a sealed field that is not a string or number', () => {
   const result = EncounterNodeSchema.safeParse({ difficulty: 3, modifiers: { fire: 2 } });
 
-  expect(result.success).toBeFalse();
-  expect(result.error?.issues).toPartiallyContain(expect.objectContaining({ path: ['modifiers'] }));
+  invariant(!result.success, 'a non-scalar sealed field must not parse');
+
+  expect(result.error.issues).toPartiallyContain(expect.objectContaining({ path: ['modifiers'] }));
+});
+
+test('it freezes a parsed node', () => {
+  expect(Object.isFrozen(EncounterNodeSchema.parse({ difficulty: 3 }))).toBeTrue();
 });

--- a/contracts/activity/src/encounter-node-schema.ts
+++ b/contracts/activity/src/encounter-node-schema.ts
@@ -4,10 +4,17 @@ import * as z from 'zod';
  * The server-resolved encounter params an activity freezes at start, sourced from its scope node
  * and folded into the start hash so a later content change can't retroactively alter an activity
  * already in flight. `poolID` is absent for content versions that predate sealed pool selection.
+ * Any further sealed field a content version stamps is a string or number — the catchall keeps it
+ * through a parse, because the start hash folds every stored field and a re-read node must carry
+ * exactly what was stamped. Parsed nodes are readonly — frozen at runtime — so a stamped node is
+ * never mutated after the start hash commits to it.
  */
-export const EncounterNodeSchema = z.object({
-  difficulty: z.number(),
-  poolID: z.string().optional(),
-});
+export const EncounterNodeSchema = z
+  .object({
+    difficulty: z.number(),
+    poolID: z.string().optional(),
+  })
+  .catchall(z.union([z.number(), z.string(), z.undefined()]))
+  .readonly();
 
 export type EncounterNode = z.infer<typeof EncounterNodeSchema>;

--- a/contracts/activity/src/index.ts
+++ b/contracts/activity/src/index.ts
@@ -26,5 +26,7 @@ export type { EntropySource } from './entropy-source-schema';
 export { EntropySourceSchema } from './entropy-source-schema';
 export { MAX_CATCH_UP_BATCH_CHECKPOINTS } from './max-catch-up-batch-checkpoints';
 export { OFFLINE_PROGRESS_CAP_MS } from './offline-progress-cap-ms';
+export type { RewardItemAffix } from './reward-item-affix-schema';
+export { RewardItemAffixSchema } from './reward-item-affix-schema';
 export type { RewardSlot } from './reward-slot-schema';
 export { RewardSlotSchema } from './reward-slot-schema';

--- a/contracts/activity/src/reward-item-affix-schema.ts
+++ b/contracts/activity/src/reward-item-affix-schema.ts
@@ -1,0 +1,13 @@
+import * as z from 'zod';
+
+/**
+ * One affix on a revealed reward item: the affix identity, the exclusivity group it rolled from,
+ * and the rolled magnitude.
+ */
+export const RewardItemAffixSchema = z.object({
+  affixID: z.string(),
+  groupID: z.string(),
+  value: z.number(),
+});
+
+export type RewardItemAffix = z.infer<typeof RewardItemAffixSchema>;

--- a/libs/data/db/src/index.ts
+++ b/libs/data/db/src/index.ts
@@ -1,5 +1,6 @@
 export { createDB } from './create-db';
 export { applyMigrations, migrationsFolder } from './apply-migrations';
+export { toJSON } from './to-json';
 
 export type {
   ActiveAvatars,

--- a/libs/data/db/src/to-json.ts
+++ b/libs/data/db/src/to-json.ts
@@ -6,9 +6,10 @@ import type { Json } from './types';
  *
  * The assertion exists because zod object types carry an `unknown`-typed index signature that
  * TypeScript cannot prove assignable to the recursive `Json` shape, even though the runtime value
- * is plain data. Callers must pass only JSON-serializable values — schema-parsed payloads or
- * literals of primitives, arrays, and plain objects; the driver serializes the value as-is, so a
- * class instance or function here would corrupt the stored row.
+ * is plain data. Callers must pass a plain object whose every field is JSON-serializable — a
+ * schema-parsed payload or a literal of primitives, arrays, and plain objects; the driver
+ * serializes the value as-is, so a class instance or function anywhere inside it would corrupt the
+ * stored row.
  */
 export function toJSON(value: Readonly<Record<string, unknown>>): Json {
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the sole sanctioned jsonb-write conversion; see the doc comment above

--- a/libs/data/db/src/to-json.ts
+++ b/libs/data/db/src/to-json.ts
@@ -1,0 +1,16 @@
+import type { Json } from './types';
+
+/**
+ * Converts a schema-validated structure into the `Json` value a jsonb column write accepts — the
+ * one place that conversion is allowed to assert.
+ *
+ * The assertion exists because zod object types carry an `unknown`-typed index signature that
+ * TypeScript cannot prove assignable to the recursive `Json` shape, even though the runtime value
+ * is plain data. Callers must pass only JSON-serializable values — schema-parsed payloads or
+ * literals of primitives, arrays, and plain objects; the driver serializes the value as-is, so a
+ * class instance or function here would corrupt the stored row.
+ */
+export function toJSON(value: Readonly<Record<string, unknown>>): Json {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the sole sanctioned jsonb-write conversion; see the doc comment above
+  return value as Json;
+}

--- a/services/activity/src/handlers/advance-activity.ts
+++ b/services/activity/src/handlers/advance-activity.ts
@@ -1,6 +1,12 @@
-import type { ActivityData, BuildSnapshot, CatchUpContinuation } from '@vers/contract-activity';
-import { buildStartHash } from '@vers/contract-activity';
-import type { Activities, ActivityStatus, DB, Json } from '@vers/db';
+import type {
+  ActivityData,
+  BuildSnapshot,
+  CatchUpContinuation,
+  EncounterNode,
+} from '@vers/contract-activity';
+import { EncounterNodeSchema, buildStartHash } from '@vers/contract-activity';
+import type { Activities, ActivityStatus, DB } from '@vers/db';
+import { toJSON } from '@vers/db';
 import { buildLevelFromXP, isTerminalCheckpointType } from '@vers/idle-core';
 import { sql } from 'kysely';
 import type { Kysely, Selectable } from 'kysely';
@@ -111,11 +117,7 @@ export async function advanceActivity(
   const pinned: PinnedActivityContext = {
     avatarId: initial.avatarId,
     contentVersion: initial.contentVersion,
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the column is untyped jsonb; every write is this service's own encounter-node resolution
-    encounterNode: initial.encounterNode as {
-      readonly difficulty: number;
-      readonly poolID?: string;
-    },
+    encounterNode: EncounterNodeSchema.parse(initial.encounterNode),
     keyVersion: initial.keyVersion,
     scopeId: initial.scopeId,
     scopeType: initial.scopeType,
@@ -187,7 +189,7 @@ export async function advanceActivity(
 interface PinnedActivityContext {
   readonly avatarId: string;
   readonly contentVersion: string;
-  readonly encounterNode: { readonly difficulty: number; readonly poolID?: string };
+  readonly encounterNode: Readonly<EncounterNode>;
   readonly keyVersion: number;
   readonly scopeId: string;
   readonly scopeType: string;
@@ -525,8 +527,7 @@ async function runContinuation(
         input.continuation.checkpoints.map((checkpoint) => ({
           activityId: input.targetActivityID,
           hash: checkpoint.hash,
-          // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the column is untyped jsonb; the value is schema-validated contract input
-          payload: checkpoint.payload as Json,
+          payload: toJSON(checkpoint.payload),
           prevHash: checkpoint.prevHash,
           version: checkpoint.version,
         })),

--- a/services/activity/src/handlers/get-activity-rewards.ts
+++ b/services/activity/src/handlers/get-activity-rewards.ts
@@ -1,3 +1,5 @@
+import type { RewardItemAffix } from '@vers/contract-activity';
+import { RewardItemAffixSchema } from '@vers/contract-activity';
 import type { DB } from '@vers/db';
 import type { Kysely } from 'kysely';
 import type { EmptyErrorPayload, MissingSessionPayload } from '../types';
@@ -15,11 +17,7 @@ interface GetActivityRewardsOpts {
 }
 
 interface RewardItem {
-  readonly affixes: Array<{
-    readonly affixID: string;
-    readonly groupID: string;
-    readonly value: number;
-  }>;
+  readonly affixes: Array<RewardItemAffix>;
   readonly baseID: string;
   readonly contentVersion: string;
   readonly rarityID: string;
@@ -86,8 +84,7 @@ export async function getActivityRewards(
     items: rows.map((row) => ({
       chainIndex: row.chainIndex,
       item: {
-        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the column is untyped jsonb; every write is this service's own mint construction, and oRPC's output validation rejects a drifted shape at the boundary
-        affixes: row.affixes as RewardItem['affixes'],
+        affixes: RewardItemAffixSchema.array().parse(row.affixes),
         baseID: row.baseId,
         contentVersion: row.contentVersion,
         rarityID: row.rarityId,

--- a/services/activity/src/handlers/to-activity-data.ts
+++ b/services/activity/src/handlers/to-activity-data.ts
@@ -1,25 +1,22 @@
-import type { ActivityData, BuildSnapshot, EncounterNode } from '@vers/contract-activity';
+import type { ActivityData } from '@vers/contract-activity';
+import { BuildSnapshotSchema, EncounterNodeSchema } from '@vers/contract-activity';
 import type { Activities } from '@vers/db';
 import type { Selectable } from 'kysely';
 
 /**
  * Maps a kysely `activities` row (camelCase columns) onto the contract's `ActivityData` shape.
- * `buildSnapshot` is cast to `BuildSnapshot`: the column is untyped jsonb, every write comes from
- * this service's own snapshot construction, and the cast cannot smuggle a drifted row past the RPC
- * boundary — oRPC validates handler output against the contract's output schema and fails the
- * request on mismatch.
+ * `buildSnapshot` and `encounterNode` are untyped jsonb columns and re-enter typed code through
+ * their contract schemas, so a drifted row fails here loudly instead of flowing on.
  */
 export function toActivityData(row: Readonly<Selectable<Activities>>): ActivityData {
   return {
     appendedAt: row.appendedAt,
     appendedHead: row.appendedHead,
     avatarID: row.avatarId,
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the column is untyped jsonb; every write is this service's own snapshot construction, and oRPC's output validation rejects a drifted shape at the boundary
-    buildSnapshot: row.buildSnapshot as BuildSnapshot,
+    buildSnapshot: BuildSnapshotSchema.parse(row.buildSnapshot),
     contentVersion: row.contentVersion,
     createdAt: row.createdAt,
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the column is untyped jsonb; every write is this service's own encounter-node resolution, and oRPC's output validation rejects a drifted shape at the boundary
-    encounterNode: row.encounterNode as EncounterNode,
+    encounterNode: EncounterNodeSchema.parse(row.encounterNode),
     id: row.id,
     keyVersion: row.keyVersion,
     lastHash: row.lastHash,

--- a/services/activity/src/handlers/to-checkpoint-data.ts
+++ b/services/activity/src/handlers/to-checkpoint-data.ts
@@ -1,19 +1,18 @@
-import type { Checkpoint, CheckpointPayload } from '@vers/contract-activity';
+import type { Checkpoint } from '@vers/contract-activity';
+import { CheckpointPayloadSchema } from '@vers/contract-activity';
 import type { ActivityCheckpoints } from '@vers/db';
 import type { Selectable } from 'kysely';
 
 /**
- * Maps a kysely `activity_checkpoints` row onto the contract's `Checkpoint` shape. `payload` is
- * cast to `CheckpointPayload`: the column is untyped jsonb, every write is schema-validated
- * contract input, and the cast cannot smuggle a drifted row past the RPC boundary — oRPC validates
- * handler output against the contract's output schema and fails the request on mismatch.
+ * Maps a kysely `activity_checkpoints` row onto the contract's `Checkpoint` shape. `payload` is an
+ * untyped jsonb column and re-enters typed code through its contract schema, so a drifted row
+ * fails here loudly instead of flowing on.
  */
 export function toCheckpointData(row: Readonly<Selectable<ActivityCheckpoints>>): Checkpoint {
   return {
     appendedAt: row.appendedAt,
     hash: row.hash,
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the column is untyped jsonb; every write is schema-validated contract input, and oRPC's output validation rejects a drifted shape at the boundary
-    payload: row.payload as CheckpointPayload,
+    payload: CheckpointPayloadSchema.parse(row.payload),
     prevHash: row.prevHash,
     version: row.version,
   };

--- a/services/activity/src/handlers/track-activity-progress.ts
+++ b/services/activity/src/handlers/track-activity-progress.ts
@@ -1,5 +1,6 @@
 import type { CheckpointBatchEntry } from '@vers/contract-activity';
-import type { DB, Json } from '@vers/db';
+import type { DB } from '@vers/db';
+import { toJSON } from '@vers/db';
 import { isTerminalCheckpointType } from '@vers/idle-core';
 import type { ServiceContext } from '@vers/service-runtime';
 import { sql } from 'kysely';
@@ -255,8 +256,7 @@ export async function trackActivityProgress(
           opts.input.checkpoints.map((checkpoint) => ({
             activityId: opts.input.activityID,
             hash: checkpoint.hash,
-            // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the column is untyped jsonb; the value is schema-validated contract input
-            payload: checkpoint.payload as Json,
+            payload: toJSON(checkpoint.payload),
             prevHash: checkpoint.prevHash,
             version: checkpoint.version,
           })),

--- a/services/activity/src/test-utils/factories/create-mock-activity.ts
+++ b/services/activity/src/test-utils/factories/create-mock-activity.ts
@@ -1,8 +1,21 @@
 import { faker } from '@faker-js/faker';
 import { createId } from '@paralleldrive/cuid2';
+import type { EncounterNode } from '@vers/contract-activity';
 import { buildStartHash } from '@vers/contract-activity';
 import type { Activities } from '@vers/db';
 import type { Insertable } from 'kysely';
+
+/**
+ * The factory's own overrides shape: the row's insertable columns, except `encounterNode` narrows
+ * from the column's untyped jsonb to the contract type, so the factory threads the typed value a
+ * caller authored instead of re-shaping the column read.
+ */
+interface CreateMockActivityOverrides extends Omit<
+  Partial<Insertable<Activities>>,
+  'encounterNode'
+> {
+  readonly encounterNode?: Readonly<EncounterNode>;
+}
 
 /**
  * A plain, unpersisted activity row with faker-generated defaults. Never requires a parent —
@@ -11,7 +24,7 @@ import type { Insertable } from 'kysely';
  * checkpoint batch.
  */
 export function createMockActivity(
-  overrides: Readonly<Partial<Insertable<Activities>>> = {},
+  overrides: Readonly<CreateMockActivityOverrides> = {},
 ): Insertable<Activities> {
   const id = overrides.id ?? `act_${createId()}`;
   const seed = overrides.seed ?? faker.string.alphanumeric({ casing: 'lower', length: 32 });
@@ -19,11 +32,9 @@ export function createMockActivity(
   const contentVersion = overrides.contentVersion ?? '0.0.0-dev';
   const keyVersion = overrides.keyVersion ?? 1;
 
-  const encounterNode =
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the column is untyped jsonb; every write is this factory's own schema-shaped literal
-    (overrides.encounterNode as { difficulty: number } | undefined) ?? {
-      difficulty: faker.number.int({ max: 10, min: 1 }),
-    };
+  const encounterNode = overrides.encounterNode ?? {
+    difficulty: faker.number.int({ max: 10, min: 1 }),
+  };
 
   const startHash =
     overrides.startHash ??

--- a/services/replay/src/queue/find-verified-anchor-predecessor.test.ts
+++ b/services/replay/src/queue/find-verified-anchor-predecessor.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'bun:test';
 import { buildStateFromSeed } from '@vers/game-utils';
 import { createTestDB } from '@vers/service-test-utils/bun';
+import invariant from 'tiny-invariant';
 import { createHonestActivityFixture } from '../test-utils/create-honest-activity-fixture';
 import { findVerifiedAnchorPredecessor } from './find-verified-anchor-predecessor';
 
@@ -36,13 +37,12 @@ test('it finds a fully verified, stopped predecessor rooted at the chain verifie
 
   const tail = fixture.checkpoints[tailCount - 1];
 
-  // oxlint-disable typescript/no-unsafe-type-assertion -- the fixture's payload is a hand-built, schema-shaped object
-  expect(predecessor).toStrictEqual({
-    chainIndex: tail?.payload['chainIndex'] as number,
-    nextSeed: tail?.payload['nextSeed'] as string,
-  });
+  invariant(tail, 'the fixture always stores a checkpoint at the trimmed tail');
 
-  // oxlint-enable typescript/no-unsafe-type-assertion
+  expect(predecessor).toStrictEqual({
+    chainIndex: tail.payload.chainIndex,
+    nextSeed: tail.payload.nextSeed,
+  });
 });
 
 test('it finds a fully verified, capped predecessor rooted at the chain verified anchor', async () => {
@@ -71,13 +71,12 @@ test('it finds a fully verified, capped predecessor rooted at the chain verified
 
   const tail = fixture.checkpoints[tailCount - 1];
 
-  // oxlint-disable typescript/no-unsafe-type-assertion -- the fixture's payload is a hand-built, schema-shaped object
-  expect(predecessor).toStrictEqual({
-    chainIndex: tail?.payload['chainIndex'] as number,
-    nextSeed: tail?.payload['nextSeed'] as string,
-  });
+  invariant(tail, 'the fixture always stores a checkpoint at the trimmed tail');
 
-  // oxlint-enable typescript/no-unsafe-type-assertion
+  expect(predecessor).toStrictEqual({
+    chainIndex: tail.payload.chainIndex,
+    nextSeed: tail.payload.nextSeed,
+  });
 });
 
 test('it finds no predecessor when the activity at that position is still active', async () => {
@@ -135,7 +134,7 @@ test('it finds no predecessor whose tail checkpoint is the Started one', async (
   });
 
   expect(fixture.checkpoints).toHaveLength(1);
-  expect(fixture.checkpoints[0]?.payload['type']).toBe('started');
+  expect(fixture.checkpoints[0]?.payload.type).toBe('started');
 
   await ctx.db
     .updateTable('activities')
@@ -163,7 +162,7 @@ test('it finds the consuming predecessor when a Started-only stopped activity sh
   });
 
   expect(startedOnly.checkpoints).toHaveLength(1);
-  expect(startedOnly.checkpoints[0]?.payload['type']).toBe('started');
+  expect(startedOnly.checkpoints[0]?.payload.type).toBe('started');
 
   await ctx.db
     .updateTable('activities')
@@ -196,13 +195,12 @@ test('it finds the consuming predecessor when a Started-only stopped activity sh
 
   const tail = consuming.checkpoints[tailCount - 1];
 
-  // oxlint-disable typescript/no-unsafe-type-assertion -- the fixture's payload is a hand-built, schema-shaped object
-  expect(predecessor).toStrictEqual({
-    chainIndex: tail?.payload['chainIndex'] as number,
-    nextSeed: tail?.payload['nextSeed'] as string,
-  });
+  invariant(tail, 'the fixture always stores a checkpoint at the trimmed tail');
 
-  // oxlint-enable typescript/no-unsafe-type-assertion
+  expect(predecessor).toStrictEqual({
+    chainIndex: tail.payload.chainIndex,
+    nextSeed: tail.payload.nextSeed,
+  });
 });
 
 test('it finds no predecessor rooted at a different chain position', async () => {

--- a/services/replay/src/replay/load-replay-segment.test.ts
+++ b/services/replay/src/replay/load-replay-segment.test.ts
@@ -76,8 +76,7 @@ test('it anchors a continuation segment on the last verified checkpoint hash and
 
   expect(predecessor).toBeDefined();
   expect(segment?.prevHash).toBe(predecessor?.hash);
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the fixture's payload is a hand-built, schema-shaped object
-  expect(segment?.seed).toBe(predecessor?.payload['nextSeed'] as string | undefined);
+  expect(segment?.seed).toBe(predecessor?.payload.nextSeed);
   expect(segment?.checkpoints).toHaveLength(fixture.checkpoints.length);
   expect(segment?.checkpoints.slice(verifiedHead)).toHaveLength(fixture.checkpoints.length - 1);
   expect(segment?.checkpoints[verifiedHead]?.version).toBe(2);

--- a/services/replay/src/replay/load-replay-segment.ts
+++ b/services/replay/src/replay/load-replay-segment.ts
@@ -1,4 +1,8 @@
-import type { CheckpointPayload } from '@vers/contract-activity';
+import {
+  BuildSnapshotSchema,
+  CheckpointPayloadSchema,
+  EncounterNodeSchema,
+} from '@vers/contract-activity';
 import type { DB } from '@vers/db';
 import type { Kysely } from 'kysely';
 import invariant from 'tiny-invariant';
@@ -10,7 +14,9 @@ import type { ReplaySegment } from './types';
  * checkpoint from version 1 through `appendedHead` — the whole stream, not just the unverified
  * tail, because a cache-miss rebuild must replay every earlier local attempt's own boundary to
  * read the stream's later `time` values correctly. Undefined when the activity row is gone (raced
- * against a concurrent cleanup) — the caller treats that as nothing to replay.
+ * against a concurrent cleanup) — the caller treats that as nothing to replay. The untyped jsonb
+ * columns re-enter typed code through their contract schemas, so a malformed row fails the load
+ * loudly instead of flowing into the verifier.
  */
 export async function loadReplaySegment(
   db: Kysely<DB>,
@@ -62,7 +68,16 @@ export async function loadReplaySegment(
     .orderBy('version')
     .execute();
 
-  const predecessor = frontier.verifiedHead === 0 ? undefined : rows[frontier.verifiedHead - 1];
+  const checkpoints = rows.map((row) => ({
+    appendedAt: row.appendedAt,
+    hash: row.hash,
+    payload: CheckpointPayloadSchema.parse(row.payload),
+    prevHash: row.prevHash,
+    version: row.version,
+  }));
+
+  const predecessor =
+    frontier.verifiedHead === 0 ? undefined : checkpoints[frontier.verifiedHead - 1];
 
   invariant(
     frontier.verifiedHead === 0 || predecessor?.version === frontier.verifiedHead,
@@ -74,9 +89,9 @@ export async function loadReplaySegment(
       appendedHead: frontier.appendedHead,
       appendedTimeMs: Number(activity.appendedTimeMs),
       avatarID: activity.avatarId,
-      buildSnapshot: readBuildSnapshot(activity.buildSnapshot),
+      buildSnapshot: BuildSnapshotSchema.parse(activity.buildSnapshot),
       contentVersion: activity.contentVersion,
-      encounterNode: readEncounterNode(activity.encounterNode),
+      encounterNode: EncounterNodeSchema.parse(activity.encounterNode),
       id: activity.id,
       keyVersion: activity.keyVersion,
       scopeID: activity.scopeId,
@@ -90,50 +105,9 @@ export async function loadReplaySegment(
       status: activity.status,
     },
     chain,
-    checkpoints: rows.map((row) => ({
-      appendedAt: row.appendedAt,
-      hash: row.hash,
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the column is untyped jsonb; every write is schema-validated contract input
-      payload: row.payload as CheckpointPayload,
-      prevHash: row.prevHash,
-      version: row.version,
-    })),
+    checkpoints,
     prevHash: predecessor === undefined ? activity.startHash : predecessor.hash,
-    seed:
-      predecessor === undefined
-        ? activity.seed
-        : readPayloadNextSeed(
-            // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the column is untyped jsonb; every write is schema-validated contract input
-            predecessor.payload as CheckpointPayload,
-          ),
+    seed: predecessor === undefined ? activity.seed : predecessor.payload.nextSeed,
     verifiedHead: frontier.verifiedHead,
   };
-}
-
-/**
- * The activities row's `build_snapshot` column is untyped jsonb; every write is schema-validated
- * contract input (`BuildSnapshotSchema`), so this reads its two known fields without re-validating.
- */
-function readBuildSnapshot(value: unknown): { level: number; xp: number } {
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the column is untyped jsonb; every write is schema-validated contract input
-  const snapshot = value as { level: number; xp: number };
-
-  return { level: snapshot.level, xp: snapshot.xp };
-}
-
-/**
- * The activities row's `encounter_node` column is untyped jsonb; every write is the activity
- * service's own server-side node resolution, so this reads its known fields without re-validating.
- * `poolID` round-trips only when the stored row carries one — an old row predating sealed pool
- * selection stays shaped exactly as it was stamped.
- */
-function readEncounterNode(value: unknown): { difficulty: number; poolID?: string } {
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the column is untyped jsonb; every write is the activity service's own server-side node resolution
-  const node = value as { difficulty: number; poolID?: string };
-
-  return { difficulty: node.difficulty, ...(node.poolID !== undefined && { poolID: node.poolID }) };
-}
-
-function readPayloadNextSeed(payload: Readonly<CheckpointPayload>): string {
-  return payload.nextSeed;
 }

--- a/services/replay/src/test-utils/create-honest-activity-fixture.test.ts
+++ b/services/replay/src/test-utils/create-honest-activity-fixture.test.ts
@@ -3,6 +3,7 @@ import { buildCheckpointHash } from '@vers/contract-activity';
 import { buildMockScopeSecret } from '@vers/mock-services/keys';
 import { createTestDB } from '@vers/service-test-utils/bun';
 import { deriveWorldmapContent } from '@vers/worldmap-content';
+import invariant from 'tiny-invariant';
 import { createHonestActivityFixture } from './create-honest-activity-fixture';
 
 test('it persists a stream whose stored hashes byte-match a fresh recompute', async () => {
@@ -17,19 +18,16 @@ test('it persists a stream whose stored hashes byte-match a fresh recompute', as
   let prevHash = fixture.activity.startHash;
 
   for (const checkpoint of fixture.checkpoints) {
-    // oxlint-disable typescript/no-unsafe-type-assertion -- the fixture's payload is a hand-built, schema-shaped object
     const recomputed = buildCheckpointHash({
-      chainIndex: checkpoint.payload['chainIndex'] as number,
+      chainIndex: checkpoint.payload.chainIndex,
       entropySource: 'server-key',
-      nextSeed: checkpoint.payload['nextSeed'] as string,
+      nextSeed: checkpoint.payload.nextSeed,
       prevHash,
-      seed: checkpoint.payload['seed'] as string,
-      time: checkpoint.payload['time'] as number,
-      type: checkpoint.payload['type'] as string,
+      seed: checkpoint.payload.seed,
+      time: checkpoint.payload.time,
+      type: checkpoint.payload.type,
       version: checkpoint.version,
     });
-
-    // oxlint-enable typescript/no-unsafe-type-assertion
 
     expect(checkpoint.hash).toBe(recomputed);
     expect(checkpoint.prevHash).toBe(prevHash);
@@ -57,20 +55,16 @@ test('it roots a successor on an already-persisted chain instead of creating a n
 
   const tail = predecessor.checkpoints.at(-1);
 
-  expect(tail).toBeDefined();
+  invariant(tail, 'the fixture always stores at least one checkpoint');
 
-  // oxlint-disable typescript/no-unsafe-type-assertion -- the fixture's payload is a hand-built, schema-shaped object
   const successor = await createHonestActivityFixture(ctx.db, {
     rootChain: predecessor.chain,
-    seed: tail?.payload['nextSeed'] as string,
-    startChainIndex: tail?.payload['chainIndex'] as number,
+    seed: tail.payload.nextSeed,
+    startChainIndex: tail.payload.chainIndex,
   });
 
-  expect(successor.activity.startChainIndex).toBe(tail?.payload['chainIndex'] as number);
-  expect(successor.activity.seed).toBe(tail?.payload['nextSeed'] as string);
-
-  // oxlint-enable typescript/no-unsafe-type-assertion
-
+  expect(successor.activity.startChainIndex).toBe(tail.payload.chainIndex);
+  expect(successor.activity.seed).toBe(tail.payload.nextSeed);
   expect(successor.activity.avatarId).toBe(predecessor.activity.avatarId);
 
   const chains = await ctx.db

--- a/services/replay/src/test-utils/create-honest-activity-fixture.ts
+++ b/services/replay/src/test-utils/create-honest-activity-fixture.ts
@@ -1,9 +1,10 @@
 import { faker } from '@faker-js/faker';
 import { createId } from '@paralleldrive/cuid2';
-import type { EncounterNode } from '@vers/contract-activity';
+import type { CheckpointPayload, EncounterNode } from '@vers/contract-activity';
 import { buildCheckpointHash, buildStartHash } from '@vers/contract-activity';
 import type { SecretRef } from '@vers/contract-keys';
-import type { Activities, ActivityChains, DB, Json } from '@vers/db';
+import type { Activities, ActivityChains, DB } from '@vers/db';
+import { toJSON } from '@vers/db';
 import { CURRENT_CONTENT_VERSION, buildStateFromSeed } from '@vers/game-utils';
 import type { ActivityCheckpoint } from '@vers/idle-core';
 import { buildSimulationInput } from '@vers/idle-core';
@@ -26,7 +27,7 @@ const DEFAULT_SCOPE_ID = '1_0';
 
 interface HonestCheckpointRow {
   readonly hash: string;
-  readonly payload: Record<string, unknown>;
+  readonly payload: CheckpointPayload;
   readonly prevHash: string;
   readonly version: number;
 }
@@ -164,8 +165,7 @@ export async function createHonestActivityFixture(
         checkpoints.map((checkpoint) => ({
           activityId: activityID,
           hash: checkpoint.hash,
-          // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the column is untyped jsonb; the value is a hand-built, schema-shaped payload
-          payload: checkpoint.payload as Json,
+          payload: toJSON(checkpoint.payload),
           prevHash: checkpoint.prevHash,
           version: checkpoint.version,
         })),
@@ -246,7 +246,7 @@ function buildHonestCheckpointRows(
       version,
     });
 
-    const payload = {
+    const payload: CheckpointPayload = {
       chainIndex,
       entropySource: 'server-key',
       nextSeed: checkpoint.nextSeed,

--- a/services/replay/src/worker/run-frontier.ts
+++ b/services/replay/src/worker/run-frontier.ts
@@ -1,4 +1,4 @@
-import type { SecretRef } from '@vers/contract-keys';
+import { SecretRefSchema } from '@vers/contract-keys';
 import type { DB } from '@vers/db';
 import type { SimulationDriver } from '@vers/idle-core';
 import { buildSimulationInput } from '@vers/idle-core';
@@ -90,8 +90,7 @@ export async function runFrontier(
       },
       {
         avatarID: segment.activity.avatarID,
-        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the column is untyped text; every write is this service's own custodied scope-ref enum
-        secretRef: segment.activity.secretRef as SecretRef,
+        secretRef: SecretRefSchema.parse(segment.activity.secretRef),
         secretVersion: segment.activity.secretVersion,
       },
     );

--- a/services/replay/src/worker/run-replay-iteration.test.ts
+++ b/services/replay/src/worker/run-replay-iteration.test.ts
@@ -1,7 +1,7 @@
 import { expect, onTestFinished, test } from 'bun:test';
 import type { ErrorEvent } from '@sentry/bun';
 import { buildCheckpointHash } from '@vers/contract-activity';
-import type { Json } from '@vers/db';
+import { toJSON } from '@vers/db';
 import { buildStateFromSeed } from '@vers/game-utils';
 import { buildLevelFromXP, buildSimulationInput } from '@vers/idle-core';
 import { createSimulationDriver } from '@vers/idle-core/replay';
@@ -13,6 +13,7 @@ import { createSimVersionRow } from '@vers/sim-registry/test-utils';
 import { waitFor } from '@vers/test-utils';
 import { createTraceContext } from '@vers/trace';
 import pino from 'pino';
+import invariant from 'tiny-invariant';
 import { MAX_REPLAY_ATTEMPTS } from '../queue/update-replay-attempts';
 import { createReplayCache } from '../replay/create-replay-cache';
 import { createActivityRow } from '../test-utils/create-activity-row';
@@ -174,8 +175,7 @@ test('it verifies a later batch from held state, not a fresh from-Started replay
       remaining.map((checkpoint) => ({
         activityId: fixture.activity.id,
         hash: checkpoint.hash,
-        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the column is untyped jsonb; the value is a hand-built, schema-shaped payload
-        payload: checkpoint.payload as Json,
+        payload: toJSON(checkpoint.payload),
         prevHash: checkpoint.prevHash,
         version: checkpoint.version,
       })),
@@ -222,31 +222,24 @@ test('it rejects a checkpoint with a forged continuation seed, rewinds the chain
   const targetVersion = 2;
   const target = fixture.checkpoints.find((checkpoint) => checkpoint.version === targetVersion);
 
-  expect(target).toBeDefined();
+  invariant(target, 'the fixture always stores a checkpoint at the tampered version');
 
-  const tamperedPayload: Record<string, unknown> = {
-    ...target?.payload,
-    nextSeed: tamperedNextSeed,
-  };
+  const tamperedPayload = { ...target.payload, nextSeed: tamperedNextSeed };
 
-  // oxlint-disable typescript/no-unsafe-type-assertion -- the fixture's payload is a hand-built, schema-shaped object
   const tamperedHash = buildCheckpointHash({
-    chainIndex: tamperedPayload['chainIndex'] as number,
+    chainIndex: tamperedPayload.chainIndex,
     entropySource: 'server-key',
     nextSeed: tamperedNextSeed,
-    prevHash: target?.prevHash ?? '',
-    seed: tamperedPayload['seed'] as string,
-    time: tamperedPayload['time'] as number,
-    type: tamperedPayload['type'] as string,
+    prevHash: target.prevHash,
+    seed: tamperedPayload.seed,
+    time: tamperedPayload.time,
+    type: tamperedPayload.type,
     version: targetVersion,
   });
 
-  // oxlint-enable typescript/no-unsafe-type-assertion
-
   await ctx.db
     .updateTable('activityCheckpoints')
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the column is untyped jsonb; the value is a hand-tampered, schema-shaped payload
-    .set({ hash: tamperedHash, payload: tamperedPayload as Json })
+    .set({ hash: tamperedHash, payload: toJSON(tamperedPayload) })
     .where('activityId', '=', fixture.activity.id)
     .where('version', '=', targetVersion)
     .execute();
@@ -313,28 +306,24 @@ test('it settles no xp and drops the rejected activity from the pending anchor w
   const targetVersion = 1;
   const target = fixture.checkpoints.find((checkpoint) => checkpoint.version === targetVersion);
 
-  expect(target).toBeDefined();
+  invariant(target, 'the fixture always stores a checkpoint at the tampered version');
 
-  const tamperedPayload: Record<string, unknown> = { ...target?.payload, chainIndex: 999 };
+  const tamperedPayload = { ...target.payload, chainIndex: 999 };
 
-  // oxlint-disable typescript/no-unsafe-type-assertion -- the fixture's payload is a hand-built, schema-shaped object
   const tamperedHash = buildCheckpointHash({
     chainIndex: 999,
     entropySource: 'server-key',
-    nextSeed: tamperedPayload['nextSeed'] as string,
-    prevHash: target?.prevHash ?? '',
-    seed: tamperedPayload['seed'] as string,
-    time: tamperedPayload['time'] as number,
-    type: tamperedPayload['type'] as string,
+    nextSeed: tamperedPayload.nextSeed,
+    prevHash: target.prevHash,
+    seed: tamperedPayload.seed,
+    time: tamperedPayload.time,
+    type: tamperedPayload.type,
     version: targetVersion,
   });
 
-  // oxlint-enable typescript/no-unsafe-type-assertion
-
   await ctx.db
     .updateTable('activityCheckpoints')
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the column is untyped jsonb; the value is a hand-tampered, schema-shaped payload
-    .set({ hash: tamperedHash, payload: tamperedPayload as Json })
+    .set({ hash: tamperedHash, payload: toJSON(tamperedPayload) })
     .where('activityId', '=', fixture.activity.id)
     .where('version', '=', targetVersion)
     .execute();
@@ -393,28 +382,24 @@ test('it rejects a checkpoint with a forged chain position', async () => {
   const targetVersion = 1;
   const target = fixture.checkpoints.find((checkpoint) => checkpoint.version === targetVersion);
 
-  expect(target).toBeDefined();
+  invariant(target, 'the fixture always stores a checkpoint at the tampered version');
 
-  const tamperedPayload: Record<string, unknown> = { ...target?.payload, chainIndex: 999 };
+  const tamperedPayload = { ...target.payload, chainIndex: 999 };
 
-  // oxlint-disable typescript/no-unsafe-type-assertion -- the fixture's payload is a hand-built, schema-shaped object
   const tamperedHash = buildCheckpointHash({
     chainIndex: 999,
     entropySource: 'server-key',
-    nextSeed: tamperedPayload['nextSeed'] as string,
-    prevHash: target?.prevHash ?? '',
-    seed: tamperedPayload['seed'] as string,
-    time: tamperedPayload['time'] as number,
-    type: tamperedPayload['type'] as string,
+    nextSeed: tamperedPayload.nextSeed,
+    prevHash: target.prevHash,
+    seed: tamperedPayload.seed,
+    time: tamperedPayload.time,
+    type: tamperedPayload.type,
     version: targetVersion,
   });
 
-  // oxlint-enable typescript/no-unsafe-type-assertion
-
   await ctx.db
     .updateTable('activityCheckpoints')
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the column is untyped jsonb; the value is a hand-tampered, schema-shaped payload
-    .set({ hash: tamperedHash, payload: tamperedPayload as Json })
+    .set({ hash: tamperedHash, payload: toJSON(tamperedPayload) })
     .where('activityId', '=', fixture.activity.id)
     .where('version', '=', targetVersion)
     .execute();
@@ -445,31 +430,24 @@ test('it rejects a checkpoint claiming the wrong entropy source', async () => {
   const targetVersion = 1;
   const target = fixture.checkpoints.find((checkpoint) => checkpoint.version === targetVersion);
 
-  expect(target).toBeDefined();
+  invariant(target, 'the fixture always stores a checkpoint at the tampered version');
 
-  const tamperedPayload: Record<string, unknown> = {
-    ...target?.payload,
-    entropySource: 'device-key',
-  };
+  const tamperedPayload = { ...target.payload, entropySource: 'device-key' };
 
-  // oxlint-disable typescript/no-unsafe-type-assertion -- the fixture's payload is a hand-built, schema-shaped object
   const tamperedHash = buildCheckpointHash({
-    chainIndex: tamperedPayload['chainIndex'] as number,
+    chainIndex: tamperedPayload.chainIndex,
     entropySource: 'device-key',
-    nextSeed: tamperedPayload['nextSeed'] as string,
-    prevHash: target?.prevHash ?? '',
-    seed: tamperedPayload['seed'] as string,
-    time: tamperedPayload['time'] as number,
-    type: tamperedPayload['type'] as string,
+    nextSeed: tamperedPayload.nextSeed,
+    prevHash: target.prevHash,
+    seed: tamperedPayload.seed,
+    time: tamperedPayload.time,
+    type: tamperedPayload.type,
     version: targetVersion,
   });
 
-  // oxlint-enable typescript/no-unsafe-type-assertion
-
   await ctx.db
     .updateTable('activityCheckpoints')
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the column is untyped jsonb; the value is a hand-tampered, schema-shaped payload
-    .set({ hash: tamperedHash, payload: tamperedPayload as Json })
+    .set({ hash: tamperedHash, payload: toJSON(tamperedPayload) })
     .where('activityId', '=', fixture.activity.id)
     .where('version', '=', targetVersion)
     .execute();
@@ -498,15 +476,13 @@ test('it rejects a checkpoint with a forged reward total', async () => {
   });
 
   const targetVersion = 1;
+  const target = fixture.checkpoints.find((checkpoint) => checkpoint.version === targetVersion);
+
+  invariant(target, 'the fixture always stores a checkpoint at the tampered version');
 
   await ctx.db
     .updateTable('activityCheckpoints')
-    .set({
-      payload: {
-        ...fixture.checkpoints.find((c) => c.version === targetVersion)?.payload,
-        rewards: { xp: 999_999 },
-      } as Json,
-    })
+    .set({ payload: toJSON({ ...target.payload, rewards: { xp: 999_999 } }) })
     .where('activityId', '=', fixture.activity.id)
     .where('version', '=', targetVersion)
     .execute();
@@ -968,18 +944,16 @@ test('it does not reject a divergence that fails to reproduce on the fresh confi
   });
 
   const corruptDriver = createSimulationDriver(corruptInput.activity, corruptInput.avatar);
+  const resumePoint = fixture.checkpoints[firstBatchCount - 1];
 
-  // oxlint-disable typescript/no-unsafe-type-assertion -- the fixture's payload is a hand-built, schema-shaped object
-  await corruptDriver.advanceToDuration(
-    fixture.checkpoints[firstBatchCount - 1]?.payload['time'] as number,
-  );
+  invariant(resumePoint, 'the fixture always stores a checkpoint at the cached head');
 
-  // oxlint-enable typescript/no-unsafe-type-assertion
+  await corruptDriver.advanceToDuration(resumePoint.payload.time);
 
   cache.set(fixture.activity.id, {
     driver: corruptDriver,
     emittedCount: firstBatchCount,
-    lastHash: fixture.checkpoints[firstBatchCount - 1]?.hash ?? '',
+    lastHash: resumePoint.hash,
   });
 
   const deps = {
@@ -1017,11 +991,11 @@ test('a user-stopped activity advances the chain verified anchor from its tail, 
   const tailCount = predecessor.checkpoints.length - 1;
   const tail = predecessor.checkpoints[tailCount - 1];
 
-  expect(tail).toBeDefined();
+  invariant(tail, 'the fixture always stores a checkpoint at the trimmed tail');
 
   await ctx.db
     .updateTable('activities')
-    .set({ appendedHead: tailCount, lastHash: tail?.hash })
+    .set({ appendedHead: tailCount, lastHash: tail.hash })
     .where('id', '=', predecessor.activity.id)
     .execute();
 
@@ -1039,13 +1013,10 @@ test('a user-stopped activity advances the chain verified anchor from its tail, 
 
   expect(predecessorOutcome).toStrictEqual({ kind: 'matched' });
 
-  // oxlint-disable typescript/no-unsafe-type-assertion -- the fixture's payload is a hand-built, schema-shaped object
   const expectedAnchor = {
-    verifiedChainIndex: tail?.payload['chainIndex'] as number,
-    verifiedNextSeed: tail?.payload['nextSeed'] as string,
+    verifiedChainIndex: tail.payload.chainIndex,
+    verifiedNextSeed: tail.payload.nextSeed,
   };
-
-  // oxlint-enable typescript/no-unsafe-type-assertion
 
   const chainAfterPredecessor = await ctx.db
     .selectFrom('activityChains')
@@ -1088,11 +1059,11 @@ test('a capped activity advances the chain verified anchor from its tail, and an
   const tailCount = predecessor.checkpoints.length - 1;
   const tail = predecessor.checkpoints[tailCount - 1];
 
-  expect(tail).toBeDefined();
+  invariant(tail, 'the fixture always stores a checkpoint at the trimmed tail');
 
   await ctx.db
     .updateTable('activities')
-    .set({ appendedHead: tailCount, lastHash: tail?.hash })
+    .set({ appendedHead: tailCount, lastHash: tail.hash })
     .where('id', '=', predecessor.activity.id)
     .execute();
 
@@ -1110,13 +1081,10 @@ test('a capped activity advances the chain verified anchor from its tail, and an
 
   expect(predecessorOutcome).toStrictEqual({ kind: 'matched' });
 
-  // oxlint-disable typescript/no-unsafe-type-assertion -- the fixture's payload is a hand-built, schema-shaped object
   const expectedAnchor = {
-    verifiedChainIndex: tail?.payload['chainIndex'] as number,
-    verifiedNextSeed: tail?.payload['nextSeed'] as string,
+    verifiedChainIndex: tail.payload.chainIndex,
+    verifiedNextSeed: tail.payload.nextSeed,
   };
-
-  // oxlint-enable typescript/no-unsafe-type-assertion
 
   const chainAfterPredecessor = await ctx.db
     .selectFrom('activityChains')
@@ -1163,11 +1131,11 @@ test('a stream fully verified while still active reconciles the anchor once a su
   const tailCount = predecessor.checkpoints.length - 1;
   const tail = predecessor.checkpoints[tailCount - 1];
 
-  expect(tail).toBeDefined();
+  invariant(tail, 'the fixture always stores a checkpoint at the trimmed tail');
 
   await ctx.db
     .updateTable('activities')
-    .set({ appendedHead: tailCount, lastHash: tail?.hash })
+    .set({ appendedHead: tailCount, lastHash: tail.hash })
     .where('id', '=', predecessor.activity.id)
     .execute();
 
@@ -1208,13 +1176,10 @@ test('a stream fully verified while still active reconciles the anchor once a su
     .where('id', '=', predecessor.activity.id)
     .execute();
 
-  // oxlint-disable typescript/no-unsafe-type-assertion -- the fixture's payload is a hand-built, schema-shaped object
   const expectedAnchor = {
-    verifiedChainIndex: tail?.payload['chainIndex'] as number,
-    verifiedNextSeed: tail?.payload['nextSeed'] as string,
+    verifiedChainIndex: tail.payload.chainIndex,
+    verifiedNextSeed: tail.payload.nextSeed,
   };
-
-  // oxlint-enable typescript/no-unsafe-type-assertion
 
   // This reconciled seed's authored encounter resolves to a terminal checkpoint at 66,250ms of
   // simulated time; a 60s duration keeps the successor mid-run so its own match never advances
@@ -1258,7 +1223,7 @@ test('a stopped activity whose only checkpoint is Started leaves the anchor unto
   });
 
   expect(predecessor.checkpoints).toHaveLength(1);
-  expect(predecessor.checkpoints[0]?.payload['type']).toBe('started');
+  expect(predecessor.checkpoints[0]?.payload.type).toBe('started');
 
   const deps = {
     db: ctx.db,

--- a/services/replay/src/worker/update-verified-anchor-from-predecessor.test.ts
+++ b/services/replay/src/worker/update-verified-anchor-from-predecessor.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'bun:test';
 import { buildStateFromSeed } from '@vers/game-utils';
 import { createTestDB } from '@vers/service-test-utils/bun';
+import invariant from 'tiny-invariant';
 import { createHonestActivityFixture } from '../test-utils/create-honest-activity-fixture';
 import { createMockReplaySegment } from '../test-utils/factories/create-mock-replay-segment';
 import { updateVerifiedAnchorFromPredecessor } from './update-verified-anchor-from-predecessor';
@@ -30,15 +31,14 @@ test('it advances the chain verified anchor from a fully verified, stopped prede
 
   const tail = fixture.checkpoints[tailCount - 1];
 
-  expect(tail).toBeDefined();
+  invariant(tail, 'the fixture always stores a checkpoint at the trimmed tail');
 
   const segment = createMockReplaySegment({
     activity: {
       avatarID: fixture.activity.avatarId,
       scopeID: fixture.activity.scopeId,
       scopeType: fixture.activity.scopeType,
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the fixture's payload is a hand-built, schema-shaped object
-      startChainIndex: tail?.payload['chainIndex'] as number,
+      startChainIndex: tail.payload.chainIndex,
     },
     chain: {
       genesisSeed: fixture.chain.genesisSeed,
@@ -49,10 +49,9 @@ test('it advances the chain verified anchor from a fully verified, stopped prede
 
   const advance = await updateVerifiedAnchorFromPredecessor(ctx.db, segment);
 
-  // oxlint-disable typescript/no-unsafe-type-assertion -- the fixture's payload is a hand-built, schema-shaped object
   expect(advance).toStrictEqual({
-    chainIndex: tail?.payload['chainIndex'] as number,
-    nextSeed: tail?.payload['nextSeed'] as string,
+    chainIndex: tail.payload.chainIndex,
+    nextSeed: tail.payload.nextSeed,
   });
 
   const chain = await ctx.db
@@ -63,11 +62,9 @@ test('it advances the chain verified anchor from a fully verified, stopped prede
     .executeTakeFirstOrThrow();
 
   expect(chain).toStrictEqual({
-    verifiedChainIndex: tail?.payload['chainIndex'] as number,
-    verifiedNextSeed: tail?.payload['nextSeed'] as string,
+    verifiedChainIndex: tail.payload.chainIndex,
+    verifiedNextSeed: tail.payload.nextSeed,
   });
-
-  // oxlint-enable typescript/no-unsafe-type-assertion
 });
 
 test('it leaves the chain untouched when the frontier is not ahead of the verified anchor', async () => {

--- a/services/session/src/handlers/to-pending-transaction-data.ts
+++ b/services/session/src/handlers/to-pending-transaction-data.ts
@@ -1,17 +1,18 @@
-import type { PendingTransactionData, SecureAction } from '@vers/contract-session';
+import type { PendingTransactionData } from '@vers/contract-session';
+import { SecureActionSchema } from '@vers/contract-session';
 import type { PendingTransactions } from '@vers/db';
 import type { Selectable } from 'kysely';
 
 /**
  * Maps a kysely `pending_transactions` row onto the contract's `PendingTransactionData` shape,
- * stripping the row's own timestamps.
+ * stripping the row's own timestamps. `action` is an untyped text column and re-enters typed code
+ * through its contract schema, so a drifted row fails here loudly instead of flowing on.
  */
 export function toPendingTransactionData(
   row: Readonly<Selectable<PendingTransactions>>,
 ): PendingTransactionData {
   return {
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the column is untyped text; every write is SecureActionSchema-validated contract input
-    action: row.action as SecureAction,
+    action: SecureActionSchema.parse(row.action),
     attempts: row.attempts,
     expiresAt: row.expiresAt,
     id: row.id,


### PR DESCRIPTION
## Description

Closes #852

Untyped jsonb/text column boundaries now re-enter typed code by contract-schema parse or by threading the value its author already holds typed, retiring every per-site `no-unsafe-type-assertion` directive at those boundaries.

- Reads parse: segment loader, pinned advance context, activity/checkpoint/pending-transaction mappers, reward affixes, scope-ref — a malformed row fails loudly at the read.
- Writes go through one documented `toJSON` converter in `@vers/db`, the sole remaining assertion.
- `RewardItemAffixSchema` is exported from `@vers/contract-activity` instead of a hand-written shape.
- Honest-fixture checkpoint rows carry `CheckpointPayload`, so replay tests assert on authored typed payloads with no re-shaping.
- `createMockActivity` accepts a typed `encounterNode` override.
- Convention added to `agents/project.md`; AGENTS.md regenerated.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality