### PR TITLE
docs: restructure the longest code comments into structured prose

### DIFF
--- a/apps/web/src/routes/-explore-current/explore-current-panel.tsx
+++ b/apps/web/src/routes/-explore-current/explore-current-panel.tsx
@@ -39,17 +39,21 @@ interface StartAttemptReport {
  * The world map node detail view: a spinner until the worker answers the requested start, then
  * the encounter, its auto-retry toggle, and its codex slot. The worker owns the whole start; the
  * panel awaits the call directly and renders its own outcome, so another tab's run never reads as
- * this one's. A failed start renders a retry action. Once the start goes live the panel navigates
- * to the engagement screen, once per activity — latched in `@vers/idle-client`'s store rather than
- * a component ref, so a remount (the browser back button, re-drilling the same node) that re-fires
- * the start call and finds the same activity already live reads it as already engaged rather than
- * bouncing the player back. A start rejected because the account's active avatar changed renders a
- * distinct notice naming the current one, with a reload action rather than the generic retry — the
- * route's own data still names the stale avatar, and only a reload re-runs every gate against the
- * new one. A start rejected because the running build's engine no longer supports the current
- * content renders its own reload notice for the same reason: no in-page recovery can fetch a newer
- * bundle. While an offline catch-up is still fast-forwarding, the panel withholds its start call
- * — the lockout overlay above it covers the UI, but this keeps a mounted panel from auto-sending a
+ * this one's. A failed start renders a retry action.
+ *
+ * Once the start goes live the panel navigates to the engagement screen, once per activity —
+ * latched in `@vers/idle-client`'s store rather than a component ref, so a remount (the browser
+ * back button, re-drilling the same node) that re-fires the start call and finds the same
+ * activity already live reads it as already engaged rather than bouncing the player back.
+ *
+ * Two rejections render a reload notice instead of the generic retry. A start refused because
+ * the account's active avatar changed names the current avatar: the route's own data still names
+ * the stale one, and only a reload re-runs every gate against the new one. A start refused
+ * because the running build's engine no longer supports the current content reloads for its own
+ * reason: no in-page recovery can fetch a newer bundle.
+ *
+ * While an offline catch-up is still fast-forwarding, the panel withholds its start call — the
+ * lockout overlay above it covers the UI, but this keeps a mounted panel from auto-sending a
  * start of its own underneath it.
  */
 export function ExploreCurrentPanel(props: Readonly<ExploreCurrentPanelProps>) {

--- a/libs/game/idle-client/src/resync/plan-offline-continuations.ts
+++ b/libs/game/idle-client/src/resync/plan-offline-continuations.ts
@@ -47,20 +47,23 @@ export interface PlanOfflineContinuationsResult {
 
 /**
  * Simulates an entire offline gap locally: no network call, no submitter. Attempt by attempt, it
- * reconstructs the confirmed row's own remaining tail for free (the already-appended prefix costs
- * nothing against the budget), then — while budget remains and the failure policy allows it —
- * derives each further attempt's seed, client id, and predicted build snapshot from the chain
- * position alone, exactly as `advanceActivity` reproduces them server-side. Prediction depends on
- * the single-active-run invariant: no other scope accrues unsettled xp during the gap, so the
+ * reconstructs the confirmed row's own remaining tail for free — the already-appended prefix
+ * costs nothing against the budget. While budget remains and the failure policy allows it, each
+ * further attempt's seed, client id, and predicted build snapshot derive from the chain position
+ * alone, exactly as the server reproduces them when it applies the catch-up. Prediction depends
+ * on the single-active-run invariant: no other scope accrues unsettled xp during the gap, so the
  * confirmed row's own snapshot is the correct baseline for every later attempt's fold, and the
- * only sources this loop must add are the gap's own continuations as they close. A failure under
- * the abort policy stops planning after that continuation's own tail — the same policy live play
- * applies after a terminal checkpoint. The wire format still mints that continuation's own fresh
- * row, since every entry both closes a row and opens the next; the caller stops that row back
- * durably rather than attaching it, so — like an aborted online failure — nothing resumes
- * automatically and the row reads idle server-side. A confirmed row whose reconstructed attempt
- * already accounts for every checkpoint through its own terminal — an empty remaining tail —
- * resolves as no fast-forward at all rather than minting a successor from nothing.
+ * only sources this loop must add are the gap's own continuations as they close.
+ *
+ * A failure under the abort policy stops planning after that continuation's own tail — the same
+ * policy live play applies after a terminal checkpoint. The wire format still mints that
+ * continuation's own fresh row, since every entry both closes a row and opens the next. The
+ * caller stops that row back durably rather than attaching it, so nothing resumes automatically
+ * and the row reads idle server-side, like an aborted online failure.
+ *
+ * A confirmed row whose reconstructed attempt already accounts for every checkpoint through its
+ * own terminal — an empty remaining tail — resolves as no fast-forward at all rather than minting
+ * a successor from nothing.
  */
 export async function planOfflineContinuations(
   options: Readonly<PlanOfflineContinuationsOptions>,

--- a/libs/game/idle-client/src/submission/create-checkpoint-submitter.ts
+++ b/libs/game/idle-client/src/submission/create-checkpoint-submitter.ts
@@ -178,23 +178,25 @@ const TERMINAL_CHECKPOINT_TYPES: ReadonlySet<string> = new Set([
 
 /**
  * Owns a worker's outbound checkpoint submissions: mapping, the durable queue, and one serialized
- * in-flight batch per activity. Response handling follows the activity service's response
- * contract: a fresh head on success or `CONFLICT` advances the cursor and confirms the queue up to
- * it; `CHECKPOINT_INVALID` and `NOT_FOUND` stop the stream (keeping and discarding its queue rows,
- * respectively); `ACTIVITY_CAPPED`, `ACTIVITY_TERMINAL`, and `SESSION_EVICTED` stop the stream and
- * discard its rows — the server accepts nothing further for it; anything else — `UNAUTHORIZED` or
- * a transport failure — holds the queue untouched and starts a per-activity retry loop. Each flush
- * rides a freshly minted trace, and a streak of non-defined flush failures reports a stall without
- * stopping the stream.
+ * in-flight batch per activity. Each flush rides a freshly minted trace, and a streak of
+ * non-defined flush failures reports a stall without stopping the stream. Response handling
+ * follows the activity service's response contract:
  *
- * An activity whose stream stops with its rows discarded — `ACTIVITY_CAPPED`, `ACTIVITY_TERMINAL`,
- * `SESSION_EVICTED`, `NOT_FOUND` — has its cursor and registration evicted from both tracking maps,
- * so a later registration re-seeds fresh rather than resolving stale state; a fully confirmed
- * terminal checkpoint evicts the same way once its flush lands. `SESSION_EVICTED` additionally
- * marks the activity as evicted until a later registration supersedes it, so lifecycle flows can
- * tell a displaced stream from one that drained clean. `CHECKPOINT_INVALID` keeps its rows and its
- * tombstoned state for the worker's lifetime, so a later registration attempt never resends what
- * the server already rejected.
+ * - a fresh head on success or `CONFLICT` advances the cursor and confirms the queue up to it
+ * - `CHECKPOINT_INVALID` stops the stream and keeps its queue rows
+ * - `NOT_FOUND` stops the stream and discards its queue rows
+ * - `ACTIVITY_CAPPED`, `ACTIVITY_TERMINAL`, and `SESSION_EVICTED` stop the stream and discard its
+ *   queue rows — the server accepts nothing further for it
+ * - anything else — `UNAUTHORIZED` or a transport failure — holds the queue untouched and starts
+ *   a per-activity retry loop
+ *
+ * An activity whose stream stops with its rows discarded has its cursor and registration evicted
+ * from both tracking maps, so a later registration re-seeds fresh rather than resolving stale
+ * state; a fully confirmed terminal checkpoint evicts the same way once its flush lands.
+ * `SESSION_EVICTED` additionally marks the activity as evicted until a later registration
+ * supersedes it, so lifecycle flows can tell a displaced stream from one that drained clean.
+ * `CHECKPOINT_INVALID` keeps its rows and its tombstoned state for the worker's lifetime, so a
+ * later registration attempt never resends what the server already rejected.
  */
 export function createCheckpointSubmitter(
   options: Readonly<CreateCheckpointSubmitterOptions>,

--- a/libs/game/idle-client/src/worker/run-continuation.ts
+++ b/libs/game/idle-client/src/worker/run-continuation.ts
@@ -16,20 +16,21 @@ import type { FlowSignals, WorkerContext } from './types';
  * Starts the next continuation after a terminal checkpoint: a fresh server row for the same
  * scope, continuing the RNG chain the terminal checkpoint's `nextSeed` anchors, registered from
  * a zero cursor. Restarting the same row is impossible — the server closed it to appends on the
- * terminal checkpoint. Duplicate deliveries dedupe on the start key, so a `CONFLICT` is a
- * genuinely different claim and is handed to a full resync — adopting a conflicting row from a
- * zero cursor would fork the checkpoint chain. The same-row case (terminal append still
- * unacknowledged) and a transport failure both park a durable start intent for a later resync's
- * drain, surviving a worker reload; any other rejection parks nothing — the service answered, so
- * the failure is the activity's, not the connection's. AVATAR_NOT_ACTIVE means the account
- * switched avatars mid-session: nothing is parked, since this avatar's chain has nowhere to
- * continue to, and the tab is told which avatar is now active rather than left on a silently
- * reset runtime. An expired sim version means this build's engine can no longer replay the
- * current content: nothing is parked, since a reload is the only remedy, and the tab is told to
- * offer it rather than left on a silently reset runtime. Queued from the tick loop, the entry
- * guard is the staleness check: a turn whose simulation/activity pair lost the runtime while it
- * waited returns untouched. Past the start call only stops can interleave; a row started under
- * one is stopped back durably.
+ * terminal checkpoint.
+ *
+ * Duplicate deliveries dedupe on the start key, so a `CONFLICT` is a genuinely different claim
+ * and is handed to a full resync — adopting a conflicting row from a zero cursor would fork the
+ * checkpoint chain. The same-row case (a terminal append still unacknowledged) and a transport
+ * failure both park a durable start intent for a later resync's drain, surviving a worker reload.
+ * Any other rejection parks nothing — the service answered, so the failure is the activity's, not
+ * the connection's. Two of those rejections also notify the tab, which would otherwise be left on
+ * a silently reset runtime: `AVATAR_NOT_ACTIVE` names the avatar the account switched to
+ * mid-session, and an expired sim version has the tab offer a reload — the only remedy once this
+ * build's engine can no longer replay the current content.
+ *
+ * Queued from the tick loop, the entry guard is the staleness check: a turn whose
+ * simulation/activity pair lost the runtime while it waited returns untouched. Past the start
+ * call only stops can interleave; a row started under one is stopped back durably.
  */
 export async function runContinuation(
   context: WorkerContext,

--- a/libs/game/idle-client/src/worker/run-resync-flow.ts
+++ b/libs/game/idle-client/src/worker/run-resync-flow.ts
@@ -35,29 +35,34 @@ import { updateWriterDisplacedStatus } from './update-writer-displaced-status';
 import type { ResyncStatus } from './worker-to-client-message-schema';
 
 /**
- * Runs one resync end to end — the mailbox-inner body: the reconnect recovery queues it as a
- * turn, while the start flow and continuations call it directly from inside their own turns
- * (queueing there would deadlock). Every install re-checks `signals.stop`, the caller's
- * entry-captured stop signal, so a stop raised after the caller began — including during a queue
- * wait — aborts the install; the cancel composite additionally cancels in-flight reads on a worker
- * shutdown. Only a plan covering a real away period broadcasts a `ResyncStatus` progression ending
- * on `done` or `capped`, so a tab's welcome-back UI always resolves; zero-gap outcomes stay
- * silent so a fresh login never opens it. An outright failure reports the fault and broadcasts
- * `failed`, never a connection-status change, and never rejects — a tab's retry re-signals it.
- * `UNAUTHORIZED` broadcasts `session-expired` instead, with no fault report: the only remedy is
- * a fresh sign-in, so the tab renders that rather than a futile retry. An abort settles silently
- * — broadcasting `failed` would flash an error for a deliberate stop. When `avatarID` came from a
- * durable start intent that the account has since switched away from, the service's own rejection
- * names the account's actual active avatar — the authoritative recovery target, never a
- * caller-derived guess that can itself be stale. That reported avatar's own catch-up runs in the
- * dead intent avatar's place whenever the two differ, and `avatar-switched` broadcasts afterward
- * as the cycle's terminal status, carrying that pass's tallies so the player sees both the switch
- * notice and what the catch-up earned; the stamped resync avatar follows the pass onto the
- * reported avatar. When the reported avatar already matches `avatarID`, no pass runs and the
- * stamped resync avatar clears instead, so a dead intent avatar isn't resynced again next cycle.
+ * Runs one resync end to end — the mailbox-inner body. The reconnect recovery queues it as a
+ * turn; the start flow and continuations call it directly from inside their own turns, where
+ * queueing would deadlock. Every install re-checks `signals.stop`, the caller's entry-captured
+ * stop signal, so a stop raised after the caller began — including during a queue wait — aborts
+ * the install; the cancel composite additionally cancels in-flight reads on a worker shutdown.
+ *
+ * Only a plan covering a real away period broadcasts a `ResyncStatus` progression ending on
+ * `done` or `capped`, so a tab's welcome-back UI always resolves. Zero-gap outcomes stay silent,
+ * so a fresh login never opens it.
+ *
+ * An outright failure reports the fault and broadcasts `failed` — never a connection-status
+ * change — and never rejects; a tab's retry re-signals it. `UNAUTHORIZED` broadcasts
+ * `session-expired` instead, with no fault report: the only remedy is a fresh sign-in, so the tab
+ * renders that rather than a futile retry. An abort settles silently — broadcasting `failed`
+ * would flash an error for a deliberate stop.
+ *
+ * When `avatarID` came from a durable start intent that the account has since switched away from,
+ * the service's own rejection names the account's actual active avatar — the authoritative
+ * recovery target, never a caller-derived guess that can itself be stale. When the two differ,
+ * the reported avatar's own catch-up runs in the dead intent avatar's place, the stamped resync
+ * avatar follows the pass onto it, and `avatar-switched` broadcasts afterward as the cycle's
+ * terminal status, carrying the pass's tallies — the player sees both the switch notice and what
+ * the catch-up earned. When they already match, no pass runs and the stamped resync avatar
+ * clears, so a dead intent avatar isn't resynced again next cycle.
+ *
  * A held intent the service refuses as stale for the current content broadcasts
- * `sim-version-expired` and runs no pass — a reload is the only remedy, on the entry drain and the
- * blocked-intent retry alike.
+ * `sim-version-expired` and runs no pass — a reload is the only remedy, on the entry drain and
+ * the blocked-intent retry alike.
  */
 export async function runResyncFlow(
   context: WorkerContext,

--- a/libs/service/service-utils/src/utils/expand-env.ts
+++ b/libs/service/service-utils/src/utils/expand-env.ts
@@ -3,19 +3,7 @@ interface Env {
 }
 
 /**
- *
- * A reusable Zod transformer that adds environment utility properties to any
- * environment schema that includes a NODE_ENV field.
- *
- * @example
- * ```ts
- * const envSchema = z
- *   .object({
- *     NODE_ENV: z.enum(['development', 'test', 'production', 'e2e']),
- *     // ... other env vars
- *   })
- *   .transform(expandEnv);
- * ```
+ * Composes with a Zod env schema as its `.transform(expandEnv)` step.
  */
 export function expandEnv<T extends Env>(env: T) {
   return {

--- a/scripts/src/deploy/plan-sim-version-actions.ts
+++ b/scripts/src/deploy/plan-sim-version-actions.ts
@@ -3,20 +3,20 @@ import { buildProviderAppName } from './build-provider-app-name';
 import type { SimVersionAction, SimVersionActionInput } from './types';
 
 /**
- * Decides what a replay deploy still needs to provision for an engine hash:
- * a fresh hash gets a new per-version provider app, its flycast IP, a
- * machine launched from the fleet's just-deployed tag, and a registry row;
- * an existing app with a machine already running the fleet's resolved digest
- * and a registry row that already points at that image and carries the
- * build's bundled content version needs nothing. A missing
- * provider app is always recreated, an app that lost its machine gets a
- * fresh machine, a machine running any other digest or sitting in any other
- * region is replaced, and every
- * non-current state refreshes the row — the fleet, not the row or the
- * running machine, is the source of truth. Launching and replacing always
- * target the fleet's tag, never its digest — `flyctl machine run` mangles a
- * `@sha256:` ref. No actions come back when the fleet has no single resolved
- * image to provision from.
+ * Decides what a replay deploy still needs to provision for an engine hash. The fleet — not the
+ * registry row or the running machine — is the source of truth:
+ *
+ * - a fresh hash gets a new per-version provider app, its flycast IP, a machine launched from the
+ *   fleet's just-deployed tag, and a registry row
+ * - a missing provider app is always recreated; an app that lost its machine gets a fresh one
+ * - a machine running any other digest, or sitting in any other region, is replaced
+ * - every non-current state refreshes the registry row
+ * - an existing app whose machine already runs the fleet's resolved digest, with a registry row
+ *   pointing at that image and carrying the build's bundled content version, needs nothing
+ *
+ * Launching and replacing always target the fleet's tag, never its digest — `flyctl machine run`
+ * mangles a `@sha256:` ref. No actions come back when the fleet has no single resolved image to
+ * provision from.
  */
 export function planSimVersionActions(
   input: Readonly<SimVersionActionInput>,

--- a/services/activity/src/handlers/advance-activity.ts
+++ b/services/activity/src/handlers/advance-activity.ts
@@ -65,30 +65,33 @@ interface AdvanceActivityOpts {
 }
 
 /**
- * Bulk mint-and-appends an offline catch-up: each `continuations` entry appends its tail onto
- * whichever row is currently active — `activityID` for the first entry, otherwise the row the
- * previous entry minted — and, once that append lands terminal, mints the entry's own
- * `id`/`startKey`/`buildSnapshot` as the next row, ready for the following entry's tail. Every
- * continuation always ends terminal by construction: the client only ever submits a full attempt,
- * never a partial one, so each entry both closes a row and opens the next.
+ * Bulk mint-and-appends an offline catch-up. Each `continuations` entry appends its tail onto the
+ * currently active row — `activityID` for the first entry, the previous entry's minted row after —
+ * and, once that append lands terminal, mints the entry's own `id`/`startKey`/`buildSnapshot` as
+ * the next row. Every entry both closes a row and opens the next: the client only ever submits a
+ * full attempt, so each continuation ends terminal by construction.
  *
- * `contentVersion`, `keyVersion`, `simVersion`, `encounterNode`, and `secretRef`/`secretVersion` are
- * inherited once from `activityID`'s own row and reused for every mint in this request — never
- * re-resolved from the service's current deploy or the world map — so the whole offline gap
- * replays under the exact engine, content, and encounter the client's own local simulation was
- * pinned to, and every minted row stays eligible for the replay verifier's descriptor check.
+ * `contentVersion`, `keyVersion`, `simVersion`, `encounterNode`, and `secretRef`/`secretVersion`
+ * are inherited once from `activityID`'s own row and reused for every mint in this request —
+ * never re-resolved from the service's current deploy or the world map. The whole offline gap
+ * therefore replays under the exact engine, content, and encounter the client's own local
+ * simulation was pinned to, and every minted row stays eligible for the replay verifier's
+ * descriptor check.
  *
- * Each continuation is its own transaction: append, then (on terminal) mint — reusing
- * `trackActivityProgress`'s head compare-and-swap, meter debit, and terminal anchor advance, and
- * `startActivity`'s chain-seed read and provenance recording. A rejection at either step unwinds
- * the whole transaction, so the confirmed head reported on any bail is always the last fully
- * committed continuation's — never a partial append with no successor. The mint step authors
- * `buildSnapshot` itself server-side; the entry's own `buildSnapshot` is only a cross-check hint,
- * and a mismatch bails with `CHECKPOINT_INVALID` — a client-supplied snapshot the server stored
- * as-is would be direct xp inflation. Mint dedup keys on the entry's own `id` plus a matching
- * `startKey` and scope, never on id and ownership alone, resolved outside any transaction once
- * the insert's unique violation has unwound one; `startActivity`'s own dedup (the active-status
- * row for the avatar) would find nothing and stall forever once a gap has already ended terminal.
+ * Each continuation is its own transaction: append, then — on terminal — mint, through the same
+ * head compare-and-swap, meter debit, terminal anchor advance, chain-seed read, and provenance
+ * recording as live play. A rejection at either step unwinds the whole transaction, so the
+ * confirmed head reported on any bail is always the last fully committed continuation's — never a
+ * partial append with no successor.
+ *
+ * The mint authors `buildSnapshot` itself server-side; the entry's own `buildSnapshot` is only a
+ * cross-check hint, and a mismatch bails with `CHECKPOINT_INVALID`. A client-supplied snapshot
+ * the server stored as-is would be direct xp inflation.
+ *
+ * Mint dedup keys on the entry's own `id` plus a matching `startKey` and scope, never on id and
+ * ownership alone, and resolves outside any transaction once the insert's unique violation has
+ * unwound one. The live start path's dedup — the avatar's active-status row — would find nothing
+ * once a gap has already ended terminal, and a retry resolved against it would stall forever.
  */
 export async function advanceActivity(
   deps: AdvanceActivityDeps,


### PR DESCRIPTION
## Description

Applies the comments rendering rules to the eight comment blocks an audit of the repo's longest comments flagged — every fact kept, the shape fixed.

- One point per paragraph with its topic sentence first; multi-fact em-dash chains split
- The checkpoint-submitter response contract and the sim-version provisioning decisions render as bullet lists
- run-continuation's twice-repeated "rather than left on a silently reset runtime" framing collapsed
- References to other declarations by name replaced with the contract they named
- expand-env keeps one line (the Zod `.transform` usage) and drops the signature restatement

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality (comment-only change)