### PR TITLE
fix: recompute the node mesh's bounding sphere on node-list changes

### DIFF
--- a/libs/game/worldmap-client/src/components-three/world-map-nodes.test.tsx
+++ b/libs/game/worldmap-client/src/components-three/world-map-nodes.test.tsx
@@ -1,6 +1,8 @@
 import { expect, test } from 'bun:test';
 import ReactThreeTestRenderer from '@react-three/test-renderer';
 import type { WorldMapNode } from '@vers/worldmap-core';
+import type { InstancedMesh, Object3D } from 'three';
+import invariant from 'tiny-invariant';
 import { useWorldmapStore } from '../state/use-worldmap-store';
 import { createMockWorldMapNode } from '../test-utils/factories/create-mock-world-map-node';
 import { WorldMapNodes } from './world-map-nodes';
@@ -50,3 +52,31 @@ test('it sets the selected node when a node instance is clicked', async () => {
 
   expect(useWorldmapStore.getState().selectedNode).toBe(nodeA);
 });
+
+test('it moves the bounding sphere with the nodes when the list is replaced at the same count', async () => {
+  const nearA = createMockWorldMapNode({ position: [0, 0] });
+  const nearB = createMockWorldMapNode({ position: [1, 0] });
+
+  const renderer = await setupTest([nearA, nearB]);
+
+  const farA = createMockWorldMapNode({ position: [100, 100] });
+  const farB = createMockWorldMapNode({ position: [101, 100] });
+
+  await renderer.update(<WorldMapNodes nodes={[farA, farB]} />);
+
+  const mesh = renderer.scene.children[0]!.instance;
+
+  invariant(isInstancedMesh(mesh), 'the component renders an instanced mesh');
+  invariant(mesh.boundingSphere, 'the layout effect computes the sphere before paint');
+
+  expect(mesh.boundingSphere.center.x).toBeCloseTo(1005);
+  expect(mesh.boundingSphere.center.y).toBeCloseTo(1000);
+});
+
+/**
+ * Duck-typed stand-in for `instanceof InstancedMesh`: the test renderer constructs objects from a
+ * different copy of three than this file imports, so an `instanceof` check never matches.
+ */
+function isInstancedMesh(object: Object3D): object is InstancedMesh {
+  return 'isInstancedMesh' in object && object.isInstancedMesh === true;
+}

--- a/libs/game/worldmap-client/src/components-three/world-map-nodes.test.tsx
+++ b/libs/game/worldmap-client/src/components-three/world-map-nodes.test.tsx
@@ -59,15 +59,22 @@ test('it moves the bounding sphere with the nodes when the list is replaced at t
 
   const renderer = await setupTest([nearA, nearB]);
 
+  const mesh = renderer.scene.children[0]!.instance;
+
+  invariant(isInstancedMesh(mesh), 'the component renders an instanced mesh');
+
+  // the renderer computes the sphere lazily on first cull; forcing it here reproduces that state,
+  // so a stale sphere after the update reads as the old center rather than a missing sphere
+  mesh.computeBoundingSphere();
+
   const farA = createMockWorldMapNode({ position: [100, 100] });
   const farB = createMockWorldMapNode({ position: [101, 100] });
 
   await renderer.update(<WorldMapNodes nodes={[farA, farB]} />);
 
-  const mesh = renderer.scene.children[0]!.instance;
+  expect(renderer.scene.children[0]!.instance).toBe(mesh);
 
-  invariant(isInstancedMesh(mesh), 'the component renders an instanced mesh');
-  invariant(mesh.boundingSphere, 'the layout effect computes the sphere before paint');
+  invariant(mesh.boundingSphere, 'the sphere was computed before the update');
 
   expect(mesh.boundingSphere.center.x).toBeCloseTo(1005);
   expect(mesh.boundingSphere.center.y).toBeCloseTo(1000);

--- a/libs/game/worldmap-client/src/components-three/world-map-nodes.tsx
+++ b/libs/game/worldmap-client/src/components-three/world-map-nodes.tsx
@@ -54,6 +54,12 @@ export function WorldMapNodes(props: Readonly<WorldMapNodesProps>) {
       mesh.instanceColor.needsUpdate = true;
     }
 
+    // three derives an InstancedMesh's bounding sphere once, lazily, and a matrix rewrite doesn't
+    // invalidate it — without this recompute, a reused mesh (same instance count, new node list)
+    // keeps the sphere anchored over the previous region, so the frustum culls every node once the
+    // camera pans away and raycasting's sphere gate stops pointer events with it
+    mesh.computeBoundingSphere();
+
     appliedSelectedNodeIDRef.current = selectedNodeID;
   }, [props.nodes]);
 


### PR DESCRIPTION
## Description

Fixes the prod /explore blank-out: after ~2 seconds of panning or zooming, every node vanished with no error. three derives an `InstancedMesh`'s bounding sphere once, lazily, and a matrix rewrite doesn't invalidate it — `WorldMapNodes` reuses its mesh whenever the node count is unchanged (a pan at fixed zoom always is, since every cell carries a node), so the sphere stayed anchored over the first-built region and the frustum eventually culled the whole mesh. The same stale sphere gates instance raycasting, so hover and click died with it.

- Recompute the sphere in the layout effect that rewrites the instance matrices.
- Regression test asserts the sphere follows a same-count node-list replacement; it fails without the fix.
- The test's `instanceof` check is duck-typed: the test renderer constructs objects from a different three copy than the file imports.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality