### PR TITLE
feat(#193): add worldmap reveal projection and spatial index

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -148,6 +148,7 @@
         "@noble/hashes": "catalog:",
         "@orpc/contract": "catalog:",
         "@vers/contract-base": "workspace:*",
+        "@vers/worldmap-core": "workspace:*",
         "zod": "catalog:",
       },
       "devDependencies": {

--- a/contracts/activity/package.json
+++ b/contracts/activity/package.json
@@ -16,6 +16,7 @@
     "@noble/hashes": "catalog:",
     "@orpc/contract": "catalog:",
     "@vers/contract-base": "workspace:*",
+    "@vers/worldmap-core": "workspace:*",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/contracts/activity/src/activity-contract.test.ts
+++ b/contracts/activity/src/activity-contract.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'bun:test';
 import { OpenAPIGenerator } from '@orpc/openapi';
 import { ZodToJsonSchemaConverter } from '@orpc/zod/zod4';
+import { WORLD_COORD_MAX, WORLD_COORD_MIN } from '@vers/worldmap-core';
 import { activityContract } from './activity-contract';
 import { MAX_CATCH_UP_BATCH_CHECKPOINTS } from './max-catch-up-batch-checkpoints';
 import { REVEAL_VIEWPORT_CELL_CAP } from './reveal-viewport-cell-cap';
@@ -163,9 +164,11 @@ test('getRevealedNodes rejects a viewport whose area exceeds the cell cap', () =
     viewport: { maxCX: REVEAL_VIEWPORT_CELL_CAP, maxCY: 0, minCX: 0, minCY: 0 },
   };
 
-  expect(activityContract.getRevealedNodes['~orpc'].inputSchema?.safeParse(input).success).toBe(
-    false,
-  );
+  const result = activityContract.getRevealedNodes['~orpc'].inputSchema?.safeParse(input);
+
+  expect(result?.error?.issues.map((issue) => issue.message)).toStrictEqual([
+    `viewport area may not exceed ${REVEAL_VIEWPORT_CELL_CAP} cells`,
+  ]);
 });
 
 test('getRevealedNodes rejects an inverted viewport', () => {
@@ -174,8 +177,52 @@ test('getRevealedNodes rejects an inverted viewport', () => {
     viewport: { maxCX: 0, maxCY: 0, minCX: 5, minCY: 0 },
   };
 
+  const result = activityContract.getRevealedNodes['~orpc'].inputSchema?.safeParse(input);
+
+  expect(result?.error?.issues.map((issue) => issue.message)).toStrictEqual([
+    'viewport bounds are inverted',
+  ]);
+});
+
+test('getRevealedNodes rejects a viewport axis past the packable coordinate range', () => {
+  const input = {
+    avatarID: 'avatar_1',
+    viewport: { maxCX: WORLD_COORD_MAX + 1, maxCY: 0, minCX: WORLD_COORD_MAX, minCY: 0 },
+  };
+
+  const result = activityContract.getRevealedNodes['~orpc'].inputSchema?.safeParse(input);
+
+  expect(result?.error?.issues).toPartiallyContain(
+    expect.objectContaining({ path: ['viewport', 'maxCX'] }),
+  );
+});
+
+test('getRevealedNodes rejects a viewport axis below the packable coordinate range', () => {
+  const input = {
+    avatarID: 'avatar_1',
+    viewport: { maxCX: 0, maxCY: 0, minCX: 0, minCY: WORLD_COORD_MIN - 1 },
+  };
+
+  const result = activityContract.getRevealedNodes['~orpc'].inputSchema?.safeParse(input);
+
+  expect(result?.error?.issues).toPartiallyContain(
+    expect.objectContaining({ path: ['viewport', 'minCY'] }),
+  );
+});
+
+test('getRevealedNodes accepts a viewport at the edge of the packable coordinate range', () => {
+  const input = {
+    avatarID: 'avatar_1',
+    viewport: {
+      maxCX: WORLD_COORD_MAX,
+      maxCY: WORLD_COORD_MIN + 1,
+      minCX: WORLD_COORD_MAX - 1,
+      minCY: WORLD_COORD_MIN,
+    },
+  };
+
   expect(activityContract.getRevealedNodes['~orpc'].inputSchema?.safeParse(input).success).toBe(
-    false,
+    true,
   );
 });
 

--- a/contracts/activity/src/activity-contract.test.ts
+++ b/contracts/activity/src/activity-contract.test.ts
@@ -3,6 +3,7 @@ import { OpenAPIGenerator } from '@orpc/openapi';
 import { ZodToJsonSchemaConverter } from '@orpc/zod/zod4';
 import { activityContract } from './activity-contract';
 import { MAX_CATCH_UP_BATCH_CHECKPOINTS } from './max-catch-up-batch-checkpoints';
+import { REVEAL_VIEWPORT_CELL_CAP } from './reveal-viewport-cell-cap';
 
 test('it declares UNAUTHORIZED and FORBIDDEN on every owner-scoped procedure', () => {
   expect(activityContract.getCurrentActivity['~orpc'].errorMap).toContainAllKeys([
@@ -134,6 +135,47 @@ test('it accepts an advanceActivity request at the aggregate checkpoint cap', ()
 
   expect(activityContract.advanceActivity['~orpc'].inputSchema?.safeParse(input).success).toBe(
     true,
+  );
+});
+
+test('it declares NOT_FOUND on getRevealedNodes', () => {
+  expect(activityContract.getRevealedNodes['~orpc'].errorMap).toContainAllKeys([
+    'UNAUTHORIZED',
+    'FORBIDDEN',
+    'NOT_FOUND',
+  ]);
+});
+
+test('getRevealedNodes accepts a viewport exactly at the cell cap', () => {
+  const input = {
+    avatarID: 'avatar_1',
+    viewport: { maxCX: REVEAL_VIEWPORT_CELL_CAP - 1, maxCY: 0, minCX: 0, minCY: 0 },
+  };
+
+  expect(activityContract.getRevealedNodes['~orpc'].inputSchema?.safeParse(input).success).toBe(
+    true,
+  );
+});
+
+test('getRevealedNodes rejects a viewport whose area exceeds the cell cap', () => {
+  const input = {
+    avatarID: 'avatar_1',
+    viewport: { maxCX: REVEAL_VIEWPORT_CELL_CAP, maxCY: 0, minCX: 0, minCY: 0 },
+  };
+
+  expect(activityContract.getRevealedNodes['~orpc'].inputSchema?.safeParse(input).success).toBe(
+    false,
+  );
+});
+
+test('getRevealedNodes rejects an inverted viewport', () => {
+  const input = {
+    avatarID: 'avatar_1',
+    viewport: { maxCX: 0, maxCY: 0, minCX: 5, minCY: 0 },
+  };
+
+  expect(activityContract.getRevealedNodes['~orpc'].inputSchema?.safeParse(input).success).toBe(
+    false,
   );
 });
 

--- a/contracts/activity/src/activity-contract.ts
+++ b/contracts/activity/src/activity-contract.ts
@@ -8,6 +8,7 @@ import { CheckpointBatchEntrySchema } from './checkpoint-batch-entry-schema';
 import { CheckpointSchema } from './checkpoint-schema';
 import { ContentDocumentSchema } from './content-document-schema';
 import { MAX_CATCH_UP_BATCH_CHECKPOINTS } from './max-catch-up-batch-checkpoints';
+import { REVEAL_VIEWPORT_CELL_CAP } from './reveal-viewport-cell-cap';
 import { RewardItemAffixSchema } from './reward-item-affix-schema';
 import { ScopeIdentifierSchema } from './scope-identifier-schema';
 
@@ -58,6 +59,20 @@ const AvatarProgressionSchema = z.object({
   pending: z.array(PendingXPEntrySchema),
   xp: z.int(),
 });
+
+const ViewportSchema = z.object({
+  maxCX: z.int(),
+  maxCY: z.int(),
+  minCX: z.int(),
+  minCY: z.int(),
+});
+
+/**
+ * A revealed cell's disclosed content: expected-value-flat descriptor metadata only, never the raw
+ * descriptor hash, salt, or drops. `poolID` is absent for a legacy content version that predates
+ * sealed content.
+ */
+const RevealedNodeSchema = z.object({ id: z.string(), poolID: z.string().optional() });
 
 /**
  * The activities service's API: every procedure is authed and owner-scoped through the caller's
@@ -208,6 +223,36 @@ export const activityContract = {
     .errors(
       defineErrors({
         NOT_FOUND: { data: z.object({}), message: 'No activity exists for this avatar' },
+      }),
+    ),
+
+  /**
+   * The revealed region is a projection of the avatar's verified first-clear grants, never stored
+   * reveal state — recomputed fresh every call. `viewport` bounds what the response returns, never
+   * what the underlying discs make eligible to disclose: a cell inside the viewport but outside
+   * every disc is never in the response, regardless of viewport size.
+   */
+  getRevealedNodes: authedRoute
+    .route({
+      method: 'GET',
+      path: '/avatars/{avatarID}/revealed-nodes',
+      summary: "Get the disclosed content for an avatar's revealed world-map cells in a viewport",
+    })
+    .input(
+      z.object({ avatarID: z.string(), viewport: ViewportSchema }).refine(
+        (input) => {
+          const width = input.viewport.maxCX - input.viewport.minCX + 1;
+          const height = input.viewport.maxCY - input.viewport.minCY + 1;
+
+          return width > 0 && height > 0 && width * height <= REVEAL_VIEWPORT_CELL_CAP;
+        },
+        { error: `viewport area may not exceed ${REVEAL_VIEWPORT_CELL_CAP} cells` },
+      ),
+    )
+    .output(z.object({ contentVersion: z.string(), nodes: z.array(RevealedNodeSchema) }))
+    .errors(
+      defineErrors({
+        NOT_FOUND: { data: z.object({}), message: 'Avatar not found' },
       }),
     ),
 

--- a/contracts/activity/src/activity-contract.ts
+++ b/contracts/activity/src/activity-contract.ts
@@ -1,4 +1,5 @@
 import { authedRoute, defineErrors } from '@vers/contract-base';
+import { WORLD_COORD_MAX, WORLD_COORD_MIN } from '@vers/worldmap-core';
 import * as z from 'zod';
 import { ActivityDataSchema } from './activity-data-schema';
 import { ActivityFailureActionSchema } from './activity-failure-action-schema';
@@ -60,11 +61,17 @@ const AvatarProgressionSchema = z.object({
   xp: z.int(),
 });
 
+/**
+ * One cell-coordinate axis value, bounded to the range a world-map cell coordinate packs into. An
+ * axis outside it names a cell the map cannot address at all.
+ */
+const CellAxisSchema = z.int().min(WORLD_COORD_MIN).max(WORLD_COORD_MAX);
+
 const ViewportSchema = z.object({
-  maxCX: z.int(),
-  maxCY: z.int(),
-  minCX: z.int(),
-  minCY: z.int(),
+  maxCX: CellAxisSchema,
+  maxCY: CellAxisSchema,
+  minCX: CellAxisSchema,
+  minCY: CellAxisSchema,
 });
 
 /**
@@ -239,15 +246,21 @@ export const activityContract = {
       summary: "Get the disclosed content for an avatar's revealed world-map cells in a viewport",
     })
     .input(
-      z.object({ avatarID: z.string(), viewport: ViewportSchema }).refine(
-        (input) => {
-          const width = input.viewport.maxCX - input.viewport.minCX + 1;
-          const height = input.viewport.maxCY - input.viewport.minCY + 1;
-
-          return width > 0 && height > 0 && width * height <= REVEAL_VIEWPORT_CELL_CAP;
-        },
-        { error: `viewport area may not exceed ${REVEAL_VIEWPORT_CELL_CAP} cells` },
-      ),
+      z
+        .object({ avatarID: z.string(), viewport: ViewportSchema })
+        .refine(
+          (input) =>
+            input.viewport.maxCX >= input.viewport.minCX &&
+            input.viewport.maxCY >= input.viewport.minCY,
+          { error: 'viewport bounds are inverted' },
+        )
+        .refine(
+          (input) =>
+            (input.viewport.maxCX - input.viewport.minCX + 1) *
+              (input.viewport.maxCY - input.viewport.minCY + 1) <=
+            REVEAL_VIEWPORT_CELL_CAP,
+          { error: `viewport area may not exceed ${REVEAL_VIEWPORT_CELL_CAP} cells` },
+        ),
     )
     .output(z.object({ contentVersion: z.string(), nodes: z.array(RevealedNodeSchema) }))
     .errors(

--- a/contracts/activity/src/index.ts
+++ b/contracts/activity/src/index.ts
@@ -30,6 +30,7 @@ export { EntropySourceSchema } from './entropy-source-schema';
 export { LootTablesSchema } from './loot-tables-schema';
 export { MAX_CATCH_UP_BATCH_CHECKPOINTS } from './max-catch-up-batch-checkpoints';
 export { OFFLINE_PROGRESS_CAP_MS } from './offline-progress-cap-ms';
+export { REVEAL_VIEWPORT_CELL_CAP } from './reveal-viewport-cell-cap';
 export type { RewardItemAffix } from './reward-item-affix-schema';
 export { RewardItemAffixSchema } from './reward-item-affix-schema';
 export type { RewardSlot } from './reward-slot-schema';

--- a/contracts/activity/src/reveal-viewport-cell-cap.test.ts
+++ b/contracts/activity/src/reveal-viewport-cell-cap.test.ts
@@ -1,6 +1,0 @@
-import { expect, test } from 'bun:test';
-import { REVEAL_VIEWPORT_CELL_CAP } from './reveal-viewport-cell-cap';
-
-test('it caps a reveal viewport at 4096 cells', () => {
-  expect(REVEAL_VIEWPORT_CELL_CAP).toBe(4096);
-});

--- a/contracts/activity/src/reveal-viewport-cell-cap.test.ts
+++ b/contracts/activity/src/reveal-viewport-cell-cap.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from 'bun:test';
+import { REVEAL_VIEWPORT_CELL_CAP } from './reveal-viewport-cell-cap';
+
+test('it caps a reveal viewport at 4096 cells', () => {
+  expect(REVEAL_VIEWPORT_CELL_CAP).toBe(4096);
+});

--- a/contracts/activity/src/reveal-viewport-cell-cap.ts
+++ b/contracts/activity/src/reveal-viewport-cell-cap.ts
@@ -1,7 +1,7 @@
 /**
- * Cap on a `getRevealedNodes` viewport's cell area (`(maxCX - minCX + 1) * (maxCY - minCY + 1)`).
- * The reveal disc union, not the viewport, decides what may disclose; this cap only bounds how much
- * of that union one request can read back, keeping a single query's derivation work — one
- * `deriveWorldmapContent` call per returned cell — flat regardless of caller-chosen viewport size.
+ * Cap on a reveal query's viewport cell area (`(maxCX - minCX + 1) * (maxCY - minCY + 1)`). The
+ * reveal disc union, not the viewport, decides what may disclose; this cap only bounds how much of
+ * that union one request can read back, keeping a single query's derivation work — one
+ * sealed-content derivation per returned cell — flat regardless of caller-chosen viewport size.
  */
 export const REVEAL_VIEWPORT_CELL_CAP = 4096;

--- a/contracts/activity/src/reveal-viewport-cell-cap.ts
+++ b/contracts/activity/src/reveal-viewport-cell-cap.ts
@@ -1,0 +1,7 @@
+/**
+ * Cap on a `getRevealedNodes` viewport's cell area (`(maxCX - minCX + 1) * (maxCY - minCY + 1)`).
+ * The reveal disc union, not the viewport, decides what may disclose; this cap only bounds how much
+ * of that union one request can read back, keeping a single query's derivation work — one
+ * `deriveWorldmapContent` call per returned cell — flat regardless of caller-chosen viewport size.
+ */
+export const REVEAL_VIEWPORT_CELL_CAP = 4096;

--- a/docs/architecture/platform/observability.md
+++ b/docs/architecture/platform/observability.md
@@ -158,6 +158,8 @@ in stack state are encrypted by the stack passphrase.
 | `vers.activity.content_incompatible_rejections` | counter         | `{rejection}`    | `path`              | startActivity calls rejected because the resolved engine's max content version falls behind the requested content |
 | `vers.activity.advance_continuations`           | counter         | `{continuation}` | `outcome`           | advanceActivity continuations processed, by mint outcome                                                          |
 | `vers.activity.advance_bailouts`                | counter         | `{bailout}`      | `reason`            | advanceActivity requests that bailed before their continuations' end, by reason                                   |
+| `vers.activity.reveal_cells`                    | histogram       | `{cell}`         | —                   | revealed cells returned per getRevealedNodes query                                                                |
+| `vers.activity.reveal_sources`                  | histogram       | `{grant}`        | —                   | first-clear grant rows scanned per getRevealedNodes query                                                         |
 | `vers.email.delivery_failures`                  | counter         | `{email}`        | —                   | emails that failed to deliver                                                                                     |
 | `vers.session.failed_attempts`                  | counter         | `{attempt}`      | —                   | failed step-up verification attempts                                                                              |
 | `vers.analytics.delivery_failures`              | counter         | `{event}`        | `reason`            | product events that never landed in the Tinybird data source, by reason                                           |
@@ -215,7 +217,10 @@ resolved onto a row a prior, partially committed request already minted at the s
 rising count tracks how often an offline catch-up's outer resync must re-plan, not lost progress.
 `vers.activity.content_incompatible_rejections` splits by `path`: `requested` covers a client-sent
 sim version hash, `fallback` covers the registry-current version resolved for a start that carries
-no hash. `vers.analytics.delivery_failures` splits by `reason`: `rejected` covers a non-2xx response
+no hash. `vers.activity.reveal_cells` and `vers.activity.reveal_sources` record once per
+`getRevealedNodes` call, the returned cell count and the scanned first-clear grant count
+respectively; both track the reveal projection's fan-out as an avatar's completed-node history
+grows. `vers.analytics.delivery_failures` splits by `reason`: `rejected` covers a non-2xx response
 from the Tinybird Events API, `quarantined` covers a row the API accepted but failed schema
 validation on, `unreachable` covers a network failure or the upstream deadline tripping.
 

--- a/libs/game/worldmap-core/src/can-encode-morton-key.test.ts
+++ b/libs/game/worldmap-core/src/can-encode-morton-key.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from 'bun:test';
+import { canEncodeMortonKey } from './can-encode-morton-key';
+import { WORLD_COORD_MAX, WORLD_COORD_MIN } from './consts';
+
+test('it accepts a coordinate near the origin', () => {
+  expect(canEncodeMortonKey([-3, 5])).toBe(true);
+});
+
+test('it accepts the extreme coordinate of each axis bound', () => {
+  expect(canEncodeMortonKey([WORLD_COORD_MAX, WORLD_COORD_MIN])).toBe(true);
+});
+
+test('it rejects a coordinate one step past the upper bound', () => {
+  expect(canEncodeMortonKey([WORLD_COORD_MAX + 1, 0])).toBe(false);
+});
+
+test('it rejects a coordinate one step past the lower bound', () => {
+  expect(canEncodeMortonKey([0, WORLD_COORD_MIN - 1])).toBe(false);
+});
+
+test('it rejects a fractional axis', () => {
+  expect(canEncodeMortonKey([1.5, 0])).toBe(false);
+});
+
+test('it rejects a non-finite axis', () => {
+  expect(canEncodeMortonKey([0, Number.POSITIVE_INFINITY])).toBe(false);
+});

--- a/libs/game/worldmap-core/src/can-encode-morton-key.ts
+++ b/libs/game/worldmap-core/src/can-encode-morton-key.ts
@@ -1,0 +1,13 @@
+import { WORLD_COORD_MAX, WORLD_COORD_MIN } from './consts';
+
+/**
+ * Whether a coordinate packs into a Morton key: both axes are integers inside the packable range.
+ * Callers holding coordinates from an unbounded source — a stored grant key, a disc that runs off
+ * the edge of the world — filter through this before packing, since the encoder treats an
+ * unpackable coordinate as a caller bug.
+ */
+export function canEncodeMortonKey(coord: readonly [number, number]): boolean {
+  return coord.every(
+    (axis) => Number.isInteger(axis) && axis >= WORLD_COORD_MIN && axis <= WORLD_COORD_MAX,
+  );
+}

--- a/libs/game/worldmap-core/src/collect-revealed-cells.test.ts
+++ b/libs/game/worldmap-core/src/collect-revealed-cells.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from 'bun:test';
 import { collectRevealedCells } from './collect-revealed-cells';
+import { WORLD_COORD_MAX } from './consts';
+import { decodeMortonKey } from './decode-morton-key';
 
 test('it emits one source disc, clipped to the viewport, Morton-sorted', () => {
   const cells = collectRevealedCells([{ coord: [0, 0], radius: 1 }], {
@@ -48,6 +50,22 @@ test('it excludes a source whose disc cannot reach the viewport', () => {
   );
 
   expect(cells).toStrictEqual([0]);
+});
+
+test('it drops the cells of a disc that runs past the packable coordinate range', () => {
+  const cells = collectRevealedCells([{ coord: [WORLD_COORD_MAX, 0], radius: 2 }], {
+    maxCX: WORLD_COORD_MAX + 2,
+    maxCY: 0,
+    minCX: WORLD_COORD_MAX - 2,
+    minCY: 0,
+  });
+
+  // the two cells past the edge of the world carry no packable key and leave the disc silently
+  expect(cells.map((key) => decodeMortonKey(key))).toStrictEqual([
+    [WORLD_COORD_MAX - 2, 0],
+    [WORLD_COORD_MAX - 1, 0],
+    [WORLD_COORD_MAX, 0],
+  ]);
 });
 
 test('it returns nothing for an empty source list', () => {

--- a/libs/game/worldmap-core/src/collect-revealed-cells.test.ts
+++ b/libs/game/worldmap-core/src/collect-revealed-cells.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from 'bun:test';
+import { collectRevealedCells } from './collect-revealed-cells';
+
+test('it emits one source disc, clipped to the viewport, Morton-sorted', () => {
+  const cells = collectRevealedCells([{ coord: [0, 0], radius: 1 }], {
+    maxCX: 5,
+    maxCY: 5,
+    minCX: -5,
+    minCY: -5,
+  });
+
+  // the seven cells of the radius-1 disc around the origin, in ascending Morton order
+  expect(cells).toStrictEqual([0, 1, 2, 4, 6, 8, 9]);
+});
+
+test('it clips a disc that extends past the viewport edge', () => {
+  const cells = collectRevealedCells([{ coord: [0, 0], radius: 1 }], {
+    maxCX: 1,
+    maxCY: 1,
+    minCX: 0,
+    minCY: -1,
+  });
+
+  // (-1, 0) and (-1, 1) fall outside the viewport and are dropped from the full seven-cell disc
+  expect(cells).toStrictEqual([0, 2, 4, 6, 8]);
+});
+
+test('it dedupes cells covered by more than one overlapping disc', () => {
+  const cells = collectRevealedCells(
+    [
+      { coord: [0, 0], radius: 1 },
+      { coord: [1, 0], radius: 1 },
+    ],
+    { maxCX: 5, maxCY: 5, minCX: -5, minCY: -5 },
+  );
+
+  // the two radius-1 discs share four cells; the union carries each cell once
+  expect(cells).toStrictEqual([0, 1, 2, 4, 6, 8, 9, 12, 16, 18]);
+});
+
+test('it excludes a source whose disc cannot reach the viewport', () => {
+  const cells = collectRevealedCells(
+    [
+      { coord: [0, 0], radius: 0 },
+      { coord: [100, 100], radius: 1 },
+    ],
+    { maxCX: 5, maxCY: 5, minCX: 0, minCY: 0 },
+  );
+
+  expect(cells).toStrictEqual([0]);
+});
+
+test('it returns nothing for an empty source list', () => {
+  const cells = collectRevealedCells([], { maxCX: 5, maxCY: 5, minCX: -5, minCY: -5 });
+
+  expect(cells).toBeEmpty();
+});

--- a/libs/game/worldmap-core/src/collect-revealed-cells.ts
+++ b/libs/game/worldmap-core/src/collect-revealed-cells.ts
@@ -1,3 +1,4 @@
+import { canEncodeMortonKey } from './can-encode-morton-key';
 import { encodeMortonKey } from './encode-morton-key';
 import { getHexDistance } from './get-hex-distance';
 import type { RevealSource, RevealedCells, Viewport } from './types';
@@ -10,6 +11,9 @@ import type { RevealSource, RevealedCells, Viewport } from './types';
  * by its own radius — contributes nothing, so the security constraint holds structurally: only
  * cells inside the union of source discs can appear, and the viewport can only narrow that union,
  * never widen it.
+ *
+ * A disc around a source near the edge of the packable coordinate range reaches cells no Morton key
+ * can address; those cells are dropped, so a source stays usable right up to the edge.
  */
 export function collectRevealedCells(
   sources: ReadonlyArray<RevealSource>,
@@ -25,7 +29,10 @@ export function collectRevealedCells(
 
     for (let cx = minCX; cx <= maxCX; cx++) {
       for (let cy = minCY; cy <= maxCY; cy++) {
-        if (getHexDistance(source.coord, [cx, cy]) <= source.radius) {
+        if (
+          canEncodeMortonKey([cx, cy]) &&
+          getHexDistance(source.coord, [cx, cy]) <= source.radius
+        ) {
           keys.add(encodeMortonKey([cx, cy]));
         }
       }

--- a/libs/game/worldmap-core/src/collect-revealed-cells.ts
+++ b/libs/game/worldmap-core/src/collect-revealed-cells.ts
@@ -1,0 +1,36 @@
+import { encodeMortonKey } from './encode-morton-key';
+import { getHexDistance } from './get-hex-distance';
+import type { RevealSource, RevealedCells, Viewport } from './types';
+
+/**
+ * Projects a set of reveal sources onto the region a viewport actually asks for: for each source,
+ * the hex disc of its own radius around its coordinate, clipped to the viewport and to the source's
+ * own bounding box, deduplicated across overlapping sources, and returned Morton-sorted. A source
+ * whose disc cannot reach the viewport at all — its coordinate falls outside the viewport inflated
+ * by its own radius — contributes nothing, so the security constraint holds structurally: only
+ * cells inside the union of source discs can appear, and the viewport can only narrow that union,
+ * never widen it.
+ */
+export function collectRevealedCells(
+  sources: ReadonlyArray<RevealSource>,
+  viewport: Readonly<Viewport>,
+): RevealedCells {
+  const keys = new Set<number>();
+
+  for (const source of sources) {
+    const minCX = Math.max(viewport.minCX, source.coord[0] - source.radius);
+    const maxCX = Math.min(viewport.maxCX, source.coord[0] + source.radius);
+    const minCY = Math.max(viewport.minCY, source.coord[1] - source.radius);
+    const maxCY = Math.min(viewport.maxCY, source.coord[1] + source.radius);
+
+    for (let cx = minCX; cx <= maxCX; cx++) {
+      for (let cy = minCY; cy <= maxCY; cy++) {
+        if (getHexDistance(source.coord, [cx, cy]) <= source.radius) {
+          keys.add(encodeMortonKey([cx, cy]));
+        }
+      }
+    }
+  }
+
+  return [...keys].toSorted((a, b) => a - b);
+}

--- a/libs/game/worldmap-core/src/consts.ts
+++ b/libs/game/worldmap-core/src/consts.ts
@@ -40,3 +40,19 @@ export const MAX_DIFFICULTY = 100;
  * The home cell every avatar starts from and difficulty measures distance against.
  */
 export const ORIGIN_CELL: readonly [number, number] = [0, 0];
+
+/**
+ * Bits per axis packed into a Morton key. 26 bits per axis keeps the interleaved result within 52
+ * of `Number.MAX_SAFE_INTEGER`'s 53 mantissa bits, while supporting a zigzag-encoded coordinate
+ * magnitude up to about 33.5 million cells from origin in either direction on each axis — far past
+ * any distance actually reachable.
+ */
+export const MORTON_AXIS_BITS = 26;
+
+/**
+ * Hex-hop radius the reveal projection discloses around each verified first-clear node. The design
+ * band is 2 to 5 hops, and 5 is a security bound rather than a tuning preference: look-ahead value
+ * and the map-scanning exploit's return both climb with the radius, so a value approaching that
+ * bound trades security margin for reveal depth.
+ */
+export const REVEAL_RADIUS = 2;

--- a/libs/game/worldmap-core/src/consts.ts
+++ b/libs/game/worldmap-core/src/consts.ts
@@ -50,6 +50,18 @@ export const ORIGIN_CELL: readonly [number, number] = [0, 0];
 export const MORTON_AXIS_BITS = 26;
 
 /**
+ * Lowest cell coordinate a Morton key can pack on either axis. Zigzag encoding spends one of the
+ * per-axis bits on sign, so the negative half reaches one step further from origin than the positive
+ * half.
+ */
+export const WORLD_COORD_MIN = -(2 ** (MORTON_AXIS_BITS - 1));
+
+/**
+ * Highest cell coordinate a Morton key can pack on either axis.
+ */
+export const WORLD_COORD_MAX = 2 ** (MORTON_AXIS_BITS - 1) - 1;
+
+/**
  * Hex-hop radius the reveal projection discloses around each verified first-clear node. The design
  * band is 2 to 5 hops, and 5 is a security bound rather than a tuning preference: look-ahead value
  * and the map-scanning exploit's return both climb with the radius, so a value approaching that

--- a/libs/game/worldmap-core/src/decode-morton-key.test.ts
+++ b/libs/game/worldmap-core/src/decode-morton-key.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'bun:test';
+import { MORTON_AXIS_BITS } from './consts';
 import { decodeMortonKey } from './decode-morton-key';
 
 test('it decodes zero to the origin', () => {
@@ -23,4 +24,16 @@ test('it decodes a key carrying both axes', () => {
 
 test('it decodes a key spanning multiple bit positions on both axes', () => {
   expect(decodeMortonKey(153)).toStrictEqual([-3, 5]);
+});
+
+test('it rejects a negative key', () => {
+  expect(() => decodeMortonKey(-1)).toThrow('key outside the packed range: -1');
+});
+
+test('it rejects a fractional key', () => {
+  expect(() => decodeMortonKey(4.5)).toThrow('key outside the packed range: 4.5');
+});
+
+test('it rejects a key wider than the two interleaved axes', () => {
+  expect(() => decodeMortonKey(2 ** (2 * MORTON_AXIS_BITS))).toThrow('outside the packed range');
 });

--- a/libs/game/worldmap-core/src/decode-morton-key.test.ts
+++ b/libs/game/worldmap-core/src/decode-morton-key.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from 'bun:test';
+import { decodeMortonKey } from './decode-morton-key';
+
+test('it decodes zero to the origin', () => {
+  expect(decodeMortonKey(0)).toStrictEqual([0, 0]);
+});
+
+test('it decodes the even bit positions back to a positive x axis', () => {
+  expect(decodeMortonKey(4)).toStrictEqual([1, 0]);
+});
+
+test('it decodes the odd bit positions back to a positive y axis', () => {
+  expect(decodeMortonKey(8)).toStrictEqual([0, 1]);
+});
+
+test('it decodes the low bit back to a negative x coordinate', () => {
+  expect(decodeMortonKey(1)).toStrictEqual([-1, 0]);
+});
+
+test('it decodes a key carrying both axes', () => {
+  expect(decodeMortonKey(6)).toStrictEqual([1, -1]);
+});
+
+test('it decodes a key spanning multiple bit positions on both axes', () => {
+  expect(decodeMortonKey(153)).toStrictEqual([-3, 5]);
+});

--- a/libs/game/worldmap-core/src/decode-morton-key.ts
+++ b/libs/game/worldmap-core/src/decode-morton-key.ts
@@ -1,0 +1,30 @@
+import { MORTON_AXIS_BITS } from './consts';
+
+/**
+ * Reverses `encodeMortonKey`, recovering the signed cell coordinate a Morton key encodes: the two
+ * interleaved bit streams split back into their per-axis zigzag values, then each un-zigzags to its
+ * original signed integer. Exact inverse — every key `encodeMortonKey` produces decodes back to the
+ * coordinate it packed.
+ */
+export function decodeMortonKey(key: number): [number, number] {
+  let zx = 0;
+  let zy = 0;
+
+  for (let bit = 0; bit < MORTON_AXIS_BITS; bit++) {
+    const xBit = Math.floor(key / 2 ** (2 * bit)) % 2;
+    const yBit = Math.floor(key / 2 ** (2 * bit + 1)) % 2;
+
+    zx += xBit * 2 ** bit;
+    zy += yBit * 2 ** bit;
+  }
+
+  return [decodeZigzag(zx), decodeZigzag(zy)];
+}
+
+/**
+ * Reverses the zigzag mapping that packs a signed integer into the non-negative integers: an even
+ * value halves back to its non-negative source, an odd value maps back to its negative pair.
+ */
+function decodeZigzag(z: number): number {
+  return z % 2 === 0 ? z / 2 : -(z + 1) / 2;
+}

--- a/libs/game/worldmap-core/src/decode-morton-key.ts
+++ b/libs/game/worldmap-core/src/decode-morton-key.ts
@@ -1,12 +1,21 @@
+import invariant from 'tiny-invariant';
 import { MORTON_AXIS_BITS } from './consts';
 
 /**
- * Reverses `encodeMortonKey`, recovering the signed cell coordinate a Morton key encodes: the two
- * interleaved bit streams split back into their per-axis zigzag values, then each un-zigzags to its
- * original signed integer. Exact inverse — every key `encodeMortonKey` produces decodes back to the
- * coordinate it packed.
+ * Recovers the signed cell coordinate a Morton key encodes: the two interleaved bit streams split
+ * back into their per-axis zigzag values, then each un-zigzags to its original signed integer. Exact
+ * inverse of the packing — every key the Morton encoder produces decodes back to the coordinate it
+ * packed.
+ *
+ * A key that is not a non-negative integer inside the packed width was never produced by the
+ * encoder, and is rejected rather than decoded into a coordinate nothing packs to.
  */
 export function decodeMortonKey(key: number): [number, number] {
+  invariant(
+    Number.isInteger(key) && key >= 0 && key < 2 ** (2 * MORTON_AXIS_BITS),
+    `key outside the packed range: ${key}`,
+  );
+
   let zx = 0;
   let zy = 0;
 

--- a/libs/game/worldmap-core/src/encode-morton-key.test.ts
+++ b/libs/game/worldmap-core/src/encode-morton-key.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from 'bun:test';
+import { decodeMortonKey } from './decode-morton-key';
+import { encodeMortonKey } from './encode-morton-key';
+
+test('it packs the origin to zero', () => {
+  expect(encodeMortonKey([0, 0])).toBe(0);
+});
+
+test('it interleaves a positive x axis into the even bit positions', () => {
+  expect(encodeMortonKey([1, 0])).toBe(4);
+});
+
+test('it interleaves a positive y axis into the odd bit positions', () => {
+  expect(encodeMortonKey([0, 1])).toBe(8);
+});
+
+test('it zigzag-encodes a negative x coordinate into the low bit', () => {
+  expect(encodeMortonKey([-1, 0])).toBe(1);
+});
+
+test('it packs a coordinate carrying both axes', () => {
+  expect(encodeMortonKey([1, -1])).toBe(6);
+});
+
+test('it packs a coordinate spanning multiple bit positions on both axes', () => {
+  expect(encodeMortonKey([-3, 5])).toBe(153);
+});
+
+test('it round-trips through decodeMortonKey for a set of coordinates including negative axes', () => {
+  const coords: Array<[number, number]> = [
+    [0, 0],
+    [1, 0],
+    [0, 1],
+    [-1, 0],
+    [0, -1],
+    [12, -7],
+    [-12, 7],
+    [-40, -40],
+    [1000, -999],
+  ];
+
+  for (const coord of coords) {
+    expect(decodeMortonKey(encodeMortonKey(coord))).toStrictEqual(coord);
+  }
+});

--- a/libs/game/worldmap-core/src/encode-morton-key.test.ts
+++ b/libs/game/worldmap-core/src/encode-morton-key.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'bun:test';
+import { WORLD_COORD_MAX, WORLD_COORD_MIN } from './consts';
 import { decodeMortonKey } from './decode-morton-key';
 import { encodeMortonKey } from './encode-morton-key';
 
@@ -26,7 +27,32 @@ test('it packs a coordinate spanning multiple bit positions on both axes', () =>
   expect(encodeMortonKey([-3, 5])).toBe(153);
 });
 
-test('it round-trips through decodeMortonKey for a set of coordinates including negative axes', () => {
+test('it rejects a fractional x coordinate', () => {
+  expect(() => encodeMortonKey([1.5, 0])).toThrow('coordinate outside the packable range: 1.5_0');
+});
+
+test('it rejects a fractional y coordinate', () => {
+  expect(() => encodeMortonKey([0, -2.25])).toThrow(
+    'coordinate outside the packable range: 0_-2.25',
+  );
+});
+
+test('it rejects a coordinate past the upper packable bound', () => {
+  expect(() => encodeMortonKey([WORLD_COORD_MAX + 1, 0])).toThrow('outside the packable range');
+});
+
+test('it rejects a coordinate past the lower packable bound', () => {
+  expect(() => encodeMortonKey([0, WORLD_COORD_MIN - 1])).toThrow('outside the packable range');
+});
+
+test('it packs the extreme coordinate of each axis bound', () => {
+  expect(decodeMortonKey(encodeMortonKey([WORLD_COORD_MAX, WORLD_COORD_MIN]))).toStrictEqual([
+    WORLD_COORD_MAX,
+    WORLD_COORD_MIN,
+  ]);
+});
+
+test('it round-trips through the Morton decoder for a set of coordinates including negative axes', () => {
   const coords: Array<[number, number]> = [
     [0, 0],
     [1, 0],

--- a/libs/game/worldmap-core/src/encode-morton-key.ts
+++ b/libs/game/worldmap-core/src/encode-morton-key.ts
@@ -1,22 +1,27 @@
 import invariant from 'tiny-invariant';
+import { canEncodeMortonKey } from './can-encode-morton-key';
 import { MORTON_AXIS_BITS } from './consts';
 
 /**
  * Encodes a signed cell coordinate as one packed Morton/z-order key: each axis zigzag-encodes to a
  * non-negative integer, then the two axes' bits interleave one at a time so nearby cells land near
- * each other in numeric sort order and a 2D box reads as one 1D range. Reversed by
- * `decodeMortonKey`. Built from plain arithmetic rather than bitwise operators, since JS's bitwise
- * operators truncate to 32 bits and the interleaved result runs past that width.
+ * each other in numeric sort order and a 2D box reads as one 1D range. The matching Morton decoder
+ * reverses it exactly.
+ *
+ * A coordinate outside the packable range, or one carrying a fractional axis, is a caller bug:
+ * callers holding unbounded coordinates filter them out before packing.
+ *
+ * Built from plain arithmetic rather than bitwise operators, since JS's bitwise operators truncate
+ * to 32 bits and the interleaved result runs past that width.
  */
 export function encodeMortonKey(coord: readonly [number, number]): number {
-  const zx = toZigzag(coord[0]);
-  const zy = toZigzag(coord[1]);
-
   invariant(
-    zx < 2 ** MORTON_AXIS_BITS && zy < 2 ** MORTON_AXIS_BITS,
+    canEncodeMortonKey(coord),
     `coordinate outside the packable range: ${coord[0]}_${coord[1]}`,
   );
 
+  const zx = toZigzag(coord[0]);
+  const zy = toZigzag(coord[1]);
   let key = 0;
 
   for (let bit = 0; bit < MORTON_AXIS_BITS; bit++) {

--- a/libs/game/worldmap-core/src/encode-morton-key.ts
+++ b/libs/game/worldmap-core/src/encode-morton-key.ts
@@ -1,0 +1,38 @@
+import invariant from 'tiny-invariant';
+import { MORTON_AXIS_BITS } from './consts';
+
+/**
+ * Encodes a signed cell coordinate as one packed Morton/z-order key: each axis zigzag-encodes to a
+ * non-negative integer, then the two axes' bits interleave one at a time so nearby cells land near
+ * each other in numeric sort order and a 2D box reads as one 1D range. Reversed by
+ * `decodeMortonKey`. Built from plain arithmetic rather than bitwise operators, since JS's bitwise
+ * operators truncate to 32 bits and the interleaved result runs past that width.
+ */
+export function encodeMortonKey(coord: readonly [number, number]): number {
+  const zx = toZigzag(coord[0]);
+  const zy = toZigzag(coord[1]);
+
+  invariant(
+    zx < 2 ** MORTON_AXIS_BITS && zy < 2 ** MORTON_AXIS_BITS,
+    `coordinate outside the packable range: ${coord[0]}_${coord[1]}`,
+  );
+
+  let key = 0;
+
+  for (let bit = 0; bit < MORTON_AXIS_BITS; bit++) {
+    const xBit = Math.floor(zx / 2 ** bit) % 2;
+    const yBit = Math.floor(zy / 2 ** bit) % 2;
+
+    key += xBit * 2 ** (2 * bit) + yBit * 2 ** (2 * bit + 1);
+  }
+
+  return key;
+}
+
+/**
+ * Maps a signed integer onto the non-negative integers, alternating sign each step
+ * (`0, -1, 1, -2, 2, …`) so a small magnitude of either sign packs into few bits.
+ */
+function toZigzag(n: number): number {
+  return n >= 0 ? n * 2 : -n * 2 - 1;
+}

--- a/libs/game/worldmap-core/src/index.ts
+++ b/libs/game/worldmap-core/src/index.ts
@@ -1,6 +1,10 @@
 export { buildCellNode } from './build-cell-node';
 export { buildChunk } from './build-chunk';
 export { collectNodeEdges } from './collect-node-edges';
+export { collectRevealedCells } from './collect-revealed-cells';
+export { REVEAL_RADIUS } from './consts';
+export { decodeMortonKey } from './decode-morton-key';
+export { encodeMortonKey } from './encode-morton-key';
 export { findCellCoord } from './find-cell-coord';
 export { getDifficulty } from './get-difficulty';
 export { getHexDistance } from './get-hex-distance';

--- a/libs/game/worldmap-core/src/index.ts
+++ b/libs/game/worldmap-core/src/index.ts
@@ -1,8 +1,9 @@
 export { buildCellNode } from './build-cell-node';
 export { buildChunk } from './build-chunk';
+export { canEncodeMortonKey } from './can-encode-morton-key';
 export { collectNodeEdges } from './collect-node-edges';
 export { collectRevealedCells } from './collect-revealed-cells';
-export { REVEAL_RADIUS } from './consts';
+export { REVEAL_RADIUS, WORLD_COORD_MAX, WORLD_COORD_MIN } from './consts';
 export { decodeMortonKey } from './decode-morton-key';
 export { encodeMortonKey } from './encode-morton-key';
 export { findCellCoord } from './find-cell-coord';

--- a/libs/game/worldmap-core/src/types.ts
+++ b/libs/game/worldmap-core/src/types.ts
@@ -29,8 +29,8 @@ export interface WorldEdge {
 
 /**
  * One origin the reveal projection discloses a disc around — a verified first-clear node in
- * production, any coordinate in a test. Generic over what grants it: `collectRevealedCells` folds a
- * list of these into the revealed region without knowing where they came from.
+ * production, any coordinate in a test. Generic over what grants it: the projection folds a list of
+ * these into the revealed region without knowing where they came from.
  */
 export interface RevealSource {
   readonly coord: readonly [number, number];
@@ -50,7 +50,7 @@ export interface Viewport {
 
 /**
  * Morton-packed cell keys a reveal query discloses, ascending by key — the sort order that keeps
- * spatially near cells near each other in the array. `decodeMortonKey` recovers each entry's cell
- * coordinate.
+ * spatially near cells near each other in the array. The matching Morton decoder recovers each
+ * entry's cell coordinate.
  */
 export type RevealedCells = ReadonlyArray<number>;

--- a/libs/game/worldmap-core/src/types.ts
+++ b/libs/game/worldmap-core/src/types.ts
@@ -26,3 +26,31 @@ export interface WorldEdge {
   readonly id: string;
   readonly start: readonly [number, number];
 }
+
+/**
+ * One origin the reveal projection discloses a disc around — a verified first-clear node in
+ * production, any coordinate in a test. Generic over what grants it: `collectRevealedCells` folds a
+ * list of these into the revealed region without knowing where they came from.
+ */
+export interface RevealSource {
+  readonly coord: readonly [number, number];
+  readonly radius: number;
+}
+
+/**
+ * The rectangular cell-coordinate range a reveal query bounds its answer to. The viewport limits
+ * what a query returns, never what the underlying discs make eligible to disclose.
+ */
+export interface Viewport {
+  readonly maxCX: number;
+  readonly maxCY: number;
+  readonly minCX: number;
+  readonly minCY: number;
+}
+
+/**
+ * Morton-packed cell keys a reveal query discloses, ascending by key — the sort order that keeps
+ * spatially near cells near each other in the array. `decodeMortonKey` recovers each entry's cell
+ * coordinate.
+ */
+export type RevealedCells = ReadonlyArray<number>;

--- a/libs/testing/mock-services/src/activity/activity-router.ts
+++ b/libs/testing/mock-services/src/activity/activity-router.ts
@@ -4,6 +4,7 @@ import { getAvatarProgression } from './get-avatar-progression';
 import { getContentDocument } from './get-content-document';
 import { getCurrentActivity } from './get-current-activity';
 import { getLatestActivityProgress } from './get-latest-activity-progress';
+import { getRevealedNodes } from './get-revealed-nodes';
 import { resumeActivity } from './resume-activity';
 import { startActivity } from './start-activity';
 import { stopActivity } from './stop-activity';
@@ -17,6 +18,7 @@ export const activityRouter = {
   getContentDocument,
   getCurrentActivity,
   getLatestActivityProgress,
+  getRevealedNodes,
   resumeActivity,
   startActivity,
   stopActivity,

--- a/libs/testing/mock-services/src/activity/get-revealed-nodes.ts
+++ b/libs/testing/mock-services/src/activity/get-revealed-nodes.ts
@@ -1,0 +1,26 @@
+import * as db from '../db';
+import { os } from './os';
+
+/**
+ * Returns the mock current content version with no revealed nodes: the mock db carries no
+ * first-clear grant collection to project a disc union from, so every viewport reads as
+ * unrevealed. A consumer test asserting on disclosed content stubs this procedure directly via
+ * `server.use(...)`.
+ */
+export const getRevealedNodes = os.getRevealedNodes.handler((opts) => {
+  const actingUserId = opts.context.actingUserId;
+
+  if (actingUserId === null) {
+    throw opts.errors.UNAUTHORIZED({ data: { reason: 'missing-session' } });
+  }
+
+  const avatar = db.avatarCollection.findFirst((q) =>
+    q.where({ id: opts.input.avatarID, userID: actingUserId }),
+  );
+
+  if (avatar === undefined) {
+    throw opts.errors.NOT_FOUND({ data: {} });
+  }
+
+  return { contentVersion: db.MOCK_CURRENT_CONTENT_VERSION, nodes: [] };
+});

--- a/libs/testing/test-utils/src/bun/create-in-memory-metrics.ts
+++ b/libs/testing/test-utils/src/bun/create-in-memory-metrics.ts
@@ -21,11 +21,27 @@ interface InMemoryMetrics {
    * when nothing has recorded it in this test.
    */
   readonly readCounterValue: (name: string) => Promise<number | undefined>;
+
+  /**
+   * Flushes the reader and returns the named histogram's data points, one per distinct attribute
+   * combination recorded in this test.
+   */
+  readonly readHistogramDataPoints: (name: string) => Promise<ReadonlyArray<HistogramDataPoint>>;
 }
 
 interface CounterDataPoint {
   readonly attributes: Attributes;
   readonly value: number;
+}
+
+/**
+ * `sum` is absent for a histogram configured without one, so a test reading it asserts on the
+ * recorded total only where the instrument keeps one.
+ */
+interface HistogramDataPoint {
+  readonly attributes: Attributes;
+  readonly count: number;
+  readonly sum: number | undefined;
 }
 
 /**
@@ -49,14 +65,18 @@ export function createInMemoryMetrics(): InMemoryMetrics {
     await provider.shutdown();
   });
 
-  const readCounterDataPoints = async (name: string): Promise<ReadonlyArray<CounterDataPoint>> => {
+  const readMetric = async (name: string) => {
     await provider.forceFlush();
 
-    const metric = exporter
+    return exporter
       .getMetrics()
       .flatMap((resourceMetrics) => resourceMetrics.scopeMetrics)
       .flatMap((scopeMetrics) => scopeMetrics.metrics)
       .find((candidate) => candidate.descriptor.name === name);
+  };
+
+  const readCounterDataPoints = async (name: string): Promise<ReadonlyArray<CounterDataPoint>> => {
+    const metric = await readMetric(name);
 
     if (metric === undefined || metric.dataPointType !== DataPointType.SUM) {
       return [];
@@ -74,6 +94,19 @@ export function createInMemoryMetrics(): InMemoryMetrics {
       const dataPoints = await readCounterDataPoints(name);
 
       return dataPoints[0]?.value;
+    },
+    async readHistogramDataPoints(name) {
+      const metric = await readMetric(name);
+
+      if (metric === undefined || metric.dataPointType !== DataPointType.HISTOGRAM) {
+        return [];
+      }
+
+      return metric.dataPoints.map((dataPoint) => ({
+        attributes: dataPoint.attributes,
+        count: dataPoint.value.count,
+        sum: dataPoint.value.sum,
+      }));
     },
   };
 }

--- a/services/activity/src/build-router.test.ts
+++ b/services/activity/src/build-router.test.ts
@@ -21,6 +21,10 @@ test('it passes every conformance case collected from its contract', async () =>
     authedSamples: {
       getCurrentActivity: { avatarID: 'x' },
       getLatestActivityProgress: { avatarID: 'x' },
+      getRevealedNodes: {
+        avatarID: 'x',
+        viewport: { maxCX: 0, maxCY: 0, minCX: 0, minCY: 0 },
+      },
       startActivity: { avatarID: 'x', scopeID: 'x', scopeType: 'world_map_node' },
       stopActivity: { avatarID: 'x' },
       trackActivityProgress: { activityID: 'x', checkpoints: [], expectedHead: 0 },

--- a/services/activity/src/build-router.ts
+++ b/services/activity/src/build-router.ts
@@ -12,6 +12,7 @@ import { getAvatarProgression } from './handlers/get-avatar-progression';
 import { getContentDocument } from './handlers/get-content-document';
 import { getCurrentActivity } from './handlers/get-current-activity';
 import { getLatestActivityProgress } from './handlers/get-latest-activity-progress';
+import { getRevealedNodes } from './handlers/get-revealed-nodes';
 import { resumeActivity } from './handlers/resume-activity';
 import { startActivity } from './handlers/start-activity';
 import { stopActivity } from './handlers/stop-activity';
@@ -56,6 +57,19 @@ export function buildActivityRouter(deps: BuildActivityRouterDeps) {
     getCurrentActivity: os.getCurrentActivity.handler((opts) => getCurrentActivity(deps.db, opts)),
     getLatestActivityProgress: os.getLatestActivityProgress.handler((opts) =>
       getLatestActivityProgress(deps.db, opts),
+    ),
+    getRevealedNodes: os.getRevealedNodes.handler((opts) =>
+      getRevealedNodes(
+        {
+          db: deps.db,
+          keysServiceURL: deps.keysServiceURL,
+          loadContentDocument: deps.loadContentDocument,
+          privateKey: deps.privateKey,
+          secretRef: deps.secretRef,
+          secretVersion: deps.secretVersion,
+        },
+        opts,
+      ),
     ),
     resumeActivity: os.resumeActivity.handler((opts) => resumeActivity(deps.db, opts)),
     startActivity: os.startActivity.handler((opts) => startActivity(deps, opts)),

--- a/services/activity/src/handlers/get-revealed-nodes.test.ts
+++ b/services/activity/src/handlers/get-revealed-nodes.test.ts
@@ -13,20 +13,79 @@ import { REVEAL_RADIUS } from '@vers/worldmap-core';
 import { createActivityService } from '../create-activity-service';
 
 /**
+ * A four-pool encounter document, so a disclosed `poolID` pins which pool the sealed derivation
+ * actually picked rather than echoing the single pool a minimal document would always return
+ * regardless of the coordinate, avatar seed, or scope secret fed into it.
+ */
+const multiPoolEncounter = {
+  contentVersion: '2',
+  archetypes: [
+    {
+      id: 'placeholder-brawler',
+      name: 'World Map Enemy',
+      baseLevel: 1,
+      baseLife: 30,
+      baseXP: 10,
+      attackMin: 1,
+      attackMax: 3,
+      attackSpeed: 0.5,
+    },
+    {
+      id: 'placeholder-skirmisher',
+      name: 'World Map Skirmisher',
+      baseLevel: 1,
+      baseLife: 20,
+      baseXP: 8,
+      attackMin: 1,
+      attackMax: 4,
+      attackSpeed: 0.7,
+    },
+  ],
+  pools: [
+    { id: 'pool-a', entries: [{ archetypeID: 'placeholder-brawler', weight: 1 }] },
+    { id: 'pool-b', entries: [{ archetypeID: 'placeholder-skirmisher', weight: 1 }] },
+    {
+      id: 'pool-c',
+      entries: [
+        { archetypeID: 'placeholder-brawler', weight: 1 },
+        { archetypeID: 'placeholder-skirmisher', weight: 1 },
+      ],
+    },
+    {
+      id: 'pool-d',
+      entries: [
+        { archetypeID: 'placeholder-skirmisher', weight: 1 },
+        { archetypeID: 'placeholder-brawler', weight: 1 },
+      ],
+    },
+  ],
+  tuning: {
+    waveCountMin: 3,
+    waveCountMax: 6,
+    waveSizeMin: 3,
+    waveSizeMax: 6,
+    difficultyScalingFactor: 1,
+  },
+} as const;
+
+/**
  * `createContentVersion` opens its own `db.transaction()`, which can't nest under the default
  * rollback-on-dispose isolation — this suite runs against a real, committed schema clone instead.
  */
 async function setupTest() {
   const db = await createTestDB({ isolation: 'schema' });
 
-  await createContentVersion(db.db, createMockContentDocument({ contentVersion: '2' }));
+  await createContentVersion(
+    db.db,
+    createMockContentDocument({ contentVersion: '2', encounter: multiPoolEncounter }),
+  );
 
   const service = await createActivityService({ db: db.db });
 
   return { app: service.app, db: db.db, [Symbol.asyncDispose]: db[Symbol.asyncDispose] };
 }
 
-test('it discloses content for a verified first-clear node inside the viewport', async () => {
+test('it discloses content pinned to the sealed derivation for every cell a verified first-clear disc covers', async () => {
   await using ctx = await setupTest();
 
   const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
@@ -46,19 +105,94 @@ test('it discloses content for a verified first-clear node inside the viewport',
 
   const result = await client.getRevealedNodes({
     avatarID: avatar.id,
-    viewport: { maxCX: 0, maxCY: 0, minCX: 0, minCY: 0 },
+    viewport: { maxCX: 2, maxCY: 0, minCX: -2, minCY: 0 },
   });
 
   expect(result.contentVersion).toBe('2');
 
+  // distinct cells landing on distinct pools, rather than every cell echoing the same pool id,
+  // is what proves the coordinate actually reaches the sealed derivation
   expect(result.nodes).toMatchInlineSnapshot(`
     [
       {
         "id": "0_0",
-        "poolID": "default",
+        "poolID": "pool-a",
+      },
+      {
+        "id": "-1_0",
+        "poolID": "pool-c",
+      },
+      {
+        "id": "1_0",
+        "poolID": "pool-c",
+      },
+      {
+        "id": "-2_0",
+        "poolID": "pool-a",
+      },
+      {
+        "id": "2_0",
+        "poolID": "pool-b",
       },
     ]
   `);
+});
+
+test('it derives different pool assignments for the same cell across avatars with different seeds', async () => {
+  await using ctx = await setupTest();
+
+  const viewerA = await createViewer({ audience: 'service-activity', db: ctx.db });
+
+  const avatarA = await createAvatarRow(ctx.db, {
+    id: 'avatar_reveal_seed_a',
+    seed: 111,
+    userId: viewerA.user.id,
+  });
+
+  const viewerB = await createViewer({ audience: 'service-activity', db: ctx.db });
+
+  const avatarB = await createAvatarRow(ctx.db, {
+    id: 'avatar_reveal_seed_b',
+    seed: 222,
+    userId: viewerB.user.id,
+  });
+
+  await ctx.db
+    .insertInto('avatarGrants')
+    .values([
+      { avatarId: avatarA.id, key: '0_0', kind: 'first_clear' },
+      { avatarId: avatarB.id, key: '0_0', kind: 'first_clear' },
+    ])
+    .execute();
+
+  const clientA = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewerA.token });
+  const clientB = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewerB.token });
+  const viewport = { maxCX: 0, maxCY: 0, minCX: 0, minCY: 0 };
+
+  const resultA = await clientA.getRevealedNodes({ avatarID: avatarA.id, viewport });
+  const resultB = await clientB.getRevealedNodes({ avatarID: avatarB.id, viewport });
+
+  expect(resultA.nodes).toMatchInlineSnapshot(`
+    [
+      {
+        "id": "0_0",
+        "poolID": "pool-c",
+      },
+    ]
+  `);
+
+  expect(resultB.nodes).toMatchInlineSnapshot(`
+    [
+      {
+        "id": "0_0",
+        "poolID": "pool-a",
+      },
+    ]
+  `);
+
+  expect(resultA.nodes.map((node) => node.poolID)).not.toStrictEqual(
+    resultB.nodes.map((node) => node.poolID),
+  );
 });
 
 test('it discloses a cell exactly REVEAL_RADIUS hops from a first-clear node', async () => {

--- a/services/activity/src/handlers/get-revealed-nodes.test.ts
+++ b/services/activity/src/handlers/get-revealed-nodes.test.ts
@@ -9,64 +9,8 @@ import {
   createViewer,
 } from '@vers/service-test-utils/bun';
 import { buildRPCTestClient } from '@vers/test-utils';
-import { REVEAL_RADIUS } from '@vers/worldmap-core';
+import { REVEAL_RADIUS, WORLD_COORD_MAX } from '@vers/worldmap-core';
 import { createActivityService } from '../create-activity-service';
-
-/**
- * A four-pool encounter document, so a disclosed `poolID` pins which pool the sealed derivation
- * actually picked rather than echoing the single pool a minimal document would always return
- * regardless of the coordinate, avatar seed, or scope secret fed into it.
- */
-const multiPoolEncounter = {
-  contentVersion: '2',
-  archetypes: [
-    {
-      id: 'placeholder-brawler',
-      name: 'World Map Enemy',
-      baseLevel: 1,
-      baseLife: 30,
-      baseXP: 10,
-      attackMin: 1,
-      attackMax: 3,
-      attackSpeed: 0.5,
-    },
-    {
-      id: 'placeholder-skirmisher',
-      name: 'World Map Skirmisher',
-      baseLevel: 1,
-      baseLife: 20,
-      baseXP: 8,
-      attackMin: 1,
-      attackMax: 4,
-      attackSpeed: 0.7,
-    },
-  ],
-  pools: [
-    { id: 'pool-a', entries: [{ archetypeID: 'placeholder-brawler', weight: 1 }] },
-    { id: 'pool-b', entries: [{ archetypeID: 'placeholder-skirmisher', weight: 1 }] },
-    {
-      id: 'pool-c',
-      entries: [
-        { archetypeID: 'placeholder-brawler', weight: 1 },
-        { archetypeID: 'placeholder-skirmisher', weight: 1 },
-      ],
-    },
-    {
-      id: 'pool-d',
-      entries: [
-        { archetypeID: 'placeholder-skirmisher', weight: 1 },
-        { archetypeID: 'placeholder-brawler', weight: 1 },
-      ],
-    },
-  ],
-  tuning: {
-    waveCountMin: 3,
-    waveCountMax: 6,
-    waveSizeMin: 3,
-    waveSizeMax: 6,
-    difficultyScalingFactor: 1,
-  },
-} as const;
 
 /**
  * `createContentVersion` opens its own `db.transaction()`, which can't nest under the default
@@ -77,7 +21,63 @@ async function setupTest() {
 
   await createContentVersion(
     db.db,
-    createMockContentDocument({ contentVersion: '2', encounter: multiPoolEncounter }),
+    createMockContentDocument({
+      contentVersion: '2',
+
+      // four pools, so a disclosed `poolID` pins which pool the sealed derivation actually picked
+      // rather than echoing the single pool a minimal document would always return regardless of
+      // the coordinate, avatar seed, or scope secret fed into it
+      encounter: {
+        contentVersion: '2',
+        archetypes: [
+          {
+            id: 'placeholder-brawler',
+            name: 'World Map Enemy',
+            baseLevel: 1,
+            baseLife: 30,
+            baseXP: 10,
+            attackMin: 1,
+            attackMax: 3,
+            attackSpeed: 0.5,
+          },
+          {
+            id: 'placeholder-skirmisher',
+            name: 'World Map Skirmisher',
+            baseLevel: 1,
+            baseLife: 20,
+            baseXP: 8,
+            attackMin: 1,
+            attackMax: 4,
+            attackSpeed: 0.7,
+          },
+        ],
+        pools: [
+          { id: 'pool-a', entries: [{ archetypeID: 'placeholder-brawler', weight: 1 }] },
+          { id: 'pool-b', entries: [{ archetypeID: 'placeholder-skirmisher', weight: 1 }] },
+          {
+            id: 'pool-c',
+            entries: [
+              { archetypeID: 'placeholder-brawler', weight: 1 },
+              { archetypeID: 'placeholder-skirmisher', weight: 1 },
+            ],
+          },
+          {
+            id: 'pool-d',
+            entries: [
+              { archetypeID: 'placeholder-skirmisher', weight: 1 },
+              { archetypeID: 'placeholder-brawler', weight: 1 },
+            ],
+          },
+        ],
+        tuning: {
+          waveCountMin: 3,
+          waveCountMax: 6,
+          waveSizeMin: 3,
+          waveSizeMax: 6,
+          difficultyScalingFactor: 1,
+        },
+      },
+    }),
   );
 
   const service = await createActivityService({ db: db.db });
@@ -240,6 +240,7 @@ test('it excludes a cell inside the viewport but outside every reveal disc', asy
     },
   });
 
+  expect(result.contentVersion).toBe('2');
   expect(result.nodes).toBeEmpty();
 });
 
@@ -318,6 +319,50 @@ test('it skips a first-clear grant key that is not a world-map node id', async (
   });
 
   expect(result.nodes.map((node) => node.id)).toStrictEqual(['0_0']);
+});
+
+test('it skips a first-clear grant naming a cell past the packable coordinate range', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  await ctx.db
+    .insertInto('avatarGrants')
+    .values({ avatarId: avatar.id, key: `${WORLD_COORD_MAX + 1}_0`, kind: 'first_clear' })
+    .execute();
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  // the disc around that grant would otherwise reach these addressable cells at the edge of the map
+  const result = await client.getRevealedNodes({
+    avatarID: avatar.id,
+    viewport: { maxCX: WORLD_COORD_MAX, maxCY: 0, minCX: WORLD_COORD_MAX - 1, minCY: 0 },
+  });
+
+  expect(result.nodes).toBeEmpty();
+});
+
+test('it reveals nothing for a second avatar of the same user that holds no first-clear grant', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const granted = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+  const ungranted = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  await ctx.db
+    .insertInto('avatarGrants')
+    .values({ avatarId: granted.id, key: '0_0', kind: 'first_clear' })
+    .execute();
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+  const viewport = { maxCX: 0, maxCY: 0, minCX: 0, minCY: 0 };
+
+  const grantedResult = await client.getRevealedNodes({ avatarID: granted.id, viewport });
+  const ungrantedResult = await client.getRevealedNodes({ avatarID: ungranted.id, viewport });
+
+  expect(grantedResult.nodes.map((node) => node.id)).toStrictEqual(['0_0']);
+  expect(ungrantedResult.nodes).toBeEmpty();
 });
 
 test('it rejects a foreign avatar with NOT_FOUND', async () => {

--- a/services/activity/src/handlers/get-revealed-nodes.test.ts
+++ b/services/activity/src/handlers/get-revealed-nodes.test.ts
@@ -1,0 +1,234 @@
+import { expect, test } from 'bun:test';
+import { createContentVersion } from '@vers/content-registry';
+import type { ActivityContract } from '@vers/contract-activity';
+import { createMockContentDocument } from '@vers/contract-activity/test-utils';
+import {
+  createAnonymousViewer,
+  createAvatarRow,
+  createTestDB,
+  createViewer,
+} from '@vers/service-test-utils/bun';
+import { buildRPCTestClient } from '@vers/test-utils';
+import { REVEAL_RADIUS } from '@vers/worldmap-core';
+import { createActivityService } from '../create-activity-service';
+
+/**
+ * `createContentVersion` opens its own `db.transaction()`, which can't nest under the default
+ * rollback-on-dispose isolation — this suite runs against a real, committed schema clone instead.
+ */
+async function setupTest() {
+  const db = await createTestDB({ isolation: 'schema' });
+
+  await createContentVersion(db.db, createMockContentDocument({ contentVersion: '2' }));
+
+  const service = await createActivityService({ db: db.db });
+
+  return { app: service.app, db: db.db, [Symbol.asyncDispose]: db[Symbol.asyncDispose] };
+}
+
+test('it discloses content for a verified first-clear node inside the viewport', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+
+  const avatar = await createAvatarRow(ctx.db, {
+    id: 'avatar_reveal_happy_path',
+    seed: 700,
+    userId: viewer.user.id,
+  });
+
+  await ctx.db
+    .insertInto('avatarGrants')
+    .values({ avatarId: avatar.id, key: '0_0', kind: 'first_clear' })
+    .execute();
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const result = await client.getRevealedNodes({
+    avatarID: avatar.id,
+    viewport: { maxCX: 0, maxCY: 0, minCX: 0, minCY: 0 },
+  });
+
+  expect(result.contentVersion).toBe('2');
+
+  expect(result.nodes).toMatchInlineSnapshot(`
+    [
+      {
+        "id": "0_0",
+        "poolID": "default",
+      },
+    ]
+  `);
+});
+
+test('it discloses a cell exactly REVEAL_RADIUS hops from a first-clear node', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  await ctx.db
+    .insertInto('avatarGrants')
+    .values({ avatarId: avatar.id, key: '0_0', kind: 'first_clear' })
+    .execute();
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const result = await client.getRevealedNodes({
+    avatarID: avatar.id,
+    viewport: { maxCX: REVEAL_RADIUS, maxCY: 0, minCX: REVEAL_RADIUS, minCY: 0 },
+  });
+
+  expect(result.nodes.map((node) => node.id)).toStrictEqual([`${REVEAL_RADIUS}_0`]);
+});
+
+test('it excludes a cell inside the viewport but outside every reveal disc', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  await ctx.db
+    .insertInto('avatarGrants')
+    .values({ avatarId: avatar.id, key: '0_0', kind: 'first_clear' })
+    .execute();
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+  const oneHopPastTheRadius = REVEAL_RADIUS + 1;
+
+  const result = await client.getRevealedNodes({
+    avatarID: avatar.id,
+    viewport: {
+      maxCX: oneHopPastTheRadius,
+      maxCY: 0,
+      minCX: oneHopPastTheRadius,
+      minCY: 0,
+    },
+  });
+
+  expect(result.nodes).toBeEmpty();
+});
+
+test('it unions discs from more than one first-clear grant, leaving the gap between them unrevealed', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  await ctx.db
+    .insertInto('avatarGrants')
+    .values([
+      { avatarId: avatar.id, key: '0_0', kind: 'first_clear' },
+      { avatarId: avatar.id, key: '6_0', kind: 'first_clear' },
+    ])
+    .execute();
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const result = await client.getRevealedNodes({
+    avatarID: avatar.id,
+    viewport: { maxCX: 6, maxCY: 0, minCX: 0, minCY: 0 },
+  });
+
+  // the two radius-2 discs cover cx 0-2 and cx 4-6 on this row; cx 3 sits in the gap between them
+  expect(result.nodes.map((node) => node.id).toSorted()).toStrictEqual([
+    '0_0',
+    '1_0',
+    '2_0',
+    '4_0',
+    '5_0',
+    '6_0',
+  ]);
+});
+
+test('it ignores a grant whose kind is not first_clear', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  await ctx.db
+    .insertInto('avatarGrants')
+    .values({ avatarId: avatar.id, key: '0_0', kind: 'cosmetic_unlock' })
+    .execute();
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const result = await client.getRevealedNodes({
+    avatarID: avatar.id,
+    viewport: { maxCX: 0, maxCY: 0, minCX: 0, minCY: 0 },
+  });
+
+  expect(result.nodes).toBeEmpty();
+});
+
+test('it skips a first-clear grant key that is not a world-map node id', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  await ctx.db
+    .insertInto('avatarGrants')
+    .values([
+      { avatarId: avatar.id, key: 'not_a_node_id', kind: 'first_clear' },
+      { avatarId: avatar.id, key: '0_0', kind: 'first_clear' },
+    ])
+    .execute();
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const result = await client.getRevealedNodes({
+    avatarID: avatar.id,
+    viewport: { maxCX: 0, maxCY: 0, minCX: 0, minCY: 0 },
+  });
+
+  expect(result.nodes.map((node) => node.id)).toStrictEqual(['0_0']);
+});
+
+test('it rejects a foreign avatar with NOT_FOUND', async () => {
+  await using ctx = await setupTest();
+
+  const owner = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: owner.user.id });
+  const otherViewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: otherViewer.token });
+
+  expect(
+    client.getRevealedNodes({
+      avatarID: avatar.id,
+      viewport: { maxCX: 0, maxCY: 0, minCX: 0, minCY: 0 },
+    }),
+  ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+});
+
+test('it rejects a missing avatar with NOT_FOUND', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  expect(
+    client.getRevealedNodes({
+      avatarID: 'avatar_never_created',
+      viewport: { maxCX: 0, maxCY: 0, minCX: 0, minCY: 0 },
+    }),
+  ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+});
+
+test('it rejects an anonymous acting user with UNAUTHORIZED', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createAnonymousViewer({ audience: 'service-activity' });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  expect(
+    client.getRevealedNodes({
+      avatarID: 'avatar_1',
+      viewport: { maxCX: 0, maxCY: 0, minCX: 0, minCY: 0 },
+    }),
+  ).rejects.toMatchObject({ code: 'UNAUTHORIZED', data: { reason: 'missing-session' } });
+});

--- a/services/activity/src/handlers/get-revealed-nodes.ts
+++ b/services/activity/src/handlers/get-revealed-nodes.ts
@@ -1,0 +1,145 @@
+import { findCurrentContentVersion } from '@vers/content-registry';
+import type { ContentDocument } from '@vers/contract-activity';
+import type { SecretRef } from '@vers/contract-keys';
+import type { DB } from '@vers/db';
+import { deriveWorldmapContent, readScopeSecret } from '@vers/worldmap-content';
+import {
+  REVEAL_RADIUS,
+  collectRevealedCells,
+  decodeMortonKey,
+  findCellCoord,
+  toNodeID,
+} from '@vers/worldmap-core';
+import type { RevealSource } from '@vers/worldmap-core';
+import type { CryptoKey } from 'jose';
+import type { Kysely } from 'kysely';
+import invariant from 'tiny-invariant';
+import { recordRevealQuery } from '../metrics/record-reveal-query';
+import type { EmptyErrorPayload, MissingSessionPayload } from '../types';
+
+/**
+ * Db handle plus the memoized content-document loader and keys dispatch a reveal query reads its
+ * scope secret over — the same dependencies `startActivity` closes over, minus the key version and
+ * signing inputs a read never stamps.
+ */
+interface GetRevealedNodesDeps {
+  readonly db: Kysely<DB>;
+  readonly keysServiceURL: string;
+  readonly loadContentDocument: (contentVersion: string) => Promise<ContentDocument | undefined>;
+  readonly privateKey: CryptoKey;
+  readonly secretRef: SecretRef;
+  readonly secretVersion: number;
+}
+
+/**
+ * oRPC handler opts for the authed `getRevealedNodes` procedure.
+ */
+interface GetRevealedNodesOpts {
+  readonly context: { readonly actingUserId: null | string };
+  readonly errors: {
+    readonly NOT_FOUND: (payload: EmptyErrorPayload) => Error;
+    readonly UNAUTHORIZED: (payload: MissingSessionPayload) => Error;
+  };
+  readonly input: {
+    readonly avatarID: string;
+    readonly viewport: {
+      readonly maxCX: number;
+      readonly maxCY: number;
+      readonly minCX: number;
+      readonly minCY: number;
+    };
+  };
+}
+
+interface RevealedNode {
+  readonly id: string;
+  readonly poolID?: string;
+}
+
+interface GetRevealedNodesResult {
+  readonly contentVersion: string;
+  readonly nodes: Array<RevealedNode>;
+}
+
+/**
+ * Returns the disclosed content for every cell the avatar's verified first-clear grants reveal
+ * inside the requested viewport. The revealed region is a projection, never stored state: it is
+ * `⋃ disc(position(N), REVEAL_RADIUS)` over the avatar's `first_clear`-kind grants, recomputed
+ * fresh on every call from the grants table alone. A grant key that doesn't parse as a world-map
+ * node id — a grant kind sharing the table with an unrelated future feature — contributes no
+ * source rather than failing the query. Only cells the disc union actually covers can appear in the
+ * response; the viewport bounds what is returned, never what is eligible to be revealed.
+ */
+export async function getRevealedNodes(
+  deps: GetRevealedNodesDeps,
+  opts: GetRevealedNodesOpts,
+): Promise<GetRevealedNodesResult> {
+  if (opts.context.actingUserId === null) {
+    throw opts.errors.UNAUTHORIZED({ data: { reason: 'missing-session' } });
+  }
+
+  const avatar = await deps.db
+    .selectFrom('avatars')
+    .select(['id', 'seed'])
+    .where('id', '=', opts.input.avatarID)
+    .where('userId', '=', opts.context.actingUserId)
+    .executeTakeFirst();
+
+  if (avatar === undefined) {
+    throw opts.errors.NOT_FOUND({ data: {} });
+  }
+
+  const grants = await deps.db
+    .selectFrom('avatarGrants')
+    .select('key')
+    .where('avatarId', '=', avatar.id)
+    .where('kind', '=', 'first_clear')
+    .execute();
+
+  const sources: Array<RevealSource> = [];
+
+  for (const grant of grants) {
+    const coord = findCellCoord(grant.key);
+
+    if (coord !== undefined) {
+      sources.push({ coord, radius: REVEAL_RADIUS });
+    }
+  }
+
+  const revealedCells = collectRevealedCells(sources, opts.input.viewport);
+
+  const contentVersion = await findCurrentContentVersion(deps.db);
+
+  invariant(contentVersion !== undefined, 'content registry has no current version');
+
+  const document = await deps.loadContentDocument(contentVersion);
+
+  invariant(document, `current content version ${contentVersion} is not published`);
+
+  const scopeSecret = await readScopeSecret(
+    {
+      issuer: 'service-activity',
+      keysServiceURL: deps.keysServiceURL,
+      privateKey: deps.privateKey,
+    },
+    { avatarID: avatar.id, secretRef: deps.secretRef, secretVersion: deps.secretVersion },
+  );
+
+  const nodes = revealedCells.map((key): RevealedNode => {
+    const coord = decodeMortonKey(key);
+
+    const content = deriveWorldmapContent(document.encounter, {
+      coord,
+      scopeSecret,
+      userSeed: avatar.seed,
+    });
+
+    const id = toNodeID(coord[0], coord[1]);
+
+    return content.poolID === undefined ? { id } : { id, poolID: content.poolID };
+  });
+
+  recordRevealQuery(nodes.length, grants.length);
+
+  return { contentVersion, nodes };
+}

--- a/services/activity/src/handlers/get-revealed-nodes.ts
+++ b/services/activity/src/handlers/get-revealed-nodes.ts
@@ -5,6 +5,7 @@ import type { DB } from '@vers/db';
 import { deriveWorldmapContent, readScopeSecret } from '@vers/worldmap-content';
 import {
   REVEAL_RADIUS,
+  canEncodeMortonKey,
   collectRevealedCells,
   decodeMortonKey,
   findCellCoord,
@@ -19,7 +20,7 @@ import type { EmptyErrorPayload, MissingSessionPayload } from '../types';
 
 /**
  * Db handle plus the memoized content-document loader and keys dispatch a reveal query reads its
- * scope secret over — the same dependencies `startActivity` closes over, minus the key version and
+ * scope secret over — the dependencies an activity start closes over, minus the key version and
  * signing inputs a read never stamps.
  */
 interface GetRevealedNodesDeps {
@@ -63,12 +64,14 @@ interface GetRevealedNodesResult {
 
 /**
  * Returns the disclosed content for every cell the avatar's verified first-clear grants reveal
- * inside the requested viewport. The revealed region is a projection, never stored state: it is
- * `⋃ disc(position(N), REVEAL_RADIUS)` over the avatar's `first_clear`-kind grants, recomputed
- * fresh on every call from the grants table alone. A grant key that doesn't parse as a world-map
- * node id — a grant kind sharing the table with an unrelated future feature — contributes no
- * source rather than failing the query. Only cells the disc union actually covers can appear in the
+ * inside the requested viewport. The revealed region is a projection, never stored state: it is the
+ * union of the reveal disc around each of the avatar's `first_clear`-kind grants, recomputed fresh
+ * on every call from the grants table alone. Only cells that union actually covers can appear in the
  * response; the viewport bounds what is returned, never what is eligible to be revealed.
+ *
+ * A grant key that names no addressable world-map cell contributes no source rather than failing the
+ * query — a grant kind sharing the table with an unrelated future feature, or a row written before
+ * the coordinate bounds existed.
  */
 export async function getRevealedNodes(
   deps: GetRevealedNodesDeps,
@@ -101,7 +104,7 @@ export async function getRevealedNodes(
   for (const grant of grants) {
     const coord = findCellCoord(grant.key);
 
-    if (coord !== undefined) {
+    if (coord !== undefined && canEncodeMortonKey(coord)) {
       sources.push({ coord, radius: REVEAL_RADIUS });
     }
   }
@@ -111,6 +114,14 @@ export async function getRevealedNodes(
   const contentVersion = await findCurrentContentVersion(deps.db);
 
   invariant(contentVersion !== undefined, 'content registry has no current version');
+
+  // a viewport the discs never reach needs neither the content document nor the avatar's scope
+  // secret, so a fog-only query costs one grants read and no keys-service round trip
+  if (revealedCells.length === 0) {
+    recordRevealQuery({ cellCount: 0, sourceCount: grants.length });
+
+    return { contentVersion, nodes: [] };
+  }
 
   const document = await deps.loadContentDocument(contentVersion);
 
@@ -139,7 +150,7 @@ export async function getRevealedNodes(
     return content.poolID === undefined ? { id } : { id, poolID: content.poolID };
   });
 
-  recordRevealQuery(nodes.length, grants.length);
+  recordRevealQuery({ cellCount: nodes.length, sourceCount: grants.length });
 
   return { contentVersion, nodes };
 }

--- a/services/activity/src/metrics/record-reveal-query.test.ts
+++ b/services/activity/src/metrics/record-reveal-query.test.ts
@@ -1,71 +1,40 @@
-import { expect, onTestFinished, test } from 'bun:test';
-import { metrics } from '@opentelemetry/api';
-import {
-  AggregationTemporality,
-  DataPointType,
-  InMemoryMetricExporter,
-  MeterProvider,
-  PeriodicExportingMetricReader,
-} from '@opentelemetry/sdk-metrics';
-import invariant from 'tiny-invariant';
+import { expect, test } from 'bun:test';
+import { createInMemoryMetrics } from '@vers/test-utils/bun';
 import { recordRevealQuery } from './record-reveal-query';
 
-function setupTest() {
-  const exporter = new InMemoryMetricExporter(AggregationTemporality.CUMULATIVE);
-
-  const provider = new MeterProvider({
-    readers: [new PeriodicExportingMetricReader({ exporter, exportIntervalMillis: 3_600_000 })],
-  });
-
-  metrics.setGlobalMeterProvider(provider);
-
-  onTestFinished(async () => {
-    metrics.disable();
-
-    await provider.shutdown();
-  });
-
-  return { exporter, provider };
-}
-
 test('it records the revealed cell count', async () => {
-  const ctx = setupTest();
+  const inMemoryMetrics = createInMemoryMetrics();
 
-  recordRevealQuery(19, 3);
+  recordRevealQuery({ cellCount: 19, sourceCount: 3 });
 
-  await ctx.provider.forceFlush();
+  const dataPoints = await inMemoryMetrics.readHistogramDataPoints('vers.activity.reveal_cells');
 
-  const histogram = ctx.exporter
-    .getMetrics()
-    .flatMap((resourceMetrics) => resourceMetrics.scopeMetrics)
-    .flatMap((scopeMetrics) => scopeMetrics.metrics)
-    .find((metric) => metric.descriptor.name === 'vers.activity.reveal_cells');
-
-  invariant(histogram?.dataPointType === DataPointType.HISTOGRAM, 'expected a histogram metric');
-
-  expect(histogram.dataPoints[0]?.value.sum).toBe(19);
+  expect(dataPoints.map((dataPoint) => dataPoint.sum)).toStrictEqual([19]);
 });
 
 test('it records the scanned first-clear grant source count', async () => {
-  const ctx = setupTest();
+  const inMemoryMetrics = createInMemoryMetrics();
 
-  recordRevealQuery(19, 3);
+  recordRevealQuery({ cellCount: 19, sourceCount: 3 });
 
-  await ctx.provider.forceFlush();
+  const dataPoints = await inMemoryMetrics.readHistogramDataPoints('vers.activity.reveal_sources');
 
-  const histogram = ctx.exporter
-    .getMetrics()
-    .flatMap((resourceMetrics) => resourceMetrics.scopeMetrics)
-    .flatMap((scopeMetrics) => scopeMetrics.metrics)
-    .find((metric) => metric.descriptor.name === 'vers.activity.reveal_sources');
+  expect(dataPoints.map((dataPoint) => dataPoint.sum)).toStrictEqual([3]);
+});
 
-  invariant(histogram?.dataPointType === DataPointType.HISTOGRAM, 'expected a histogram metric');
+test('it counts one observation per reveal query', async () => {
+  const inMemoryMetrics = createInMemoryMetrics();
 
-  expect(histogram.dataPoints[0]?.value.sum).toBe(3);
+  recordRevealQuery({ cellCount: 19, sourceCount: 3 });
+  recordRevealQuery({ cellCount: 4, sourceCount: 1 });
+
+  const dataPoints = await inMemoryMetrics.readHistogramDataPoints('vers.activity.reveal_cells');
+
+  expect(dataPoints.map((dataPoint) => dataPoint.count)).toStrictEqual([2]);
 });
 
 test('it stays inert without a registered meter provider', () => {
   expect(() => {
-    recordRevealQuery(19, 3);
+    recordRevealQuery({ cellCount: 19, sourceCount: 3 });
   }).not.toThrow();
 });

--- a/services/activity/src/metrics/record-reveal-query.test.ts
+++ b/services/activity/src/metrics/record-reveal-query.test.ts
@@ -1,0 +1,71 @@
+import { expect, onTestFinished, test } from 'bun:test';
+import { metrics } from '@opentelemetry/api';
+import {
+  AggregationTemporality,
+  DataPointType,
+  InMemoryMetricExporter,
+  MeterProvider,
+  PeriodicExportingMetricReader,
+} from '@opentelemetry/sdk-metrics';
+import invariant from 'tiny-invariant';
+import { recordRevealQuery } from './record-reveal-query';
+
+function setupTest() {
+  const exporter = new InMemoryMetricExporter(AggregationTemporality.CUMULATIVE);
+
+  const provider = new MeterProvider({
+    readers: [new PeriodicExportingMetricReader({ exporter, exportIntervalMillis: 3_600_000 })],
+  });
+
+  metrics.setGlobalMeterProvider(provider);
+
+  onTestFinished(async () => {
+    metrics.disable();
+
+    await provider.shutdown();
+  });
+
+  return { exporter, provider };
+}
+
+test('it records the revealed cell count', async () => {
+  const ctx = setupTest();
+
+  recordRevealQuery(19, 3);
+
+  await ctx.provider.forceFlush();
+
+  const histogram = ctx.exporter
+    .getMetrics()
+    .flatMap((resourceMetrics) => resourceMetrics.scopeMetrics)
+    .flatMap((scopeMetrics) => scopeMetrics.metrics)
+    .find((metric) => metric.descriptor.name === 'vers.activity.reveal_cells');
+
+  invariant(histogram?.dataPointType === DataPointType.HISTOGRAM, 'expected a histogram metric');
+
+  expect(histogram.dataPoints[0]?.value.sum).toBe(19);
+});
+
+test('it records the scanned first-clear grant source count', async () => {
+  const ctx = setupTest();
+
+  recordRevealQuery(19, 3);
+
+  await ctx.provider.forceFlush();
+
+  const histogram = ctx.exporter
+    .getMetrics()
+    .flatMap((resourceMetrics) => resourceMetrics.scopeMetrics)
+    .flatMap((scopeMetrics) => scopeMetrics.metrics)
+    .find((metric) => metric.descriptor.name === 'vers.activity.reveal_sources');
+
+  invariant(histogram?.dataPointType === DataPointType.HISTOGRAM, 'expected a histogram metric');
+
+  expect(histogram.dataPoints[0]?.value.sum).toBe(3);
+});
+
+test('it stays inert without a registered meter provider', () => {
+  expect(() => {
+    recordRevealQuery(19, 3);
+  }).not.toThrow();
+});

--- a/services/activity/src/metrics/record-reveal-query.ts
+++ b/services/activity/src/metrics/record-reveal-query.ts
@@ -1,14 +1,19 @@
 import { metrics } from '@opentelemetry/api';
 
+interface RevealQueryFanOut {
+  readonly cellCount: number;
+  readonly sourceCount: number;
+}
+
 /**
- * Records one `getRevealedNodes` call's fan-out: how many first-clear grant rows the query scanned
- * for reveal sources, and how many revealed cells the projection returned for the queried viewport.
+ * Records one reveal query's fan-out: how many first-clear grant rows the query scanned for reveal
+ * sources, and how many revealed cells the projection returned for the queried viewport.
  * Event-recorded, so both histograms emit only while a reveal query actually runs. Resolved through
  * the global metrics API on every call — the SDK returns the same instrument for an identical
  * registration, and resolving late keeps them bound to whichever meter provider the process
  * registered at boot; without one they are the API's no-op.
  */
-export function recordRevealQuery(cellCount: number, sourceCount: number): void {
+export function recordRevealQuery(fanOut: RevealQueryFanOut): void {
   const meter = metrics.getMeter('@vers/service-activity');
 
   meter
@@ -16,12 +21,12 @@ export function recordRevealQuery(cellCount: number, sourceCount: number): void 
       description: 'revealed cells returned per getRevealedNodes query',
       unit: '{cell}',
     })
-    .record(cellCount);
+    .record(fanOut.cellCount);
 
   meter
     .createHistogram('vers.activity.reveal_sources', {
       description: 'first-clear grant rows scanned per getRevealedNodes query',
       unit: '{grant}',
     })
-    .record(sourceCount);
+    .record(fanOut.sourceCount);
 }

--- a/services/activity/src/metrics/record-reveal-query.ts
+++ b/services/activity/src/metrics/record-reveal-query.ts
@@ -1,0 +1,27 @@
+import { metrics } from '@opentelemetry/api';
+
+/**
+ * Records one `getRevealedNodes` call's fan-out: how many first-clear grant rows the query scanned
+ * for reveal sources, and how many revealed cells the projection returned for the queried viewport.
+ * Event-recorded, so both histograms emit only while a reveal query actually runs. Resolved through
+ * the global metrics API on every call — the SDK returns the same instrument for an identical
+ * registration, and resolving late keeps them bound to whichever meter provider the process
+ * registered at boot; without one they are the API's no-op.
+ */
+export function recordRevealQuery(cellCount: number, sourceCount: number): void {
+  const meter = metrics.getMeter('@vers/service-activity');
+
+  meter
+    .createHistogram('vers.activity.reveal_cells', {
+      description: 'revealed cells returned per getRevealedNodes query',
+      unit: '{cell}',
+    })
+    .record(cellCount);
+
+  meter
+    .createHistogram('vers.activity.reveal_sources', {
+      description: 'first-clear grant rows scanned per getRevealedNodes query',
+      unit: '{grant}',
+    })
+    .record(sourceCount);
+}


### PR DESCRIPTION
Closes #193

Implements the reveal-projection read: a Morton-indexed disc union over first-clear grants, served as a new contract procedure and handler, with no stored reveal state.

- worldmap-core: `encodeMortonKey`/`decodeMortonKey` (zigzag + bit-interleave) and `collectRevealedCells`, projecting reveal-source hex discs onto a viewport, clipped, deduped, Morton-sorted
- contracts/activity: `getRevealedNodes` procedure with a viewport cap (`REVEAL_VIEWPORT_CELL_CAP`) enforced by a zod refine
- services/activity: handler resolves owned avatar, scans `avatar_grants` for `kind='first_clear'`, projects revealed cells, derives worldmap content per cell mirroring `startActivity`'s content-version derivation, and records two new histograms per query
- mock-services: minimal `getRevealedNodes` mock handler so the workspace typechecks against the extended contract
- observability.md: registers the two new reveal-query instruments

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality