### PR TITLE
feat(#844): sweep stranded machines before a bluegreen cutover

### DIFF
--- a/docs/architecture/platform/deployment.md
+++ b/docs/architecture/platform/deployment.md
@@ -206,6 +206,21 @@ later deploy with "found multiple image versions".
 A rollout can fail on transient `syd` host-capacity refusals ("could not reserve resource"); Fly
 rolls back cleanly, so re-run the failed job.
 
+### Stranded-machine sweep
+
+A deploy or cutover leg reads the fleet before running flyctl and groups its machines by image. A
+single group is clean. Multiple groups mean a prior rollout left machines stranded on a second
+image, and the leg sweeps them: it picks the group to keep, destroys every machine outside it, then
+proceeds — so flyctl's own preflight never hits "found multiple image versions".
+
+The kept group is the one whose machines all carry the app's recorded release git SHA. When no group
+matches that SHA, the kept group falls back to the single image group holding a started machine
+whose health checks all pass. A started machine outside the kept group is never a destroy target:
+the leg fails instead, printing the fleet's machine table (id, state, image, git SHA) so an operator
+can resolve it by hand. `deploy verify` reports a mixed-image fleet as its own finding — each image
+with its machine count — in place of the generic finding that no trustworthy SHA is recorded, and
+never sweeps; the fleet is left exactly as found.
+
 ### Pinned upstream images
 
 `vers-bugsink` and `vers-umami` ship pinned upstream images. Neither sits in the turbo task graph,

--- a/docs/architecture/platform/deployment.md
+++ b/docs/architecture/platform/deployment.md
@@ -217,9 +217,11 @@ The kept group is the one whose machines all carry the app's recorded release gi
 matches that SHA, the kept group falls back to the single image group holding a started machine
 whose health checks all pass. A started machine outside the kept group is never a destroy target:
 the leg fails instead, printing the fleet's machine table (id, state, image, git SHA) so an operator
-can resolve it by hand. `deploy verify` reports a mixed-image fleet as its own finding — each image
-with its machine count — in place of the generic finding that no trustworthy SHA is recorded, and
-never sweeps; the fleet is left exactly as found.
+can resolve it by hand. A machine whose image flyctl did not report is never itself a group to keep
+or destroy: once a second image group exists, it fails the leg the same way, naming the machine so
+an operator can resolve it by hand. `deploy verify` reports a mixed-image fleet as its own finding —
+each image with its machine count — in place of the generic finding that no trustworthy SHA is
+recorded, and never sweeps; the fleet is left exactly as found.
 
 ### Pinned upstream images
 

--- a/docs/architecture/platform/deployment.md
+++ b/docs/architecture/platform/deployment.md
@@ -217,11 +217,11 @@ The kept group is the one whose machines all carry the app's recorded release gi
 matches that SHA, the kept group falls back to the single image group holding a started machine
 whose health checks all pass. A started machine outside the kept group is never a destroy target:
 the leg fails instead, printing the fleet's machine table (id, state, image, git SHA) so an operator
-can resolve it by hand. A machine whose image flyctl did not report is never itself a group to keep
-or destroy: once a second image group exists, it fails the leg the same way, naming the machine so
-an operator can resolve it by hand. `deploy verify` reports a mixed-image fleet as its own finding —
-each image with its machine count — in place of the generic finding that no trustworthy SHA is
-recorded, and never sweeps; the fleet is left exactly as found.
+can resolve it by hand — as is a machine whose image flyctl did not report, which is never itself a
+group to keep or destroy and fails the leg the same way, named in the table, once a second image
+group exists. `deploy verify` reports a mixed-image fleet as its own finding — each image with its
+machine count — in place of the generic finding that no trustworthy SHA is recorded, names any
+machine reporting no image, and never sweeps; the fleet is left exactly as found.
 
 ### Pinned upstream images
 

--- a/scripts/src/bin/deploy.ts
+++ b/scripts/src/bin/deploy.ts
@@ -9,6 +9,7 @@ import type { Kysely } from 'kysely';
 import { applyBuild } from '../deploy/apply-build';
 import { applyDeploy } from '../deploy/apply-deploy';
 import { applyIPPostureActions } from '../deploy/apply-ip-posture-actions';
+import { applyMachineSweepActions } from '../deploy/apply-machine-sweep-actions';
 import { applyRetentionActions } from '../deploy/apply-retention-actions';
 import { applyScheduledMachineActions } from '../deploy/apply-scheduled-machine-actions';
 import { applySimVersionActions } from '../deploy/apply-sim-version-actions';
@@ -17,9 +18,11 @@ import { buildProviderAppName } from '../deploy/build-provider-app-name';
 import { checkParkedApp } from '../deploy/check-parked-app';
 import { checkTarget } from '../deploy/check-target';
 import { findStaleReason } from '../deploy/find-stale-reason';
+import { formatMachineTable } from '../deploy/format-machine-table';
 import { loadDeployManifest } from '../deploy/load-deploy-manifest';
 import { PINNED_BUN_VERSION, loadEngineHash } from '../deploy/load-engine-hash';
 import { planIPPosture } from '../deploy/plan-ip-posture';
+import { planMachineSweep } from '../deploy/plan-machine-sweep';
 import { planRetentionActions } from '../deploy/plan-retention-actions';
 import { planScheduledMachineActions } from '../deploy/plan-scheduled-machine-actions';
 import { planSimVersionActions } from '../deploy/plan-sim-version-actions';
@@ -301,10 +304,13 @@ async function withReleaseDB(run: (db: Kysely<DB>) => Promise<void>): Promise<vo
 
 /**
  * One rollout from an already-built image (null for targets that deploy their fly.toml stock
- * image): ensure the target's IP posture, cut the fleet over, reconcile, probe. Probes
- * passing records the release as the app's next rollback target; probes failing rolls the fleet
- * back to the previous recorded release and leaves the run red either way, so the failure ships
- * forward on a later push instead of a broken release serving meanwhile.
+ * image): sweep any machines stranded on a second image by an aborted rollout, ensure the target's
+ * IP posture, cut the fleet over, reconcile, probe. Probes passing records the release as the app's
+ * next rollback target; probes failing rolls the fleet back to the previous recorded release and
+ * leaves the run red either way, so the failure ships forward on a later push instead of a broken
+ * release serving meanwhile. A sweep the planner can't resolve unambiguously fails the leg before
+ * flyctl ever runs, rather than let its own "found multiple image versions" preflight fail it with
+ * no path to recovery but a manual machine destroy.
  */
 async function runRollout(
   db: Kysely<DB>,
@@ -313,6 +319,23 @@ async function runRollout(
   image: string | null,
 ): Promise<void> {
   const previous = await findLatestRelease(db, target.app);
+  const fleet = await readAppState(target.app);
+
+  const recordedRelease = previous === undefined ? null : { gitSHA: previous.gitSha };
+  const sweepPlan = planMachineSweep(fleet.machines, recordedRelease);
+
+  if (sweepPlan.kind === 'ambiguous') {
+    console.error(`✗ ${target.app} — ${sweepPlan.reason}`);
+    console.error(formatMachineTable(fleet.machines));
+
+    process.exitCode = 1;
+
+    return;
+  }
+
+  if (sweepPlan.kind === 'sweep') {
+    await applyMachineSweepActions(target.app, sweepPlan.machines);
+  }
 
   await runIPPostureReconcile(target);
   await applyDeploy(target, sha, image);

--- a/scripts/src/deploy/apply-machine-sweep-actions.ts
+++ b/scripts/src/deploy/apply-machine-sweep-actions.ts
@@ -1,0 +1,17 @@
+import { runFlyctl } from '../utils/run-flyctl';
+import type { MachineSweepTarget } from './plan-machine-sweep';
+
+/**
+ * Destroys each stranded machine the planner found outside the fleet's kept image group,
+ * sequentially, logging each one before the destroy so the sweep's output shows what it acted on.
+ */
+export async function applyMachineSweepActions(
+  app: string,
+  machines: ReadonlyArray<MachineSweepTarget>,
+): Promise<void> {
+  for (const machine of machines) {
+    console.log(`sweeping stranded machine ${machine.id} (${machine.image ?? '-'})`);
+
+    await runFlyctl(['machine', 'destroy', '--force', machine.id, '-a', app]);
+  }
+}

--- a/scripts/src/deploy/apply-machine-sweep-actions.ts
+++ b/scripts/src/deploy/apply-machine-sweep-actions.ts
@@ -1,5 +1,5 @@
 import { runFlyctl } from '../utils/run-flyctl';
-import type { MachineSweepTarget } from './plan-machine-sweep';
+import type { MachineSweepTarget } from './types';
 
 /**
  * Destroys each stranded machine the planner found outside the fleet's kept image group,

--- a/scripts/src/deploy/check-target.test.ts
+++ b/scripts/src/deploy/check-target.test.ts
@@ -193,6 +193,8 @@ test('it flags a mixed-image fleet with the images and their machine counts, not
   const state = {
     deployedSHA: null,
     machines: [
+      { gitSHA: 'shaOLD', id: 'm2', image: 'registry.fly.io/x:old', state: 'suspended' },
+      { gitSHA: 'shaOLD', id: 'm3', image: 'registry.fly.io/x:old', state: 'suspended' },
       {
         checks: [{ name: 'servicecheck-00-http-3000', status: 'passing' }],
         gitSHA: 'shaNEW',
@@ -200,14 +202,30 @@ test('it flags a mixed-image fleet with the images and their machine counts, not
         image: 'registry.fly.io/x:new',
         state: 'started',
       },
-      { gitSHA: 'shaOLD', id: 'm2', image: 'registry.fly.io/x:old', state: 'suspended' },
     ],
     scheduledMachines: [],
     serviceImage: null,
   };
 
   expect(checkTarget(target, state, null)).toStrictEqual([
-    'fleet splits across 2 images: registry.fly.io/x:new (1 machine), registry.fly.io/x:old (1 machine)',
+    'fleet splits across 2 images: registry.fly.io/x:new (1 machine), registry.fly.io/x:old (2 machines)',
+  ]);
+});
+
+test('it flags a machine flyctl reported no image for beside its single-image peers', () => {
+  const state = {
+    deployedSHA: null,
+    machines: [
+      { gitSHA: 'abc123', id: 'm1', image: 'registry.fly.io/x:tag1', state: 'started' },
+      { gitSHA: null, id: 'm2', image: null, state: 'suspended' },
+    ],
+    scheduledMachines: [],
+    serviceImage: null,
+  };
+
+  expect(checkTarget(target, state, null)).toStrictEqual([
+    'machine(s) m2 report no image — flyctl did not read an image for them',
+    'stale: no trustworthy deployed SHA recorded on the fleet',
   ]);
 });
 

--- a/scripts/src/deploy/check-target.test.ts
+++ b/scripts/src/deploy/check-target.test.ts
@@ -18,7 +18,7 @@ test('it flags an app with no machines', () => {
 test('it passes a current app with a suspended machine', () => {
   const state = {
     deployedSHA: 'abc123',
-    machines: [{ gitSHA: 'abc123', id: 'm1', state: 'suspended' }],
+    machines: [{ gitSHA: 'abc123', id: 'm1', image: 'registry.fly.io/x:tag1', state: 'suspended' }],
     scheduledMachines: [],
     serviceImage: 'registry.fly.io/x:tag1',
   };
@@ -33,7 +33,7 @@ test('it flags an app below its warm-machine floor', () => {
 
   const state = {
     deployedSHA: 'abc123',
-    machines: [{ gitSHA: 'abc123', id: 'm1', state: 'suspended' }],
+    machines: [{ gitSHA: 'abc123', id: 'm1', image: 'registry.fly.io/x:tag1', state: 'suspended' }],
     scheduledMachines: [],
     serviceImage: 'registry.fly.io/x:tag1',
   };
@@ -53,6 +53,7 @@ test('it flags a started machine with a non-passing health check', () => {
         checks: [{ name: 'servicecheck-00-http-3000', status: 'critical' }],
         gitSHA: 'abc123',
         id: 'm1',
+        image: 'registry.fly.io/x:tag1',
         state: 'started',
       },
     ],
@@ -75,6 +76,7 @@ test('it passes a started machine whose health checks pass', () => {
         checks: [{ name: 'servicecheck-00-http-3000', status: 'passing' }],
         gitSHA: 'abc123',
         id: 'm1',
+        image: 'registry.fly.io/x:tag1',
         state: 'started',
       },
     ],
@@ -95,6 +97,7 @@ test('it ignores the checks of a machine parked in its idle state', () => {
         checks: [{ name: 'servicecheck-00-http-3000', status: 'warning' }],
         gitSHA: 'abc123',
         id: 'm1',
+        image: 'registry.fly.io/x:tag1',
         state: 'suspended',
       },
     ],
@@ -110,7 +113,7 @@ test('it ignores the checks of a machine parked in its idle state', () => {
 test('it flags a stale app whose package changed since the deployed SHA', () => {
   const state = {
     deployedSHA: 'abc123',
-    machines: [{ gitSHA: 'abc123', id: 'm1', state: 'started' }],
+    machines: [{ gitSHA: 'abc123', id: 'm1', image: 'registry.fly.io/x:tag1', state: 'started' }],
     scheduledMachines: [],
     serviceImage: 'registry.fly.io/x:tag1',
   };
@@ -133,7 +136,7 @@ const emailTarget: DeployTarget = { ...target, scheduledMachines: [emailSweeper]
 test('it flags a declared scheduled machine that does not exist', () => {
   const state = {
     deployedSHA: 'abc123',
-    machines: [{ gitSHA: 'abc123', id: 'm1', state: 'started' }],
+    machines: [{ gitSHA: 'abc123', id: 'm1', image: 'registry.fly.io/x:tag1', state: 'started' }],
     scheduledMachines: [],
     serviceImage: 'registry.fly.io/x:tag1',
   };
@@ -148,7 +151,7 @@ test('it flags a declared scheduled machine that does not exist', () => {
 test('it flags a declared scheduled machine on a different image than the service machines', () => {
   const state = {
     deployedSHA: 'abc123',
-    machines: [{ gitSHA: 'abc123', id: 'm1', state: 'started' }],
+    machines: [{ gitSHA: 'abc123', id: 'm1', image: 'registry.fly.io/x:tag1', state: 'started' }],
     scheduledMachines: [{ id: 'm2', image: 'registry.fly.io/x:old', name: 'email-sweeper' }],
     serviceImage: 'registry.fly.io/x:tag1',
   };
@@ -163,7 +166,7 @@ test('it flags a declared scheduled machine on a different image than the servic
 test('it passes a declared scheduled machine already on the service image', () => {
   const state = {
     deployedSHA: 'abc123',
-    machines: [{ gitSHA: 'abc123', id: 'm1', state: 'started' }],
+    machines: [{ gitSHA: 'abc123', id: 'm1', image: 'registry.fly.io/x:tag1', state: 'started' }],
     scheduledMachines: [{ id: 'm2', image: 'registry.fly.io/x:tag1', name: 'email-sweeper' }],
     serviceImage: 'registry.fly.io/x:tag1',
   };
@@ -176,7 +179,7 @@ test('it passes a declared scheduled machine already on the service image', () =
 test('it leaves an app with no scheduled-machine declarations untouched', () => {
   const state = {
     deployedSHA: 'abc123',
-    machines: [{ gitSHA: 'abc123', id: 'm1', state: 'started' }],
+    machines: [{ gitSHA: 'abc123', id: 'm1', image: 'registry.fly.io/x:tag1', state: 'started' }],
     scheduledMachines: [{ id: 'm2', image: 'registry.fly.io/x:old', name: 'some-other-machine' }],
     serviceImage: 'registry.fly.io/x:tag1',
   };
@@ -184,4 +187,42 @@ test('it leaves an app with no scheduled-machine declarations untouched', () => 
   const changes = { affectedPkgs: [], changedPaths: [] };
 
   expect(checkTarget(target, state, changes)).toBeEmpty();
+});
+
+test('it flags a mixed-image fleet with the images and their machine counts, not the vague stale reason', () => {
+  const state = {
+    deployedSHA: null,
+    machines: [
+      {
+        checks: [{ name: 'servicecheck-00-http-3000', status: 'passing' }],
+        gitSHA: 'shaNEW',
+        id: 'm1',
+        image: 'registry.fly.io/x:new',
+        state: 'started',
+      },
+      { gitSHA: 'shaOLD', id: 'm2', image: 'registry.fly.io/x:old', state: 'suspended' },
+    ],
+    scheduledMachines: [],
+    serviceImage: null,
+  };
+
+  expect(checkTarget(target, state, null)).toStrictEqual([
+    'fleet splits across 2 images: registry.fly.io/x:new (1 machine), registry.fly.io/x:old (1 machine)',
+  ]);
+});
+
+test('it still flags no trustworthy deployed SHA on a single-image fleet', () => {
+  const state = {
+    deployedSHA: null,
+    machines: [
+      { gitSHA: 'shaA', id: 'm1', image: 'registry.fly.io/x:tag1', state: 'started' },
+      { gitSHA: 'shaB', id: 'm2', image: 'registry.fly.io/x:tag1', state: 'started' },
+    ],
+    scheduledMachines: [],
+    serviceImage: 'registry.fly.io/x:tag1',
+  };
+
+  expect(checkTarget(target, state, null)).toStrictEqual([
+    'stale: no trustworthy deployed SHA recorded on the fleet',
+  ]);
 });

--- a/scripts/src/deploy/check-target.ts
+++ b/scripts/src/deploy/check-target.ts
@@ -1,4 +1,4 @@
-import { findStaleReason } from './find-stale-reason';
+import { NO_TRUSTWORTHY_SHA_REASON, findStaleReason } from './find-stale-reason';
 import type { AppState, ChangeSet, DeployTarget } from './types';
 
 /**
@@ -34,6 +34,12 @@ export function checkTarget(
 
   if (mixedImageFinding !== null) {
     findings.push(mixedImageFinding);
+  }
+
+  const unreportedImageFinding = findUnreportedImageFinding(state);
+
+  if (unreportedImageFinding !== null) {
+    findings.push(unreportedImageFinding);
   }
 
   const staleReason = state.machines.length === 0 ? null : findStaleReason(target, changes);
@@ -80,14 +86,31 @@ function findMixedImageFinding(state: AppState): string | null {
     return null;
   }
 
-  const parts = [...counts.entries()]
-    .toSorted(([imageA], [imageB]) => imageA.localeCompare(imageB))
-    .map(([image, count]) => `${image} (${count} machine${count === 1 ? '' : 's'})`);
+  // default string sort — code-unit order keeps the finding text identical across locales
+  const parts = [...counts.keys()].toSorted().map((image) => {
+    const count = counts.get(image) ?? 0;
+
+    return `${image} (${count} machine${count === 1 ? '' : 's'})`;
+  });
 
   return `fleet splits across ${counts.size} images: ${parts.join(', ')}`;
 }
 
-const NO_TRUSTWORTHY_SHA_REASON = 'no trustworthy deployed SHA recorded on the fleet';
+/**
+ * A machine whose image flyctl did not report keeps the rollout planner from trusting the fleet's
+ * image groups, so verify names those machines rather than passing the fleet as single-image.
+ */
+function findUnreportedImageFinding(state: AppState): string | null {
+  const unreported = state.machines.filter((machine) => machine.image === null);
+
+  if (unreported.length === 0 || state.machines.length === unreported.length) {
+    return null;
+  }
+
+  const ids = unreported.map((machine) => machine.id).join(', ');
+
+  return `machine(s) ${ids} report no image — flyctl did not read an image for them`;
+}
 
 /**
  * A mixed-image fleet already explains why no single deployed SHA is trustworthy — reporting both

--- a/scripts/src/deploy/check-target.ts
+++ b/scripts/src/deploy/check-target.ts
@@ -30,9 +30,15 @@ export function checkTarget(
 
   findings.push(...checkMachineHealth(state));
 
+  const mixedImageFinding = findMixedImageFinding(state);
+
+  if (mixedImageFinding !== null) {
+    findings.push(mixedImageFinding);
+  }
+
   const staleReason = state.machines.length === 0 ? null : findStaleReason(target, changes);
 
-  if (staleReason !== null) {
+  if (staleReason !== null && !isSuppressedByMixedImages(staleReason, mixedImageFinding)) {
     findings.push(`stale: ${staleReason}`);
   }
 
@@ -57,6 +63,38 @@ function checkMachineHealth(state: AppState): ReadonlyArray<string> {
   }
 
   return findings;
+}
+
+function findMixedImageFinding(state: AppState): string | null {
+  const counts = new Map<string, number>();
+
+  for (const machine of state.machines) {
+    if (machine.image === null) {
+      continue;
+    }
+
+    counts.set(machine.image, (counts.get(machine.image) ?? 0) + 1);
+  }
+
+  if (counts.size <= 1) {
+    return null;
+  }
+
+  const parts = [...counts.entries()]
+    .toSorted(([imageA], [imageB]) => imageA.localeCompare(imageB))
+    .map(([image, count]) => `${image} (${count} machine${count === 1 ? '' : 's'})`);
+
+  return `fleet splits across ${counts.size} images: ${parts.join(', ')}`;
+}
+
+const NO_TRUSTWORTHY_SHA_REASON = 'no trustworthy deployed SHA recorded on the fleet';
+
+/**
+ * A mixed-image fleet already explains why no single deployed SHA is trustworthy — reporting both
+ * findings would restate the same cause as two symptoms.
+ */
+function isSuppressedByMixedImages(staleReason: string, mixedImageFinding: string | null): boolean {
+  return mixedImageFinding !== null && staleReason === NO_TRUSTWORTHY_SHA_REASON;
 }
 
 function checkScheduledMachines(target: DeployTarget, state: AppState): ReadonlyArray<string> {

--- a/scripts/src/deploy/find-stale-reason.ts
+++ b/scripts/src/deploy/find-stale-reason.ts
@@ -1,6 +1,13 @@
 import type { ChangeSet, DeployTarget } from './types';
 
 /**
+ * The reason reported for a fleet whose machines don't agree on a single deployed SHA — exported
+ * so callers that know the more specific cause can suppress this generic one by identity rather
+ * than by matching message text.
+ */
+export const NO_TRUSTWORTHY_SHA_REASON = 'no trustworthy deployed SHA recorded on the fleet';
+
+/**
  * Decides whether a target's deployed state is behind HEAD, returning the
  * human-readable reason or null when it's current. A null change set (no
  * recorded deploy SHA, or one this repo doesn't contain) is always stale:
@@ -8,7 +15,7 @@ import type { ChangeSet, DeployTarget } from './types';
  */
 export function findStaleReason(target: DeployTarget, changes: ChangeSet | null): string | null {
   if (changes === null) {
-    return 'no trustworthy deployed SHA recorded on the fleet';
+    return NO_TRUSTWORTHY_SHA_REASON;
   }
 
   if (target.trigger.kind === 'turbo-affected') {

--- a/scripts/src/deploy/format-machine-table.test.ts
+++ b/scripts/src/deploy/format-machine-table.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from 'bun:test';
+import { formatMachineTable } from './format-machine-table';
+
+test('it renders one column-aligned line per machine', () => {
+  const machines = [
+    { checks: [], gitSHA: 'abc123', id: 'm1', image: 'registry.fly.io/x:tag1', state: 'started' },
+    { checks: [], gitSHA: null, id: 'machine-2', image: null, state: 'suspended' },
+  ];
+
+  expect(formatMachineTable(machines)).toBe(
+    [
+      'm1         started    registry.fly.io/x:tag1  abc123',
+      'machine-2  suspended  -                       -',
+    ].join('\n'),
+  );
+});
+
+test('it renders an empty string for an empty fleet', () => {
+  expect(formatMachineTable([])).toBe('');
+});

--- a/scripts/src/deploy/format-machine-table.ts
+++ b/scripts/src/deploy/format-machine-table.ts
@@ -1,0 +1,25 @@
+import type { AppMachine } from './types';
+
+/**
+ * Renders one column-aligned line per machine — id, state, image, git SHA — for an operator reading
+ * a sweep-ambiguity failure. A missing image or git SHA prints as `-`.
+ */
+export function formatMachineTable(machines: ReadonlyArray<AppMachine>): string {
+  const rows = machines.map((machine) => ({
+    gitSHA: machine.gitSHA ?? '-',
+    id: machine.id,
+    image: machine.image ?? '-',
+    state: machine.state,
+  }));
+
+  const idWidth = Math.max(0, ...rows.map((row) => row.id.length));
+  const stateWidth = Math.max(0, ...rows.map((row) => row.state.length));
+  const imageWidth = Math.max(0, ...rows.map((row) => row.image.length));
+
+  return rows
+    .map(
+      (row) =>
+        `${row.id.padEnd(idWidth)}  ${row.state.padEnd(stateWidth)}  ${row.image.padEnd(imageWidth)}  ${row.gitSHA}`,
+    )
+    .join('\n');
+}

--- a/scripts/src/deploy/parse-app-state.test.ts
+++ b/scripts/src/deploy/parse-app-state.test.ts
@@ -20,8 +20,20 @@ test('it reads the deployed SHA and image the whole fleet agrees on', () => {
   expect(parseAppState(json)).toStrictEqual({
     deployedSHA: 'abc123',
     machines: [
-      { checks: [], gitSHA: 'abc123', id: 'm1', state: 'started' },
-      { checks: [], gitSHA: 'abc123', id: 'm2', state: 'suspended' },
+      {
+        checks: [],
+        gitSHA: 'abc123',
+        id: 'm1',
+        image: 'registry.fly.io/x:tag1',
+        state: 'started',
+      },
+      {
+        checks: [],
+        gitSHA: 'abc123',
+        id: 'm2',
+        image: 'registry.fly.io/x:tag1',
+        state: 'suspended',
+      },
     ],
     scheduledMachines: [],
     serviceImage: 'registry.fly.io/x:tag1',
@@ -50,6 +62,7 @@ test('it carries each machine health check through as name and status', () => {
       ],
       gitSHA: 'abc123',
       id: 'm1',
+      image: null,
       state: 'started',
     },
   ]);
@@ -79,6 +92,18 @@ test('it treats a fleet with mixed images as having no service image', () => {
   expect(parseAppState(json).serviceImage).toBeNull();
 });
 
+test('it carries each machine own image through even when the fleet as a whole disagrees', () => {
+  const json = [
+    { config: { image: 'registry.fly.io/x:tag1' }, id: 'm1', name: 'm1', state: 'started' },
+    { config: { image: 'registry.fly.io/x:tag2' }, id: 'm2', name: 'm2', state: 'started' },
+  ];
+
+  expect(parseAppState(json).machines).toStrictEqual([
+    { checks: [], gitSHA: null, id: 'm1', image: 'registry.fly.io/x:tag1', state: 'started' },
+    { checks: [], gitSHA: null, id: 'm2', image: 'registry.fly.io/x:tag2', state: 'started' },
+  ]);
+});
+
 test('it ignores machines outside the app process group', () => {
   const json = [
     { config: { env: { GIT_SHA: 'abc123' } }, id: 'm1', name: 'm1', state: 'started' },
@@ -92,7 +117,7 @@ test('it ignores machines outside the app process group', () => {
 
   expect(parseAppState(json)).toStrictEqual({
     deployedSHA: 'abc123',
-    machines: [{ checks: [], gitSHA: 'abc123', id: 'm1', state: 'started' }],
+    machines: [{ checks: [], gitSHA: 'abc123', id: 'm1', image: null, state: 'started' }],
     scheduledMachines: [],
     serviceImage: null,
   });
@@ -116,7 +141,15 @@ test('it separates a scheduled machine from the app process group by its schedul
 
   expect(parseAppState(json)).toStrictEqual({
     deployedSHA: 'abc123',
-    machines: [{ checks: [], gitSHA: 'abc123', id: 'm1', state: 'started' }],
+    machines: [
+      {
+        checks: [],
+        gitSHA: 'abc123',
+        id: 'm1',
+        image: 'registry.fly.io/x:tag1',
+        state: 'started',
+      },
+    ],
     scheduledMachines: [{ id: 'm2', image: 'registry.fly.io/x:old', name: 'sweeper' }],
     serviceImage: 'registry.fly.io/x:tag1',
   });
@@ -143,7 +176,15 @@ test('it reads images with the resolved digest stripped', () => {
 
   expect(parseAppState(json)).toStrictEqual({
     deployedSHA: 'abc123',
-    machines: [{ checks: [], gitSHA: 'abc123', id: 'm1', state: 'started' }],
+    machines: [
+      {
+        checks: [],
+        gitSHA: 'abc123',
+        id: 'm1',
+        image: 'registry.fly.io/x:tag1',
+        state: 'started',
+      },
+    ],
     scheduledMachines: [{ id: 'm2', image: 'registry.fly.io/x:tag1', name: 'sweeper' }],
     serviceImage: 'registry.fly.io/x:tag1',
   });

--- a/scripts/src/deploy/parse-app-state.ts
+++ b/scripts/src/deploy/parse-app-state.ts
@@ -51,6 +51,7 @@ export function parseAppState(json: unknown): AppState {
     id: machine.id,
     state: machine.state,
     gitSHA: machine.config?.env?.['GIT_SHA'] ?? null,
+    image: normalizeImage(machine.config?.image),
     checks: machine.checks ?? [],
   }));
 

--- a/scripts/src/deploy/plan-machine-sweep.test.ts
+++ b/scripts/src/deploy/plan-machine-sweep.test.ts
@@ -129,6 +129,30 @@ test('it reports ambiguous when a started machine sits outside the chosen keep g
   });
 });
 
+test('it reports ambiguous when a machine has no reported image alongside a real image group', () => {
+  const machines = [
+    { checks: [], gitSHA: 'sha1', id: 'm1', image: 'img-a', state: 'started' },
+    { checks: [], gitSHA: null, id: 'm2', image: null, state: 'started' },
+  ];
+
+  const plan = planMachineSweep(machines, null);
+
+  expect(plan).toStrictEqual({
+    kind: 'ambiguous',
+    reason:
+      "machine(s) m2 report no image — flyctl did not read an image for them, so the fleet's image groups cannot be trusted",
+  });
+});
+
+test('it treats a fleet where every machine has no reported image as clean', () => {
+  const machines = [
+    { checks: [], gitSHA: null, id: 'm1', image: null, state: 'started' },
+    { checks: [], gitSHA: null, id: 'm2', image: null, state: 'suspended' },
+  ];
+
+  expect(planMachineSweep(machines, null)).toStrictEqual({ kind: 'clean' });
+});
+
 test('it never counts a started machine with no checks as healthy for the fallback', () => {
   const machines = [
     { checks: [], gitSHA: 'shaA', id: 'm1', image: 'img-a', state: 'started' },

--- a/scripts/src/deploy/plan-machine-sweep.test.ts
+++ b/scripts/src/deploy/plan-machine-sweep.test.ts
@@ -1,0 +1,144 @@
+import { expect, test } from 'bun:test';
+import { planMachineSweep } from './plan-machine-sweep';
+
+test('it treats a fleet on a single image as clean', () => {
+  const machines = [
+    { checks: [], gitSHA: 'sha1', id: 'm1', image: 'img1', state: 'started' },
+    { checks: [], gitSHA: 'sha1', id: 'm2', image: 'img1', state: 'suspended' },
+  ];
+
+  expect(planMachineSweep(machines, null)).toStrictEqual({ kind: 'clean' });
+});
+
+test('it treats an empty fleet as clean', () => {
+  expect(planMachineSweep([], null)).toStrictEqual({ kind: 'clean' });
+});
+
+test('it keeps the image group matching the recorded release and sweeps the rest', () => {
+  const machines = [
+    {
+      checks: [{ name: 'http', status: 'passing' }],
+      gitSHA: 'shaNEW',
+      id: 'm1',
+      image: 'img-new',
+      state: 'started',
+    },
+    { checks: [], gitSHA: 'shaOLD', id: 'm2', image: 'img-old', state: 'suspended' },
+  ];
+
+  expect(planMachineSweep(machines, { gitSHA: 'shaNEW' })).toStrictEqual({
+    kind: 'sweep',
+    machines: [{ id: 'm2', image: 'img-old' }],
+  });
+});
+
+test('it falls back to the healthy started group when the recorded SHA matches no group', () => {
+  const machines = [
+    {
+      checks: [{ name: 'http', status: 'passing' }],
+      gitSHA: 'shaOLD',
+      id: 'm1',
+      image: 'img-a',
+      state: 'started',
+    },
+    { checks: [], gitSHA: 'shaOLD2', id: 'm2', image: 'img-b', state: 'suspended' },
+  ];
+
+  expect(planMachineSweep(machines, { gitSHA: 'shaNEW' })).toStrictEqual({
+    kind: 'sweep',
+    machines: [{ id: 'm2', image: 'img-b' }],
+  });
+});
+
+test('it keeps the single healthy started group when no release is recorded', () => {
+  const machines = [
+    {
+      checks: [{ name: 'http', status: 'passing' }],
+      gitSHA: 'shaA',
+      id: 'm1',
+      image: 'img-a',
+      state: 'started',
+    },
+    { checks: [], gitSHA: 'shaB', id: 'm2', image: 'img-b', state: 'suspended' },
+  ];
+
+  expect(planMachineSweep(machines, null)).toStrictEqual({
+    kind: 'sweep',
+    machines: [{ id: 'm2', image: 'img-b' }],
+  });
+});
+
+test('it reports ambiguous with no recorded release and no started machine', () => {
+  const machines = [
+    { checks: [], gitSHA: 'shaA', id: 'm1', image: 'img-a', state: 'suspended' },
+    { checks: [], gitSHA: 'shaB', id: 'm2', image: 'img-b', state: 'suspended' },
+  ];
+
+  const plan = planMachineSweep(machines, null);
+
+  expect(plan).toStrictEqual({
+    kind: 'ambiguous',
+    reason: 'no recorded release to match, and no image group has a healthy started machine',
+  });
+});
+
+test('it reports ambiguous when two image groups each have a healthy started machine', () => {
+  const machines = [
+    {
+      checks: [{ name: 'http', status: 'passing' }],
+      gitSHA: 'shaA',
+      id: 'm1',
+      image: 'img-a',
+      state: 'started',
+    },
+    {
+      checks: [{ name: 'http', status: 'passing' }],
+      gitSHA: 'shaB',
+      id: 'm2',
+      image: 'img-b',
+      state: 'started',
+    },
+  ];
+
+  const plan = planMachineSweep(machines, null);
+
+  expect(plan).toStrictEqual({
+    kind: 'ambiguous',
+    reason: '2 image groups each have a healthy started machine — ambiguous which is current',
+  });
+});
+
+test('it reports ambiguous when a started machine sits outside the chosen keep group', () => {
+  const machines = [
+    {
+      checks: [{ name: 'http', status: 'passing' }],
+      gitSHA: 'shaNEW',
+      id: 'm1',
+      image: 'img-new',
+      state: 'started',
+    },
+    { checks: [], gitSHA: 'shaOLD', id: 'm2', image: 'img-old', state: 'started' },
+  ];
+
+  const plan = planMachineSweep(machines, { gitSHA: 'shaNEW' });
+
+  expect(plan).toStrictEqual({
+    kind: 'ambiguous',
+    reason:
+      'machine(s) m2 are started on an image outside the kept group — refusing to destroy a started machine',
+  });
+});
+
+test('it never counts a started machine with no checks as healthy for the fallback', () => {
+  const machines = [
+    { checks: [], gitSHA: 'shaA', id: 'm1', image: 'img-a', state: 'started' },
+    { checks: [], gitSHA: 'shaB', id: 'm2', image: 'img-b', state: 'suspended' },
+  ];
+
+  const plan = planMachineSweep(machines, null);
+
+  expect(plan).toStrictEqual({
+    kind: 'ambiguous',
+    reason: 'no recorded release to match, and no image group has a healthy started machine',
+  });
+});

--- a/scripts/src/deploy/plan-machine-sweep.ts
+++ b/scripts/src/deploy/plan-machine-sweep.ts
@@ -1,0 +1,142 @@
+import invariant from 'tiny-invariant';
+import type { AppMachine } from './types';
+
+export interface MachineSweepTarget {
+  readonly id: string;
+  readonly image: string | null;
+}
+
+export type MachineSweepPlan =
+  | { readonly kind: 'clean' }
+  | { readonly kind: 'sweep'; readonly machines: ReadonlyArray<MachineSweepTarget> }
+  | { readonly kind: 'ambiguous'; readonly reason: string };
+
+/**
+ * Decides whether a fleet carries stranded machines from an aborted bluegreen rollout. Groups
+ * service machines by normalized image; a single image group (or none) is clean. Multiple groups
+ * pick a keep group by the recorded release's git SHA, falling back to the one image group with a
+ * healthy started machine when the SHA doesn't resolve it uniquely. A keep group chosen by either
+ * rule that still leaves a started machine outside it is reported ambiguous rather than swept — a
+ * started machine is never a destroy target.
+ */
+export function planMachineSweep(
+  machines: ReadonlyArray<AppMachine>,
+  recordedRelease: { readonly gitSHA: string } | null,
+): MachineSweepPlan {
+  const groups = buildImageGroups(machines);
+
+  if (groups.size <= 1) {
+    return { kind: 'clean' };
+  }
+
+  const keep = pickKeepImage(groups, recordedRelease);
+
+  if (keep.kind === 'ambiguous') {
+    return keep;
+  }
+
+  const stranded = [...groups.entries()]
+    .filter(([image]) => image !== keep.image)
+    .flatMap(([, group]) => group);
+
+  const startedOutsideKeep = stranded.filter((machine) => machine.state === 'started');
+
+  if (startedOutsideKeep.length > 0) {
+    const ids = startedOutsideKeep.map((machine) => machine.id).join(', ');
+
+    return {
+      kind: 'ambiguous',
+      reason: `machine(s) ${ids} are started on an image outside the kept group — refusing to destroy a started machine`,
+    };
+  }
+
+  return {
+    kind: 'sweep',
+    machines: stranded.map((machine) => ({ id: machine.id, image: machine.image })),
+  };
+}
+
+function buildImageGroups(
+  machines: ReadonlyArray<AppMachine>,
+): ReadonlyMap<string | null, ReadonlyArray<AppMachine>> {
+  const groups = new Map<string | null, Array<AppMachine>>();
+
+  for (const machine of machines) {
+    const group = groups.get(machine.image);
+
+    if (group === undefined) {
+      groups.set(machine.image, [machine]);
+      continue;
+    }
+
+    group.push(machine);
+  }
+
+  return groups;
+}
+
+interface KeepImage {
+  readonly image: string | null;
+  readonly kind: 'keep';
+}
+
+interface AmbiguousResult {
+  readonly kind: 'ambiguous';
+  readonly reason: string;
+}
+
+function pickKeepImage(
+  groups: ReadonlyMap<string | null, ReadonlyArray<AppMachine>>,
+  recordedRelease: { readonly gitSHA: string } | null,
+): KeepImage | AmbiguousResult {
+  if (recordedRelease !== null) {
+    const matching = [...groups.entries()].filter(([, group]) =>
+      group.every((machine) => machine.gitSHA === recordedRelease.gitSHA),
+    );
+
+    if (matching.length === 1) {
+      const [entry] = matching;
+
+      invariant(entry, 'matching has exactly one entry');
+
+      return { image: entry[0], kind: 'keep' };
+    }
+  }
+
+  const healthy = [...groups.entries()].filter(([, group]) =>
+    group.some((machine) => isHealthyStarted(machine)),
+  );
+
+  if (healthy.length === 1) {
+    const [entry] = healthy;
+
+    invariant(entry, 'healthy has exactly one entry');
+
+    return { image: entry[0], kind: 'keep' };
+  }
+
+  if (healthy.length === 0) {
+    return {
+      kind: 'ambiguous',
+      reason:
+        recordedRelease === null
+          ? 'no recorded release to match, and no image group has a healthy started machine'
+          : `no image group matches the recorded release SHA ${recordedRelease.gitSHA}, and no image group has a healthy started machine`,
+    };
+  }
+
+  return {
+    kind: 'ambiguous',
+    reason: `${healthy.length} image groups each have a healthy started machine — ambiguous which is current`,
+  };
+}
+
+function isHealthyStarted(machine: AppMachine): boolean {
+  const checks = machine.checks ?? [];
+
+  return (
+    machine.state === 'started' &&
+    checks.length > 0 &&
+    checks.every((check) => check.status === 'passing')
+  );
+}

--- a/scripts/src/deploy/plan-machine-sweep.ts
+++ b/scripts/src/deploy/plan-machine-sweep.ts
@@ -13,11 +13,14 @@ export type MachineSweepPlan =
 
 /**
  * Decides whether a fleet carries stranded machines from an aborted bluegreen rollout. Groups
- * service machines by normalized image; a single image group (or none) is clean. Multiple groups
- * pick a keep group by the recorded release's git SHA, falling back to the one image group with a
- * healthy started machine when the SHA doesn't resolve it uniquely. A keep group chosen by either
- * rule that still leaves a started machine outside it is reported ambiguous rather than swept — a
- * started machine is never a destroy target.
+ * service machines by normalized image; a single image group (or none) is clean. A machine whose
+ * image flyctl did not report sits in its own null-keyed group and, once more than one group
+ * exists, makes the fleet ambiguous rather than a candidate to keep or destroy — a missing image
+ * is never evidence either way. Otherwise, multiple groups pick a keep group by the recorded
+ * release's git SHA, falling back to the one image group with a healthy started machine when the
+ * SHA doesn't resolve it uniquely. A keep group chosen by either rule that still leaves a started
+ * machine outside it is reported ambiguous rather than swept — a started machine is never a
+ * destroy target.
  */
 export function planMachineSweep(
   machines: ReadonlyArray<AppMachine>,
@@ -27,6 +30,12 @@ export function planMachineSweep(
 
   if (groups.size <= 1) {
     return { kind: 'clean' };
+  }
+
+  const unknownImage = findUnknownImageAmbiguity(groups);
+
+  if (unknownImage !== null) {
+    return unknownImage;
   }
 
   const keep = pickKeepImage(groups, recordedRelease);
@@ -75,14 +84,35 @@ function buildImageGroups(
   return groups;
 }
 
-interface KeepImage {
-  readonly image: string | null;
-  readonly kind: 'keep';
-}
-
 interface AmbiguousResult {
   readonly kind: 'ambiguous';
   readonly reason: string;
+}
+
+/**
+ * Reports ambiguous when the null-keyed group exists — machines whose image flyctl did not
+ * report never count as evidence for keeping or destroying anything.
+ */
+function findUnknownImageAmbiguity(
+  groups: ReadonlyMap<string | null, ReadonlyArray<AppMachine>>,
+): AmbiguousResult | null {
+  const unknown = groups.get(null);
+
+  if (unknown === undefined) {
+    return null;
+  }
+
+  const ids = unknown.map((machine) => machine.id).join(', ');
+
+  return {
+    kind: 'ambiguous',
+    reason: `machine(s) ${ids} report no image — flyctl did not read an image for them, so the fleet's image groups cannot be trusted`,
+  };
+}
+
+interface KeepImage {
+  readonly image: string | null;
+  readonly kind: 'keep';
 }
 
 function pickKeepImage(

--- a/scripts/src/deploy/plan-machine-sweep.ts
+++ b/scripts/src/deploy/plan-machine-sweep.ts
@@ -1,10 +1,5 @@
 import invariant from 'tiny-invariant';
-import type { AppMachine } from './types';
-
-export interface MachineSweepTarget {
-  readonly id: string;
-  readonly image: string | null;
-}
+import type { AppMachine, MachineSweepTarget } from './types';
 
 export type MachineSweepPlan =
   | { readonly kind: 'clean' }

--- a/scripts/src/deploy/types.ts
+++ b/scripts/src/deploy/types.ts
@@ -88,6 +88,15 @@ export interface ScheduledMachineState {
   readonly image: string;
 }
 
+/**
+ * A stranded machine the sweep planner marked for destruction — `image` is null when flyctl
+ * reported none, retained so the sweep's log names what it removed.
+ */
+export interface MachineSweepTarget {
+  readonly id: string;
+  readonly image: string | null;
+}
+
 export type ScheduledMachineAction =
   | { readonly kind: 'create'; readonly machine: ScheduledMachine; readonly image: string }
   | { readonly kind: 'update-image'; readonly machineID: string; readonly image: string };

--- a/scripts/src/deploy/types.ts
+++ b/scripts/src/deploy/types.ts
@@ -69,6 +69,7 @@ export interface AppMachine {
   readonly id: string;
   readonly state: string;
   readonly gitSHA: string | null;
+  readonly image: string | null;
   readonly checks?: ReadonlyArray<MachineCheck>;
 }
 


### PR DESCRIPTION
## Description

Closes #844

A deploy or cutover leg now sweeps machines a prior aborted rollout left stranded on a second image, before flyctl's own preflight can fail on "found multiple image versions".

- `planMachineSweep` groups service machines by image; picks the keep group by the recorded release's git SHA, falling back to the one image group with a healthy started machine.
- Refuses to sweep (reports ambiguous, prints the machine table) rather than destroy a started machine outside the keep group, or trust a machine flyctl reported no image for.
- Recorded decision: stranded greens still in `started` state are never swept — the leg fails with the table until Fly auto-stop parks them, then heals on the next run.
- `deploy`/`cutover` both run the sweep inside `runRollout`; `deploy verify` reports mixed-image fleets and unreported-image machines read-only.
- No new metrics: the deploy CLI has no service meter provider; the per-machine sweep log is the observability.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
