### PR TITLE
docs(testing): expand the testing skill with principles and inline examples

### DIFF
--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -27,7 +27,8 @@ The rules below decide most situations; where they don't, these do:
 
 - Clarity over abstraction: repetition in a test isn't a smell, hidden setup is.
 - Isolation is non-negotiable: every test passes alone and in any order.
-- Test behaviour, not implementation: swapping a `forEach` for `Promise.all` breaks no test.
+- Test behaviour, not implementation: a refactor that preserves the observable contract — renaming a
+  private helper, restructuring a loop — breaks no test.
 - Every mock is a divergence from reality: mock only what is genuinely out of reach, and keep it
   high-fidelity — correct codes, realistic shapes, shared types.
 - Test utilities are production code, extracted and tested with the same rigour.
@@ -108,9 +109,9 @@ The rules below decide most situations; where they don't, these do:
   distinct outputs — because a mock's exact digests are not contract.
 - A deterministic pipeline's suite opens with a frozen-golden test: one hand-written literal input
   (never a factory — regenerating with `bun test -u` must never move the input), the full output
-  pinned with `toMatchInlineSnapshot`. Its companion is a one-line purity test,
+  pinned with `toMatchInlineSnapshot`. Its companion is a one-line same-input determinism test,
   `expect(collectNodeEdges(chunk)).toStrictEqual(collectNodeEdges(chunk))` — the snapshot pins the
-  value, the pair pins that it's a function.
+  value, the pair pins that equal inputs give equal outputs.
 - A thrown error is asserted at the strictness its contract demands: bare
   `expect(() => …).toThrow()` when only throwing matters, `toThrowWithMessage(Error, /…/)` when the
   message is contract, and a typed service rejection narrows on `code` — never on message strings.
@@ -119,13 +120,13 @@ The rules below decide most situations; where they don't, these do:
   value into a passing comparison — and a conditional path in a test means two tests. An `if` inside
   an MSW handler implementation scripting a call sequence ("first call fails, second succeeds") is
   handler scripting, not test branching.
-- Nothing fakes the clock — no fake timers, no `setSystemTime`. Code that steps with time takes a
-  duration or timestamp argument (`simulation.run(10_000)`, `advanceToDuration(20_000)`); code with
-  an internal loop takes an injected clock handle stepped explicitly (xstate's `SimulatedClock`
-  driven by `clock.increment(ms)`, or a `createFastClock()` passed as the runtime's `now` option). A
-  wall-clock-dependent row is built with a relative fixture
-  (`expiresAt: new Date(Date.now() - 1000)`) and asserted with range matchers (`toBeAfter`,
-  `toBeBefore`, `toBeWithin`).
+- Nothing replaces global timers or wall-clock reads — no fake timers, no `setSystemTime`. Code that
+  steps with time takes a duration or timestamp argument (`simulation.run(10_000)`,
+  `advanceToDuration(20_000)`); code with an internal loop takes an injected controlled clock
+  stepped explicitly (xstate's `SimulatedClock` driven by `clock.increment(ms)`, or a
+  `createFastClock()` passed as the runtime's `now` option). A wall-clock-dependent row is built
+  with a relative fixture (`expiresAt: new Date(Date.now() - 1000)`) and asserted with range
+  matchers (`toBeAfter`, `toBeBefore`, `toBeWithin`).
 - Waiting on an async condition is `waitFor`, never a `setTimeout` — RTL's `waitFor` in React
   packages (it wraps retries in `act`), `@vers/test-utils` elsewhere.
 - A test that passes alone but fails in the full run has a cleanup gap: binary-search the file list
@@ -173,7 +174,7 @@ The rules below decide most situations; where they don't, these do:
     `toHaveBeenCalledAfter`
   - errors/async: `toThrowWithMessage`, `toResolve`, `toReject` (both return a promise — always
     `await`)
-- Matchers also work asymmetrically inside `toEqual`/`toMatchObject`
+- Matchers also work asymmetrically inside `toStrictEqual`/`toMatchObject`
   (`status: expect.toBeOneOf([…])`).
 - Known gaps: `expect.pass`/`expect.fail` are unimplemented upstream and excluded from our types.
   It's `toEqualCaseInsensitive` — not `…Insensitively` as some docs claim; unknown matcher names
@@ -230,10 +231,10 @@ The rules below decide most situations; where they don't, these do:
   `renderer.fireEvent` — never a shortcut past a real interaction.
 - Query by what the user perceives: `getByRole` (with `name`) first, then
   `getByLabelText`/`getByText`; `getByTestId` last. `getBy*` asserts presence, `queryBy*` absence,
-  `findBy*` async appearance — the first query after render is an `await findBy*` so suspense
-  settles, with synchronous queries after it. `findBy*` replaces `waitFor(() => getBy*)` — the
-  combination double-polls; `waitFor` is for conditions that aren't DOM queries (store state, mock
-  call counts).
+  `findBy*` async appearance — after a render that suspends or fetches, the first query is an
+  `await findBy*` so the settled tree is what sync queries then read; a synchronous render starts
+  with `getBy*` directly. `findBy*` replaces `waitFor(() => getBy*)` — the combination double-polls;
+  `waitFor` is for conditions that aren't DOM queries (store state, mock call counts).
 
   ```tsx
   const user = userEvent.setup();

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -120,13 +120,16 @@ The rules below decide most situations; where they don't, these do:
   value into a passing comparison — and a conditional path in a test means two tests. An `if` inside
   an MSW handler implementation scripting a call sequence ("first call fails, second succeeds") is
   handler scripting, not test branching.
-- Nothing replaces global timers or wall-clock reads — no fake timers, no `setSystemTime`. Code that
-  steps with time takes a duration or timestamp argument (`simulation.run(10_000)`,
-  `advanceToDuration(20_000)`); code with an internal loop takes an injected controlled clock
-  stepped explicitly (xstate's `SimulatedClock` driven by `clock.increment(ms)`, or a
-  `createFastClock()` passed as the runtime's `now` option). A wall-clock-dependent row is built
-  with a relative fixture (`expiresAt: new Date(Date.now() - 1000)`) and asserted with range
-  matchers (`toBeAfter`, `toBeBefore`, `toBeWithin`).
+- Time control follows the code's own shape, most explicit form first. Code that steps with time
+  takes a duration or timestamp argument (`simulation.run(10_000)`, `advanceToDuration(20_000)`);
+  code with an internal loop takes an injected controlled clock stepped explicitly (xstate's
+  `SimulatedClock` driven by `clock.increment(ms)`, or a `createFastClock()` passed as the runtime's
+  `now` option). A unit with no injection point that reads the global clock or schedules real timers
+  is driven with `setSystemTime` and fake timers, restored when the test finishes — the fallback for
+  code whose time the test cannot otherwise reach, not a substitute for an injection point the code
+  already offers. A wall-clock-dependent row is built with a relative fixture
+  (`expiresAt: new Date(Date.now() - 1000)`) and asserted with range matchers (`toBeAfter`,
+  `toBeBefore`, `toBeWithin`).
 - Waiting on an async condition is `waitFor`, never a `setTimeout` — RTL's `waitFor` in React
   packages (it wraps retries in `act`), `@vers/test-utils` elsewhere.
 - A test that passes alone but fails in the full run has a cleanup gap: binary-search the file list

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -3,8 +3,9 @@ name: testing
 description:
   vers testing conventions — the three regimes by package kind, the no-mock / no-branching /
   co-location rules, `bun test` process-wide lifecycle, isolation levels, factories and composites,
-  jest-extended matchers, and the MSW / RSC / Forms / real-database specifics. Load when designing,
-  writing, or reviewing tests.
+  jest-extended matchers, authorisation pairs, time and timestamp rules, forced infrastructure
+  failures, golden values and determinism, observability harnesses, contract-schema idioms, and the
+  MSW / RSC / Forms / real-database specifics. Load when designing, writing, or reviewing tests.
 ---
 
 # Testing
@@ -20,16 +21,51 @@ package kind:
 - **MSW-mocked packages** — clients of mocked services and app-web.
 - **Real-database packages** — services, apps, and DB-backed libraries exercising a real postgres.
 
+## Principles
+
+The rules below decide most situations; where they don't, these do:
+
+- Clarity over abstraction: repetition in a test isn't a smell, hidden setup is.
+- Isolation is non-negotiable: every test passes alone and in any order.
+- Test behaviour, not implementation: swapping a `forEach` for `Promise.all` breaks no test.
+- Every mock is a divergence from reality: mock only what is genuinely out of reach, and keep it
+  high-fidelity — correct codes, realistic shapes, shared types.
+- Test utilities are production code, extracted and tested with the same rigour.
+- Assertions are the contract: one loose assertion makes the rest of the test theatre.
+
 ## Everywhere
 
 - Never use `describe` — write flat `test(…)` blocks with behavioural titles that start with "it"
   (`test('it pads before a return statement', …)`).
+- A test body arranges, acts, asserts — phases separated by blank lines, never `// arrange`
+  comments; the act is usually a single call. A body with two act-assert pairs is two tests. A
+  pure-function test may collapse all three onto one expression.
+- `test.each` is sanctioned only for a closed decision table — data-only rows and a title template
+  that starts with "it" and interpolates the distinguishing input
+  (`test.each(rows)('it picks %s when the action is %s', …)`). Anything else is one `test()` per
+  case.
+- A loop over a module's own exports proving registry completeness (`Object.keys(generators)`) is
+  sanctioned iteration, not test branching — but the loop must not re-implement the transformation
+  it checks.
+- An assertion inside a callback the unit may never invoke passes vacuously when the callback is
+  skipped — capture into a const outside the scope and assert after the callback returns.
 - Test files are co-located with the module they test (`parse-source.ts` beside
   `parse-source.test.ts`) — no `test/`, `tests/` or `__tests__` directories. Declaration emit
   excludes `*.test.ts`, so they never ship.
 - A test whose unit consumes a domain object or DTO takes it from the package's faker-defaulted
   `create-mock-*` factory in `test-utils/factories/` (each factory has its own test), overriding
-  only the fields the unit reads.
+  only the fields the unit reads. Extraction follows where the type lives, not how many tests use
+  it: a type that crosses module boundaries gets its factory immediately; a type local to the module
+  under test stays an inline literal. Defaults are faker-dynamic where the value is arbitrary —
+  proving the unit doesn't depend on specific data — and static only for a constrained field (an
+  enum, a discriminator) or throughout a deterministic engine package, where a faker value would
+  churn every golden snapshot. The factory's own test pair keeps fixed titles —
+  `it builds a default X` asserting the whole shape with `toStrictEqual` plus asymmetric matchers,
+  and `it applies overrides on top of the defaults`; it may additionally round-trip the contract
+  schema, never instead. A factory defaults every foreign key to a freshly generated id
+  (`createId()`), never a real parent's — parent wiring is a composite's job. A row factory returns
+  the table's `Insertable<…>`; a DTO factory returns the contract type — distinct artefacts in the
+  packages that own each shape.
 - A unit that parses or validates raw input — a zod schema, a decoder — is tested with inline
   literal payloads, valid and invalid, never factory output: a factory built to satisfy a schema
   cannot falsify it. A rejection test asserts the reported issue path, never bare `success: false` —
@@ -45,16 +81,57 @@ package kind:
   for the stand-in (`create-stub-worker-context`, `create-test-connection`), and are never called
   factories.
 - `setupTest` wires runtime — servers, handlers, clients, recorders — and returns no domain data and
-  no data-builders.
+  no data-builders. It builds the environment; the scenario — every row, every override — is written
+  in the test body.
 - `toStrictEqual` when the test determines every field of the expected value — the full shape is the
   contract, and writing it out is the point. `toMatchObject`, or asymmetric matchers inside
   `toStrictEqual`, when the value carries fields the test doesn't determine: faker defaults,
   timestamps, engine-computed state. Choosing partial because the full literal is long is a defect —
   length is the contract. Never `toEqual`.
+
+  ```ts
+  expect(checkpoint).toStrictEqual({
+    nextSeed: expect.toBeString(),
+    rewards: expect.toBeObject(),
+    rewardSlots: expect.toBeArray(),
+    time: expect.toBeNumber(),
+    type: ActivityCheckpointType.Progress,
+  });
+  ```
+
+- Snapshots are inline only: `toMatchInlineSnapshot` pins deterministic machine output no human
+  derives by reading the code (AGENTS.md "Golden values in tests"). File-based snapshots
+  (`toMatchSnapshot`, `.snap`) and component snapshots never appear; a large-object expectation is
+  `toStrictEqual` with explicit values.
+- Production derivation output is a golden value and is pinned; a mock implementation's derived
+  values assert properties instead — output shape, same-input determinism, distinct inputs give
+  distinct outputs — because a mock's exact digests are not contract.
+- A deterministic pipeline's suite opens with a frozen-golden test: one hand-written literal input
+  (never a factory — regenerating with `bun test -u` must never move the input), the full output
+  pinned with `toMatchInlineSnapshot`. Its companion is a one-line purity test,
+  `expect(collectNodeEdges(chunk)).toStrictEqual(collectNodeEdges(chunk))` — the snapshot pins the
+  value, the pair pins that it's a function.
+- A thrown error is asserted at the strictness its contract demands: bare
+  `expect(() => …).toThrow()` when only throwing matters, `toThrowWithMessage(Error, /…/)` when the
+  message is contract, and a typed service rejection narrows on `code` — never on message strings.
 - A test body contains no branching: narrowing a maybe-value is a one-line `invariant(...)`
-  (`tiny-invariant`), waiting on an async condition is `waitFor` (`@vers/test-utils`), and a
-  conditional path in a test means two tests. An `if` inside an MSW handler implementation scripting
-  a call sequence ("first call fails, second succeeds") is handler scripting, not test branching.
+  (`tiny-invariant`) — never `?.`/`??` fallbacks inside `expect` arguments, which turn a missing
+  value into a passing comparison — and a conditional path in a test means two tests. An `if` inside
+  an MSW handler implementation scripting a call sequence ("first call fails, second succeeds") is
+  handler scripting, not test branching.
+- Nothing fakes the clock — no fake timers, no `setSystemTime`. Code that steps with time takes a
+  duration or timestamp argument (`simulation.run(10_000)`, `advanceToDuration(20_000)`); code with
+  an internal loop takes an injected clock handle stepped explicitly (xstate's `SimulatedClock`
+  driven by `clock.increment(ms)`, or a `createFastClock()` passed as the runtime's `now` option). A
+  wall-clock-dependent row is built with a relative fixture
+  (`expiresAt: new Date(Date.now() - 1000)`) and asserted with range matchers (`toBeAfter`,
+  `toBeBefore`, `toBeWithin`).
+- Waiting on an async condition is `waitFor`, never a `setTimeout` — RTL's `waitFor` in React
+  packages (it wraps retries in `act`), `@vers/test-utils` elsewhere.
+- A test that passes alone but fails in the full run has a cleanup gap: binary-search the file list
+  for the leaking test, find the leaked state — a cache, a singleton, an unreset store — and add its
+  reset to the preload's `afterEach`. Reordering tests or picking unique keys to dodge the collision
+  hides the gap.
 - Global mock reset lives in the preload's `afterEach` (`mock.restore()`), never per-test.
 - State a preload reset owns — Zustand stores (`registerZustandReset`, `@vers/client-test-utils`),
   MSW handlers (`registerMSWLifecycle`), the `@msw/data` store, registered mock holders, storage
@@ -74,9 +151,16 @@ package kind:
 - jest-extended matchers come from the `@zgeoff/bun-test-extended` preload; a package-local
   `augment-bun-test.ts` side-effect import brings their types into `tsc`.
 - Test titles describe observable behaviour and never cite internal identifiers
-  (`it flags the run as invalid`, not `it sets isValid to false`).
+  (`it flags the run as invalid`, not `it sets isValid to false`). A title is built verb + outcome +
+  condition (`it rejects an activity owned by another caller with NOT_FOUND`), so a CI failure reads
+  as a broken behaviour, not a broken implementation detail.
 - Bound test-result names: `ctx` for a `setupTest(…)` result, `hook` for `renderHook(…)`, `rendered`
-  for RTL `render(…)` — member-access off them, never pick properties into loose consts.
+  for RTL `render(…)`, `signedIn` for a `createSignedInUser(…)` result — member-access off them,
+  never pick properties into loose consts.
+- An entity-construction ladder whose intermediates the test acts on stays inline — idle-core's
+  `createMockSimulationContext()` → `createAvatar(data, ctx)` → `createActivity(data, ctx)` →
+  `createCombatExecutor(activity, avatar, ctx)` is four lines in every suite by design; extracting a
+  composite would hide the handles the test drives.
 - Reach for jest-extended matchers instead of hand-rolling assertions. Frequently useful:
   - arrays: `toIncludeAllMembers`, `toIncludeSameMembers`, `toPartiallyContain`,
     `toIncludeAllPartialMembers`, `toSatisfyAll`
@@ -98,15 +182,36 @@ package kind:
 ## MSW-mocked packages
 
 - MSW mocks the external HTTP/service boundary — never internal abstractions. One shared `server`
-  (`setupServer()`) per package in a `mocks/` module, its lifecycle wired by
+  (`setupServer()`) per package in `mocks/node.ts`, its lifecycle wired by
   `registerMSWLifecycle(server)` (`@vers/test-utils/bun`) in the preload with
   `onUnhandledRequest: 'error'`. For oRPC procedures, per-test handlers are built with
   `buildMockService` / `mockService` (`@vers/client-test-utils/orpc`).
 - A per-test `server.use(...)` handler models a deviation — an error code, a transport failure, a
-  scripted call sequence — or captures inputs for assertion. Happy-path behaviour comes from the
-  service's stateful mock handlers over the `@msw/data` store (`build<Service>MockHandlers`,
-  `@vers/mock-services`), driven by seeding its collections; a handler that re-implements service
-  logic inline is a defect.
+  scripted call sequence — or captures inputs for assertion. Everything the stateful handlers can
+  model comes from shaping the store, not an override: a missing row is already a not-found from the
+  default handler. Happy-path behaviour comes from the service's stateful mock handlers over the
+  `@msw/data` store (`build<Service>MockHandlers`, `@vers/mock-services`), driven by seeding its
+  collections; a handler that re-implements service logic inline is a defect.
+- Inputs are captured with an inline `mock()` the per-test handler feeds, asserted through the mock
+  matchers. A side-effect endpoint with no `@msw/data` backing that several tests inspect — an email
+  send, a webhook — instead exports a stateful store from its handler module (`sentEmails`), swept
+  by the preload; the store, the URL constant, and the resolver are separate exports so a per-test
+  deviation can wrap or replace them.
+
+  ```ts
+  const track = mock<(input: unknown) => void>();
+
+  server.use(
+    mockActivityService.getActivityRewards.handler((opts) => {
+      track(opts.input);
+
+      return { items: [], verifiedHead: 2 };
+    }),
+  );
+
+  expect(track).toHaveBeenCalledExactlyOnceWith({ activityID: activity.id });
+  ```
+
 - Stateful backends use `@msw/data`: an in-memory store built from a zod schema
   (`new Collection({ schema })`, `.create()`/`.createMany()`, `.findFirst()`/`.findMany()`,
   `.defineRelations()`) read and written directly from the oRPC mock handlers — never `@msw/data`'s
@@ -119,6 +224,34 @@ package kind:
   data through the MSW handlers and `@msw/data` store — never by stubbing hooks. Drive client state
   through a package's exported setters (`setSelectedNode`), never raw `setState` pokes; `waitFor`
   the fetch before asserting.
+- Interactions go through `userEvent.setup()`, created once per test and driving the full chain
+  (`user.type`, `user.click`). `fireEvent` is reserved for events `userEvent` cannot produce — a raw
+  `input` on an OTP field, an outside-dismiss pointer sequence on `document.body`, a react-three
+  `renderer.fireEvent` — never a shortcut past a real interaction.
+- Query by what the user perceives: `getByRole` (with `name`) first, then
+  `getByLabelText`/`getByText`; `getByTestId` last. `getBy*` asserts presence, `queryBy*` absence,
+  `findBy*` async appearance — the first query after render is an `await findBy*` so suspense
+  settles, with synchronous queries after it. `findBy*` replaces `waitFor(() => getBy*)` — the
+  combination double-polls; `waitFor` is for conditions that aren't DOM queries (store state, mock
+  call counts).
+
+  ```tsx
+  const user = userEvent.setup();
+  const rendered = renderWithRouter(<LoginForm action={rejectWithResponse} />);
+
+  const email = await rendered.findByLabelText('Email');
+
+  await user.type(email, 'player@vers.test');
+  await user.type(rendered.getByLabelText('Password'), 'password123');
+  await user.click(rendered.getByRole('button', { name: 'Login' }));
+  ```
+
+- Proving an element never appears is a bounded rejection —
+  `await expect(rendered.findByTestId('spinner')).toReject()` with a short per-call `timeout` and a
+  comment justifying the window — never a fixed sleep.
+- A three-scene component (`components-three/`) renders through `ReactThreeTestRenderer` and fires
+  events with `renderer.fireEvent(mesh, 'pointerEnter', …)`, asserting on store state; a DOM
+  component (`components-ui/`) goes through RTL and `userEvent`.
 - Router-aware components mount through `renderWithRouter`, which returns the `router` beside the
   render utils. Assert a transition on `router.state.location.pathname` — memory history makes every
   `navigate` a real transition — and declare each destination through the `routes` option so it
@@ -145,7 +278,24 @@ package kind:
   real-runtime smoke suite.
 - Ambient request context (`@tanstack/react-start/server`) is stubbed only through the shared
   `withRequestContext` util, installed once in the preload behind a mutable holder — never Start's
-  RSC/render APIs. Every stubbed ambient path is also crossed by the smoke suite.
+  RSC/render APIs. Every stubbed ambient path is also crossed by the smoke suite. A test wraps the
+  render and its assertions in the callback; the call is awaited for its `{ cookies, value }`
+  outcome, or deliberately left un-awaited so a rejection can be asserted on it.
+
+  ```tsx
+  const signedIn = await createSignedInUser();
+
+  await withRequestContext({ cookies: signedIn.cookies }, async () => {
+    const rendered = renderWithRouter(<AccountScreen />);
+
+    await expect(rendered.findByText(signedIn.username)).resolves.toBeInTheDocument();
+  });
+  ```
+
+- A thrown router redirect is asserted directly —
+  `expect(promise).rejects.toMatchObject({ options: { href: '/login' } })` — and the no-redirect
+  branch asserts the resolved value. Never a `.catch(isRedirect)` ternary, never a sentinel return,
+  never an `instanceof` throw-guard where `invariant` narrows.
 
 ## Forms (Conform)
 
@@ -182,10 +332,25 @@ package kind:
   statement poisons the rest of a shared test transaction. `database` (a real, committed clone
   database) is reserved for database-scoped state (advisory locks, LISTEN/NOTIFY), DDL and migration
   exercises, and structures `LIKE` can't reproduce (partitioned parents). Inject the handle's `db`
-  into the code under test — code that opens its own connection bypasses the isolation.
+  into the code under test — code that opens its own connection bypasses the isolation. A suite that
+  opts out of `transaction` carries a comment naming the code path that forces it ("createChain
+  opens its own interactive transaction, which the default handle can't nest").
 - **Test setup.** A local `setupTest()` per suite — typed config in, named props out, no `if` —
-  builds the db and boots the service, with no data. Never centralise it: a shared `setupTest`
-  accretes conditionals as services multiply.
+  builds the db and boots the service. It may seed what the service needs to boot (a sim version, a
+  content document); scenario data — anything a test asserts on — stays in the test body. Never
+  centralise it: a shared `setupTest` accretes conditionals as services multiply. Multiple
+  `await using` handles tear down last-in-first-out, so a resource declared after the db closes
+  before the db drops.
+
+  ```ts
+  async function setupTest() {
+    const db = await createTestDB();
+    const service = await createAvatarService({ db: db.db });
+
+    return { app: service.app, db: db.db, [Symbol.asyncDispose]: db[Symbol.asyncDispose] };
+  }
+  ```
+
 - **Test data — factories + composites.** Every domain entity/DTO gets a faker-defaulted
   `create-mock-*.ts` factory in `test-utils/factories/` (a plain object, never persisted, never
   requiring a parent), each with its own test. Persisted or wired data goes through a
@@ -195,13 +360,151 @@ package kind:
   still build actors bespoke. `createViewer`/`createAnonymousViewer`
   (`@vers/service-test-utils/bun`) are the shared s2s-actor composites; build the client in-test via
   `buildRPCTestClient(app, { token })`.
+- **A composite maps to a domain concept the system already names.** Two engineers reading only the
+  name agree on what it wires (`createViewer`, `createSignedInUser`); a name that needs the file
+  opened (`createUserWithAvatarAndTwoActivities`) is a convenience grouping — the test composes
+  primitives instead. A variant is its own file and export (`createAnonymousViewer` beside
+  `createViewer`), never a flag or an `if` inside one composite. No batch overloads: several rows
+  are several calls, mapped through `Promise.all` when order doesn't matter.
+- A row composite's doc comment names the scenario the service's own procedures can't reach —
+  seeding another user's rows, backdating `createdAt`, writing a known TOTP secret. That
+  justification is the test for whether a direct database write is legitimate; a composite that
+  can't state one is a procedure call that should go through the service. Its test pair asserts the
+  wiring with `toMatchObject` (the persisted row carries DB-computed fields) and that overrides
+  apply.
+- Read-back verification is `.selectFrom(…).selectAll().where(…).executeTakeFirstOrThrow()` when the
+  row must exist — narrowing to `.select('col')` when one column is the subject — and absence is
+  `executeTakeFirst()` with `toBeUndefined()`. A utility that interpolates an identifier into SQL
+  carries a dedicated rejection test for its guard.
+- **Every service carries the same scaffolding suites.** `create-<service>-service.test.ts` holds
+  the injection pair — an injected db is wired into the router (drive one write, assert the row
+  landed in the handle), and the service boots from `env.DATABASE_URL` when none is injected, each
+  boot disposed. `build-router.test.ts` holds the conformance loop: every case from
+  `collectConformanceCases` driven through `await expect(case.run(ctx.app)).toResolve()` — the
+  sanctioned loop over assertions.
 - **Failure paths are contract.** Assert on the rejection directly —
   `expect(promise).rejects.toMatchObject({ code })` — never try/catch, and test each declared error.
   Bun's matcher types declare `.rejects`/`.resolves` chains synchronous, so they are not `await`ed;
-  `toResolve()`/`toReject()` are the two matchers typed as promises and are `await`ed.
+  `toResolve()`/`toReject()` are the two matchers typed as promises and are `await`ed. When a later
+  query in the same test must observe the rejected call's transaction settled, drain it first:
+  `await request.catch(() => {});` then the un-awaited `expect(request).rejects.toMatchObject(…)`.
+- **Authorisation is tested in pairs.** Every ownership or access rule lands with its positive and
+  its negative test — "the owner reads it" and "another caller is rejected" are two tests, and the
+  cross-actor case is named explicitly. Each actor is minted with `createViewer` and holds its own
+  client. A write or targeted read rejects; a read path that hides instead of rejecting asserts
+  `toBeNull()`. The anonymous pair (`createAnonymousViewer`) applies to procedures that resolve the
+  acting user; a pure service-to-service procedure carries none.
+
+  ```ts
+  test('it rejects an activity owned by another caller with NOT_FOUND', async () => {
+    await using ctx = await setupTest();
+
+    const owner = await createViewer({ audience: 'service-activity', db: ctx.db });
+    const avatar = await createAvatarRow(ctx.db, { userId: owner.user.id });
+
+    const ownerClient = buildRPCTestClient<ActivityContract>(ctx.app, { token: owner.token });
+
+    const started = await ownerClient.startActivity({ avatarID: avatar.id, scopeID: '0_0' });
+    const other = await createViewer({ audience: 'service-activity', db: ctx.db });
+
+    const otherClient = buildRPCTestClient<ActivityContract>(ctx.app, { token: other.token });
+
+    expect(otherClient.getActivityRewards({ activityID: started.id })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+  ```
+
+- **Timestamps never encode insertion order.** Under `transaction` isolation `now()` is pinned to
+  the transaction's start, so every DB-defaulted timestamp column in a test carries the same value —
+  and JS-side factory defaults collide at millisecond resolution anyway. A test asserting an order,
+  or a winner, among rows whose sort keys tie passes explicit distinct timestamps. A production
+  query ordered by a timestamp carries a total-order tiebreaker
+  (`.orderBy('deployedAt', 'desc').orderBy('id', 'desc')`) when callers need a stable result, and
+  the tie gets its own test:
+
+  ```ts
+  test('it breaks a deployedAt tie toward the later insert', async () => {
+    await using ctx = await setupTest();
+
+    const at = new Date('2026-01-01T00:00:00Z');
+
+    await createReleaseRow(ctx.db, { app: 'vers-app-web', deployedAt: at });
+
+    const later = await createReleaseRow(ctx.db, { app: 'vers-app-web', deployedAt: at });
+
+    expect(findLatestRelease(ctx.db, 'vers-app-web')).resolves.toStrictEqual(later);
+  });
+  ```
+
+- **Infrastructure failures run on real transports.** A database-unreachable branch runs the real
+  driver against an address nothing listens on — never a stubbed query method — with the handle
+  destroyed in `onTestFinished`. A downstream-service failure is a per-test MSW handler that throws.
+
+  ```ts
+  const unreachableDB = createDB({ databaseURL: 'postgresql://bad:bad@127.0.0.1:1/nope' });
+
+  onTestFinished(async () => {
+    await unreachableDB.destroy();
+  });
+
+  const drained = await drainReplayQueue({ db: unreachableDB });
+
+  expect(drained).toBe(0);
+  ```
+
+  ```ts
+  server.use(
+    mockKeysService.deriveScopeSecret.handler(() => {
+      throw new Error('keys backend unreachable');
+    }),
+  );
+
+  expect(client.startActivity(input)).rejects.toMatchObject({ code: 'INTERNAL_SERVER_ERROR' });
+  ```
+
 - **Naming.** Prefix titles `#procedureName` only when one file holds several procedures' tests;
   plain `it …` when a file covers one unit.
 - **Env.** Permanent env is a direct `process.env` assignment in the preload; per-test overrides go
   through `updateEnv`, restored by `removeEnvOverrides` in the preload's `registerBunTestCleanup()`.
 - **Auth.** s2s tests use the real verification path: an asymmetric keypair from
   `getTestServiceKeyPair()`, tokens minted with `createServiceToken`.
+
+## Observability
+
+- A counter's suite is two tests: record it two or three times with distinct attributes and read the
+  points back through `createInMemoryMetrics()` (`@vers/test-utils/bun`) — never a hand-rolled
+  `MeterProvider` — then the fixed-title `it stays inert without a registered meter provider`
+  asserting the record call doesn't throw.
+- Spans are captured with an in-memory harness: `InMemorySpanExporter` behind a
+  `NodeTracerProvider({ spanProcessors: [new SimpleSpanProcessor(exporter)] })`, registered in the
+  test and torn down in `onTestFinished` as `trace.disable()` **then** `await provider.shutdown()` —
+  that order, or the global registration leaks process-wide.
+- Error reporting is asserted against the real Sentry SDK: a well-formed fake DSN,
+  `disableDefaultIntegrations: true`, and a `beforeSend` that records the event and returns `null`
+  so nothing egresses; `waitFor` the recorder before asserting.
+- A log line is asserted through an injected write-capture stream —
+  `createLogger({ level, stream: { write: (line) => lines.push(line) } })`, `JSON.parse` the line,
+  `toMatchObject` — always paired with a below-level test asserting `toBeEmpty()`. Never a spy on
+  the logger.
+- An OTLP exporter's success path runs against a loopback receiver: `Bun.serve({ port: 0 })`
+  capturing requests, the endpoint injected with `updateEnv`, the server stopped in
+  `onTestFinished`; assert path, headers, and a non-empty body.
+
+## Contracts and scripts
+
+- A contract module's suite is a triad: each procedure's `errorMap` keys via
+  `toContainAllKeys`/`toContainKey`, an explicit `status` assertion per bespoke code, and a closing
+  OpenAPI-generation test through `new OpenAPIGenerator({ schemaConverters: […] })`.
+- A schema rejection asserts the issue path with one matcher shape —
+  `expect(result.error?.issues).toPartiallyContain(expect.objectContaining({ path: ['field'] }))` —
+  never positional `issues[0]` (couples the test to issue ordering) and never `code` in place of
+  path.
+- An accept test reads `result.data` — `expect(Schema.parse(payload)).toStrictEqual(payload)` where
+  the schema passes values through, explicit expected values where it transforms. A bare
+  `success: true` passes for a schema that strips, coerces, or defaults wrongly.
+- A rejection payload restates the full valid literal with one field changed — the deliberate
+  consequence of banning module-level fixtures, not duplication to clean up.
+- A collection scanner's suite carries an explicit negative-scope test naming what it never touches
+  (`it never touches other machines' databases`) — for sweep logic that drops resources, the test
+  that matters most.


### PR DESCRIPTION
## Description

Expands the testing skill with a principles block, inline examples for the highest-misstep rules, and rules distilled from a five-agent audit of the existing suites — every rule and example is grounded in a pattern the suites already use, with each snippet verified against oxfmt, format-codemod, and oxlint.

- Principles block for situations the specific rules don't cover
- Inline examples: asymmetric `toStrictEqual`, `setupTest`, authorisation shape, input capture, RTL interaction, ambient request context
- Rules for time control (duration args, injected clocks), isolation debugging, authorisation pairs, timestamp ties, infrastructure failures via real transports, RTL query priority and `userEvent`, golden values and the determinism pair, factory and composite discipline, redirect assertions, `test.each` scope
- New Observability section (metrics/span/Sentry/log/OTLP harnesses) and Contracts-and-scripts section (error-map triad, issue-path idiom, accept-side `result.data`, negative-scope sweeps)

## Testing

- [ ] `bun run typecheck` passes
- [ ] `bun run test` passes
- [ ] `bun run lint` passes
- [ ] New tests added for new functionality

Doc-only change; `bun run format:check` passes locally, CI covers the rest.
