### PR TITLE
fix: bump the nanoid override to 3.3.18 for the revised advisory

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1249,7 +1249,7 @@
     "@types/react-dom": "19.2.3",
     "fast-uri": "3.1.5",
     "js-yaml": "4.3.1",
-    "nanoid": "3.3.17",
+    "nanoid": "3.3.18",
   },
   "catalog": {
     "@ark-ui/react": "5.37.2",
@@ -3951,7 +3951,7 @@
 
     "nan": ["nan@2.28.0", "", {}, "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ=="],
 
-    "nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "native-duplexpair": ["native-duplexpair@1.0.0", "", {}, "sha512-E7QQoM+3jvNtlmyfqRZ0/U75VFgCls+fSkbml2MpgWkWyz3ox8Y58gNhfuziuQYGNNQAbFZJQck55LHCnCK6CA=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -11,7 +11,7 @@ minimumReleaseAge = 604800
 # an exclude lives only as long as its pinned version is younger than the gate —
 # once the version ages past it, the entry is dead weight; remove it
 # hono 4.13.0 (published 2026-08-03, patches GHSA-8j4g-w8fx-2239) ages past the gate ~2026-08-10 — remove then (#837)
-# nanoid 3.3.17 (published 2026-08-03, patches GHSA-2v37-7h3g-55p8) ages past the gate ~2026-08-10 — remove then (#839)
+# nanoid 3.3.18 (published 2026-08-07, patches the revised GHSA-2v37-7h3g-55p8) ages past the gate ~2026-08-14 — remove then (#839)
 minimumReleaseAgeExcludes = ["hono", "nanoid"]
 
 [test]

--- a/package.json
+++ b/package.json
@@ -225,7 +225,7 @@
     "@types/react-dom": "19.2.3",
     "fast-uri": "3.1.5",
     "js-yaml": "4.3.1",
-    "nanoid": "3.3.17"
+    "nanoid": "3.3.18"
   },
   "packageManager": "bun@1.3.10",
   "patchedDependencies": {


### PR DESCRIPTION
## Description

GHSA-2v37-7h3g-55p8 was revised to flag every nanoid release below 3.3.18, so the 3.3.17 override adopted for the original advisory now fails `bun audit` — and with it the checks job on every open PR. The existing `minimumReleaseAgeExcludes` entry admits the young release.

- Override bumped 3.3.17 → 3.3.18; audit is clean
- bunfig comment updated with the new maturity date (~2026-08-14)
- #839's upkeep cleanup covers dropping both the exclude and the override once the release ages past the gate

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality — none: dependency pin only