### PR TITLE
fix(#865): lazily initialize trace storage to avoid browser-side async_hooks eval

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -393,6 +393,28 @@
   },
   "overrides": [
     {
+      // the trace storage constructs AsyncLocalStorage lazily through a
+      // namespace import, so browser bundles reaching it through the orpc
+      // barrel never touch node:async_hooks at module evaluation; a named
+      // import moves that access back to module scope under bundlers that
+      // stub the builtin, silently reintroducing the browser throw
+      "files": ["**/libs/service/service-utils/src/**"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "paths": [
+              {
+                "importNames": ["AsyncLocalStorage"],
+                "message": "Import the node:async_hooks namespace (import * as asyncHooks) and construct lazily inside a function — a named import evaluates the browser stub at module scope.",
+                "name": "node:async_hooks"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
       "files": ["**/schema.generated.ts"],
       // kysely-codegen column overrides emit inline `import()` type annotations; the file is
       // generated, so the style rule has nothing to teach it

--- a/libs/service/service-utils/src/trace/find-trace-context.ts
+++ b/libs/service/service-utils/src/trace/find-trace-context.ts
@@ -1,10 +1,10 @@
 import type { TraceContext } from '@vers/trace';
-import { traceStorage } from './trace-storage';
+import { getTraceStorage } from './get-trace-storage';
 
 /**
  * The active request's trace context; undefined outside a `withTraceContext` scope (boot code,
  * timers, tests that never entered a request).
  */
 export function findTraceContext(): TraceContext | undefined {
-  return traceStorage.getStore();
+  return getTraceStorage().getStore();
 }

--- a/libs/service/service-utils/src/trace/get-trace-storage.test.ts
+++ b/libs/service/service-utils/src/trace/get-trace-storage.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from 'bun:test';
+import { getTraceStorage } from './get-trace-storage';
+
+test('it returns the same storage instance across calls', () => {
+  expect(getTraceStorage()).toBe(getTraceStorage());
+});

--- a/libs/service/service-utils/src/trace/get-trace-storage.ts
+++ b/libs/service/service-utils/src/trace/get-trace-storage.ts
@@ -1,3 +1,4 @@
+// oxlint-disable-next-line no-restricted-imports -- the one sanctioned async_hooks import: the namespace form defers the browser stub's throwing property access to the accessor's first call
 import * as asyncHooks from 'node:async_hooks';
 import type { TraceContext } from '@vers/trace';
 

--- a/libs/service/service-utils/src/trace/get-trace-storage.ts
+++ b/libs/service/service-utils/src/trace/get-trace-storage.ts
@@ -1,7 +1,7 @@
-import { AsyncLocalStorage } from 'node:async_hooks';
+import * as asyncHooks from 'node:async_hooks';
 import type { TraceContext } from '@vers/trace';
 
-let storage: AsyncLocalStorage<TraceContext> | undefined;
+let storage: asyncHooks.AsyncLocalStorage<TraceContext> | undefined;
 
 /**
  * Process-wide holder for the active request's trace context, created on first access. Written
@@ -9,12 +9,14 @@ let storage: AsyncLocalStorage<TraceContext> | undefined;
  * every log line inside a request carries its trace id without threading it through call
  * signatures.
  *
- * Construction is deferred to the call site so that importing this module — or anything that
+ * Construction is deferred to the call site, and the binding it constructs from is read through
+ * a namespace import rather than a named one, so that importing this module — or anything that
  * re-exports it, like the `orpc` barrel — never touches `node:async_hooks` on its own. A
- * browser bundle that never calls into a request scope never runs this accessor.
+ * bundler that externalizes the builtin for the browser only throws when a property on it is
+ * actually read; a browser bundle that never calls into a request scope never reads one.
  */
-export function getTraceStorage(): AsyncLocalStorage<TraceContext> {
-  storage ??= new AsyncLocalStorage<TraceContext>();
+export function getTraceStorage(): asyncHooks.AsyncLocalStorage<TraceContext> {
+  storage ??= new asyncHooks.AsyncLocalStorage<TraceContext>();
 
   return storage;
 }

--- a/libs/service/service-utils/src/trace/get-trace-storage.ts
+++ b/libs/service/service-utils/src/trace/get-trace-storage.ts
@@ -1,0 +1,20 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type { TraceContext } from '@vers/trace';
+
+let storage: AsyncLocalStorage<TraceContext> | undefined;
+
+/**
+ * Process-wide holder for the active request's trace context, created on first access. Written
+ * only by `withTraceContext`; read anywhere via `findTraceContext` — including pino mixins, so
+ * every log line inside a request carries its trace id without threading it through call
+ * signatures.
+ *
+ * Construction is deferred to the call site so that importing this module — or anything that
+ * re-exports it, like the `orpc` barrel — never touches `node:async_hooks` on its own. A
+ * browser bundle that never calls into a request scope never runs this accessor.
+ */
+export function getTraceStorage(): AsyncLocalStorage<TraceContext> {
+  storage ??= new AsyncLocalStorage<TraceContext>();
+
+  return storage;
+}

--- a/libs/service/service-utils/src/trace/trace-storage.ts
+++ b/libs/service/service-utils/src/trace/trace-storage.ts
@@ -1,9 +1,0 @@
-import { AsyncLocalStorage } from 'node:async_hooks';
-import type { TraceContext } from '@vers/trace';
-
-/**
- * Process-wide holder for the active request's trace context. Written only by
- * `withTraceContext`; read anywhere via `findTraceContext` — including pino mixins, so every log
- * line inside a request carries its trace id without threading it through call signatures.
- */
-export const traceStorage = new AsyncLocalStorage<TraceContext>();

--- a/libs/service/service-utils/src/trace/with-trace-context.ts
+++ b/libs/service/service-utils/src/trace/with-trace-context.ts
@@ -1,10 +1,10 @@
 import type { TraceContext } from '@vers/trace';
-import { traceStorage } from './trace-storage';
+import { getTraceStorage } from './get-trace-storage';
 
 /**
  * Runs the given scope with the trace context active, making it visible to `findTraceContext`
  * across every await inside it.
  */
 export function withTraceContext<T>(trace: Readonly<TraceContext>, scope: () => T): T {
-  return traceStorage.run(trace, scope);
+  return getTraceStorage().run(trace, scope);
 }


### PR DESCRIPTION
## Description

Closes #865

The `orpc` barrel evaluated server-only trace storage in the browser: `libs/service/service-utils/src/trace/trace-storage.ts` constructed `new AsyncLocalStorage<TraceContext>()` at module scope, and any import of the barrel — even for browser-safe retry helpers — pulled in `buildTracingInterceptor`, which reached this module and evaluated it eagerly, throwing where Vite stubs `node:async_hooks`.

- Renamed `trace-storage.ts` → `get-trace-storage.ts`, replacing the module-scope `traceStorage` export with a lazily-initialized singleton behind `getTraceStorage()`
- Reads the `AsyncLocalStorage` binding through a namespace import so the module never touches `node:async_hooks` until a caller actually invokes `getTraceStorage()`
- Updated `with-trace-context.ts` and `find-trace-context.ts` to call `getTraceStorage()` at use time instead of capturing storage at module scope
- Added a regression test asserting `getTraceStorage()` returns the same instance across calls
- Grepped the rest of the package for other module-scope `AsyncLocalStorage`/`async_hooks` construction reachable from the barrel — none found; `otel/start-trace-export.ts` is server-only bootstrap, not reachable from the barrel, and is unchanged

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
