### PR TITLE
docs: expand the docs-writing skill with anti-patterns and formatting

### DIFF
--- a/.claude/skills/docs-writing/SKILL.md
+++ b/.claude/skills/docs-writing/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: docs-writing
 description:
-  Writing rules for repo prose — AGENTS.md and agents/ partials, docs/, README content, and doc
-  comments. Load before writing or editing any of them.
+  Prose rules for everything committed to the repo — docs/, READMEs, AGENTS.md and agents/ partials,
+  and doc comments. Use when writing, editing, or reviewing any repo prose.
 ---
 
 # Docs writing
@@ -11,9 +11,10 @@ Write every sentence as if it had always existed, for a reader who saw none of t
 produced it.
 
 Two passes govern every doc. **Selection** decides which points the doc makes; it is ruthless.
-**Rendering** decides how a surviving point is written — its sentences, its structure, its stance;
-it is generous. Shorten a doc by removing points, never by compressing the sentences that state a
-surviving point. When a draft feels long, return to Selection — Rendering is never the knife.
+**Rendering** decides how a surviving point is written — its sentences, its words, its shape, its
+stance; it is generous. Shorten a doc by removing points, never by compressing the sentences that
+state a surviving point. When a draft feels long, return to Selection — Rendering is never the
+knife.
 
 ## Selection — which points the doc makes
 
@@ -23,11 +24,21 @@ surviving point. When a draft feels long, return to Selection — Rendering is n
   `baseline(#236)` marker) is a fact of the code, not a reference. An external upstream issue
   identifying a defect the tree works around (`turborepo#11007`) is a fact of the workaround, not
   tracking — it stays.
+- **Shed process residue.** The work session leaves no trace in the doc. A date stamp in prose
+  (`Verified 2026-05-26:`) rots — git history records when work happened; date-prefixed filenames
+  and header metadata rows are structural and stay. Investigation framing ("Verified against…", "I
+  checked…") belongs in the commit or PR body — state the finding itself. A citation of an agent's
+  private memory file is a reference no other reader can resolve — cite the source file the memory
+  points at, or omit.
 - **The point test.** A point is a fact plus its rationale, however many sentences it takes to
   state. Cover the point; if a reader with the file open would know and do everything the same,
   delete the whole point. This test judges whole points, never single sentences — a sentence that
   orients, names a referent, or summarizes is kept or cut on how it reads, not on whether it carries
   a point.
+- **No defensive points.** A paragraph defending a decision against unlikely scenarios — enumerated
+  edge cases requiring external tampering, "in case someone", scope-defending re-statements — is a
+  point that fails the point test. A paragraph past 8 lines is the audit trigger: most ballooning is
+  over-explaining decisions that don't need defending.
 - **One owner per fact.** Each fact is explained in one place — its owner — across the whole docs
   tree, not just within one document. Any section that needs a fact it doesn't own states it in at
   most one sentence and links to the owner, and the rationale appears at the owner only. When two
@@ -111,6 +122,41 @@ surviving point. When a draft feels long, return to Selection — Rendering is n
   most one parenthetical per sentence. A consequence is never parenthetical — render it as its own
   sentence or after a colon.
 
+## Words — what to cut on sight
+
+- **Throat-clearing.** Filler that adds no information — find and cull: "naturally", "organically",
+  "cleanly", "honestly", "trivially", "earns its complexity", "lays foundation for", "cheap
+  insurance", "the right level". "Easy", "simple", and "quick" pressure the reader and read as
+  marketing — describe the thing instead ("one command", "on by default"). `Mitigation:` as a label
+  — drop the label, state the mitigation.
+- **Adjective stacks.** Five adjectives deep on one noun reads as marketing copy. Rewrite
+  fact-first.
+  - Bad: "This work introduces continuations — session-scoped, chain-rooted, identity-bearing rows
+    that resume an activity…"
+  - Good: "A continuation is a row minted from a chain coordinate. The session that owns it resumes
+    the activity through it."
+- **Weasel words.** Vague qualifiers where a specific claim belongs: "significantly", "many",
+  "often", "typically", "generally", "near-instant". State the figure and its source, or make the
+  concrete claim the qualifier is dodging. "~28.7KB gzipped on average over a 7-day window" survives
+  review; "artifacts are small" doesn't.
+- **Repeated framing.** The same rhetorical move three times in a row: "X, not Y" (pick the
+  strongest contrast, drop the rest); "no new A, no new B, no new C" (collapse to one line); "means"
+  / "is the" as the spine of every sentence (vary).
+- **Generated-prose tells.** Patterns that mark prose as machine-drafted. Cut or rewrite on sight:
+  - Summary-style transitions recapping the previous paragraph ("With this setup complete…", "Now
+    that we've covered…"). Pivot straight to the next point.
+  - Spec-sheet voice narrating features instead of stating facts ("provides", "is configurable",
+    "offers a flexible way to").
+  - Stop-start fragments splitting one dependent idea ("Previously this was manual. Now it's
+    automatic. This saves time." — one sentence). A short sentence for emphasis is fine.
+  - Personified artifacts performing human actions ("the token hands the browser a session"); state
+    what the system does ("the browser fetches the session"). Errors and status codes are not actors
+    either: "on the 400, the client refetches", never "the 400 refetches".
+  - Template framing not specific to this doc ("The question most teams face is…").
+  - Rhetorical questions setting up the answer the next sentence gives ("So why not cache it?
+    Because…"). State the point.
+- **Banned words.** The AGENTS.md banned-words list applies to all prose; fix a violation on sight.
+
 ## Structure — the shape points take
 
 - **Summary before detail.** A doc opens with three to six plain sentences saying what the system
@@ -142,6 +188,14 @@ surviving point. When a draft feels long, return to Selection — Rendering is n
   multi-paragraph block, so all of them promote. Two shapes stay: one-line inline markers
   (`**Why:**`, `**Depends on:** phase 1.`) and a catalogue's run of same-shape sibling entries,
   which would gain a heading per entry and no navigation.
+- **No label wrappers.** A bold label naming the body's role — `**Design**`, `**Details**`,
+  `**Rationale**`, `**Overview**` — adds nothing: the body already is its design, detail, or
+  rationale. Drop the wrapper; replace a per-section `**Rationale**` block with inline `**Why:**`
+  markers at the specific decisions whose rationale isn't visible. A section heading naming a role
+  instead of a topic (`## Overview`, `## Notes`) is the heading-scale form — fold its content into
+  the doc's intro or name what the section actually covers.
+- **No horizontal rules.** `---` between sections is a heading that lost its name — headings already
+  divide the doc. Delete it; if the break felt necessary, the section below it wants a heading.
 
 ## Stance — how the doc regards its reader and itself
 
@@ -153,81 +207,7 @@ surviving point. When a draft feels long, return to Selection — Rendering is n
   two domain states ("a `pruned` row means expired; a missing row means unknown") is a fact about
   the domain, not positional framing, and stands.
 
-## Anti-patterns — what fails review in practice
-
-Four families: process residue the draft should have shed, bloat, fake structure, and
-cross-reference rot.
-
-### Process residue
-
-- **Inline date stamps.** `(2026-05-26)`, `Verified 2026-05-26:` — any date stamp in committed
-  prose, whatever the format. Git history records when work happened; dates in prose rot.
-  Date-prefixed filenames and header metadata rows are structural, not prose.
-- **"Investigation" / "Verified" framing.** "Verified against…:", "Investigation count…:", "I
-  checked…" belongs in a commit message or PR body, not the doc. State the finding: "Touched in
-  total: 4 entities, 14 services, 3 controllers. Zero frontend references."
-- **Memory-file citations.** An agent-assisted draft that cites the agent's private memory by slug
-  is a reference no other reader can resolve. Cite the source file the memory points at, or omit.
-- **Generated-prose tells.** Patterns that mark prose as machine-drafted and survive into commits.
-  Cut or rewrite on sight:
-  - Summary-style transitions recapping the previous paragraph ("With this setup complete…", "Now
-    that we've covered…"). Pivot straight to the next point.
-  - Spec-sheet voice narrating features instead of stating facts ("provides", "is configurable",
-    "offers a flexible way to").
-  - Stop-start fragments splitting one dependent idea ("Previously this was manual. Now it's
-    automatic. This saves time." — one sentence). A short sentence for emphasis is fine.
-  - Personified artifacts performing human actions ("the token hands the browser a session"); state
-    what the system does ("the browser fetches the session"). Errors and status codes are not actors
-    either: "on the 400, the client refetches", never "the 400 refetches".
-  - Template framing not specific to this doc ("The question most teams face is…").
-  - Rhetorical questions setting up the answer the next sentence gives ("So why not cache it?
-    Because…"). State the point.
-
-### Bloat
-
-- **Throat-clearing.** Filler that adds no information — find and cull: "naturally", "organically",
-  "cleanly", "honestly", "trivially", "earns its complexity", "lays foundation for", "cheap
-  insurance", "the right level". "Easy", "simple", and "quick" pressure the reader and read as
-  marketing — describe the thing instead ("one command", "on by default"). `Mitigation:` as a label
-  — drop the label, state the mitigation.
-- **The adjective stack.** The opener-scale form of throat-clearing: five adjectives deep on one
-  noun reads as marketing copy. Rewrite fact-first.
-  - Bad: "This work introduces continuations — session-scoped, chain-rooted, identity-bearing rows
-    that resume an activity…"
-  - Good: "A continuation is a row minted from a chain coordinate. The session that owns it resumes
-    the activity through it."
-- **Weasel words.** Vague qualifiers where a specific claim belongs: "significantly", "many",
-  "often", "typically", "generally", "near-instant". State the figure and its source, or make the
-  concrete claim the qualifier is dodging. "~28.7KB gzipped on average over a 7-day window" survives
-  review; "artifacts are small" doesn't.
-- **Defensive prose.** Wall-of-text paragraphs defending decisions against unlikely scenarios:
-  enumerated edge cases requiring external tampering, "in case someone", scope-defending
-  re-statements. Budget: a paragraph runs 8 lines at most; over that, audit — most ballooning is
-  over-explaining decisions that don't need defending.
-- **Repeated framing.** The same rhetorical move three times in a row: "X, not Y" (pick the
-  strongest contrast, drop the rest); "no new A, no new B, no new C" (collapse to one line); "means"
-  / "is the" as the spine of every sentence (vary).
-- **Banned words.** The AGENTS.md banned-words list applies to all prose; fix a violation on sight.
-
-### Fake structure
-
-- **Label wrappers.** A bold label naming the body's role — `**Design**`, `**Details**`,
-  `**Rationale**`, `**Overview**` — adds nothing: the body already is its design, detail, or
-  rationale. Drop the wrapper; replace a per-section `**Rationale**` block with inline `**Why:**`
-  markers at the specific decisions whose rationale isn't visible. A section heading naming a role
-  instead of a topic (`## Overview`, `## Notes`) is the heading-scale form — fold its content into
-  the doc's intro or name what the section actually covers.
-- **Horizontal rules.** `---` between sections is a heading that lost its name — headings already
-  divide the doc. Delete it; if the break felt necessary, the section below it wants a heading.
-
-### Cross-reference rot
-
-- **`§` is forbidden** — bare in prose and inside link text. Link the section by its title; the link
-  itself makes the section nature clear.
-- **Restated cross-references.** Linking the same target six times across one section is noise. Link
-  once where it first matters, then refer to the topic by name.
-
-## Formatting
+## Formatting and links
 
 - **Write paragraphs as single long lines.** oxfmt reflows prose on commit (`proseWrap: "always"`,
   100 columns); hand-wrapping creates churn. Code blocks are left untouched — alignment inside
@@ -244,27 +224,27 @@ cross-reference rot.
   `<TOKEN>`.
 - **Anchors are GitHub's kebab-case** (`### Atomic cells` → `#atomic-cells`; `&` and `/` collapse to
   extra hyphens). A cross-doc link goes via a path relative to the linking file.
+- **Link a target once** where it first matters, then refer to the topic by name — linking the same
+  target six times across one section is noise.
+- **`§` is forbidden** — bare in prose and inside link text. Link the section by its title; the link
+  itself makes the section nature clear.
 
-## Pre-commit checklist
+## Review workflow
 
-Scripted checks plus one visual audit, run against the docs you touched before every commit. Don't
-run them against this skill's own file — it documents the forbidden patterns and contains them as
-examples.
+Before committing docs, run this sequence over the files you touched:
 
-````bash
-# Anti-pattern grep. Each match is a violation; fix in place.
-git grep -nP \
-  'Verified 20[0-9]{2}-|Investigation count|\(see memory |\([0-9]{2,4}-[0-9]{2}-[0-9]{2}\)|^Mitigation:|§' \
-  -- <path>
+1. Selection pass: cover each point and apply the point test; check each fact against its owner
+   elsewhere in the tree.
+2. Rendering pass: reread each surviving paragraph against Sentences, Words, Structure, and Stance.
+3. Run the scripted checks from the repo root:
 
-# Banned-word grep. AGENTS.md owns the list — keep the pattern in sync. Judgment-only bans
-# (bites, ceiling, floor) and legitimate markdown-fence mentions need review, not grep.
-git grep -nPi '\bsurfaces?\b|load-bearing|\bseams?\b|\bfenc(e|ed|ing)\b|\bCAS\b' -- <path>
+   ```bash
+   bash .claude/skills/docs-writing/scripts/check-prose.sh <path>...
+   ```
 
-# Untagged code fences. Each match is a violation.
-git ls-files -- '<path>/*.md' | xargs awk \
-  'FNR==1{n=0} /^```/{n++; if (n%2==1 && $0=="```") print FILENAME": "FNR}'
-````
+   The script greps the given paths for process residue, greppable banned words, and untagged code
+   fences, and exits non-zero on any hit. It skips this skill's own directory, which documents the
+   forbidden patterns and contains them as examples.
 
-The visual audit: walk each changed section's links and confirm every link's text still matches its
-target heading.
+4. Visual audit: walk each changed section's links and confirm every link's text still matches its
+   target heading.

--- a/.claude/skills/docs-writing/SKILL.md
+++ b/.claude/skills/docs-writing/SKILL.md
@@ -32,7 +32,7 @@ surviving point. When a draft feels long, return to Selection — Rendering is n
   tree, not just within one document. Any section that needs a fact it doesn't own states it in at
   most one sentence and links to the owner, and the rationale appears at the owner only. When two
   docs disagree, the owner is right: fix the other doc against it, then check the owner against the
-  tree.
+  tree. An index restates owned facts at one line each — orientation is its job.
 - **The tree owns its rosters.** A list, count, or mapping derivable from the repo — the packages
   under a directory, the apps in a manifest, which app reads which env key (its env schema) — is
   stated as the rule that derives it, never transcribed member by member. Name a member only where
@@ -72,8 +72,12 @@ surviving point. When a draft feels long, return to Selection — Rendering is n
   test: reading only first sentences yields a correct coarse version of the doc.
 - **Lead with the fact.** The answer first, framing never — "Reuses the existing bucket", not "What
   we want to do here is…".
+- **Active over passive.** "The sweep drops each stranded machine and records the set removed", not
+  "stranded machines are dropped and the removed set is recorded". The test: append "by monkeys" — a
+  sentence that still parses is passive.
 - **Decisions read as decisions.** A made call never reads "may", "should", or "might" — hedged
-  modals mark genuinely open options only.
+  modals mark genuinely open options only. A conditional that defines criteria ("a change may be
+  treated as standard-risk when…") is a definition, not a hedge.
 - **Rule, then exception.** An exception takes its own sentence, placed after the rule's sentence —
   never a subordinate clause inside it. Two or more exceptions become a list.
   - Bad: "A background report carries a fresh trace id, except that a request-triggered drain
@@ -82,7 +86,27 @@ surviving point. When a draft feels long, return to Selection — Rendering is n
     request-triggered fire-and-forget drain inherits the originating request's trace."
 - **Name the referent.** A pronoun's referent lives in the same sentence or the one before it; any
   farther back, repeat the noun. Repeating a noun is never a defect; a re-read to resolve a pronoun
-  is.
+  is. The same rule covers definite nouns: where the doc has more than one cap, filter, or budget,
+  the bare form ("the cap") is legal only after the qualified form ("the cardinality cap") earlier
+  in the same paragraph.
+- **First use defines.** Spell an acronym out where it first appears ("Content Security Policy
+  (CSP)"); a term of art gets a one-line definition or a link to its owner.
+- **Same term for the same thing.** Varying a term to dodge repetition ("the runner… the executor…
+  the worker") makes the reader ask whether they differ. Elegant variation is a defect in technical
+  prose.
+- **Qualify nominalized verbs.** A verb used as a noun ("a reveal", "the split", "an append") is a
+  coinage: compound it with the noun it acts on ("checkpoint reveal", "partition split", "chain
+  append") or restructure the sentence around the verb. Define the compound at first use. A
+  nominalization that names a design concept is reserved for that concept — pick a different word
+  for the everyday sense.
+- **Negate the verb or object, never the subject.** "A drain never delivers entries out of order",
+  not "no drain delivers entries out of order" — a negated subject garden-paths. Noun stacks
+  garden-path too: three bare nouns in a row unstack. A reduced relative clause appended after a
+  dash takes "that" or "which".
+- **Attribution takes a verb.** Name the owning doc or component as the subject: "the overview owns
+  the boundaries", never "the boundaries are the overview's". A possessive on a markdown link ("the
+  [sweep](url)'s seven readers") garden-paths twice over — put the link in a prepositional phrase
+  instead.
 - **Parentheses hold identifiers, paths, and values.** Never a gloss restating the prose, and at
   most one parenthetical per sentence. A consequence is never parenthetical — render it as its own
   sentence or after a colon.
@@ -102,14 +126,22 @@ surviving point. When a draft feels long, return to Selection — Rendering is n
 - **Atomic cells.** A table cell holds one atomic value — an identifier, a number, a short phrase. A
   cell holding a list, a full clause, or a reference to another row means the table is the wrong
   shape. Resolve in order: point at the tree file that owns the mapping; render as a nested list;
-  re-cut the table's axes.
+  re-cut the table's axes. A decision table's prose column — a discriminator plus its trade-off or
+  when to reach for it — is the shape doing its job, not a mis-cut.
 - **Procedures are numbered steps.** Actions the reader performs in order render as a numbered list,
   one action per step; a step needing its own explanation gets a sentence under the step, not a
   longer step. A fenced code block inside a step is indented to the step — indentation is layout,
-  not a content change. A sequence a system performs is narration — render it as prose or
-  subsections, never as numbered steps.
-- **A multi-paragraph bold-lead is a heading.** It is dodging the outline — promote it. A one-line
-  `**Topic.**` lead is fine.
+  not a content change. A procedure states its expected outcome verbatim ("Expect: HTTP 202", exact
+  error text), never "should succeed". A verification checklist with no inherent order renders as
+  bullets. A sequence a system performs is narration, never dressed as reader instructions; where
+  the order itself is the fact (a pipeline, a request lifecycle), it renders as numbered stages
+  written declarative, not imperative.
+- **A multi-paragraph bold-lead is a heading.** One paragraph of body keeps a bold-lead; a second
+  paragraph or a fenced code block makes it a section — promote it. Repeated template labels
+  (`**Scope**` / `**Risk**` across the phases of a plan) still count: each introduces a
+  multi-paragraph block, so all of them promote. Two shapes stay: one-line inline markers
+  (`**Why:**`, `**Depends on:** phase 1.`) and a catalogue's run of same-shape sibling entries,
+  which would gain a heading per entry and no navigation.
 
 ## Stance — how the doc regards its reader and itself
 
@@ -120,3 +152,119 @@ surviving point. When a draft feels long, return to Selection — Rendering is n
   second…", "another…", "also sanctioned", a table cell reading "the above + …". A contrast between
   two domain states ("a `pruned` row means expired; a missing row means unknown") is a fact about
   the domain, not positional framing, and stands.
+
+## Anti-patterns — what fails review in practice
+
+Four families: process residue the draft should have shed, bloat, fake structure, and
+cross-reference rot.
+
+### Process residue
+
+- **Inline date stamps.** `(2026-05-26)`, `Verified 2026-05-26:` — any date stamp in committed
+  prose, whatever the format. Git history records when work happened; dates in prose rot.
+  Date-prefixed filenames and header metadata rows are structural, not prose.
+- **"Investigation" / "Verified" framing.** "Verified against…:", "Investigation count…:", "I
+  checked…" belongs in a commit message or PR body, not the doc. State the finding: "Touched in
+  total: 4 entities, 14 services, 3 controllers. Zero frontend references."
+- **Memory-file citations.** An agent-assisted draft that cites the agent's private memory by slug
+  is a reference no other reader can resolve. Cite the source file the memory points at, or omit.
+- **Generated-prose tells.** Patterns that mark prose as machine-drafted and survive into commits.
+  Cut or rewrite on sight:
+  - Summary-style transitions recapping the previous paragraph ("With this setup complete…", "Now
+    that we've covered…"). Pivot straight to the next point.
+  - Spec-sheet voice narrating features instead of stating facts ("provides", "is configurable",
+    "offers a flexible way to").
+  - Stop-start fragments splitting one dependent idea ("Previously this was manual. Now it's
+    automatic. This saves time." — one sentence). A short sentence for emphasis is fine.
+  - Personified artifacts performing human actions ("the token hands the browser a session"); state
+    what the system does ("the browser fetches the session"). Errors and status codes are not actors
+    either: "on the 400, the client refetches", never "the 400 refetches".
+  - Template framing not specific to this doc ("The question most teams face is…").
+  - Rhetorical questions setting up the answer the next sentence gives ("So why not cache it?
+    Because…"). State the point.
+
+### Bloat
+
+- **Throat-clearing.** Filler that adds no information — find and cull: "naturally", "organically",
+  "cleanly", "honestly", "trivially", "earns its complexity", "lays foundation for", "cheap
+  insurance", "the right level". "Easy", "simple", and "quick" pressure the reader and read as
+  marketing — describe the thing instead ("one command", "on by default"). `Mitigation:` as a label
+  — drop the label, state the mitigation.
+- **The adjective stack.** The opener-scale form of throat-clearing: five adjectives deep on one
+  noun reads as marketing copy. Rewrite fact-first.
+  - Bad: "This work introduces continuations — session-scoped, chain-rooted, identity-bearing rows
+    that resume an activity…"
+  - Good: "A continuation is a row minted from a chain coordinate. The session that owns it resumes
+    the activity through it."
+- **Weasel words.** Vague qualifiers where a specific claim belongs: "significantly", "many",
+  "often", "typically", "generally", "near-instant". State the figure and its source, or make the
+  concrete claim the qualifier is dodging. "~28.7KB gzipped on average over a 7-day window" survives
+  review; "artifacts are small" doesn't.
+- **Defensive prose.** Wall-of-text paragraphs defending decisions against unlikely scenarios:
+  enumerated edge cases requiring external tampering, "in case someone", scope-defending
+  re-statements. Budget: a paragraph runs 8 lines at most; over that, audit — most ballooning is
+  over-explaining decisions that don't need defending.
+- **Repeated framing.** The same rhetorical move three times in a row: "X, not Y" (pick the
+  strongest contrast, drop the rest); "no new A, no new B, no new C" (collapse to one line); "means"
+  / "is the" as the spine of every sentence (vary).
+- **Banned words.** The AGENTS.md banned-words list applies to all prose; fix a violation on sight.
+
+### Fake structure
+
+- **Label wrappers.** A bold label naming the body's role — `**Design**`, `**Details**`,
+  `**Rationale**`, `**Overview**` — adds nothing: the body already is its design, detail, or
+  rationale. Drop the wrapper; replace a per-section `**Rationale**` block with inline `**Why:**`
+  markers at the specific decisions whose rationale isn't visible. A section heading naming a role
+  instead of a topic (`## Overview`, `## Notes`) is the heading-scale form — fold its content into
+  the doc's intro or name what the section actually covers.
+- **Horizontal rules.** `---` between sections is a heading that lost its name — headings already
+  divide the doc. Delete it; if the break felt necessary, the section below it wants a heading.
+
+### Cross-reference rot
+
+- **`§` is forbidden** — bare in prose and inside link text. Link the section by its title; the link
+  itself makes the section nature clear.
+- **Restated cross-references.** Linking the same target six times across one section is noise. Link
+  once where it first matters, then refer to the topic by name.
+
+## Formatting
+
+- **Write paragraphs as single long lines.** oxfmt reflows prose on commit (`proseWrap: "always"`,
+  100 columns); hand-wrapping creates churn. Code blocks are left untouched — alignment inside
+  fences survives.
+- **Every code block carries a language tag** (`bash`, `ts`; `text` for plain output). An untagged
+  block renders flat on GitHub and hides what it is.
+- **Link code, don't transcribe it.** A fenced block holds commands the reader runs or a short
+  illustrative shape. Code that exists in the repo is linked, never transcribed — a transcribed
+  block is a roster: it rots with no signal, and the source file is typechecked where the block is
+  not.
+- **Units attach directly to their value** (`200ms`, `30s`, `64KB`). Numerals for counts ("8
+  deployments", not "eight").
+- **Placeholders name their content** (`<task_list_id>`, `<service_id>`), never `xxx`, `ABC123`, or
+  `<TOKEN>`.
+- **Anchors are GitHub's kebab-case** (`### Atomic cells` → `#atomic-cells`; `&` and `/` collapse to
+  extra hyphens). A cross-doc link goes via a path relative to the linking file.
+
+## Pre-commit checklist
+
+Scripted checks plus one visual audit, run against the docs you touched before every commit. Don't
+run them against this skill's own file — it documents the forbidden patterns and contains them as
+examples.
+
+````bash
+# Anti-pattern grep. Each match is a violation; fix in place.
+git grep -nP \
+  'Verified 20[0-9]{2}-|Investigation count|\(see memory |\([0-9]{2,4}-[0-9]{2}-[0-9]{2}\)|^Mitigation:|§' \
+  -- <path>
+
+# Banned-word grep. AGENTS.md owns the list — keep the pattern in sync. Judgment-only bans
+# (bites, ceiling, floor) and legitimate markdown-fence mentions need review, not grep.
+git grep -nPi '\bsurfaces?\b|load-bearing|\bseams?\b|\bfenc(e|ed|ing)\b|\bCAS\b' -- <path>
+
+# Untagged code fences. Each match is a violation.
+git ls-files -- '<path>/*.md' | xargs awk \
+  'FNR==1{n=0} /^```/{n++; if (n%2==1 && $0=="```") print FILENAME": "FNR}'
+````
+
+The visual audit: walk each changed section's links and confirm every link's text still matches its
+target heading.

--- a/.claude/skills/docs-writing/scripts/check-prose.sh
+++ b/.claude/skills/docs-writing/scripts/check-prose.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Greps committed docs for prose violations; exits non-zero when any are found.
+# Usage (from the repo root): check-prose.sh <path>...
+set -uo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: check-prose.sh <path>..." >&2
+  exit 2
+fi
+
+# The skill's own files document the forbidden patterns and contain them as examples.
+set -- "$@" ':(exclude).claude/skills/docs-writing'
+
+fail=0
+
+report() {
+  local label=$1 out=$2
+  if [ -n "$out" ]; then
+    fail=1
+    printf '%s\n%s\n\n' "$label" "$out"
+  fi
+}
+
+report 'Process residue (date stamps, investigation framing, memory citations, §):' \
+  "$(git grep -nP 'Verified 20[0-9]{2}-|Investigation count|\(see memory |\([0-9]{2,4}-[0-9]{2}-[0-9]{2}\)|^Mitigation:|§' -- "$@")"
+
+# AGENTS.md owns the banned-words list; keep this pattern in sync. Judgment-only bans
+# (bites, ceiling, floor) are not grepped. CAS stays case-sensitive so "CAs" passes.
+report 'Banned words (judge each match — the AGENTS.md registry and markdown-fence senses are legal):' \
+  "$(git grep -nPi '\bsurfaces?\b|load-bearing|\bseams?\b|\bfenc(e|ed|ing)\b|(?-i:\bCAS\b)' -- "$@")"
+
+report 'Untagged code fences:' \
+  "$(git ls-files -- "$@" | grep '\.md$' | xargs -r awk \
+    'FNR==1{n=0} /^```/{n++; if (n%2==1 && $0=="```") print FILENAME": "FNR}')"
+
+if [ "$fail" -eq 0 ]; then
+  echo 'check-prose: clean'
+fi
+
+exit "$fail"

--- a/.claude/skills/docs-writing/scripts/check-prose.sh
+++ b/.claude/skills/docs-writing/scripts/check-prose.sh
@@ -27,7 +27,7 @@ report 'Process residue (date stamps, investigation framing, memory citations, Â
 # AGENTS.md owns the banned-words list; keep this pattern in sync. Judgment-only bans
 # (bites, ceiling, floor) are not grepped. CAS stays case-sensitive so "CAs" passes.
 report 'Banned words (judge each match â€” the AGENTS.md registry and markdown-fence senses are legal):' \
-  "$(git grep -nPi '\bsurfaces?\b|load-bearing|\bseams?\b|\bfenc(e|ed|ing)\b|(?-i:\bCAS\b)' -- "$@")"
+  "$(git grep -nPi '\bsurfaces?\b|load-bearing|\bseams?\b|\bfenc(e|es|ed|ing)\b|(?-i:\bCAS\b)' -- "$@")"
 
 report 'Untagged code fences:' \
   "$(git ls-files -- "$@" | grep '\.md$' | xargs -r awk \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -327,9 +327,13 @@ text.
 - `bites` (figurative) — "applies", "takes effect", or name the consequence.
 - `CAS` (the acronym) — "compare-and-swap" spelled out, or name the behaviour: a guarded update that
   applies only if the cursor still holds its expected value.
+- `ceiling` (figurative limit) — "cap", "limit", "maximum", "upper bound"; a timeout is a "timeout".
+  A game mechanic the design names a ceiling keeps the name.
 - `fence` / `fencing` (the distributed-systems metaphor) — state the rule it enforces: "each
   activity has a single writer", "an append from any other session is rejected". A markdown code
   fence is a different word and stays.
+- `floor` (figurative minimum) — "minimum", "lower bound", "at least". A literal floor and a game
+  mechanic the design names a floor keep the name.
 - `load-bearing` — "required", "essential", or name what breaks without it.
 - `seam` — "boundary", "join", "integration point".
 - `surface` — noun: "area", "API", the concrete thing itself; verb: "show", "raise", "report".

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,20 +37,6 @@ what tooling can't check.
   it starts a name. File names are unaffected: kebab-case lowercases everything (`parse-cli-args.ts`
   exports `parseCLIArgs`).
 
-### Comments
-
-- Comments that document a declaration are JSDoc blocks, always multi-line (`/**` alone, one
-  `*`-prefixed line per point, `*/` alone — never single-line `/** … */`), attached directly to the
-  declaration they describe; `//` is for statement-level commentary inside bodies.
-- Comment a declaration only for what the file doesn't already show — an invariant, cross-file or
-  runtime behavior, or why the choice is necessary. A comment that restates the name or signature is
-  a defect — delete it.
-- Comments describe the code as it is now — no history ("previously", "now uses"), no project state
-  (issue numbers, phase labels, "not wired yet"); those live in the commit message.
-- Comments don't name other declarations — renames strand the reference. State the contract instead:
-  "callers must pass edits sorted last-to-first", not "(buildEditsFromAST's contract)". A
-  declaration's own parameters and signature types are fine to name.
-
 ### Function naming
 
 Every function name starts with a prefix from the closed list below: pick from it, or extend this
@@ -193,6 +179,23 @@ Project-level additions to the shared function-naming taxonomy, under the same r
 | `submit`    | accept a payload into a durable outbound queue and schedule its delivery               | `submit`                |
 | `sweep`     | bulk-remove stale or orphaned resources found by a scan, returning the set removed     | `sweepDevDBs`           |
 | `upgrade`   | hand a structural port to an RPC handler so it starts serving calls over it            | `upgrade`               |
+
+## Comments
+
+- Comments that document a declaration are JSDoc blocks, always multi-line (`/**` alone, one
+  `*`-prefixed line per point, `*/` alone — never single-line `/** … */`), attached directly to the
+  declaration they describe; `//` is for statement-level commentary inside bodies.
+- Comment a declaration only for what the file doesn't already show — an invariant, cross-file or
+  runtime behavior, or why the choice is necessary. A comment that restates the name or signature is
+  a defect — delete it.
+- Comments describe the code as it is now — no history ("previously", "now uses"), no project state
+  (issue numbers, phase labels, "not wired yet"); those live in the commit message.
+- Comments don't name other declarations — renames strand the reference. State the contract instead:
+  "callers must pass edits sorted last-to-first", not "(buildEditsFromAST's contract)". A
+  declaration's own parameters and signature types are fine to name.
+- A comment past a few lines is structured prose: one point per paragraph, led by its topic
+  sentence; one fact per sentence; enumeration-shaped content (an outcome map, a state-to-action
+  table) as a bullet list. Load the `docs-writing` skill before writing or reworking one.
 
 ## Golden values in tests
 

--- a/agents/project.md
+++ b/agents/project.md
@@ -165,9 +165,13 @@ text.
 - `bites` (figurative) — "applies", "takes effect", or name the consequence.
 - `CAS` (the acronym) — "compare-and-swap" spelled out, or name the behaviour: a guarded update that
   applies only if the cursor still holds its expected value.
+- `ceiling` (figurative limit) — "cap", "limit", "maximum", "upper bound"; a timeout is a "timeout".
+  A game mechanic the design names a ceiling keeps the name.
 - `fence` / `fencing` (the distributed-systems metaphor) — state the rule it enforces: "each
   activity has a single writer", "an append from any other session is rejected". A markdown code
   fence is a different word and stays.
+- `floor` (figurative minimum) — "minimum", "lower bound", "at least". A literal floor and a game
+  mechanic the design names a floor keep the name.
 - `load-bearing` — "required", "essential", or name what breaks without it.
 - `seam` — "boundary", "join", "integration point".
 - `surface` — noun: "area", "API", the concrete thing itself; verb: "show", "raise", "report".

--- a/agents/project.md
+++ b/agents/project.md
@@ -32,6 +32,23 @@ Project-level additions to the shared function-naming taxonomy, under the same r
 | `sweep`     | bulk-remove stale or orphaned resources found by a scan, returning the set removed     | `sweepDevDBs`           |
 | `upgrade`   | hand a structural port to an RPC handler so it starts serving calls over it            | `upgrade`               |
 
+## Comments
+
+- Comments that document a declaration are JSDoc blocks, always multi-line (`/**` alone, one
+  `*`-prefixed line per point, `*/` alone — never single-line `/** … */`), attached directly to the
+  declaration they describe; `//` is for statement-level commentary inside bodies.
+- Comment a declaration only for what the file doesn't already show — an invariant, cross-file or
+  runtime behavior, or why the choice is necessary. A comment that restates the name or signature is
+  a defect — delete it.
+- Comments describe the code as it is now — no history ("previously", "now uses"), no project state
+  (issue numbers, phase labels, "not wired yet"); those live in the commit message.
+- Comments don't name other declarations — renames strand the reference. State the contract instead:
+  "callers must pass edits sorted last-to-first", not "(buildEditsFromAST's contract)". A
+  declaration's own parameters and signature types are fine to name.
+- A comment past a few lines is structured prose: one point per paragraph, led by its topic
+  sentence; one fact per sentence; enumeration-shaped content (an outcome map, a state-to-action
+  table) as a bullet list. Load the `docs-writing` skill before writing or reworking one.
+
 ## Golden values in tests
 
 - A golden value — transcribed machine output no human derives by reading the code: a stream's draw

--- a/agents/shared.md
+++ b/agents/shared.md
@@ -35,20 +35,6 @@ what tooling can't check.
   it starts a name. File names are unaffected: kebab-case lowercases everything (`parse-cli-args.ts`
   exports `parseCLIArgs`).
 
-### Comments
-
-- Comments that document a declaration are JSDoc blocks, always multi-line (`/**` alone, one
-  `*`-prefixed line per point, `*/` alone — never single-line `/** … */`), attached directly to the
-  declaration they describe; `//` is for statement-level commentary inside bodies.
-- Comment a declaration only for what the file doesn't already show — an invariant, cross-file or
-  runtime behavior, or why the choice is necessary. A comment that restates the name or signature is
-  a defect — delete it.
-- Comments describe the code as it is now — no history ("previously", "now uses"), no project state
-  (issue numbers, phase labels, "not wired yet"); those live in the commit message.
-- Comments don't name other declarations — renames strand the reference. State the contract instead:
-  "callers must pass edits sorted last-to-first", not "(buildEditsFromAST's contract)". A
-  declaration's own parameters and signature types are fine to name.
-
 ### Function naming
 
 Every function name starts with a prefix from the closed list below: pick from it, or extend this

--- a/docs/architecture/game/game-entropy.md
+++ b/docs/architecture/game/game-entropy.md
@@ -56,7 +56,7 @@ stops gating and detection takes over: an avatar whose results ride the favorabl
 verified history is a behavioural cheat signal, scored offline
 ([game simulation](./game-simulation.md#replay)). Bounded margins keep any single attempt's edge
 small throughout. The residual is a wealthy, motivated actor with a purpose-built tool: defended in
-layers, never zero, the ceiling of anti-cheat in any game.
+layers, never zero, the upper bound of anti-cheat in any game.
 
 ## Rolled rewards and the avatar key
 

--- a/docs/architecture/game/worldmap.md
+++ b/docs/architecture/game/worldmap.md
@@ -180,7 +180,7 @@ reward magnitude.
 
 `REVEAL_RADIUS` is the one knob that sets both the look-ahead bound and offline exploration depth.
 It holds in the range of 2 to 5 hops, and never above 5: look-ahead value climbs with the radius and
-the scanning exploit returns as it approaches infinity, so the ceiling is a security bound, not a
+the scanning exploit returns as it approaches infinity, so the cap is a security bound, not a
 preference.
 
 ## Package layout

--- a/docs/architecture/platform/observability.md
+++ b/docs/architecture/platform/observability.md
@@ -234,7 +234,7 @@ exporter. It is the explicit signal that the replay queue may go undrained despi
 appending unverified work.
 
 The `vers slow requests` threshold monitor watches `vers-traces` for any non-probe server span past
-a fixed 30s duration ceiling and notifies `vers alarms`, evaluated on its own schedule rather than
+a fixed 30s duration threshold and notifies `vers alarms`, evaluated on its own schedule rather than
 at span close. Health-probe routes are excluded because their latency tracks scale-to-zero machine
 wake rather than request handling. It is the fleet-wide alarm for a hung or pathologically slow
 request, independent of the per-request slow-request warn log a service's own `slowRequestMs`


### PR DESCRIPTION
## Description

Expands the docs-writing skill with the prose rules it lacked, restructured into a single taxonomy: the Selection/Rendering two-pass frame is the only spine, with every violation stated beside the rule it breaks.

- Sections: Selection, Sentences, Words, Structure, Stance, Formatting and links, Review workflow
- Grep checks move to `scripts/check-prose.sh` — excludes the skill's own directory, keeps the `CAS` ban case-sensitive so "CAs" passes
- `ceiling` and `floor` join the AGENTS.md banned words with a game-mechanic carve-out; the three figurative `ceiling` uses in docs/architecture are fixed
- `anchor` stays legal — appended/verified anchors are reserved seed-chain vocabulary
- The comments section moves from the shared partial (dropped upstream in zgeoff/tools#76) into `agents/project.md`, gaining a rendering bridge: long comments follow the docs-writing skill's sentence and structure rules

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality (docs and script only)