### PR TITLE
feat(#877): worldmap perf HUD, scatter toggle, and pan benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ testem.log
 /coverage
 **/.test-results
 **/.stack-test-results
+**/.bench-test-results
 
 # System Files
 .DS_Store

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -463,7 +463,11 @@
       // playwright resolves fixtures by statically parsing the destructure
       // pattern in a test callback's first parameter — a plain parameter
       // fails at collection, so the framework convention wins here
-      "files": ["**/apps/web-e2e/src/**", "**/apps/web-e2e/specs/**"],
+      "files": [
+        "**/apps/web-e2e/src/**",
+        "**/apps/web-e2e/specs/**",
+        "**/apps/web-e2e/benchmarks/**"
+      ],
       "rules": {
         "zgeoff/no-destructured-params": "off"
       }

--- a/apps/web-e2e/benchmarks/drag-pan.spec.ts
+++ b/apps/web-e2e/benchmarks/drag-pan.spec.ts
@@ -23,6 +23,15 @@ const DRAG_STEPS_PER_LEG = 20;
 const DROPPED_FRAME_THRESHOLD_MS = 32;
 
 /**
+ * The frame-gap sampler's state, parked on the page's own `globalThis` so it survives across the
+ * two separate `page.evaluate` round trips that start and read it.
+ */
+interface DragPanWindow {
+  __dragPanFrameGaps: Array<number>;
+  __dragPanFrameLoopID: number;
+}
+
+/**
  * Repeatable drag-pan performance probe for the explore map, standing in for the spike's manual
  * benchmark (HARVEST.md, "Performance model"; spike baseline: 409ms peak / 16 dropped frames before
  * chunked scatter builds, 7ms / 0 dropped after). Reports peak frame gap and dropped-frame count
@@ -70,6 +79,8 @@ test('it drag-pans across the explore map and reports peak frame gap and dropped
   }
 
   await page.evaluate(() => {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the sampler's state lives on the page's own globalThis with no declared type; DragPanWindow names the two fields this benchmark parks there
+    const dragPanWindow = globalThis as unknown as DragPanWindow;
     const gaps: Array<number> = [];
     let last = performance.now();
 
@@ -79,15 +90,11 @@ test('it drag-pans across the explore map and reports peak frame gap and dropped
       gaps.push(now - last);
 
       last = now;
-
-      (globalThis as unknown as { __dragPanFrameLoopID: number }).__dragPanFrameLoopID =
-        requestAnimationFrame(advanceFrame);
+      dragPanWindow.__dragPanFrameLoopID = requestAnimationFrame(advanceFrame);
     };
 
-    (globalThis as unknown as { __dragPanFrameGaps: Array<number> }).__dragPanFrameGaps = gaps;
-
-    (globalThis as unknown as { __dragPanFrameLoopID: number }).__dragPanFrameLoopID =
-      requestAnimationFrame(advanceFrame);
+    dragPanWindow.__dragPanFrameGaps = gaps;
+    dragPanWindow.__dragPanFrameLoopID = requestAnimationFrame(advanceFrame);
   });
 
   const centerY = box.y + box.height / 2;
@@ -104,11 +111,12 @@ test('it drag-pans across the explore map and reports peak frame gap and dropped
   }
 
   const frameGaps = await page.evaluate(() => {
-    cancelAnimationFrame(
-      (globalThis as unknown as { __dragPanFrameLoopID: number }).__dragPanFrameLoopID,
-    );
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- see the setup evaluate above
+    const dragPanWindow = globalThis as unknown as DragPanWindow;
 
-    return (globalThis as unknown as { __dragPanFrameGaps: Array<number> }).__dragPanFrameGaps;
+    cancelAnimationFrame(dragPanWindow.__dragPanFrameLoopID);
+
+    return dragPanWindow.__dragPanFrameGaps;
   });
 
   // the first sample is the gap from the sampler's own setup, not a rendered frame

--- a/apps/web-e2e/benchmarks/drag-pan.spec.ts
+++ b/apps/web-e2e/benchmarks/drag-pan.spec.ts
@@ -1,3 +1,4 @@
+import type { Page } from '@playwright/test';
 import { expect, test } from '../src/test';
 import { waitForHoneypotWindow } from '../src/wait-for-honeypot-window';
 
@@ -21,6 +22,20 @@ const DRAG_STEPS_PER_LEG = 20;
  * dropped frame.
  */
 const DROPPED_FRAME_THRESHOLD_MS = 32;
+
+/**
+ * A frame gap under this many milliseconds counts as settled for the scene-readiness gate — loose
+ * enough that a single fast frame during mount doesn't pass it, tight enough that the still-loading
+ * scene's own long frames keep failing it.
+ */
+const STABLE_FRAME_GAP_THRESHOLD_MS = 20;
+
+/**
+ * Consecutive settled frames required before the explore scene counts as ready. One fast frame can
+ * land by chance while world data is still loading, the biome field is still building, or the
+ * first-frame WebGPU pipelines are still compiling; a run of them can't.
+ */
+const STABLE_FRAME_COUNT = 5;
 
 /**
  * The frame-gap sampler's state, parked on the page's own `globalThis` so it survives across the
@@ -78,6 +93,21 @@ test('it drag-pans across the explore map and reports peak frame gap and dropped
     throw new Error('the explore canvas reported no bounding box');
   }
 
+  await waitForStableFrames(page);
+
+  const centerY = box.y + box.height / 2;
+  const leftX = box.x + box.width * 0.2;
+  const rightX = box.x + box.width * 0.8;
+
+  // a throwaway warm-up leg, run before the sampler is installed, so the measured legs below don't
+  // pay for whatever a drag itself first warms up (pointer-event handler JIT, first-drag camera-
+  // controls allocations) on top of the scene readiness waitForStableFrames already gated on. Ends
+  // at rightX, where the first measured leg (below) starts, so no extra jump sits between them.
+  await page.mouse.move(leftX, centerY);
+  await page.mouse.down();
+  await page.mouse.move(rightX, centerY, { steps: DRAG_STEPS_PER_LEG });
+  await page.mouse.up();
+
   await page.evaluate(() => {
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the sampler's state lives on the page's own globalThis with no declared type; DragPanWindow names the two fields this benchmark parks there
     const dragPanWindow = globalThis as unknown as DragPanWindow;
@@ -96,10 +126,6 @@ test('it drag-pans across the explore map and reports peak frame gap and dropped
     dragPanWindow.__dragPanFrameGaps = gaps;
     dragPanWindow.__dragPanFrameLoopID = requestAnimationFrame(advanceFrame);
   });
-
-  const centerY = box.y + box.height / 2;
-  const leftX = box.x + box.width * 0.2;
-  const rightX = box.x + box.width * 0.8;
 
   for (let leg = 0; leg < DRAG_LEG_COUNT; leg++) {
     const [startX, endX] = leg % 2 === 0 ? [rightX, leftX] : [leftX, rightX];
@@ -139,3 +165,39 @@ test('it drag-pans across the explore map and reports peak frame gap and dropped
 
   expect(renderedGaps.length).toBeGreaterThan(0);
 });
+
+/**
+ * Waits for the explore scene to settle into steady rendering, rather than starting the benchmark
+ * the instant its canvas mounts. The canvas locator resolves to the persistent world canvas, which
+ * is already visible on the previous route, so `toBeVisible()` alone returns before the scene has
+ * loaded world data, built its biome field, or compiled its first-frame WebGPU pipelines — frame
+ * gaps from that mount cost would otherwise dominate the reported peak.
+ */
+async function waitForStableFrames(page: Page): Promise<void> {
+  await page.evaluate(
+    ({ stableFrameCount, thresholdMs }) =>
+      new Promise<void>((resolve) => {
+        let consecutiveStableFrames = 0;
+        let last = performance.now();
+
+        const advanceFrame = () => {
+          const now = performance.now();
+          const gap = now - last;
+
+          last = now;
+          consecutiveStableFrames = gap < thresholdMs ? consecutiveStableFrames + 1 : 0;
+
+          if (consecutiveStableFrames >= stableFrameCount) {
+            resolve();
+
+            return;
+          }
+
+          requestAnimationFrame(advanceFrame);
+        };
+
+        requestAnimationFrame(advanceFrame);
+      }),
+    { stableFrameCount: STABLE_FRAME_COUNT, thresholdMs: STABLE_FRAME_GAP_THRESHOLD_MS },
+  );
+}

--- a/apps/web-e2e/benchmarks/drag-pan.spec.ts
+++ b/apps/web-e2e/benchmarks/drag-pan.spec.ts
@@ -1,6 +1,6 @@
-import type { Page } from '@playwright/test';
 import { expect, test } from '../src/test';
 import { waitForHoneypotWindow } from '../src/wait-for-honeypot-window';
+import { waitForStableFrames } from '../src/wait-for-stable-frames';
 
 /**
  * How many drag legs to walk. Each leg drags 60% of the canvas width in the same direction, so
@@ -24,27 +24,6 @@ const DRAG_STEPS_PER_LEG = 20;
  * dropped frame.
  */
 const DROPPED_FRAME_THRESHOLD_MS = 32;
-
-/**
- * A frame gap under this many milliseconds counts as settled for the scene-readiness gate — loose
- * enough that a single fast frame during mount doesn't pass it, tight enough that the still-loading
- * scene's own long frames keep failing it.
- */
-const STABLE_FRAME_GAP_THRESHOLD_MS = 20;
-
-/**
- * Consecutive settled frames required before the explore scene counts as ready. One fast frame can
- * land by chance while world data is still loading, the biome field is still building, or the
- * first-frame WebGPU pipelines are still compiling; a run of them can't.
- */
-const STABLE_FRAME_COUNT = 5;
-
-/**
- * How long the scene-readiness gate keeps trying before the run fails with an explicit message. A
- * machine whose scene never settles (software WebGPU, heavy contention) would otherwise hang the
- * gate silently until the whole test times out, hiding which step hung.
- */
-const STABLE_GATE_BUDGET_MS = 60 * 1000;
 
 /**
  * The frame-gap sampler's state, parked on the page's own `globalThis` so it survives across the
@@ -175,57 +154,3 @@ test('it drag-pans across the explore map and reports peak frame gap and dropped
       `(>${DROPPED_FRAME_THRESHOLD_MS}ms)`,
   );
 });
-
-/**
- * Waits for the explore scene to settle into steady rendering, rather than starting the benchmark
- * the instant its canvas mounts. The canvas locator resolves to the persistent world canvas, which
- * is already visible on the previous route, so `toBeVisible()` alone returns before the scene has
- * loaded world data, built its biome field, or compiled its first-frame WebGPU pipelines — frame
- * gaps from that mount cost would otherwise dominate the reported peak.
- */
-async function waitForStableFrames(page: Page): Promise<void> {
-  const settled = await page.evaluate(
-    ({ budgetMs, stableFrameCount, thresholdMs }) =>
-      new Promise<boolean>((resolve) => {
-        const startedAt = performance.now();
-        let consecutiveStableFrames = 0;
-        let last = performance.now();
-
-        const advanceFrame = () => {
-          const now = performance.now();
-          const gap = now - last;
-
-          last = now;
-          consecutiveStableFrames = gap < thresholdMs ? consecutiveStableFrames + 1 : 0;
-
-          if (consecutiveStableFrames >= stableFrameCount) {
-            resolve(true);
-
-            return;
-          }
-
-          if (now - startedAt > budgetMs) {
-            resolve(false);
-
-            return;
-          }
-
-          requestAnimationFrame(advanceFrame);
-        };
-
-        requestAnimationFrame(advanceFrame);
-      }),
-    {
-      budgetMs: STABLE_GATE_BUDGET_MS,
-      stableFrameCount: STABLE_FRAME_COUNT,
-      thresholdMs: STABLE_FRAME_GAP_THRESHOLD_MS,
-    },
-  );
-
-  if (!settled) {
-    throw new Error(
-      `the explore scene never settled within ${STABLE_GATE_BUDGET_MS}ms — ` +
-        `no run of ${STABLE_FRAME_COUNT} consecutive frames under ${STABLE_FRAME_GAP_THRESHOLD_MS}ms`,
-    );
-  }
-}

--- a/apps/web-e2e/benchmarks/drag-pan.spec.ts
+++ b/apps/web-e2e/benchmarks/drag-pan.spec.ts
@@ -3,10 +3,12 @@ import { expect, test } from '../src/test';
 import { waitForHoneypotWindow } from '../src/wait-for-honeypot-window';
 
 /**
- * How many drag legs to walk. Each leg is a full-canvas-width mouse drag, generously more ground
- * than one generation chunk covers at any zoom level — enough legs in a row cross many chunk
- * boundaries without reading the client's internal chunk-size constants, which would couple this
- * black-box benchmark to worldmap-client's geometry.
+ * How many drag legs to walk. Each leg drags 60% of the canvas width in the same direction, so
+ * travel accumulates leg over leg — enough total ground to cross many chunk boundaries without
+ * reading the client's internal chunk-size constants, which would couple this black-box benchmark
+ * to worldmap-client's geometry. Direction never alternates: a there-and-back oscillation would
+ * revisit the same chunks, and once chunk generation is cached the benchmark would measure cache
+ * replays instead of the generation cost it exists to track.
  */
 const DRAG_LEG_COUNT = 12;
 
@@ -38,6 +40,13 @@ const STABLE_FRAME_GAP_THRESHOLD_MS = 20;
 const STABLE_FRAME_COUNT = 5;
 
 /**
+ * How long the scene-readiness gate keeps trying before the run fails with an explicit message. A
+ * machine whose scene never settles (software WebGPU, heavy contention) would otherwise hang the
+ * gate silently until the whole test times out, hiding which step hung.
+ */
+const STABLE_GATE_BUDGET_MS = 60 * 1000;
+
+/**
  * The frame-gap sampler's state, parked on the page's own `globalThis` so it survives across the
  * two separate `page.evaluate` round trips that start and read it.
  */
@@ -47,17 +56,17 @@ interface DragPanWindow {
 }
 
 /**
- * Repeatable drag-pan performance probe for the explore map, standing in for the spike's manual
- * benchmark (HARVEST.md, "Performance model"; spike baseline: 409ms peak / 16 dropped frames before
- * chunked scatter builds, 7ms / 0 dropped after). Reports peak frame gap and dropped-frame count
- * for a multi-leg drag across the world map to `console.log` and a test annotation; it makes no
- * pass/fail claim about specific numbers, since headless-GPU throughput varies by machine.
+ * Repeatable drag-pan performance probe for the explore map. Reports peak frame gap and
+ * dropped-frame count for a multi-leg one-way drag across the world map to `console.log` and a
+ * test annotation; it makes no pass/fail claim about specific numbers, since headless-GPU
+ * throughput varies by machine.
  *
  * Excluded from every default run: this config's `testDir` is `./benchmarks`, never scanned by
- * `playwright.config.ts`'s `./specs`, so neither `bun run e2e` nor CI ever picks it up. Run it
- * on demand:
+ * `playwright.config.ts`'s `./specs`, so neither `bun run e2e` nor CI ever picks it up. The app
+ * server serves the prebuilt artifact, so build first, then run on demand:
  *
  * ```sh
+ * bun run build --filter=@vers/web
  * bun run --cwd apps/web-e2e e2e:bench -- --headed
  * ```
  *
@@ -127,12 +136,12 @@ test('it drag-pans across the explore map and reports peak frame gap and dropped
     dragPanWindow.__dragPanFrameLoopID = requestAnimationFrame(advanceFrame);
   });
 
+  // every measured leg drags the same direction, so the camera travels across fresh world; the
+  // button-up return to the start point moves only the cursor, never the camera
   for (let leg = 0; leg < DRAG_LEG_COUNT; leg++) {
-    const [startX, endX] = leg % 2 === 0 ? [rightX, leftX] : [leftX, rightX];
-
-    await page.mouse.move(startX, centerY);
+    await page.mouse.move(rightX, centerY);
     await page.mouse.down();
-    await page.mouse.move(endX, centerY, { steps: DRAG_STEPS_PER_LEG });
+    await page.mouse.move(leftX, centerY, { steps: DRAG_STEPS_PER_LEG });
     await page.mouse.up();
   }
 
@@ -147,6 +156,9 @@ test('it drag-pans across the explore map and reports peak frame gap and dropped
 
   // the first sample is the gap from the sampler's own setup, not a rendered frame
   const renderedGaps = frameGaps.slice(1);
+
+  expect(renderedGaps.length).toBeGreaterThan(0);
+
   const peakGapMs = Math.max(...renderedGaps);
   const droppedFrameCount = renderedGaps.filter((gap) => gap > DROPPED_FRAME_THRESHOLD_MS).length;
 
@@ -162,8 +174,6 @@ test('it drag-pans across the explore map and reports peak frame gap and dropped
       `peak gap ${peakGapMs.toFixed(1)}ms, ${droppedFrameCount} dropped ` +
       `(>${DROPPED_FRAME_THRESHOLD_MS}ms)`,
   );
-
-  expect(renderedGaps.length).toBeGreaterThan(0);
 });
 
 /**
@@ -174,9 +184,10 @@ test('it drag-pans across the explore map and reports peak frame gap and dropped
  * gaps from that mount cost would otherwise dominate the reported peak.
  */
 async function waitForStableFrames(page: Page): Promise<void> {
-  await page.evaluate(
-    ({ stableFrameCount, thresholdMs }) =>
-      new Promise<void>((resolve) => {
+  const settled = await page.evaluate(
+    ({ budgetMs, stableFrameCount, thresholdMs }) =>
+      new Promise<boolean>((resolve) => {
+        const startedAt = performance.now();
         let consecutiveStableFrames = 0;
         let last = performance.now();
 
@@ -188,7 +199,13 @@ async function waitForStableFrames(page: Page): Promise<void> {
           consecutiveStableFrames = gap < thresholdMs ? consecutiveStableFrames + 1 : 0;
 
           if (consecutiveStableFrames >= stableFrameCount) {
-            resolve();
+            resolve(true);
+
+            return;
+          }
+
+          if (now - startedAt > budgetMs) {
+            resolve(false);
 
             return;
           }
@@ -198,6 +215,17 @@ async function waitForStableFrames(page: Page): Promise<void> {
 
         requestAnimationFrame(advanceFrame);
       }),
-    { stableFrameCount: STABLE_FRAME_COUNT, thresholdMs: STABLE_FRAME_GAP_THRESHOLD_MS },
+    {
+      budgetMs: STABLE_GATE_BUDGET_MS,
+      stableFrameCount: STABLE_FRAME_COUNT,
+      thresholdMs: STABLE_FRAME_GAP_THRESHOLD_MS,
+    },
   );
+
+  if (!settled) {
+    throw new Error(
+      `the explore scene never settled within ${STABLE_GATE_BUDGET_MS}ms — ` +
+        `no run of ${STABLE_FRAME_COUNT} consecutive frames under ${STABLE_FRAME_GAP_THRESHOLD_MS}ms`,
+    );
+  }
 }

--- a/apps/web-e2e/benchmarks/drag-pan.spec.ts
+++ b/apps/web-e2e/benchmarks/drag-pan.spec.ts
@@ -1,0 +1,133 @@
+import { expect, test } from '../src/test';
+import { waitForHoneypotWindow } from '../src/wait-for-honeypot-window';
+
+/**
+ * How many drag legs to walk. Each leg is a full-canvas-width mouse drag, generously more ground
+ * than one generation chunk covers at any zoom level — enough legs in a row cross many chunk
+ * boundaries without reading the client's internal chunk-size constants, which would couple this
+ * black-box benchmark to worldmap-client's geometry.
+ */
+const DRAG_LEG_COUNT = 12;
+
+/**
+ * Intermediate pointer-move events per leg. Camera-controls reads a drag as a series of pointermove
+ * deltas, not a single teleport — too few steps understates a real drag's incremental chunk
+ * crossings.
+ */
+const DRAG_STEPS_PER_LEG = 20;
+
+/**
+ * A frame gap past this many milliseconds — more than one missed vsync at 60fps — counts as a
+ * dropped frame.
+ */
+const DROPPED_FRAME_THRESHOLD_MS = 32;
+
+/**
+ * Repeatable drag-pan performance probe for the explore map, standing in for the spike's manual
+ * benchmark (HARVEST.md, "Performance model"; spike baseline: 409ms peak / 16 dropped frames before
+ * chunked scatter builds, 7ms / 0 dropped after). Reports peak frame gap and dropped-frame count
+ * for a multi-leg drag across the world map to `console.log` and a test annotation; it makes no
+ * pass/fail claim about specific numbers, since headless-GPU throughput varies by machine.
+ *
+ * Excluded from every default run: this config's `testDir` is `./benchmarks`, never scanned by
+ * `playwright.config.ts`'s `./specs`, so neither `bun run e2e` nor CI ever picks it up. Run it
+ * on demand:
+ *
+ * ```sh
+ * bun run --cwd apps/web-e2e e2e:bench -- --headed
+ * ```
+ *
+ * `--headed` is recommended: headless Chromium's software WebGPU path measures compositor
+ * throughput this benchmark doesn't care about, not the app's own frame cost.
+ */
+test('it drag-pans across the explore map and reports peak frame gap and dropped frames', async ({
+  page,
+}) => {
+  await page.setExtraHTTPHeaders({ 'x-forwarded-for': '127.0.0.1' });
+  await page.goto('/login');
+  await page.locator('html[data-hydrated]').waitFor();
+  await page.getByLabel('Email').fill('e2e-drag-pan@vers.test');
+  await page.getByLabel('Password').fill('password123');
+
+  await waitForHoneypotWindow(page);
+
+  await page.getByRole('button', { exact: true, name: 'Login' }).click();
+
+  await expect(page).toHaveURL(/\/respite$/);
+
+  await page.getByRole('link', { exact: true, name: 'Explore' }).click();
+
+  await expect(page).toHaveURL(/\/explore$/);
+
+  const canvas = page.locator('canvas').first();
+
+  await expect(canvas).toBeVisible();
+
+  const box = await canvas.boundingBox();
+
+  if (box === null) {
+    throw new Error('the explore canvas reported no bounding box');
+  }
+
+  await page.evaluate(() => {
+    const gaps: Array<number> = [];
+    let last = performance.now();
+
+    const advanceFrame = () => {
+      const now = performance.now();
+
+      gaps.push(now - last);
+
+      last = now;
+
+      (globalThis as unknown as { __dragPanFrameLoopID: number }).__dragPanFrameLoopID =
+        requestAnimationFrame(advanceFrame);
+    };
+
+    (globalThis as unknown as { __dragPanFrameGaps: Array<number> }).__dragPanFrameGaps = gaps;
+
+    (globalThis as unknown as { __dragPanFrameLoopID: number }).__dragPanFrameLoopID =
+      requestAnimationFrame(advanceFrame);
+  });
+
+  const centerY = box.y + box.height / 2;
+  const leftX = box.x + box.width * 0.2;
+  const rightX = box.x + box.width * 0.8;
+
+  for (let leg = 0; leg < DRAG_LEG_COUNT; leg++) {
+    const [startX, endX] = leg % 2 === 0 ? [rightX, leftX] : [leftX, rightX];
+
+    await page.mouse.move(startX, centerY);
+    await page.mouse.down();
+    await page.mouse.move(endX, centerY, { steps: DRAG_STEPS_PER_LEG });
+    await page.mouse.up();
+  }
+
+  const frameGaps = await page.evaluate(() => {
+    cancelAnimationFrame(
+      (globalThis as unknown as { __dragPanFrameLoopID: number }).__dragPanFrameLoopID,
+    );
+
+    return (globalThis as unknown as { __dragPanFrameGaps: Array<number> }).__dragPanFrameGaps;
+  });
+
+  // the first sample is the gap from the sampler's own setup, not a rendered frame
+  const renderedGaps = frameGaps.slice(1);
+  const peakGapMs = Math.max(...renderedGaps);
+  const droppedFrameCount = renderedGaps.filter((gap) => gap > DROPPED_FRAME_THRESHOLD_MS).length;
+
+  test
+    .info()
+    .annotations.push(
+      { description: `${peakGapMs.toFixed(1)}ms`, type: 'drag-pan-peak-frame-gap' },
+      { description: `${droppedFrameCount}`, type: 'drag-pan-dropped-frames' },
+    );
+
+  console.log(
+    `[drag-pan] sampled ${renderedGaps.length} frames across ${DRAG_LEG_COUNT} legs — ` +
+      `peak gap ${peakGapMs.toFixed(1)}ms, ${droppedFrameCount} dropped ` +
+      `(>${DROPPED_FRAME_THRESHOLD_MS}ms)`,
+  );
+
+  expect(renderedGaps.length).toBeGreaterThan(0);
+});

--- a/apps/web-e2e/package.json
+++ b/apps/web-e2e/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "e2e": "playwright test",
+    "e2e:bench": "playwright test --config playwright.bench.config.ts",
     "e2e:stack": "playwright test --config playwright.stack.config.ts",
     "stack:seed": "bun src/create-stack-seed.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit"

--- a/apps/web-e2e/playwright.bench.config.ts
+++ b/apps/web-e2e/playwright.bench.config.ts
@@ -1,26 +1,10 @@
-import path from 'node:path';
 import { defineConfig, devices } from '@playwright/test';
+import { loadE2EEnvironment } from './src/load-e2e-environment';
 import type { E2EOptions } from './src/test';
 
-const baseURL = process.env['BASE_URL'] ?? 'http://localhost:3000';
-
-/**
- * Resolves the project root without relying on `__dirname`, which is unreliable when this file is
- * parsed for the task graph rather than run from its own directory.
- */
-const projectRoot = process.cwd().includes('web-e2e')
-  ? process.cwd()
-  : `${process.cwd()}/apps/web-e2e`;
-
-const appWebRoot = path.resolve(projectRoot, '..', 'web');
-const dotEnvFile = path.join(projectRoot, '.env');
-
-try {
-  process.loadEnvFile(dotEnvFile);
-} catch {
-  // no .env locally (CI writes one from a secret) — the smoke spec that runs without a .env
-  // needs no secrets
-}
+// no FEATURE_GAME_RENDERER override here: unlike the default config, a benchmark's whole point is
+// measuring the real WebGPU/R3F canvas, not the placeholder
+const environment = loadE2EEnvironment({});
 
 /**
  * On-demand perf benchmarks: run manually against a real GPU, never picked up by `bun run e2e`'s
@@ -51,41 +35,11 @@ export default defineConfig<E2EOptions>({
   retries: 0,
   timeout: 120 * 1000,
   use: {
-    baseURL,
+    baseURL: environment.baseURL,
     codeSource: 'mock',
     mockVerificationURL: process.env['VERIFICATION_SERVICE_URL'] ?? 'http://localhost:3004',
     screenshot: 'only-on-failure',
     trace: 'retain-on-failure',
   },
-  webServer: [
-    {
-      // the same stateful mock backends the default config boots; a benchmark run still needs a
-      // login and an avatar for the seeded account, not just the app server
-      command: 'bun src/serve-mock-services.ts',
-      cwd: projectRoot,
-      reuseExistingServer: false,
-      stderr: 'pipe',
-      stdout: 'pipe',
-      timeout: 60 * 1000,
-      url: `${process.env['USER_SERVICE_URL'] ?? 'http://localhost:3003'}/health`,
-    },
-    {
-      // no FEATURE_GAME_RENDERER override here: unlike the default config, this benchmark's whole
-      // point is measuring the real WebGPU/R3F canvas, not the placeholder
-      command: 'node ./server.mjs',
-      cwd: appWebRoot,
-      env: {
-        FEATURE_MARKET: 'true',
-        LOGGING: 'warn',
-        NODE_ENV: 'production',
-        PORT: new URL(baseURL).port,
-        SESSION_SECRET: 'e2e-session-secret-32-characters',
-      },
-      reuseExistingServer: false,
-      stderr: 'pipe',
-      stdout: 'pipe',
-      timeout: 240 * 1000,
-      url: `${baseURL}/health`,
-    },
-  ],
+  webServer: [...environment.webServer],
 });

--- a/apps/web-e2e/playwright.bench.config.ts
+++ b/apps/web-e2e/playwright.bench.config.ts
@@ -1,0 +1,91 @@
+import path from 'node:path';
+import { defineConfig, devices } from '@playwright/test';
+import type { E2EOptions } from './src/test';
+
+const baseURL = process.env['BASE_URL'] ?? 'http://localhost:3000';
+
+/**
+ * Resolves the project root without relying on `__dirname`, which is unreliable when this file is
+ * parsed for the task graph rather than run from its own directory.
+ */
+const projectRoot = process.cwd().includes('web-e2e')
+  ? process.cwd()
+  : `${process.cwd()}/apps/web-e2e`;
+
+const appWebRoot = path.resolve(projectRoot, '..', 'web');
+const dotEnvFile = path.join(projectRoot, '.env');
+
+try {
+  process.loadEnvFile(dotEnvFile);
+} catch {
+  // no .env locally (CI writes one from a secret) — the smoke spec that runs without a .env
+  // needs no secrets
+}
+
+/**
+ * On-demand perf benchmarks: run manually against a real GPU, never picked up by `bun run e2e`'s
+ * default config. Its own `testDir` keeps every benchmark spec out of `playwright.config.ts`'s
+ * discovery entirely, so nothing here can ever land on the CI critical path.
+ */
+export default defineConfig<E2EOptions>({
+  expect: {
+    timeout: 10 * 1000,
+  },
+  fullyParallel: false,
+  outputDir: '.bench-test-results',
+  testDir: './benchmarks',
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+
+        // best-effort GPU acceleration under headless Chromium; run with `--headed` for numbers
+        // that reflect a real compositor instead of software rendering
+        launchOptions: {
+          args: ['--enable-unsafe-webgpu', '--ignore-gpu-blocklist'],
+        },
+      },
+    },
+  ],
+  retries: 0,
+  timeout: 120 * 1000,
+  use: {
+    baseURL,
+    codeSource: 'mock',
+    mockVerificationURL: process.env['VERIFICATION_SERVICE_URL'] ?? 'http://localhost:3004',
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+  },
+  webServer: [
+    {
+      // the same stateful mock backends the default config boots; a benchmark run still needs a
+      // login and an avatar for the seeded account, not just the app server
+      command: 'bun src/serve-mock-services.ts',
+      cwd: projectRoot,
+      reuseExistingServer: false,
+      stderr: 'pipe',
+      stdout: 'pipe',
+      timeout: 60 * 1000,
+      url: `${process.env['USER_SERVICE_URL'] ?? 'http://localhost:3003'}/health`,
+    },
+    {
+      // no FEATURE_GAME_RENDERER override here: unlike the default config, this benchmark's whole
+      // point is measuring the real WebGPU/R3F canvas, not the placeholder
+      command: 'node ./server.mjs',
+      cwd: appWebRoot,
+      env: {
+        FEATURE_MARKET: 'true',
+        LOGGING: 'warn',
+        NODE_ENV: 'production',
+        PORT: new URL(baseURL).port,
+        SESSION_SECRET: 'e2e-session-secret-32-characters',
+      },
+      reuseExistingServer: false,
+      stderr: 'pipe',
+      stdout: 'pipe',
+      timeout: 240 * 1000,
+      url: `${baseURL}/health`,
+    },
+  ],
+});

--- a/apps/web-e2e/playwright.config.ts
+++ b/apps/web-e2e/playwright.config.ts
@@ -1,26 +1,14 @@
-import path from 'node:path';
 import { defineConfig, devices } from '@playwright/test';
+import { loadE2EEnvironment } from './src/load-e2e-environment';
 import type { E2EOptions } from './src/test';
 
-const baseURL = process.env['BASE_URL'] ?? 'http://localhost:3000';
-
-/**
- * Resolves the project root without relying on `__dirname`, which is unreliable when this file is
- * parsed for the task graph rather than run from its own directory.
- */
-const projectRoot = process.cwd().includes('web-e2e')
-  ? process.cwd()
-  : `${process.cwd()}/apps/web-e2e`;
-
-const appWebRoot = path.resolve(projectRoot, '..', 'web');
-const dotEnvFile = path.join(projectRoot, '.env');
-
-try {
-  process.loadEnvFile(dotEnvFile);
-} catch {
-  // no .env locally (CI writes one from a secret) — the smoke spec that runs without a .env
-  // needs no secrets
-}
+const environment = loadE2EEnvironment({
+  appWebEnv: {
+    // the live WebGPU/R3F canvas blocks the main thread long enough under CI's software-GL to
+    // drop nav clicks; the placeholder canvas keeps every canvas-lifecycle assertion valid
+    FEATURE_GAME_RENDERER: 'false',
+  },
+});
 
 export default defineConfig<E2EOptions>({
   expect: {
@@ -42,7 +30,7 @@ export default defineConfig<E2EOptions>({
   retries: 0,
   timeout: 30 * 1000,
   use: {
-    baseURL,
+    baseURL: environment.baseURL,
     codeSource: 'mock',
 
     // serve-mock-services.ts binds the verification listener to this origin
@@ -51,53 +39,7 @@ export default defineConfig<E2EOptions>({
     screenshot: 'only-on-failure',
     trace: 'retain-on-failure',
   },
-  webServer: [
-    {
-      // the stateful mock backends as real HTTP listeners on the service dev ports the artifact's
-      // SERVICE_URLS defaults resolve. Never reuse an already-listening server: a service
-      // answering on these ports could be the real dev stack, and specs must never mutate it.
-      command: 'bun src/serve-mock-services.ts',
-      cwd: projectRoot,
-      reuseExistingServer: false,
-      stderr: 'pipe',
-      stdout: 'pipe',
-      timeout: 60 * 1000,
-
-      // the same override-then-default resolution the spawned listeners apply per service
-      url: `${process.env['USER_SERVICE_URL'] ?? 'http://localhost:3003'}/health`,
-    },
-    {
-      // every spec runs against the deployable artifact, exactly as built — no mock backend
-      // in-process, no build-time env overrides. The e2e turbo task depends on the app's build
-      // task, so the artifact is already on disk (cached or fresh) — serving it here must not
-      // rebuild it. Downstream service calls leave the process over HTTP and land on the mock
-      // listeners above. Never reuse an already-listening server: whatever answers on this port
-      // (a leftover vite dev, another app) is not the artifact, and reusing it silently voids
-      // the production-build guarantee.
-      command: 'node ./server.mjs',
-      cwd: appWebRoot,
-      env: {
-        // the live WebGPU/R3F canvas blocks the main thread long enough under CI's software-GL to
-        // drop nav clicks; the placeholder canvas keeps every canvas-lifecycle assertion valid
-        FEATURE_GAME_RENDERER: 'false',
-
-        // canvas-persistence.spec.ts clicks through to the Market nav link
-        FEATURE_MARKET: 'true',
-
-        LOGGING: 'warn',
-        NODE_ENV: 'production',
-        PORT: new URL(baseURL).port,
-
-        // Start's session sealing rejects any password under 32 characters
-        SESSION_SECRET: 'e2e-session-secret-32-characters',
-      },
-      reuseExistingServer: false,
-      stderr: 'pipe',
-      stdout: 'pipe',
-      timeout: 240 * 1000,
-      url: `${baseURL}/health`,
-    },
-  ],
+  webServer: [...environment.webServer],
 
   // CI runners have 4 cores shared with both webServers; more workers than this starves the
   // canvas specs' software-GL rendering

--- a/apps/web-e2e/src/load-e2e-environment.ts
+++ b/apps/web-e2e/src/load-e2e-environment.ts
@@ -33,8 +33,6 @@ interface LoadE2EEnvironmentOptions {
  * drift apart.
  */
 export function loadE2EEnvironment(options: Readonly<LoadE2EEnvironmentOptions>): E2EEnvironment {
-  const baseURL = process.env['BASE_URL'] ?? 'http://localhost:3000';
-
   // resolve the project root without relying on `__dirname`, which is unreliable when a config is
   // parsed for the task graph rather than run from its own directory
   const projectRoot = process.cwd().includes('web-e2e')
@@ -43,12 +41,19 @@ export function loadE2EEnvironment(options: Readonly<LoadE2EEnvironmentOptions>)
 
   const appWebRoot = path.resolve(projectRoot, '..', 'web');
 
+  // the .env load runs before any env read below, so a BASE_URL defined in the file is honored the
+  // same as every other key
   try {
     process.loadEnvFile(path.join(projectRoot, '.env'));
-  } catch {
-    // no .env locally (CI writes one from a secret) — the smoke spec that runs without a .env
-    // needs no secrets
+  } catch (error) {
+    // only a missing .env is fine (CI writes one from a secret; the smoke spec needs no secrets) —
+    // a present-but-unreadable file is a real configuration fault and must not be swallowed
+    if (!(error instanceof Error) || !('code' in error) || error.code !== 'ENOENT') {
+      throw error;
+    }
   }
+
+  const baseURL = process.env['BASE_URL'] ?? 'http://localhost:3000';
 
   return {
     baseURL,

--- a/apps/web-e2e/src/load-e2e-environment.ts
+++ b/apps/web-e2e/src/load-e2e-environment.ts
@@ -1,0 +1,103 @@
+import path from 'node:path';
+
+interface WebServerEntry {
+  readonly command: string;
+  readonly cwd: string;
+  readonly env?: Readonly<Record<string, string>>;
+  readonly reuseExistingServer: boolean;
+  readonly stderr: 'pipe';
+  readonly stdout: 'pipe';
+  readonly timeout: number;
+  readonly url: string;
+}
+
+interface E2EEnvironment {
+  readonly baseURL: string;
+  readonly projectRoot: string;
+  readonly webServer: ReadonlyArray<WebServerEntry>;
+}
+
+interface LoadE2EEnvironmentOptions {
+  /**
+   * Extra env keys for the app-web server beyond the shared set — the default config forces the
+   * placeholder canvas with `FEATURE_GAME_RENDERER: 'false'`; benchmark runs omit it to measure
+   * the real WebGPU/R3F canvas.
+   */
+  readonly appWebEnv?: Readonly<Record<string, string>>;
+}
+
+/**
+ * The environment pieces every playwright config in this package shares: the resolved roots, the
+ * `.env` load, and the two web servers. Config-specific knobs (testDir, outputDir, timeouts,
+ * projects) stay in each config file; the server topology lives here once so the configs cannot
+ * drift apart.
+ */
+export function loadE2EEnvironment(options: Readonly<LoadE2EEnvironmentOptions>): E2EEnvironment {
+  const baseURL = process.env['BASE_URL'] ?? 'http://localhost:3000';
+
+  // resolve the project root without relying on `__dirname`, which is unreliable when a config is
+  // parsed for the task graph rather than run from its own directory
+  const projectRoot = process.cwd().includes('web-e2e')
+    ? process.cwd()
+    : `${process.cwd()}/apps/web-e2e`;
+
+  const appWebRoot = path.resolve(projectRoot, '..', 'web');
+
+  try {
+    process.loadEnvFile(path.join(projectRoot, '.env'));
+  } catch {
+    // no .env locally (CI writes one from a secret) — the smoke spec that runs without a .env
+    // needs no secrets
+  }
+
+  return {
+    baseURL,
+    projectRoot,
+    webServer: [
+      {
+        // the stateful mock backends as real HTTP listeners on the service dev ports the
+        // artifact's SERVICE_URLS defaults resolve. Never reuse an already-listening server: a
+        // service answering on these ports could be the real dev stack, and specs must never
+        // mutate it.
+        command: 'bun src/serve-mock-services.ts',
+        cwd: projectRoot,
+        reuseExistingServer: false,
+        stderr: 'pipe',
+        stdout: 'pipe',
+        timeout: 60 * 1000,
+
+        // the same override-then-default resolution the spawned listeners apply per service
+        url: `${process.env['USER_SERVICE_URL'] ?? 'http://localhost:3003'}/health`,
+      },
+      {
+        // every spec runs against the deployable artifact, exactly as built — no mock backend
+        // in-process, no build-time env overrides. Serving it here must not rebuild it: the e2e
+        // turbo task depends on the app's build task, and any other entrypoint builds first.
+        // Downstream service calls leave the process over HTTP and land on the mock listeners
+        // above. Never reuse an already-listening server: whatever answers on this port (a
+        // leftover vite dev, another app) is not the artifact, and reusing it silently voids the
+        // production-build guarantee.
+        command: 'node ./server.mjs',
+        cwd: appWebRoot,
+        env: {
+          // canvas-persistence.spec.ts clicks through to the Market nav link
+          FEATURE_MARKET: 'true',
+
+          LOGGING: 'warn',
+          NODE_ENV: 'production',
+          PORT: new URL(baseURL).port,
+
+          // Start's session sealing rejects any password under 32 characters
+          SESSION_SECRET: 'e2e-session-secret-32-characters',
+
+          ...options.appWebEnv,
+        },
+        reuseExistingServer: false,
+        stderr: 'pipe',
+        stdout: 'pipe',
+        timeout: 240 * 1000,
+        url: `${baseURL}/health`,
+      },
+    ],
+  };
+}

--- a/apps/web-e2e/src/wait-for-stable-frames.ts
+++ b/apps/web-e2e/src/wait-for-stable-frames.ts
@@ -1,0 +1,77 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * A frame gap under this many milliseconds counts as settled — loose enough that a single fast
+ * frame during mount doesn't pass it, tight enough that a still-loading scene's own long frames
+ * keep failing it.
+ */
+const STABLE_FRAME_GAP_THRESHOLD_MS = 20;
+
+/**
+ * Consecutive settled frames required before the scene counts as ready. One fast frame can land by
+ * chance while world data is still loading, a field is still building, or first-frame WebGPU
+ * pipelines are still compiling; a run of them can't.
+ */
+const STABLE_FRAME_COUNT = 5;
+
+/**
+ * How long the gate keeps trying before it fails with an explicit message. A machine whose scene
+ * never settles (software WebGPU, heavy contention) would otherwise hang the gate silently until
+ * the whole test times out, hiding which step hung.
+ */
+const STABLE_GATE_BUDGET_MS = 60 * 1000;
+
+/**
+ * Waits for a live rendering scene to settle into steady frames, rather than proceeding the instant
+ * its canvas mounts. A persistent canvas is often already visible from the previous route, so a
+ * `toBeVisible()` check returns before the scene has loaded its data, built its fields, or compiled
+ * its first-frame WebGPU pipelines — mount-cost frame gaps would otherwise dominate anything the
+ * caller measures next. Throws with an explicit message if the scene never settles within the gate
+ * budget, so a stuck scene names itself rather than failing later as an opaque test timeout.
+ */
+export async function waitForStableFrames(page: Page): Promise<void> {
+  const settled = await page.evaluate(
+    ({ budgetMs, stableFrameCount, thresholdMs }) =>
+      new Promise<boolean>((resolve) => {
+        const startedAt = performance.now();
+        let consecutiveStableFrames = 0;
+        let last = performance.now();
+
+        const advanceFrame = () => {
+          const now = performance.now();
+          const gap = now - last;
+
+          last = now;
+          consecutiveStableFrames = gap < thresholdMs ? consecutiveStableFrames + 1 : 0;
+
+          if (consecutiveStableFrames >= stableFrameCount) {
+            resolve(true);
+
+            return;
+          }
+
+          if (now - startedAt > budgetMs) {
+            resolve(false);
+
+            return;
+          }
+
+          requestAnimationFrame(advanceFrame);
+        };
+
+        requestAnimationFrame(advanceFrame);
+      }),
+    {
+      budgetMs: STABLE_GATE_BUDGET_MS,
+      stableFrameCount: STABLE_FRAME_COUNT,
+      thresholdMs: STABLE_FRAME_GAP_THRESHOLD_MS,
+    },
+  );
+
+  if (!settled) {
+    throw new Error(
+      `the scene never settled within ${STABLE_GATE_BUDGET_MS}ms — ` +
+        `no run of ${STABLE_FRAME_COUNT} consecutive frames under ${STABLE_FRAME_GAP_THRESHOLD_MS}ms`,
+    );
+  }
+}

--- a/apps/web-e2e/tsconfig.json
+++ b/apps/web-e2e/tsconfig.json
@@ -4,5 +4,12 @@
     "lib": ["ES2024", "DOM"],
     "types": ["node", "bun"]
   },
-  "include": ["playwright.config.ts", "playwright.stack.config.ts", "src/**/*.ts", "specs/**/*.ts"]
+  "include": [
+    "playwright.bench.config.ts",
+    "playwright.config.ts",
+    "playwright.stack.config.ts",
+    "src/**/*.ts",
+    "specs/**/*.ts",
+    "benchmarks/**/*.ts"
+  ]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -684,6 +684,7 @@
         "@react-three/fiber": "catalog:",
         "@vers/client-test-utils": "workspace:*",
         "@vers/design-system": "workspace:*",
+        "@vers/game-rendering": "workspace:*",
         "@vers/styled-system": "workspace:*",
         "@vers/worldmap-core": "workspace:*",
         "camera-controls": "catalog:",

--- a/libs/game/worldmap-client/package.json
+++ b/libs/game/worldmap-client/package.json
@@ -17,6 +17,7 @@
     "@react-three/fiber": "catalog:",
     "@vers/client-test-utils": "workspace:*",
     "@vers/design-system": "workspace:*",
+    "@vers/game-rendering": "workspace:*",
     "@vers/styled-system": "workspace:*",
     "@vers/worldmap-core": "workspace:*",
     "camera-controls": "catalog:",

--- a/libs/game/worldmap-client/src/components-three/perf-probe.test.tsx
+++ b/libs/game/worldmap-client/src/components-three/perf-probe.test.tsx
@@ -1,8 +1,11 @@
 import { expect, onTestFinished, test } from 'bun:test';
 import ReactThreeTestRenderer from '@react-three/test-renderer';
+import { useRenderer } from '@vers/game-rendering';
 import { scatterBuildStats } from '../scatter-build-stats';
 import { useWorldmapStore } from '../state/use-worldmap-store';
 import { PerfProbe } from './perf-probe';
+
+type Renderer = ReturnType<typeof useRenderer>;
 
 test('it samples fps, worst-frame timing, and scatter build stats once the sample window elapses', async () => {
   scatterBuildStats.buildMs = 12;
@@ -38,3 +41,34 @@ test('it writes nothing to the store before the sample window elapses', async ()
 
   expect(useWorldmapStore.getState().perfStats).toBeNull();
 });
+
+test('it disables the renderer info auto-reset while mounted and restores it on unmount', async () => {
+  const captured: { renderer: Renderer | null } = { renderer: null };
+
+  const renderer = await ReactThreeTestRenderer.create(
+    <>
+      <CaptureRenderer
+        onRenderer={(value) => {
+          captured.renderer = value;
+        }}
+      />
+      <PerfProbe />
+    </>,
+  );
+
+  if (captured.renderer === null) {
+    throw new Error('the capture component never received the renderer');
+  }
+
+  expect(captured.renderer.info.autoReset).toBe(false);
+
+  await renderer.unmount();
+
+  expect(captured.renderer.info.autoReset).toBe(true);
+});
+
+function CaptureRenderer(props: Readonly<{ onRenderer: (renderer: Renderer) => void }>) {
+  props.onRenderer(useRenderer());
+
+  return null;
+}

--- a/libs/game/worldmap-client/src/components-three/perf-probe.test.tsx
+++ b/libs/game/worldmap-client/src/components-three/perf-probe.test.tsx
@@ -20,6 +20,8 @@ test('it samples fps, worst-frame timing, and scatter build stats once the sampl
 
   const renderer = await ReactThreeTestRenderer.create(<PerfProbe />);
 
+  onTestFinished(() => renderer.unmount());
+
   // 30 frames at a constant 1/60s delta cross the 500ms sample window on the 30th frame
   await renderer.advanceFrames(30, 1 / 60);
 
@@ -36,6 +38,8 @@ test('it samples fps, worst-frame timing, and scatter build stats once the sampl
 
 test('it writes nothing to the store before the sample window elapses', async () => {
   const renderer = await ReactThreeTestRenderer.create(<PerfProbe />);
+
+  onTestFinished(() => renderer.unmount());
 
   await renderer.advanceFrames(10, 1 / 60);
 

--- a/libs/game/worldmap-client/src/components-three/perf-probe.test.tsx
+++ b/libs/game/worldmap-client/src/components-three/perf-probe.test.tsx
@@ -1,0 +1,40 @@
+import { expect, onTestFinished, test } from 'bun:test';
+import ReactThreeTestRenderer from '@react-three/test-renderer';
+import { scatterBuildStats } from '../scatter-build-stats';
+import { useWorldmapStore } from '../state/use-worldmap-store';
+import { PerfProbe } from './perf-probe';
+
+test('it samples fps, worst-frame timing, and scatter build stats once the sample window elapses', async () => {
+  scatterBuildStats.buildMs = 12;
+  scatterBuildStats.glowCount = 40;
+  scatterBuildStats.partCount = 400;
+
+  onTestFinished(() => {
+    scatterBuildStats.buildMs = 0;
+    scatterBuildStats.glowCount = 0;
+    scatterBuildStats.partCount = 0;
+  });
+
+  const renderer = await ReactThreeTestRenderer.create(<PerfProbe />);
+
+  // 30 frames at a constant 1/60s delta cross the 500ms sample window on the 30th frame
+  await renderer.advanceFrames(30, 1 / 60);
+
+  expect(useWorldmapStore.getState().perfStats).toStrictEqual({
+    drawCalls: 0,
+    fps: expect.toBeWithin(59, 61),
+    scatterBuildMs: 12,
+    scatterGlowCount: 40,
+    scatterPartCount: 400,
+    triangleCount: 0,
+    worstFrameMs: expect.toBeWithin(16, 17),
+  });
+});
+
+test('it writes nothing to the store before the sample window elapses', async () => {
+  const renderer = await ReactThreeTestRenderer.create(<PerfProbe />);
+
+  await renderer.advanceFrames(10, 1 / 60);
+
+  expect(useWorldmapStore.getState().perfStats).toBeNull();
+});

--- a/libs/game/worldmap-client/src/components-three/perf-probe.tsx
+++ b/libs/game/worldmap-client/src/components-three/perf-probe.tsx
@@ -50,9 +50,7 @@ export function PerfProbe() {
   }, [renderer]);
 
   useFrame((_state, delta) => {
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- three's WebGPURenderer type
-    // claims `info.render` always carries `drawCalls`, but the classic `WebGLRenderer` some test
-    // harnesses construct by default carries `calls` in its place; RenderInfo reflects both
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- WebGPURenderer's type claims info.render always carries drawCalls, but the classic WebGLRenderer some test harnesses construct by default carries calls in its place; RenderInfo reflects both
     const render = renderer.info.render as unknown as RenderInfo;
     const drawCalls = render.drawCalls ?? render.calls ?? 0;
     const triangleCount = render.triangles ?? 0;

--- a/libs/game/worldmap-client/src/components-three/perf-probe.tsx
+++ b/libs/game/worldmap-client/src/components-three/perf-probe.tsx
@@ -34,19 +34,27 @@ interface RollingFrameWindow {
  * rendering can interrupt and replay a memo, which would misreport the elapsed time between two
  * unrelated renders as a frame duration.
  *
- * The renderer never resets `info.render` on its own here: that reset lives in an internal
- * animation loop this app never starts, since R3F drives its own `requestAnimationFrame` loop and
- * calls `renderer.render()` directly. This probe owns the reset instead, exactly as three's own
- * `Info` docs prescribe for an app managing its own loop — reading each tick's counts one frame
- * after the render they describe, then zeroing them so the next read covers only the frame after
- * that.
+ * three's own internal animation loop would reset `info.render` on its own rAF cadence, but that
+ * loop races R3F's separate `requestAnimationFrame` loop, which is what actually drives
+ * `renderer.render()` here — a reset on the wrong cadence would zero counts between this probe's
+ * read and the frame they describe. While mounted, this probe takes ownership of the reset
+ * instead: reading each tick's counts one frame after the render they describe, then zeroing them
+ * so the next read covers only the frame after that. The renderer persists across scene swaps, so
+ * the effect restores `autoReset` on cleanup — otherwise every other scene would keep accumulating
+ * counts three's own loop never gets a chance to clear.
  */
 export function PerfProbe() {
   const renderer = useRenderer();
   const frameWindow = useRef<RollingFrameWindow>({ count: 0, elapsedMs: 0, worstFrameMs: 0 });
 
   useEffect(() => {
+    const previousAutoReset = renderer.info.autoReset;
+
     renderer.info.autoReset = false;
+
+    return () => {
+      renderer.info.autoReset = previousAutoReset;
+    };
   }, [renderer]);
 
   useFrame((_state, delta) => {

--- a/libs/game/worldmap-client/src/components-three/perf-probe.tsx
+++ b/libs/game/worldmap-client/src/components-three/perf-probe.tsx
@@ -1,0 +1,89 @@
+import { useFrame } from '@react-three/fiber';
+import { useRenderer } from '@vers/game-rendering';
+import { useEffect, useRef } from 'react';
+import { scatterBuildStats } from '../scatter-build-stats';
+import { setPerfStats } from '../state/set-perf-stats';
+
+/**
+ * How often the rolling frame-timing window folds into a store write. Short enough to feel live in
+ * the dev tools panel, long enough that the write itself never shows up in the numbers it reports.
+ */
+const SAMPLE_INTERVAL_MS = 500;
+
+/**
+ * three ships two renderer classes with two different `info.render` shapes: the common
+ * WebGPU/WebGL-fallback backend this app always constructs in production names the per-frame draw
+ * count `drawCalls`; the classic `WebGLRenderer` some test harnesses construct by default names the
+ * same count `calls` and carries no `drawCalls` field at all.
+ */
+interface RenderInfo {
+  readonly calls?: number;
+  readonly drawCalls?: number;
+  readonly triangles?: number;
+}
+
+interface RollingFrameWindow {
+  count: number;
+  elapsedMs: number;
+  worstFrameMs: number;
+}
+
+/**
+ * Samples frame timing and the renderer's draw stats into the store roughly twice a second, for
+ * the dev tools panel's perf HUD. Every read happens inside `useFrame`, never a memo — concurrent
+ * rendering can interrupt and replay a memo, which would misreport the elapsed time between two
+ * unrelated renders as a frame duration.
+ *
+ * The renderer never resets `info.render` on its own here: that reset lives in an internal
+ * animation loop this app never starts, since R3F drives its own `requestAnimationFrame` loop and
+ * calls `renderer.render()` directly. This probe owns the reset instead, exactly as three's own
+ * `Info` docs prescribe for an app managing its own loop — reading each tick's counts one frame
+ * after the render they describe, then zeroing them so the next read covers only the frame after
+ * that.
+ */
+export function PerfProbe() {
+  const renderer = useRenderer();
+  const frameWindow = useRef<RollingFrameWindow>({ count: 0, elapsedMs: 0, worstFrameMs: 0 });
+
+  useEffect(() => {
+    renderer.info.autoReset = false;
+  }, [renderer]);
+
+  useFrame((_state, delta) => {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- three's WebGPURenderer type
+    // claims `info.render` always carries `drawCalls`, but the classic `WebGLRenderer` some test
+    // harnesses construct by default carries `calls` in its place; RenderInfo reflects both
+    const render = renderer.info.render as unknown as RenderInfo;
+    const drawCalls = render.drawCalls ?? render.calls ?? 0;
+    const triangleCount = render.triangles ?? 0;
+
+    renderer.info.reset();
+
+    const rolling = frameWindow.current;
+    const deltaMs = delta * 1000;
+
+    rolling.count += 1;
+    rolling.elapsedMs += deltaMs;
+    rolling.worstFrameMs = Math.max(rolling.worstFrameMs, deltaMs);
+
+    if (rolling.elapsedMs < SAMPLE_INTERVAL_MS) {
+      return;
+    }
+
+    setPerfStats({
+      drawCalls,
+      fps: (rolling.count / rolling.elapsedMs) * 1000,
+      scatterBuildMs: scatterBuildStats.buildMs,
+      scatterGlowCount: scatterBuildStats.glowCount,
+      scatterPartCount: scatterBuildStats.partCount,
+      triangleCount,
+      worstFrameMs: rolling.worstFrameMs,
+    });
+
+    rolling.count = 0;
+    rolling.elapsedMs = 0;
+    rolling.worstFrameMs = 0;
+  });
+
+  return null;
+}

--- a/libs/game/worldmap-client/src/components-three/scene.tsx
+++ b/libs/game/worldmap-client/src/components-three/scene.tsx
@@ -7,6 +7,7 @@ import { DevCamera } from './dev-camera';
 import { Floor } from './floor';
 import { FogOfWar } from './fog-of-war';
 import { IsometricCamera } from './isometric-camera';
+import { PerfProbe } from './perf-probe';
 import { ViewportTracker } from './viewport-tracker';
 import { WorldEdges } from './world-edges';
 import { WorldMapNodes } from './world-map-nodes';
@@ -36,6 +37,7 @@ export function Scene() {
         <>
           <DevCamera />
           <AxesHelper />
+          <PerfProbe />
         </>
       )}
     </>

--- a/libs/game/worldmap-client/src/components-ui/dev-tools.styles.ts
+++ b/libs/game/worldmap-client/src/components-ui/dev-tools.styles.ts
@@ -8,3 +8,17 @@ export const container = css({
   top: '2',
   zIndex: '[2]',
 });
+
+export const perfHUD = css({
+  borderTopColor: 'border',
+  borderTopWidth: '[1px]',
+  color: 'text.muted',
+  fontFamily: 'mono',
+  fontSize: '2xs',
+  marginTop: '2',
+  paddingTop: '2',
+});
+
+export const perfLine = css({
+  whiteSpace: '[pre]',
+});

--- a/libs/game/worldmap-client/src/components-ui/dev-tools.test.tsx
+++ b/libs/game/worldmap-client/src/components-ui/dev-tools.test.tsx
@@ -1,6 +1,7 @@
 import { expect, test } from 'bun:test';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { setPerfStats } from '../state/set-perf-stats';
 import { useWorldmapStore } from '../state/use-worldmap-store';
 import { DevTools } from './dev-tools';
 
@@ -17,9 +18,13 @@ test('it renders all dev tool controls', () => {
 
   const devCameraField = screen.getByLabelText('Dev Camera');
   const axesHelperField = screen.getByLabelText('Axes Helper');
+  const fogOfWarField = screen.getByLabelText('Fog of War');
+  const scatterField = screen.getByLabelText('Scatter');
 
   expect(devCameraField).toBeInTheDocument();
   expect(axesHelperField).toBeInTheDocument();
+  expect(fogOfWarField).toBeInTheDocument();
+  expect(scatterField).toBeInTheDocument();
 });
 
 test('it toggles the axes helper visibility', async () => {
@@ -50,4 +55,44 @@ test('it toggles the dev camera', async () => {
   expect(useWorldmapStore.getState()).toMatchObject({
     isDevCameraActive: true,
   });
+});
+
+test('it toggles scatter visibility', async () => {
+  const ctx = setupTest();
+  const scatterCheckbox = screen.getByLabelText('Scatter');
+
+  expect(scatterCheckbox).toBeChecked();
+
+  await ctx.user.click(scatterCheckbox);
+
+  expect(scatterCheckbox).not.toBeChecked();
+
+  expect(useWorldmapStore.getState()).toMatchObject({
+    isScatterVisible: false,
+  });
+});
+
+test('it renders no perf HUD before the frame probe samples anything', () => {
+  setupTest();
+
+  expect(screen.queryByText(/^fps /)).not.toBeInTheDocument();
+});
+
+test('it renders the sampled perf HUD once the store carries a snapshot', () => {
+  setPerfStats({
+    drawCalls: 12,
+    fps: 60,
+    scatterBuildMs: 24,
+    scatterGlowCount: 40,
+    scatterPartCount: 400,
+    triangleCount: 12_000,
+    worstFrameMs: 7,
+  });
+
+  setupTest();
+
+  expect(screen.getByText('fps 60 worst 7ms')).toBeInTheDocument();
+  expect(screen.getByText('draws 12 tris 12k')).toBeInTheDocument();
+  expect(screen.getByText('scatter 400 parts + 40 glow')).toBeInTheDocument();
+  expect(screen.getByText('last scatter build 24ms')).toBeInTheDocument();
 });

--- a/libs/game/worldmap-client/src/components-ui/dev-tools.tsx
+++ b/libs/game/worldmap-client/src/components-ui/dev-tools.tsx
@@ -1,16 +1,22 @@
-import { CheckboxField } from '@vers/design-system';
+import { CheckboxField, Text } from '@vers/design-system';
 import { toggleAxesHelper } from '../state/toggle-axes-helper';
 import { toggleDevCamera } from '../state/toggle-dev-camera';
 import { toggleFogOfWar } from '../state/toggle-fog-of-war';
+import { toggleScatter } from '../state/toggle-scatter';
 import { useIsAxesHelperVisible } from '../state/use-is-axes-helper-visible';
 import { useIsDevCameraActive } from '../state/use-is-dev-camera-active';
 import { useIsFogOfWarVisible } from '../state/use-is-fog-of-war-visible';
+import { useIsScatterVisible } from '../state/use-is-scatter-visible';
+import { usePerfStats } from '../state/use-perf-stats';
+import type { PerfStats } from '../types';
 import * as styles from './dev-tools.styles';
 
 export function DevTools() {
   const isDevCameraActive = useIsDevCameraActive();
   const isAxesHelperVisible = useIsAxesHelperVisible();
   const isFogOfWarVisible = useIsFogOfWarVisible();
+  const isScatterVisible = useIsScatterVisible();
+  const perfStats = usePerfStats();
 
   return (
     <div className={styles.container}>
@@ -38,6 +44,41 @@ export function DevTools() {
         errors={[]}
         labelProps={{ children: 'Fog of War' }}
       />
+      <CheckboxField
+        checkboxProps={{
+          checked: isScatterVisible,
+          onClick: toggleScatter,
+        }}
+        errors={[]}
+        labelProps={{ children: 'Scatter' }}
+      />
+      {perfStats && <PerfHUD perfStats={perfStats} />}
+    </div>
+  );
+}
+
+interface PerfHUDProps {
+  readonly perfStats: PerfStats;
+}
+
+function PerfHUD(props: Readonly<PerfHUDProps>) {
+  const perfStats = props.perfStats;
+  const triangleCountK = (perfStats.triangleCount / 1000).toFixed(0);
+
+  return (
+    <div className={styles.perfHUD}>
+      <Text className={styles.perfLine}>
+        {`fps ${perfStats.fps.toFixed(0)}  worst ${perfStats.worstFrameMs.toFixed(0)}ms`}
+      </Text>
+      <Text className={styles.perfLine}>
+        {`draws ${perfStats.drawCalls}  tris ${triangleCountK}k`}
+      </Text>
+      <Text className={styles.perfLine}>
+        {`scatter ${perfStats.scatterPartCount} parts + ${perfStats.scatterGlowCount} glow`}
+      </Text>
+      <Text className={styles.perfLine}>
+        {`last scatter build ${perfStats.scatterBuildMs.toFixed(0)}ms`}
+      </Text>
     </div>
   );
 }

--- a/libs/game/worldmap-client/src/scatter-build-stats.test.ts
+++ b/libs/game/worldmap-client/src/scatter-build-stats.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from 'bun:test';
+import { scatterBuildStats } from './scatter-build-stats';
+
+test('it starts at zero for every field', () => {
+  expect(scatterBuildStats).toStrictEqual({
+    buildMs: 0,
+    glowCount: 0,
+    partCount: 0,
+  });
+});

--- a/libs/game/worldmap-client/src/scatter-build-stats.ts
+++ b/libs/game/worldmap-client/src/scatter-build-stats.ts
@@ -1,10 +1,10 @@
 import type { ScatterBuildStats } from './types';
 
 /**
- * Mutable scatter-build telemetry the perf HUD samples every frame. A per-build write must never
- * route through the Zustand store, since that would re-render every store subscriber on every
- * chunk rebuild — so the scatter build pipeline writes its latest counts and duration here
- * directly instead.
+ * Mutable scatter-build telemetry the perf HUD samples from the frame loop. This stays out of the
+ * Zustand store because of write cadence: the scatter build pipeline writes on every chunk rebuild
+ * — not a React state transition — and the one consumer reads imperatively each frame, so a store
+ * subscription would add churn without buying any reactivity.
  */
 export const scatterBuildStats: ScatterBuildStats = {
   buildMs: 0,

--- a/libs/game/worldmap-client/src/scatter-build-stats.ts
+++ b/libs/game/worldmap-client/src/scatter-build-stats.ts
@@ -1,0 +1,13 @@
+import type { ScatterBuildStats } from './types';
+
+/**
+ * Mutable scatter-build telemetry the perf HUD samples every frame. A per-build write must never
+ * route through the Zustand store, since that would re-render every store subscriber on every
+ * chunk rebuild — so the scatter build pipeline writes its latest counts and duration here
+ * directly instead.
+ */
+export const scatterBuildStats: ScatterBuildStats = {
+  buildMs: 0,
+  glowCount: 0,
+  partCount: 0,
+};

--- a/libs/game/worldmap-client/src/state/create-dev-slice.test.ts
+++ b/libs/game/worldmap-client/src/state/create-dev-slice.test.ts
@@ -6,5 +6,6 @@ test('it builds the default dev-tool state', () => {
     isAxesHelperVisible: false,
     isDevCameraActive: false,
     isFogOfWarVisible: true,
+    isScatterVisible: true,
   });
 });

--- a/libs/game/worldmap-client/src/state/create-dev-slice.ts
+++ b/libs/game/worldmap-client/src/state/create-dev-slice.ts
@@ -2,6 +2,7 @@ export interface DevSlice {
   isAxesHelperVisible: boolean;
   isDevCameraActive: boolean;
   isFogOfWarVisible: boolean;
+  isScatterVisible: boolean;
 }
 
 export function createDevSlice(): DevSlice {
@@ -9,5 +10,6 @@ export function createDevSlice(): DevSlice {
     isAxesHelperVisible: false,
     isDevCameraActive: false,
     isFogOfWarVisible: true,
+    isScatterVisible: true,
   };
 }

--- a/libs/game/worldmap-client/src/state/create-perf-slice.test.ts
+++ b/libs/game/worldmap-client/src/state/create-perf-slice.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from 'bun:test';
+import { createPerfSlice } from './create-perf-slice';
+
+test('it builds the unsampled perf state', () => {
+  expect(createPerfSlice()).toStrictEqual({
+    perfStats: null,
+  });
+});

--- a/libs/game/worldmap-client/src/state/create-perf-slice.ts
+++ b/libs/game/worldmap-client/src/state/create-perf-slice.ts
@@ -1,0 +1,11 @@
+import type { PerfStats } from '../types';
+
+export interface PerfSlice {
+  perfStats: null | PerfStats;
+}
+
+export function createPerfSlice(): PerfSlice {
+  return {
+    perfStats: null,
+  };
+}

--- a/libs/game/worldmap-client/src/state/set-perf-stats.test.ts
+++ b/libs/game/worldmap-client/src/state/set-perf-stats.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from 'bun:test';
+import { renderHook } from '@testing-library/react';
+import { setPerfStats } from './set-perf-stats';
+import { useWorldmapStore } from './use-worldmap-store';
+
+test('it sets the perf stats in the store', () => {
+  const perfStats = {
+    drawCalls: 12,
+    fps: 60,
+    scatterBuildMs: 24,
+    scatterGlowCount: 40,
+    scatterPartCount: 400,
+    triangleCount: 12_000,
+    worstFrameMs: 7,
+  };
+
+  setPerfStats(perfStats);
+
+  const hook = renderHook(() => useWorldmapStore((state) => state.perfStats));
+
+  expect(hook.result.current).toStrictEqual(perfStats);
+});

--- a/libs/game/worldmap-client/src/state/set-perf-stats.ts
+++ b/libs/game/worldmap-client/src/state/set-perf-stats.ts
@@ -1,0 +1,6 @@
+import type { PerfStats } from '../types';
+import { useWorldmapStore } from './use-worldmap-store';
+
+export function setPerfStats(perfStats: PerfStats) {
+  useWorldmapStore.setState({ perfStats });
+}

--- a/libs/game/worldmap-client/src/state/toggle-scatter.test.ts
+++ b/libs/game/worldmap-client/src/state/toggle-scatter.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from 'bun:test';
+import { renderHook } from '@testing-library/react';
+import { toggleScatter } from './toggle-scatter';
+import { useIsScatterVisible } from './use-is-scatter-visible';
+
+test('it toggles scatter visibility from true to false', () => {
+  const hook = renderHook(() => useIsScatterVisible());
+
+  expect(hook.result.current).toBeTrue();
+
+  toggleScatter();
+
+  hook.rerender();
+
+  expect(hook.result.current).toBeFalse();
+
+  toggleScatter();
+
+  hook.rerender();
+
+  expect(hook.result.current).toBeTrue();
+});

--- a/libs/game/worldmap-client/src/state/toggle-scatter.ts
+++ b/libs/game/worldmap-client/src/state/toggle-scatter.ts
@@ -1,0 +1,7 @@
+import { useWorldmapStore } from './use-worldmap-store';
+
+export function toggleScatter() {
+  useWorldmapStore.setState((state) => ({
+    isScatterVisible: !state.isScatterVisible,
+  }));
+}

--- a/libs/game/worldmap-client/src/state/use-is-scatter-visible.test.ts
+++ b/libs/game/worldmap-client/src/state/use-is-scatter-visible.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from 'bun:test';
+import { renderHook } from '@testing-library/react';
+import { useIsScatterVisible } from './use-is-scatter-visible';
+
+test('it returns the current scatter visibility state', () => {
+  const hook = renderHook(() => useIsScatterVisible());
+
+  expect(hook.result.current).toBeTrue();
+});

--- a/libs/game/worldmap-client/src/state/use-is-scatter-visible.ts
+++ b/libs/game/worldmap-client/src/state/use-is-scatter-visible.ts
@@ -1,0 +1,5 @@
+import { useWorldmapStore } from './use-worldmap-store';
+
+export function useIsScatterVisible() {
+  return useWorldmapStore((state) => state.isScatterVisible);
+}

--- a/libs/game/worldmap-client/src/state/use-perf-stats.test.ts
+++ b/libs/game/worldmap-client/src/state/use-perf-stats.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from 'bun:test';
+import { renderHook } from '@testing-library/react';
+import { setPerfStats } from './set-perf-stats';
+import { usePerfStats } from './use-perf-stats';
+
+test('it returns the current perf stats', () => {
+  const perfStats = {
+    drawCalls: 12,
+    fps: 60,
+    scatterBuildMs: 24,
+    scatterGlowCount: 40,
+    scatterPartCount: 400,
+    triangleCount: 12_000,
+    worstFrameMs: 7,
+  };
+
+  setPerfStats(perfStats);
+
+  const hook = renderHook(() => usePerfStats());
+
+  expect(hook.result.current).toStrictEqual(perfStats);
+});

--- a/libs/game/worldmap-client/src/state/use-perf-stats.ts
+++ b/libs/game/worldmap-client/src/state/use-perf-stats.ts
@@ -1,0 +1,5 @@
+import { useWorldmapStore } from './use-worldmap-store';
+
+export function usePerfStats() {
+  return useWorldmapStore((state) => state.perfStats);
+}

--- a/libs/game/worldmap-client/src/state/use-worldmap-store.test.ts
+++ b/libs/game/worldmap-client/src/state/use-worldmap-store.test.ts
@@ -3,6 +3,7 @@ import { createCameraSlice } from './create-camera-slice';
 import { createDevSlice } from './create-dev-slice';
 import { createGraphSlice } from './create-graph-slice';
 import { createInteractionSlice } from './create-interaction-slice';
+import { createPerfSlice } from './create-perf-slice';
 import { createRevealSlice } from './create-reveal-slice';
 import { createViewportSlice } from './create-viewport-slice';
 import { useWorldmapStore } from './use-worldmap-store';
@@ -13,6 +14,7 @@ test('it composes every slice into one store', () => {
     ...createDevSlice(),
     ...createGraphSlice(),
     ...createInteractionSlice(),
+    ...createPerfSlice(),
     ...createRevealSlice(),
     ...createViewportSlice(),
   });

--- a/libs/game/worldmap-client/src/state/use-worldmap-store.ts
+++ b/libs/game/worldmap-client/src/state/use-worldmap-store.ts
@@ -7,6 +7,8 @@ import type { GraphSlice } from './create-graph-slice';
 import { createGraphSlice } from './create-graph-slice';
 import type { InteractionSlice } from './create-interaction-slice';
 import { createInteractionSlice } from './create-interaction-slice';
+import type { PerfSlice } from './create-perf-slice';
+import { createPerfSlice } from './create-perf-slice';
 import type { RevealSlice } from './create-reveal-slice';
 import { createRevealSlice } from './create-reveal-slice';
 import type { ViewportSlice } from './create-viewport-slice';
@@ -16,6 +18,7 @@ type WorldmapStore = CameraSlice &
   DevSlice &
   GraphSlice &
   InteractionSlice &
+  PerfSlice &
   RevealSlice &
   ViewportSlice;
 
@@ -24,6 +27,7 @@ export const useWorldmapStore = create<WorldmapStore>()(() => ({
   ...createDevSlice(),
   ...createGraphSlice(),
   ...createInteractionSlice(),
+  ...createPerfSlice(),
   ...createRevealSlice(),
   ...createViewportSlice(),
 }));

--- a/libs/game/worldmap-client/src/types.ts
+++ b/libs/game/worldmap-client/src/types.ts
@@ -10,3 +10,28 @@ export interface WorldGraph {
   readonly edges: Readonly<Record<string, WorldEdge>>;
   readonly nodes: Readonly<Record<string, WorldMapNode>>;
 }
+
+/**
+ * The scatter build pipeline's latest telemetry: how many instanced parts and glow instances its
+ * most recent chunk rebuild produced, and how long that rebuild took. The pipeline owns writing
+ * these fields directly; the perf HUD only reads them.
+ */
+export interface ScatterBuildStats {
+  buildMs: number;
+  glowCount: number;
+  partCount: number;
+}
+
+/**
+ * A rolling snapshot of frame timing and scatter build telemetry, refreshed roughly twice a second
+ * by the perf HUD's frame probe for display in the dev tools panel.
+ */
+export interface PerfStats {
+  readonly drawCalls: number;
+  readonly fps: number;
+  readonly scatterBuildMs: number;
+  readonly scatterGlowCount: number;
+  readonly scatterPartCount: number;
+  readonly triangleCount: number;
+  readonly worstFrameMs: number;
+}

--- a/libs/testing/mock-services/src/demo-accounts.ts
+++ b/libs/testing/mock-services/src/demo-accounts.ts
@@ -61,4 +61,11 @@ export const DEMO_ACCOUNTS: ReadonlyArray<DemoAccount> = [
     password: 'password123',
     username: 'e2e-avatar-roster',
   },
+  {
+    avatarName: 'Drag Pan Test Avatar',
+    email: 'e2e-drag-pan@vers.test',
+    name: 'Drag Pan Demo Account',
+    password: 'password123',
+    username: 'e2e-drag-pan',
+  },
 ];


### PR DESCRIPTION
## Description

Closes #877

Adds the worldmap dev tooling the biome procgen spike proved necessary: a perf HUD in the dev tools panel, a scatter visibility toggle, and an on-demand drag-pan benchmark.

- Perf HUD samples fps, rolling worst-frame, draw/triangle counts, and scatter build stats from the frame loop, twice a second; the probe owns the renderer's info reset while mounted and restores it on unmount
- Scatter build stats live in a small mutable module (not the store) because writes land per chunk rebuild and the one reader samples imperatively per frame
- Scatter toggle follows dev-slice conventions; the checkbox is inert groundwork — the scatter layer itself arrives with #878
- Drag-pan benchmark drags one direction so travel accumulates across fresh chunks; excluded from CI by its own playwright config; both configs share one environment module so the server topology cannot drift

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality