### PR TITLE
feat(#878): stream biome ground chunks through an LRU chunk cache

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -41,6 +41,7 @@
           "serve",
           "submit",
           "sweep",
+          "sync",
           "upgrade"
         ],
         "exemptNames": [

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -54,11 +54,7 @@
           "replaySegment",
           "resumeActivity",
           "trackActivityProgress",
-          "wake",
-          // LRUMap extends the built-in Map and must keep its exact method
-          // names to remain a drop-in Map subclass
-          "clear",
-          "delete"
+          "wake"
         ]
       }
     ],

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -24,6 +24,7 @@
           "advance",
           "broadcast",
           "compare",
+          "dispose",
           "flush",
           "fold",
           "mint",
@@ -52,7 +53,11 @@
           "replaySegment",
           "resumeActivity",
           "trackActivityProgress",
-          "wake"
+          "wake",
+          // LRUMap extends the built-in Map and must keep its exact method
+          // names to remain a drop-in Map subclass
+          "clear",
+          "delete"
         ]
       }
     ],
@@ -149,6 +154,9 @@
           // a live three.js geometry handle: attribute buffers rewritten in place, no readonly
           // form
           { "from": "package", "name": "BufferGeometry", "package": "three" },
+          // a live three.js WebGPU node-material handle: shader graph and GPU pipeline state, no
+          // readonly form
+          { "from": "package", "name": "MeshBasicNodeMaterial", "package": "three" },
           // a live three.js renderer handle: GPU backend and canvas state, no readonly form
           { "from": "package", "name": "WebGPURenderer", "package": "three" },
           // a query-log event: its `query` field is Kysely's internal operation-node AST, built

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,27 +159,28 @@ Project-level additions to the shared function-naming taxonomy, under the same r
 
 **Effectful** — touches the world (filesystem, streams, processes, registries):
 
-| Prefix      | Contract                                                                               | Example                  |
-| ----------- | -------------------------------------------------------------------------------------- | ------------------------ |
-| `advance`   | step a stateful cursor, clock, or simulation forward in place, optionally to a target  | `advanceToDuration`      |
-| `broadcast` | post one message to every connected client on whichever transport carries it           | `broadcast`              |
-| `dispose`   | release the resources a built entry holds (a GPU buffer, texture, or subscription)     | `disposeBiomeChunkEntry` |
-| `flush`     | attempt delivery of the durable outbound backlog, removing entries confirmed received  | `flush`                  |
-| `mint`      | create and persist a new identity-bearing row rooted in a chain or coordinate          | `mintContinuation`       |
-| `park`      | set a work item aside in a parked status for later resumption                          | `parkActivity`           |
-| `record`    | durably note that an event occurred (counter, log, audit row)                          | `recordFailedAttempt`    |
-| `redirect`  | return a redirect response for a request failing a gate, else defer                    | `redirectToHTTPS`        |
-| `refresh`   | rebuild a derived resource in place from its current source, discarding prior contents | `refreshDevBase`         |
-| `reject`    | mark a work item refused and apply the consequences                                    | `rejectActivity`         |
-| `report`    | forward a fault to the error backend                                                   | `reportUnexpectedError`  |
-| `restart`   | return a long-running resource to service from its initial state                       | `restartActivity`        |
-| `roll`      | consume typed draws from a roll stream to produce an outcome, advancing its cursor     | `rollItemFromStream`     |
-| `schedule`  | enqueue an event or callback for deferred execution                                    | `scheduleEvent`          |
-| `select`    | persist the caller's choice among owned alternatives as the new state                  | `selectAvatar`           |
-| `serve`     | answer a request for a static resource, else defer                                     | `serveClientAssets`      |
-| `submit`    | accept a payload into a durable outbound queue and schedule its delivery               | `submit`                 |
-| `sweep`     | bulk-remove stale or orphaned resources found by a scan, returning the set removed     | `sweepDevDBs`            |
-| `upgrade`   | hand a structural port to an RPC handler so it starts serving calls over it            | `upgrade`                |
+| Prefix      | Contract                                                                                    | Example                  |
+| ----------- | ------------------------------------------------------------------------------------------- | ------------------------ |
+| `advance`   | step a stateful cursor, clock, or simulation forward in place, optionally to a target       | `advanceToDuration`      |
+| `broadcast` | post one message to every connected client on whichever transport carries it                | `broadcast`              |
+| `dispose`   | release the resources a built entry holds (a GPU buffer, texture, or subscription)          | `disposeBiomeChunkEntry` |
+| `flush`     | attempt delivery of the durable outbound backlog, removing entries confirmed received       | `flush`                  |
+| `mint`      | create and persist a new identity-bearing row rooted in a chain or coordinate               | `mintContinuation`       |
+| `park`      | set a work item aside in a parked status for later resumption                               | `parkActivity`           |
+| `record`    | durably note that an event occurred (counter, log, audit row)                               | `recordFailedAttempt`    |
+| `redirect`  | return a redirect response for a request failing a gate, else defer                         | `redirectToHTTPS`        |
+| `refresh`   | rebuild a derived resource in place from its current source, discarding prior contents      | `refreshDevBase`         |
+| `reject`    | mark a work item refused and apply the consequences                                         | `rejectActivity`         |
+| `report`    | forward a fault to the error backend                                                        | `reportUnexpectedError`  |
+| `restart`   | return a long-running resource to service from its initial state                            | `restartActivity`        |
+| `roll`      | consume typed draws from a roll stream to produce an outcome, advancing its cursor          | `rollItemFromStream`     |
+| `schedule`  | enqueue an event or callback for deferred execution                                         | `scheduleEvent`          |
+| `select`    | persist the caller's choice among owned alternatives as the new state                       | `selectAvatar`           |
+| `serve`     | answer a request for a static resource, else defer                                          | `serveClientAssets`      |
+| `submit`    | accept a payload into a durable outbound queue and schedule its delivery                    | `submit`                 |
+| `sweep`     | bulk-remove stale or orphaned resources found by a scan, returning the set removed          | `sweepDevDBs`            |
+| `sync`      | reconcile cached state to an external source, clearing it the first time the source changes | `syncSeed`               |
+| `upgrade`   | hand a structural port to an RPC handler so it starts serving calls over it                 | `upgrade`                |
 
 ## Comments
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,26 +159,27 @@ Project-level additions to the shared function-naming taxonomy, under the same r
 
 **Effectful** — touches the world (filesystem, streams, processes, registries):
 
-| Prefix      | Contract                                                                               | Example                 |
-| ----------- | -------------------------------------------------------------------------------------- | ----------------------- |
-| `advance`   | step a stateful cursor, clock, or simulation forward in place, optionally to a target  | `advanceToDuration`     |
-| `broadcast` | post one message to every connected client on whichever transport carries it           | `broadcast`             |
-| `flush`     | attempt delivery of the durable outbound backlog, removing entries confirmed received  | `flush`                 |
-| `mint`      | create and persist a new identity-bearing row rooted in a chain or coordinate          | `mintContinuation`      |
-| `park`      | set a work item aside in a parked status for later resumption                          | `parkActivity`          |
-| `record`    | durably note that an event occurred (counter, log, audit row)                          | `recordFailedAttempt`   |
-| `redirect`  | return a redirect response for a request failing a gate, else defer                    | `redirectToHTTPS`       |
-| `refresh`   | rebuild a derived resource in place from its current source, discarding prior contents | `refreshDevBase`        |
-| `reject`    | mark a work item refused and apply the consequences                                    | `rejectActivity`        |
-| `report`    | forward a fault to the error backend                                                   | `reportUnexpectedError` |
-| `restart`   | return a long-running resource to service from its initial state                       | `restartActivity`       |
-| `roll`      | consume typed draws from a roll stream to produce an outcome, advancing its cursor     | `rollItemFromStream`    |
-| `schedule`  | enqueue an event or callback for deferred execution                                    | `scheduleEvent`         |
-| `select`    | persist the caller's choice among owned alternatives as the new state                  | `selectAvatar`          |
-| `serve`     | answer a request for a static resource, else defer                                     | `serveClientAssets`     |
-| `submit`    | accept a payload into a durable outbound queue and schedule its delivery               | `submit`                |
-| `sweep`     | bulk-remove stale or orphaned resources found by a scan, returning the set removed     | `sweepDevDBs`           |
-| `upgrade`   | hand a structural port to an RPC handler so it starts serving calls over it            | `upgrade`               |
+| Prefix      | Contract                                                                               | Example                  |
+| ----------- | -------------------------------------------------------------------------------------- | ------------------------ |
+| `advance`   | step a stateful cursor, clock, or simulation forward in place, optionally to a target  | `advanceToDuration`      |
+| `broadcast` | post one message to every connected client on whichever transport carries it           | `broadcast`              |
+| `dispose`   | release the resources a built entry holds (a GPU buffer, texture, or subscription)     | `disposeBiomeChunkEntry` |
+| `flush`     | attempt delivery of the durable outbound backlog, removing entries confirmed received  | `flush`                  |
+| `mint`      | create and persist a new identity-bearing row rooted in a chain or coordinate          | `mintContinuation`       |
+| `park`      | set a work item aside in a parked status for later resumption                          | `parkActivity`           |
+| `record`    | durably note that an event occurred (counter, log, audit row)                          | `recordFailedAttempt`    |
+| `redirect`  | return a redirect response for a request failing a gate, else defer                    | `redirectToHTTPS`        |
+| `refresh`   | rebuild a derived resource in place from its current source, discarding prior contents | `refreshDevBase`         |
+| `reject`    | mark a work item refused and apply the consequences                                    | `rejectActivity`         |
+| `report`    | forward a fault to the error backend                                                   | `reportUnexpectedError`  |
+| `restart`   | return a long-running resource to service from its initial state                       | `restartActivity`        |
+| `roll`      | consume typed draws from a roll stream to produce an outcome, advancing its cursor     | `rollItemFromStream`     |
+| `schedule`  | enqueue an event or callback for deferred execution                                    | `scheduleEvent`          |
+| `select`    | persist the caller's choice among owned alternatives as the new state                  | `selectAvatar`           |
+| `serve`     | answer a request for a static resource, else defer                                     | `serveClientAssets`      |
+| `submit`    | accept a payload into a durable outbound queue and schedule its delivery               | `submit`                 |
+| `sweep`     | bulk-remove stale or orphaned resources found by a scan, returning the set removed     | `sweepDevDBs`            |
+| `upgrade`   | hand a structural port to an RPC handler so it starts serving calls over it            | `upgrade`                |
 
 ## Comments
 

--- a/agents/project.md
+++ b/agents/project.md
@@ -11,26 +11,27 @@ Project-level additions to the shared function-naming taxonomy, under the same r
 
 **Effectful** — touches the world (filesystem, streams, processes, registries):
 
-| Prefix      | Contract                                                                               | Example                 |
-| ----------- | -------------------------------------------------------------------------------------- | ----------------------- |
-| `advance`   | step a stateful cursor, clock, or simulation forward in place, optionally to a target  | `advanceToDuration`     |
-| `broadcast` | post one message to every connected client on whichever transport carries it           | `broadcast`             |
-| `flush`     | attempt delivery of the durable outbound backlog, removing entries confirmed received  | `flush`                 |
-| `mint`      | create and persist a new identity-bearing row rooted in a chain or coordinate          | `mintContinuation`      |
-| `park`      | set a work item aside in a parked status for later resumption                          | `parkActivity`          |
-| `record`    | durably note that an event occurred (counter, log, audit row)                          | `recordFailedAttempt`   |
-| `redirect`  | return a redirect response for a request failing a gate, else defer                    | `redirectToHTTPS`       |
-| `refresh`   | rebuild a derived resource in place from its current source, discarding prior contents | `refreshDevBase`        |
-| `reject`    | mark a work item refused and apply the consequences                                    | `rejectActivity`        |
-| `report`    | forward a fault to the error backend                                                   | `reportUnexpectedError` |
-| `restart`   | return a long-running resource to service from its initial state                       | `restartActivity`       |
-| `roll`      | consume typed draws from a roll stream to produce an outcome, advancing its cursor     | `rollItemFromStream`    |
-| `schedule`  | enqueue an event or callback for deferred execution                                    | `scheduleEvent`         |
-| `select`    | persist the caller's choice among owned alternatives as the new state                  | `selectAvatar`          |
-| `serve`     | answer a request for a static resource, else defer                                     | `serveClientAssets`     |
-| `submit`    | accept a payload into a durable outbound queue and schedule its delivery               | `submit`                |
-| `sweep`     | bulk-remove stale or orphaned resources found by a scan, returning the set removed     | `sweepDevDBs`           |
-| `upgrade`   | hand a structural port to an RPC handler so it starts serving calls over it            | `upgrade`               |
+| Prefix      | Contract                                                                               | Example                  |
+| ----------- | -------------------------------------------------------------------------------------- | ------------------------ |
+| `advance`   | step a stateful cursor, clock, or simulation forward in place, optionally to a target  | `advanceToDuration`      |
+| `broadcast` | post one message to every connected client on whichever transport carries it           | `broadcast`              |
+| `dispose`   | release the resources a built entry holds (a GPU buffer, texture, or subscription)     | `disposeBiomeChunkEntry` |
+| `flush`     | attempt delivery of the durable outbound backlog, removing entries confirmed received  | `flush`                  |
+| `mint`      | create and persist a new identity-bearing row rooted in a chain or coordinate          | `mintContinuation`       |
+| `park`      | set a work item aside in a parked status for later resumption                          | `parkActivity`           |
+| `record`    | durably note that an event occurred (counter, log, audit row)                          | `recordFailedAttempt`    |
+| `redirect`  | return a redirect response for a request failing a gate, else defer                    | `redirectToHTTPS`        |
+| `refresh`   | rebuild a derived resource in place from its current source, discarding prior contents | `refreshDevBase`         |
+| `reject`    | mark a work item refused and apply the consequences                                    | `rejectActivity`         |
+| `report`    | forward a fault to the error backend                                                   | `reportUnexpectedError`  |
+| `restart`   | return a long-running resource to service from its initial state                       | `restartActivity`        |
+| `roll`      | consume typed draws from a roll stream to produce an outcome, advancing its cursor     | `rollItemFromStream`     |
+| `schedule`  | enqueue an event or callback for deferred execution                                    | `scheduleEvent`          |
+| `select`    | persist the caller's choice among owned alternatives as the new state                  | `selectAvatar`           |
+| `serve`     | answer a request for a static resource, else defer                                     | `serveClientAssets`      |
+| `submit`    | accept a payload into a durable outbound queue and schedule its delivery               | `submit`                 |
+| `sweep`     | bulk-remove stale or orphaned resources found by a scan, returning the set removed     | `sweepDevDBs`            |
+| `upgrade`   | hand a structural port to an RPC handler so it starts serving calls over it            | `upgrade`                |
 
 ## Comments
 

--- a/agents/project.md
+++ b/agents/project.md
@@ -11,27 +11,28 @@ Project-level additions to the shared function-naming taxonomy, under the same r
 
 **Effectful** — touches the world (filesystem, streams, processes, registries):
 
-| Prefix      | Contract                                                                               | Example                  |
-| ----------- | -------------------------------------------------------------------------------------- | ------------------------ |
-| `advance`   | step a stateful cursor, clock, or simulation forward in place, optionally to a target  | `advanceToDuration`      |
-| `broadcast` | post one message to every connected client on whichever transport carries it           | `broadcast`              |
-| `dispose`   | release the resources a built entry holds (a GPU buffer, texture, or subscription)     | `disposeBiomeChunkEntry` |
-| `flush`     | attempt delivery of the durable outbound backlog, removing entries confirmed received  | `flush`                  |
-| `mint`      | create and persist a new identity-bearing row rooted in a chain or coordinate          | `mintContinuation`       |
-| `park`      | set a work item aside in a parked status for later resumption                          | `parkActivity`           |
-| `record`    | durably note that an event occurred (counter, log, audit row)                          | `recordFailedAttempt`    |
-| `redirect`  | return a redirect response for a request failing a gate, else defer                    | `redirectToHTTPS`        |
-| `refresh`   | rebuild a derived resource in place from its current source, discarding prior contents | `refreshDevBase`         |
-| `reject`    | mark a work item refused and apply the consequences                                    | `rejectActivity`         |
-| `report`    | forward a fault to the error backend                                                   | `reportUnexpectedError`  |
-| `restart`   | return a long-running resource to service from its initial state                       | `restartActivity`        |
-| `roll`      | consume typed draws from a roll stream to produce an outcome, advancing its cursor     | `rollItemFromStream`     |
-| `schedule`  | enqueue an event or callback for deferred execution                                    | `scheduleEvent`          |
-| `select`    | persist the caller's choice among owned alternatives as the new state                  | `selectAvatar`           |
-| `serve`     | answer a request for a static resource, else defer                                     | `serveClientAssets`      |
-| `submit`    | accept a payload into a durable outbound queue and schedule its delivery               | `submit`                 |
-| `sweep`     | bulk-remove stale or orphaned resources found by a scan, returning the set removed     | `sweepDevDBs`            |
-| `upgrade`   | hand a structural port to an RPC handler so it starts serving calls over it            | `upgrade`                |
+| Prefix      | Contract                                                                                    | Example                  |
+| ----------- | ------------------------------------------------------------------------------------------- | ------------------------ |
+| `advance`   | step a stateful cursor, clock, or simulation forward in place, optionally to a target       | `advanceToDuration`      |
+| `broadcast` | post one message to every connected client on whichever transport carries it                | `broadcast`              |
+| `dispose`   | release the resources a built entry holds (a GPU buffer, texture, or subscription)          | `disposeBiomeChunkEntry` |
+| `flush`     | attempt delivery of the durable outbound backlog, removing entries confirmed received       | `flush`                  |
+| `mint`      | create and persist a new identity-bearing row rooted in a chain or coordinate               | `mintContinuation`       |
+| `park`      | set a work item aside in a parked status for later resumption                               | `parkActivity`           |
+| `record`    | durably note that an event occurred (counter, log, audit row)                               | `recordFailedAttempt`    |
+| `redirect`  | return a redirect response for a request failing a gate, else defer                         | `redirectToHTTPS`        |
+| `refresh`   | rebuild a derived resource in place from its current source, discarding prior contents      | `refreshDevBase`         |
+| `reject`    | mark a work item refused and apply the consequences                                         | `rejectActivity`         |
+| `report`    | forward a fault to the error backend                                                        | `reportUnexpectedError`  |
+| `restart`   | return a long-running resource to service from its initial state                            | `restartActivity`        |
+| `roll`      | consume typed draws from a roll stream to produce an outcome, advancing its cursor          | `rollItemFromStream`     |
+| `schedule`  | enqueue an event or callback for deferred execution                                         | `scheduleEvent`          |
+| `select`    | persist the caller's choice among owned alternatives as the new state                       | `selectAvatar`           |
+| `serve`     | answer a request for a static resource, else defer                                          | `serveClientAssets`      |
+| `submit`    | accept a payload into a durable outbound queue and schedule its delivery                    | `submit`                 |
+| `sweep`     | bulk-remove stale or orphaned resources found by a scan, returning the set removed          | `sweepDevDBs`            |
+| `sync`      | reconcile cached state to an external source, clearing it the first time the source changes | `syncSeed`               |
+| `upgrade`   | hand a structural port to an RPC handler so it starts serving calls over it                 | `upgrade`                |
 
 ## Comments
 

--- a/libs/game/worldmap-client/src/chunk-stream/build-chunk-key.test.ts
+++ b/libs/game/worldmap-client/src/chunk-stream/build-chunk-key.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from 'bun:test';
+import { buildChunkKey } from './build-chunk-key';
+
+test('it joins a chunk coordinate with an underscore', () => {
+  expect(buildChunkKey(3, -7)).toBe('3_-7');
+});
+
+test('it gives distinct coordinates distinct keys', () => {
+  expect(buildChunkKey(1, 2)).not.toBe(buildChunkKey(2, 1));
+});

--- a/libs/game/worldmap-client/src/chunk-stream/build-chunk-key.ts
+++ b/libs/game/worldmap-client/src/chunk-stream/build-chunk-key.ts
@@ -1,0 +1,7 @@
+/**
+ * Encodes a chunk coordinate as the cache key `ChunkCache` stores it under. Reversed by
+ * `parseChunkKey`.
+ */
+export function buildChunkKey(chunkX: number, chunkY: number): string {
+  return `${chunkX}_${chunkY}`;
+}

--- a/libs/game/worldmap-client/src/chunk-stream/create-chunk-cache.test.ts
+++ b/libs/game/worldmap-client/src/chunk-stream/create-chunk-cache.test.ts
@@ -1,0 +1,111 @@
+import { expect, test } from 'bun:test';
+import { createChunkCache } from './create-chunk-cache';
+
+test('it returns undefined for a coordinate never set', () => {
+  const cache = createChunkCache<string>({ capacity: 4, dispose: () => {} });
+
+  expect(cache.get('0_0')).toBeUndefined();
+  expect(cache.has('0_0')).toBeFalse();
+});
+
+test('it returns a set entry by its key', () => {
+  const cache = createChunkCache<string>({ capacity: 4, dispose: () => {} });
+
+  cache.set('0_0', 'tile');
+
+  expect(cache.get('0_0')).toBe('tile');
+  expect(cache.has('0_0')).toBeTrue();
+});
+
+test('it disposes the least-recently-used entry once a set passes capacity', () => {
+  const disposed: Array<string> = [];
+
+  const cache = createChunkCache<string>({
+    capacity: 2,
+    dispose: (entry) => {
+      disposed.push(entry);
+    },
+  });
+
+  cache.set('0_0', 'a');
+  cache.set('1_0', 'b');
+  cache.set('2_0', 'c');
+
+  expect(disposed).toStrictEqual(['a']);
+  expect(cache.has('0_0')).toBeFalse();
+  expect(cache.has('1_0')).toBeTrue();
+  expect(cache.has('2_0')).toBeTrue();
+});
+
+test('it spares a recently read entry from eviction', () => {
+  const disposed: Array<string> = [];
+
+  const cache = createChunkCache<string>({
+    capacity: 2,
+    dispose: (entry) => {
+      disposed.push(entry);
+    },
+  });
+
+  cache.set('0_0', 'a');
+  cache.set('1_0', 'b');
+  cache.get('0_0');
+  cache.set('2_0', 'c');
+
+  expect(disposed).toStrictEqual(['b']);
+  expect(cache.has('0_0')).toBeTrue();
+});
+
+test('it disposes every entry and clears the cache the first time syncSeed sees a new seed', () => {
+  const disposed: Array<string> = [];
+
+  const cache = createChunkCache<string>({
+    capacity: 4,
+    dispose: (entry) => {
+      disposed.push(entry);
+    },
+  });
+
+  cache.set('0_0', 'a');
+  cache.set('1_0', 'b');
+  cache.syncSeed(42);
+
+  expect(disposed).toIncludeSameMembers(['a', 'b']);
+  expect(cache.size).toBe(0);
+});
+
+test('it leaves the cache untouched when syncSeed repeats the already-synced seed', () => {
+  const disposed: Array<string> = [];
+
+  const cache = createChunkCache<string>({
+    capacity: 4,
+    dispose: (entry) => {
+      disposed.push(entry);
+    },
+  });
+
+  cache.syncSeed(42);
+  cache.set('0_0', 'a');
+  cache.syncSeed(42);
+
+  expect(disposed).toHaveLength(0);
+  expect(cache.get('0_0')).toBe('a');
+});
+
+test('it disposes every remaining entry on clear', () => {
+  const disposed: Array<string> = [];
+
+  const cache = createChunkCache<string>({
+    capacity: 4,
+    dispose: (entry) => {
+      disposed.push(entry);
+    },
+  });
+
+  cache.set('0_0', 'a');
+  cache.set('1_0', 'b');
+  cache.clear();
+
+  expect(disposed).toIncludeSameMembers(['a', 'b']);
+  expect(cache.size).toBe(0);
+});

--- a/libs/game/worldmap-client/src/chunk-stream/create-chunk-cache.ts
+++ b/libs/game/worldmap-client/src/chunk-stream/create-chunk-cache.ts
@@ -21,6 +21,7 @@ export interface ChunkCache<TEntry> {
   readonly clear: () => void;
   readonly get: (key: string) => TEntry | undefined;
   readonly has: (key: string) => boolean;
+  readonly isSyncedTo: (userSeed: number) => boolean;
   readonly set: (key: string, entry: TEntry) => void;
   readonly size: number;
   readonly syncSeed: (userSeed: number) => void;
@@ -58,6 +59,8 @@ export function createChunkCache<TEntry>(
     get: (key) => map.get(key),
 
     has: (key) => map.has(key),
+
+    isSyncedTo: (userSeed) => syncedSeed === userSeed,
 
     set: (key, entry) => {
       map.set(key, entry);

--- a/libs/game/worldmap-client/src/chunk-stream/create-chunk-cache.ts
+++ b/libs/game/worldmap-client/src/chunk-stream/create-chunk-cache.ts
@@ -1,0 +1,76 @@
+import { LRUMap } from '../utils/lru-map';
+
+export interface CreateChunkCacheOptions<TEntry> {
+  /**
+   * Cached entries kept before evicting the least-recently-used one — the bound that keeps a long
+   * free pan from growing the cache's GPU resources without limit.
+   */
+  readonly capacity: number;
+
+  /**
+   * Releases whatever resources an entry holds. Called for an entry evicted past capacity and for
+   * every entry a seed change clears, never for an entry a fresh `set` overwrites in place.
+   */
+  readonly dispose: (entry: TEntry) => void;
+}
+
+/**
+ * A chunk-keyed store for one streamed content layer's built entries.
+ */
+export interface ChunkCache<TEntry> {
+  readonly clear: () => void;
+  readonly get: (key: string) => TEntry | undefined;
+  readonly has: (key: string) => boolean;
+  readonly set: (key: string, entry: TEntry) => void;
+  readonly size: number;
+  readonly syncSeed: (userSeed: number) => void;
+}
+
+/**
+ * Builds a chunk-keyed cache for one streamed content layer, generic over the entry shape so a
+ * relief or scatter layer can cache its own richer entry type without reworking the cache itself.
+ * Capacity-bounded and least-recently-used evicted via `LRUMap`, disposing an evicted entry through
+ * `options.dispose`.
+ *
+ * `syncSeed` additionally clears the whole cache — disposing every entry — the first time it sees a
+ * seed other than the one it last synced: a cached entry's content is derived from the seed that
+ * built it, and a chunk coordinate never carries that seed in its key, so a seed change would
+ * otherwise resolve stale content at every coordinate. `clear` exposes the same disposal for a
+ * caller that owns the cache's whole lifetime, such as an unmounting consumer releasing every
+ * entry it still holds.
+ */
+export function createChunkCache<TEntry>(
+  options: Readonly<CreateChunkCacheOptions<TEntry>>,
+): ChunkCache<TEntry> {
+  const map = new LRUMap<string, TEntry>(options.capacity, options.dispose);
+
+  let syncedSeed: number | null = null;
+
+  return {
+    get size() {
+      return map.size;
+    },
+
+    clear: () => {
+      map.clear();
+    },
+
+    get: (key) => map.get(key),
+
+    has: (key) => map.has(key),
+
+    set: (key, entry) => {
+      map.set(key, entry);
+    },
+
+    syncSeed: (userSeed) => {
+      if (syncedSeed === userSeed) {
+        return;
+      }
+
+      syncedSeed = userSeed;
+
+      map.clear();
+    },
+  };
+}

--- a/libs/game/worldmap-client/src/chunk-stream/parse-chunk-key.test.ts
+++ b/libs/game/worldmap-client/src/chunk-stream/parse-chunk-key.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'bun:test';
+import { buildChunkKey } from './build-chunk-key';
+import { parseChunkKey } from './parse-chunk-key';
+
+test('it recovers the coordinate a matching buildChunkKey call encoded', () => {
+  expect(parseChunkKey(buildChunkKey(3, -7))).toStrictEqual([3, -7]);
+});
+
+test('it rejects a key with a non-numeric component', () => {
+  expect(() => parseChunkKey('3_north')).toThrow();
+});
+
+test('it rejects a key missing its second component', () => {
+  expect(() => parseChunkKey('3')).toThrow();
+});

--- a/libs/game/worldmap-client/src/chunk-stream/parse-chunk-key.test.ts
+++ b/libs/game/worldmap-client/src/chunk-stream/parse-chunk-key.test.ts
@@ -13,3 +13,13 @@ test('it rejects a key with a non-numeric component', () => {
 test('it rejects a key missing its second component', () => {
   expect(() => parseChunkKey('3')).toThrow();
 });
+
+test('it rejects a key with an empty component that would coerce to zero', () => {
+  expect(() => parseChunkKey('3_')).toThrow();
+  expect(() => parseChunkKey('_4')).toThrow();
+});
+
+test('it rejects a key carrying more than two components', () => {
+  expect(() => parseChunkKey('3_4_5')).toThrow();
+  expect(() => parseChunkKey('3__4')).toThrow();
+});

--- a/libs/game/worldmap-client/src/chunk-stream/parse-chunk-key.ts
+++ b/libs/game/worldmap-client/src/chunk-stream/parse-chunk-key.ts
@@ -1,0 +1,22 @@
+import invariant from 'tiny-invariant';
+
+/**
+ * Recovers the chunk coordinate `buildChunkKey` encoded. The cache never mints a key any other
+ * way, so a key that fails to parse back into two integers can only mean the cache holds a key this
+ * module didn't write.
+ */
+export function parseChunkKey(key: string): readonly [chunkX: number, chunkY: number] {
+  const [rawX, rawY] = key.split('_');
+  const chunkX = Number(rawX);
+  const chunkY = Number(rawY);
+
+  invariant(
+    rawX !== undefined &&
+      rawY !== undefined &&
+      Number.isInteger(chunkX) &&
+      Number.isInteger(chunkY),
+    'a chunk key always encodes two integer coordinates',
+  );
+
+  return [chunkX, chunkY];
+}

--- a/libs/game/worldmap-client/src/chunk-stream/parse-chunk-key.ts
+++ b/libs/game/worldmap-client/src/chunk-stream/parse-chunk-key.ts
@@ -6,13 +6,17 @@ import invariant from 'tiny-invariant';
  * module didn't write.
  */
 export function parseChunkKey(key: string): readonly [chunkX: number, chunkY: number] {
-  const [rawX, rawY] = key.split('_');
+  const parts = key.split('_');
+  const [rawX, rawY] = parts;
   const chunkX = Number(rawX);
   const chunkY = Number(rawY);
 
+  // reject anything `buildChunkKey` could not have minted: a wrong component count, or an empty
+  // component `Number` would silently coerce to 0 (`Number('') === 0`)
   invariant(
-    rawX !== undefined &&
-      rawY !== undefined &&
+    parts.length === 2 &&
+      rawX !== '' &&
+      rawY !== '' &&
       Number.isInteger(chunkX) &&
       Number.isInteger(chunkY),
     'a chunk key always encodes two integer coordinates',

--- a/libs/game/worldmap-client/src/chunk-stream/resolve-chunk-stream.test.ts
+++ b/libs/game/worldmap-client/src/chunk-stream/resolve-chunk-stream.test.ts
@@ -1,0 +1,110 @@
+import { expect, test } from 'bun:test';
+import { createChunkCache } from './create-chunk-cache';
+import type { ChunkRange } from './resolve-chunk-stream';
+import { resolveChunkStream } from './resolve-chunk-stream';
+
+// two chunks wide (chunk x 0 and 1), one chunk tall (chunk y 0)
+const TWO_CHUNK_VIEWPORT = { maxCX: 31, maxCY: 15, minCX: 0, minCY: 0 };
+
+test('it reports every chunk the viewport covers as a miss when the cache is empty', () => {
+  const cache = createChunkCache<string>({ capacity: 8, dispose: () => {} });
+  const resolved = resolveChunkStream(cache, TWO_CHUNK_VIEWPORT, null);
+
+  expect(resolved.entries).toHaveLength(0);
+  expect(resolved.misses).toIncludeSameMembers(['0_0', '1_0']);
+  expect(resolved.range).toStrictEqual({ maxChunkX: 1, maxChunkY: 0, minChunkX: 0, minChunkY: 0 });
+});
+
+test('it resolves a cached chunk as an entry and drops it from the misses', () => {
+  const cache = createChunkCache<string>({ capacity: 8, dispose: () => {} });
+
+  cache.set('0_0', 'tile-0-0');
+
+  const resolved = resolveChunkStream(cache, TWO_CHUNK_VIEWPORT, null);
+
+  expect(resolved.entries).toStrictEqual(['tile-0-0']);
+  expect(resolved.misses).toStrictEqual(['1_0']);
+});
+
+test('it queues no leading-edge strip on the first resolve, with no previous range', () => {
+  const cache = createChunkCache<string>({ capacity: 8, dispose: () => {} });
+  const resolved = resolveChunkStream(cache, TWO_CHUNK_VIEWPORT, null);
+
+  expect(resolved.misses).toIncludeSameMembers(['0_0', '1_0']);
+});
+
+test('it queues no leading-edge strip when the range is unchanged from the previous resolve', () => {
+  const cache = createChunkCache<string>({ capacity: 8, dispose: () => {} });
+
+  cache.set('0_0', 'tile-0-0');
+  cache.set('1_0', 'tile-1-0');
+
+  const previousRange: ChunkRange = { maxChunkX: 1, maxChunkY: 0, minChunkX: 0, minChunkY: 0 };
+  const resolved = resolveChunkStream(cache, TWO_CHUNK_VIEWPORT, previousRange);
+
+  expect(resolved.misses).toHaveLength(0);
+});
+
+test('it queues the strip beyond the max-x edge when the range advanced in the positive x direction', () => {
+  const cache = createChunkCache<string>({ capacity: 8, dispose: () => {} });
+
+  // chunks 1 and 2 (previously 0 and 1), already cached so only the prefetch strip should surface
+  cache.set('1_0', 'tile-1-0');
+  cache.set('2_0', 'tile-2-0');
+
+  const previousRange: ChunkRange = { maxChunkX: 1, maxChunkY: 0, minChunkX: 0, minChunkY: 0 };
+
+  const resolved = resolveChunkStream(
+    cache,
+    { maxCX: 47, maxCY: 15, minCX: 16, minCY: 0 },
+    previousRange,
+  );
+
+  expect(resolved.misses).toStrictEqual(['3_0']);
+});
+
+test('it queues the strip beyond the min-x edge when the range retreated in the negative x direction', () => {
+  const cache = createChunkCache<string>({ capacity: 8, dispose: () => {} });
+
+  cache.set('0_0', 'tile-0-0');
+  cache.set('1_0', 'tile-1-0');
+
+  const previousRange: ChunkRange = { maxChunkX: 2, maxChunkY: 0, minChunkX: 1, minChunkY: 0 };
+  const resolved = resolveChunkStream(cache, TWO_CHUNK_VIEWPORT, previousRange);
+
+  expect(resolved.misses).toStrictEqual(['-1_0']);
+});
+
+test('it queues the strip beyond the min-y edge when the range retreated in the negative y direction', () => {
+  const cache = createChunkCache<string>({ capacity: 8, dispose: () => {} });
+
+  cache.set('0_0', 'tile-0-0');
+
+  const previousRange: ChunkRange = { maxChunkX: 0, maxChunkY: 1, minChunkX: 0, minChunkY: 1 };
+
+  const resolved = resolveChunkStream(
+    cache,
+    { maxCX: 15, maxCY: 15, minCX: 0, minCY: 0 },
+    previousRange,
+  );
+
+  expect(resolved.misses).toStrictEqual(['0_-1']);
+});
+
+test('it never re-queues a leading-edge chunk the cache already holds', () => {
+  const cache = createChunkCache<string>({ capacity: 8, dispose: () => {} });
+
+  cache.set('1_0', 'tile-1-0');
+  cache.set('2_0', 'tile-2-0');
+  cache.set('3_0', 'tile-3-0');
+
+  const previousRange: ChunkRange = { maxChunkX: 1, maxChunkY: 0, minChunkX: 0, minChunkY: 0 };
+
+  const resolved = resolveChunkStream(
+    cache,
+    { maxCX: 47, maxCY: 15, minCX: 16, minCY: 0 },
+    previousRange,
+  );
+
+  expect(resolved.misses).toHaveLength(0);
+});

--- a/libs/game/worldmap-client/src/chunk-stream/resolve-chunk-stream.test.ts
+++ b/libs/game/worldmap-client/src/chunk-stream/resolve-chunk-stream.test.ts
@@ -1,4 +1,6 @@
 import { expect, test } from 'bun:test';
+import { CHUNK_SIZE, WORLD_COORD_MAX } from '@vers/worldmap-core';
+import { buildChunkKey } from './build-chunk-key';
 import { createChunkCache } from './create-chunk-cache';
 import type { ChunkRange } from './resolve-chunk-stream';
 import { resolveChunkStream } from './resolve-chunk-stream';
@@ -107,4 +109,28 @@ test('it never re-queues a leading-edge chunk the cache already holds', () => {
   );
 
   expect(resolved.misses).toHaveLength(0);
+});
+
+test('it stops the prefetch strip at the world chunk boundary rather than queuing an ungeneratable chunk', () => {
+  const cache = createChunkCache<string>({ capacity: 8, dispose: () => {} });
+
+  // the last in-bounds chunk on the +X axis, reached by a pan that just advanced east
+  const maxChunk = Math.floor(WORLD_COORD_MAX / CHUNK_SIZE);
+  const edgeOrigin = maxChunk * CHUNK_SIZE;
+
+  const previousRange: ChunkRange = {
+    maxChunkX: maxChunk - 1,
+    maxChunkY: 0,
+    minChunkX: maxChunk - 1,
+    minChunkY: 0,
+  };
+
+  const resolved = resolveChunkStream(
+    cache,
+    { maxCX: edgeOrigin + CHUNK_SIZE - 1, maxCY: CHUNK_SIZE - 1, minCX: edgeOrigin, minCY: 0 },
+    previousRange,
+  );
+
+  // only the entered chunk itself is a miss; the strip one beyond it lies past the world edge
+  expect(resolved.misses).toStrictEqual([buildChunkKey(maxChunk, 0)]);
 });

--- a/libs/game/worldmap-client/src/chunk-stream/resolve-chunk-stream.ts
+++ b/libs/game/worldmap-client/src/chunk-stream/resolve-chunk-stream.ts
@@ -1,7 +1,14 @@
 import type { Viewport } from '@vers/worldmap-core';
-import { CHUNK_SIZE } from '@vers/worldmap-core';
+import { CHUNK_SIZE, WORLD_COORD_MAX, WORLD_COORD_MIN } from '@vers/worldmap-core';
 import { buildChunkKey } from './build-chunk-key';
 import type { ChunkCache } from './create-chunk-cache';
+
+/**
+ * Chunk indices past these hold cells outside the world coordinate range, so the prefetch strip
+ * stops here rather than queuing a chunk whose cells can never generate.
+ */
+const MIN_WORLD_CHUNK = Math.floor(WORLD_COORD_MIN / CHUNK_SIZE);
+const MAX_WORLD_CHUNK = Math.floor(WORLD_COORD_MAX / CHUNK_SIZE);
 
 export interface ChunkRange {
   readonly maxChunkX: number;
@@ -62,6 +69,36 @@ export function resolveChunkStream<TEntry>(
 }
 
 /**
+ * Reads the cached entries a chunk-aligned viewport currently covers, refreshing each hit's recency
+ * but building and queuing nothing. This is the read a render performs to show whatever the cache
+ * already holds, leaving every write — seed invalidation, miss queuing, the range the prefetch
+ * compares against — to a committed effect, so an abandoned concurrent render never disposes or
+ * queues against state the committed scene still depends on.
+ */
+export function collectCachedEntries<TEntry>(
+  cache: Readonly<ChunkCache<TEntry>>,
+  viewport: Readonly<Viewport>,
+): ReadonlyArray<TEntry> {
+  const entries: Array<TEntry> = [];
+  const minChunkY = Math.floor(viewport.minCY / CHUNK_SIZE);
+  const maxChunkY = Math.floor(viewport.maxCY / CHUNK_SIZE);
+  const minChunkX = Math.floor(viewport.minCX / CHUNK_SIZE);
+  const maxChunkX = Math.floor(viewport.maxCX / CHUNK_SIZE);
+
+  for (let chunkY = minChunkY; chunkY <= maxChunkY; chunkY++) {
+    for (let chunkX = minChunkX; chunkX <= maxChunkX; chunkX++) {
+      const entry = cache.get(buildChunkKey(chunkX, chunkY));
+
+      if (entry !== undefined) {
+        entries.push(entry);
+      }
+    }
+  }
+
+  return entries;
+}
+
+/**
  * Collects the chunk strip one step beyond whichever edge the range advanced past since
  * `previousRange`, per axis, skipping a chunk the main scan above already queued. The range's own
  * minimum corner is the movement signal: a genuine pan holds the range's span constant while both
@@ -81,11 +118,15 @@ function collectLeadingEdgeMisses<TEntry>(
   if (movedX !== 0) {
     const edgeX = movedX > 0 ? range.maxChunkX + 1 : range.minChunkX - 1;
 
-    for (let chunkY = range.minChunkY; chunkY <= range.maxChunkY; chunkY++) {
-      const key = buildChunkKey(edgeX, chunkY);
+    if (edgeX >= MIN_WORLD_CHUNK && edgeX <= MAX_WORLD_CHUNK) {
+      for (let chunkY = range.minChunkY; chunkY <= range.maxChunkY; chunkY++) {
+        const key = buildChunkKey(edgeX, chunkY);
 
-      if (!cache.has(key)) {
-        misses.push(key);
+        // resolve through `get`, not `has`, so an already-cached prefetch chunk refreshes its
+        // recency and survives eviction until the pan that queued it arrives
+        if (cache.get(key) === undefined) {
+          misses.push(key);
+        }
       }
     }
   }
@@ -93,11 +134,13 @@ function collectLeadingEdgeMisses<TEntry>(
   if (movedY !== 0) {
     const edgeY = movedY > 0 ? range.maxChunkY + 1 : range.minChunkY - 1;
 
-    for (let chunkX = range.minChunkX; chunkX <= range.maxChunkX; chunkX++) {
-      const key = buildChunkKey(chunkX, edgeY);
+    if (edgeY >= MIN_WORLD_CHUNK && edgeY <= MAX_WORLD_CHUNK) {
+      for (let chunkX = range.minChunkX; chunkX <= range.maxChunkX; chunkX++) {
+        const key = buildChunkKey(chunkX, edgeY);
 
-      if (!cache.has(key)) {
-        misses.push(key);
+        if (cache.get(key) === undefined) {
+          misses.push(key);
+        }
       }
     }
   }

--- a/libs/game/worldmap-client/src/chunk-stream/resolve-chunk-stream.ts
+++ b/libs/game/worldmap-client/src/chunk-stream/resolve-chunk-stream.ts
@@ -1,0 +1,106 @@
+import type { Viewport } from '@vers/worldmap-core';
+import { CHUNK_SIZE } from '@vers/worldmap-core';
+import { buildChunkKey } from './build-chunk-key';
+import type { ChunkCache } from './create-chunk-cache';
+
+export interface ChunkRange {
+  readonly maxChunkX: number;
+  readonly maxChunkY: number;
+  readonly minChunkX: number;
+  readonly minChunkY: number;
+}
+
+export interface ResolveChunkStreamResult<TEntry> {
+  readonly entries: ReadonlyArray<TEntry>;
+  readonly misses: ReadonlyArray<string>;
+  readonly range: ChunkRange;
+}
+
+/**
+ * Resolves the chunk entries a chunk-aligned viewport currently finds cached, plus the chunk keys
+ * still missing — the viewport's own uncached chunks first, then, once `previousRange` shows the
+ * range moved, the strip one chunk beyond the edge the pan is heading toward, so terrain exists
+ * before the pan arrives. Purely a function of the cache's current contents and the two ranges: it
+ * builds nothing itself, so a caller drives progressive filling by handing each returned miss to
+ * the cache in a later tick and resolving again — the mutable-cache read this performs on every
+ * call is what lets that later resolve see chunks a previous tick built, never a memo staled
+ * against the cache.
+ */
+export function resolveChunkStream<TEntry>(
+  cache: Readonly<ChunkCache<TEntry>>,
+  viewport: Readonly<Viewport>,
+  previousRange: Readonly<ChunkRange> | null,
+): ResolveChunkStreamResult<TEntry> {
+  const range: ChunkRange = {
+    maxChunkX: Math.floor(viewport.maxCX / CHUNK_SIZE),
+    maxChunkY: Math.floor(viewport.maxCY / CHUNK_SIZE),
+    minChunkX: Math.floor(viewport.minCX / CHUNK_SIZE),
+    minChunkY: Math.floor(viewport.minCY / CHUNK_SIZE),
+  };
+
+  const entries: Array<TEntry> = [];
+  const misses: Array<string> = [];
+
+  for (let chunkY = range.minChunkY; chunkY <= range.maxChunkY; chunkY++) {
+    for (let chunkX = range.minChunkX; chunkX <= range.maxChunkX; chunkX++) {
+      const key = buildChunkKey(chunkX, chunkY);
+      const entry = cache.get(key);
+
+      if (entry === undefined) {
+        misses.push(key);
+      } else {
+        entries.push(entry);
+      }
+    }
+  }
+
+  if (previousRange !== null) {
+    misses.push(...collectLeadingEdgeMisses(cache, range, previousRange));
+  }
+
+  return { entries, misses, range };
+}
+
+/**
+ * Collects the chunk strip one step beyond whichever edge the range advanced past since
+ * `previousRange`, per axis, skipping a chunk the main scan above already queued. The range's own
+ * minimum corner is the movement signal: a genuine pan holds the range's span constant while both
+ * corners shift together, so a change on the minimum alone unambiguously names the direction: a
+ * span change with no shift (a zoom) reports no movement on that axis and collects no strip, since
+ * the zoom's own newly visible area already came from the main scan above.
+ */
+function collectLeadingEdgeMisses<TEntry>(
+  cache: Readonly<ChunkCache<TEntry>>,
+  range: Readonly<ChunkRange>,
+  previousRange: Readonly<ChunkRange>,
+): Array<string> {
+  const misses: Array<string> = [];
+  const movedX = Math.sign(range.minChunkX - previousRange.minChunkX);
+  const movedY = Math.sign(range.minChunkY - previousRange.minChunkY);
+
+  if (movedX !== 0) {
+    const edgeX = movedX > 0 ? range.maxChunkX + 1 : range.minChunkX - 1;
+
+    for (let chunkY = range.minChunkY; chunkY <= range.maxChunkY; chunkY++) {
+      const key = buildChunkKey(edgeX, chunkY);
+
+      if (!cache.has(key)) {
+        misses.push(key);
+      }
+    }
+  }
+
+  if (movedY !== 0) {
+    const edgeY = movedY > 0 ? range.maxChunkY + 1 : range.minChunkY - 1;
+
+    for (let chunkX = range.minChunkX; chunkX <= range.maxChunkX; chunkX++) {
+      const key = buildChunkKey(chunkX, edgeY);
+
+      if (!cache.has(key)) {
+        misses.push(key);
+      }
+    }
+  }
+
+  return misses;
+}

--- a/libs/game/worldmap-client/src/chunk-stream/use-chunk-stream.test.ts
+++ b/libs/game/worldmap-client/src/chunk-stream/use-chunk-stream.test.ts
@@ -1,11 +1,21 @@
 import { expect, test } from 'bun:test';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import type { Viewport } from '@vers/worldmap-core';
+import { StrictMode, createElement } from 'react';
+import type { ReactNode } from 'react';
 import { useChunkStream } from './use-chunk-stream';
 
 interface StubEntry {
   readonly chunkX: number;
   readonly chunkY: number;
+}
+
+interface ViewportProps {
+  readonly viewport: Viewport;
+}
+
+interface WrapperProps {
+  readonly children: ReactNode;
 }
 
 const ONE_CHUNK_VIEWPORT: Viewport = { maxCX: 15, maxCY: 15, minCX: 0, minCY: 0 };
@@ -181,5 +191,45 @@ test('it reports each build tick to onBuildTick with the chunk count it built', 
 
   await waitFor(() => {
     expect(ticks).toStrictEqual([{ builtChunkCount: 1 }]);
+  });
+});
+
+test('it still prefetches the leading-edge chunk under development double-rendering', async () => {
+  const built: Array<string> = [];
+
+  const hook = renderHook(
+    (props: ViewportProps) =>
+      useChunkStream<StubEntry>({
+        build: (_userSeed, chunkX, chunkY) => {
+          built.push(`${chunkX}_${chunkY}`);
+
+          return { chunkX, chunkY };
+        },
+        cacheCapacity: 32,
+        dispose: () => {},
+        userSeed: 1,
+        viewport: props.viewport,
+      }),
+    {
+      initialProps: { viewport: ONE_CHUNK_VIEWPORT },
+      wrapper: (props: WrapperProps) => createElement(StrictMode, null, props.children),
+    },
+  );
+
+  await waitFor(() => {
+    expect(built).toContain('0_0');
+  });
+
+  // pan one chunk east: the entered chunk 1_0 streams in, and the prefetch strip one beyond the
+  // leading edge queues chunk 2_0 — a movement the write-in-render version silently missed here,
+  // because StrictMode's second render read the range the first render already advanced
+  await act(() => {
+    hook.rerender({ viewport: { maxCX: 31, maxCY: 15, minCX: 16, minCY: 0 } });
+
+    return Promise.resolve();
+  });
+
+  await waitFor(() => {
+    expect(built).toContain('2_0');
   });
 });

--- a/libs/game/worldmap-client/src/chunk-stream/use-chunk-stream.test.ts
+++ b/libs/game/worldmap-client/src/chunk-stream/use-chunk-stream.test.ts
@@ -1,0 +1,185 @@
+import { expect, test } from 'bun:test';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { Viewport } from '@vers/worldmap-core';
+import { useChunkStream } from './use-chunk-stream';
+
+interface StubEntry {
+  readonly chunkX: number;
+  readonly chunkY: number;
+}
+
+const ONE_CHUNK_VIEWPORT: Viewport = { maxCX: 15, maxCY: 15, minCX: 0, minCY: 0 };
+const TWO_CHUNK_VIEWPORT: Viewport = { maxCX: 31, maxCY: 15, minCX: 0, minCY: 0 };
+
+test('it returns no entries while the seed or the viewport is missing', () => {
+  const hook = renderHook(() =>
+    useChunkStream<StubEntry>({
+      build: (_userSeed, chunkX, chunkY) => ({ chunkX, chunkY }),
+      cacheCapacity: 8,
+      dispose: () => {},
+      userSeed: null,
+      viewport: ONE_CHUNK_VIEWPORT,
+    }),
+  );
+
+  expect(hook.result.current).toHaveLength(0);
+});
+
+test('it fills a miss over following animation frames rather than on the first render', async () => {
+  const hook = renderHook(() =>
+    useChunkStream<StubEntry>({
+      build: (_userSeed, chunkX, chunkY) => ({ chunkX, chunkY }),
+      cacheCapacity: 8,
+      dispose: () => {},
+      userSeed: 1,
+      viewport: ONE_CHUNK_VIEWPORT,
+    }),
+  );
+
+  expect(hook.result.current).toHaveLength(0);
+
+  await waitFor(() => {
+    expect(hook.result.current).toStrictEqual([{ chunkX: 0, chunkY: 0 }]);
+  });
+});
+
+test('it fills a two-chunk miss set across two separate animation-frame ticks, never both in one', async () => {
+  const ticks: Array<number> = [];
+
+  const hook = renderHook(() =>
+    useChunkStream<StubEntry>({
+      build: (_userSeed, chunkX, chunkY) => ({ chunkX, chunkY }),
+      cacheCapacity: 8,
+      dispose: () => {},
+      onBuildTick: (_buildMs, builtChunkCount) => {
+        ticks.push(builtChunkCount);
+      },
+      userSeed: 1,
+      viewport: TWO_CHUNK_VIEWPORT,
+    }),
+  );
+
+  await waitFor(() => {
+    expect(hook.result.current).toIncludeSameMembers([
+      { chunkX: 0, chunkY: 0 },
+      { chunkX: 1, chunkY: 0 },
+    ]);
+  });
+
+  expect(ticks).toStrictEqual([1, 1]);
+});
+
+test('it resolves an already-built chunk instantly on a later render, with no further build', async () => {
+  const disposed: Array<StubEntry> = [];
+
+  const hook = renderHook(
+    (viewport: Viewport) =>
+      useChunkStream<StubEntry>({
+        build: (_userSeed, chunkX, chunkY) => ({ chunkX, chunkY }),
+        cacheCapacity: 8,
+        dispose: (entry) => {
+          disposed.push(entry);
+        },
+        userSeed: 1,
+        viewport,
+      }),
+    { initialProps: ONE_CHUNK_VIEWPORT },
+  );
+
+  await waitFor(() => {
+    expect(hook.result.current).toStrictEqual([{ chunkX: 0, chunkY: 0 }]);
+  });
+
+  const otherViewport: Viewport = { maxCX: 47, maxCY: 15, minCX: 32, minCY: 0 };
+
+  act(() => {
+    hook.rerender(otherViewport);
+  });
+
+  await waitFor(() => {
+    expect(hook.result.current).toStrictEqual([{ chunkX: 2, chunkY: 0 }]);
+  });
+
+  act(() => {
+    hook.rerender(ONE_CHUNK_VIEWPORT);
+  });
+
+  expect(hook.result.current).toStrictEqual([{ chunkX: 0, chunkY: 0 }]);
+  expect(disposed).toHaveLength(0);
+});
+
+test('it disposes every cached entry the moment the seed changes', async () => {
+  const disposed: Array<StubEntry> = [];
+
+  const hook = renderHook(
+    (userSeed: number) =>
+      useChunkStream<StubEntry>({
+        build: (_seed, chunkX, chunkY) => ({ chunkX, chunkY }),
+        cacheCapacity: 8,
+        dispose: (entry) => {
+          disposed.push(entry);
+        },
+        userSeed,
+        viewport: ONE_CHUNK_VIEWPORT,
+      }),
+    { initialProps: 1 },
+  );
+
+  await waitFor(() => {
+    expect(hook.result.current).toStrictEqual([{ chunkX: 0, chunkY: 0 }]);
+  });
+
+  act(() => {
+    hook.rerender(2);
+  });
+
+  expect(hook.result.current).toHaveLength(0);
+  expect(disposed).toStrictEqual([{ chunkX: 0, chunkY: 0 }]);
+});
+
+test('it disposes every cached entry on unmount', async () => {
+  const disposed: Array<StubEntry> = [];
+
+  const hook = renderHook(() =>
+    useChunkStream<StubEntry>({
+      build: (_userSeed, chunkX, chunkY) => ({ chunkX, chunkY }),
+      cacheCapacity: 8,
+      dispose: (entry) => {
+        disposed.push(entry);
+      },
+      userSeed: 1,
+      viewport: ONE_CHUNK_VIEWPORT,
+    }),
+  );
+
+  await waitFor(() => {
+    expect(hook.result.current).toStrictEqual([{ chunkX: 0, chunkY: 0 }]);
+  });
+
+  act(() => {
+    hook.unmount();
+  });
+
+  expect(disposed).toStrictEqual([{ chunkX: 0, chunkY: 0 }]);
+});
+
+test('it reports each build tick to onBuildTick with the chunk count it built', async () => {
+  const ticks: Array<{ builtChunkCount: number }> = [];
+
+  renderHook(() =>
+    useChunkStream<StubEntry>({
+      build: (_userSeed, chunkX, chunkY) => ({ chunkX, chunkY }),
+      cacheCapacity: 8,
+      dispose: () => {},
+      onBuildTick: (_buildMs, builtChunkCount) => {
+        ticks.push({ builtChunkCount });
+      },
+      userSeed: 1,
+      viewport: ONE_CHUNK_VIEWPORT,
+    }),
+  );
+
+  await waitFor(() => {
+    expect(ticks).toStrictEqual([{ builtChunkCount: 1 }]);
+  });
+});

--- a/libs/game/worldmap-client/src/chunk-stream/use-chunk-stream.ts
+++ b/libs/game/worldmap-client/src/chunk-stream/use-chunk-stream.ts
@@ -1,0 +1,155 @@
+import type { Viewport } from '@vers/worldmap-core';
+import { useDeferredValue, useEffect, useReducer, useRef } from 'react';
+import { createChunkCache } from './create-chunk-cache';
+import { parseChunkKey } from './parse-chunk-key';
+import type { ChunkRange } from './resolve-chunk-stream';
+import { resolveChunkStream } from './resolve-chunk-stream';
+
+export interface UseChunkStreamOptions<TEntry> {
+  /**
+   * Builds one chunk's entry from the seed and its coordinate. Only ever called with the seed
+   * `userSeed` currently holds — a miss never reaches this while `userSeed` is `null`.
+   */
+  readonly build: (userSeed: number, chunkX: number, chunkY: number) => TEntry;
+
+  readonly cacheCapacity: number;
+
+  /**
+   * Releases an entry's resources. Called for an entry evicted past capacity, for every entry a
+   * seed change drops, and for every entry still cached when the hook unmounts.
+   */
+  readonly dispose: (entry: TEntry) => void;
+
+  /**
+   * Reports one progressive-build tick's wall time and how many chunks it built, for the caller to
+   * fold into its own perf telemetry.
+   */
+  readonly onBuildTick?: (buildMs: number, builtChunkCount: number) => void;
+
+  readonly userSeed: number | null;
+
+  /**
+   * A chunk-aligned viewport — `buildChunkAlignedViewport`'s output, or `null` before one exists.
+   */
+  readonly viewport: Viewport | null;
+}
+
+/**
+ * Chunk builds allowed per animation frame. Bounding it to the single biggest build a frame can
+ * absorb is what keeps a pan interruptible: a multi-chunk batch on one frame reintroduces the
+ * synchronous stall this hook exists to remove, while still draining a large miss set within a
+ * handful of frames.
+ */
+const BUILDS_PER_TICK = 1;
+
+/**
+ * Streams a chunk-keyed content layer over a chunk-aligned viewport: cached chunks resolve
+ * instantly on every render, a bounded number of misses build per animation frame so a pan never
+ * stalls, and the strip one chunk beyond the pan's leading edge prefetches ahead of the viewport
+ * that will need it. `viewport` is wrapped in `useDeferredValue` here, once, so every layer this
+ * hook drives gets an interruptible transition on a chunk-crossing pan without wrapping it itself.
+ *
+ * Entries resolve fresh against the mutable cache on every render rather than through a memo: the
+ * progressive builder's own re-renders are what deliver a freshly built chunk to the returned
+ * array, and a memo keyed on the viewport would never observe a build that lands without the
+ * viewport changing.
+ */
+export function useChunkStream<TEntry>(
+  options: Readonly<UseChunkStreamOptions<TEntry>>,
+): ReadonlyArray<TEntry> {
+  const deferredViewport = useDeferredValue(options.viewport);
+  const cacheRef = useRef<ReturnType<typeof createChunkCache<TEntry>> | null>(null);
+  const previousRangeRef = useRef<ChunkRange | null>(null);
+  const pendingRef = useRef<ReadonlyArray<string>>([]);
+  const [, forceUpdate] = useReducer((tick: number) => tick + 1, 0);
+
+  cacheRef.current ??= createChunkCache<TEntry>({
+    capacity: options.cacheCapacity,
+    dispose: options.dispose,
+  });
+
+  const cache = cacheRef.current;
+
+  useEffect(
+    () => () => {
+      cache.clear();
+    },
+    [cache],
+  );
+
+  let entries: ReadonlyArray<TEntry> = [];
+  const userSeed = options.userSeed;
+
+  if (userSeed !== null && deferredViewport !== null) {
+    cache.syncSeed(userSeed);
+
+    const resolved = resolveChunkStream(cache, deferredViewport, previousRangeRef.current);
+
+    entries = resolved.entries;
+
+    // read by both the progressive-build effect below and this branch's next resolve — see the
+    // hook's own doc comment for why this is a direct render-body write rather than a memo
+    previousRangeRef.current = resolved.range;
+    pendingRef.current = resolved.misses;
+  } else {
+    pendingRef.current = [];
+  }
+
+  useEffect(() => {
+    if (userSeed === null || pendingRef.current.length === 0) {
+      return () => {};
+    }
+
+    let cancelled = false;
+
+    const advanceBuildQueue = () => {
+      if (cancelled || pendingRef.current.length === 0) {
+        return;
+      }
+
+      const batch = pendingRef.current.slice(0, BUILDS_PER_TICK);
+
+      pendingRef.current = pendingRef.current.slice(BUILDS_PER_TICK);
+
+      const startedAt = performance.now();
+      let builtChunkCount = 0;
+
+      for (const key of batch) {
+        if (cache.has(key)) {
+          continue;
+        }
+
+        const [chunkX, chunkY] = parseChunkKey(key);
+
+        cache.set(key, options.build(userSeed, chunkX, chunkY));
+
+        builtChunkCount += 1;
+      }
+
+      options.onBuildTick?.(performance.now() - startedAt, builtChunkCount);
+
+      // schedules the render that surfaces this tick's builds; the effect above re-derives
+      // `pendingRef.current` from that render's own resolve, so an emptied queue here is never
+      // stale against work a viewport change queued in the meantime
+      forceUpdate();
+
+      if (pendingRef.current.length > 0) {
+        requestAnimationFrame(advanceBuildQueue);
+      }
+    };
+
+    const frame = requestAnimationFrame(advanceBuildQueue);
+
+    return () => {
+      cancelled = true;
+
+      cancelAnimationFrame(frame);
+    };
+
+    // no dependency array: runs after every render and exits immediately once nothing is pending,
+    // so the progressive builder always drains the render body's latest queue and never strands
+    // itself on a stale closure
+  });
+
+  return entries;
+}

--- a/libs/game/worldmap-client/src/chunk-stream/use-chunk-stream.ts
+++ b/libs/game/worldmap-client/src/chunk-stream/use-chunk-stream.ts
@@ -3,7 +3,7 @@ import { useDeferredValue, useEffect, useReducer, useRef } from 'react';
 import { createChunkCache } from './create-chunk-cache';
 import { parseChunkKey } from './parse-chunk-key';
 import type { ChunkRange } from './resolve-chunk-stream';
-import { resolveChunkStream } from './resolve-chunk-stream';
+import { collectCachedEntries, resolveChunkStream } from './resolve-chunk-stream';
 
 export interface UseChunkStreamOptions<TEntry> {
   /**
@@ -49,10 +49,13 @@ const BUILDS_PER_TICK = 1;
  * that will need it. `viewport` is wrapped in `useDeferredValue` here, once, so every layer this
  * hook drives gets an interruptible transition on a chunk-crossing pan without wrapping it itself.
  *
- * Entries resolve fresh against the mutable cache on every render rather than through a memo: the
- * progressive builder's own re-renders are what deliver a freshly built chunk to the returned
- * array, and a memo keyed on the viewport would never observe a build that lands without the
- * viewport changing.
+ * The render body only reads the cache — it shows whatever chunks are already built and touches no
+ * shared state, so a concurrent render React starts and abandons never disposes or queues against
+ * the committed scene. Every write — invalidating the cache on a seed change, recording the range
+ * the prefetch compares against, queuing the misses to build — happens in a committed effect, which
+ * also keeps the predictive prefetch working under React's development double-render. Newly built
+ * chunks reach the returned array through the progressive builder's own re-renders: a memo keyed on
+ * the viewport would never observe a build that lands without the viewport changing.
  */
 export function useChunkStream<TEntry>(
   options: Readonly<UseChunkStreamOptions<TEntry>>,
@@ -69,6 +72,7 @@ export function useChunkStream<TEntry>(
   });
 
   const cache = cacheRef.current;
+  const userSeed = options.userSeed;
 
   useEffect(
     () => () => {
@@ -77,23 +81,31 @@ export function useChunkStream<TEntry>(
     [cache],
   );
 
-  let entries: ReadonlyArray<TEntry> = [];
-  const userSeed = options.userSeed;
+  // committed write pass: invalidate the cache when the seed changes, then record the range and the
+  // miss queue the builder drains. Deferred to an effect so neither a discarded concurrent render
+  // nor development's double-invoked render body ever runs these writes.
+  useEffect(() => {
+    if (userSeed === null || deferredViewport === null) {
+      pendingRef.current = [];
 
-  if (userSeed !== null && deferredViewport !== null) {
+      return;
+    }
+
     cache.syncSeed(userSeed);
 
     const resolved = resolveChunkStream(cache, deferredViewport, previousRangeRef.current);
 
-    entries = resolved.entries;
-
-    // read by both the progressive-build effect below and this branch's next resolve — see the
-    // hook's own doc comment for why this is a direct render-body write rather than a memo
     previousRangeRef.current = resolved.range;
     pendingRef.current = resolved.misses;
-  } else {
-    pendingRef.current = [];
-  }
+
+    // surface any chunks already cached for this viewport, and kick the builder for the misses
+    forceUpdate();
+  }, [cache, userSeed, deferredViewport]);
+
+  const entries =
+    userSeed !== null && deferredViewport !== null && cache.isSyncedTo(userSeed)
+      ? collectCachedEntries(cache, deferredViewport)
+      : [];
 
   useEffect(() => {
     if (userSeed === null || pendingRef.current.length === 0) {

--- a/libs/game/worldmap-client/src/components-three/biome-ground.test.tsx
+++ b/libs/game/worldmap-client/src/components-three/biome-ground.test.tsx
@@ -1,14 +1,20 @@
-import { expect, test } from 'bun:test';
+import { expect, onTestFinished, test } from 'bun:test';
 import ReactThreeTestRenderer from '@react-three/test-renderer';
-import type { Viewport } from '@vers/worldmap-core';
 import { CHUNK_SIZE } from '@vers/worldmap-core';
 import { DataTexture } from 'three';
 import type { Mesh, Object3D } from 'three';
 import invariant from 'tiny-invariant';
+import { scatterBuildStats } from '../scatter-build-stats';
 import { setViewport } from '../state/set-viewport';
 import { setWorldRegion } from '../state/set-world-region';
-import { buildChunkAlignedViewport } from '../utils/build-chunk-aligned-viewport';
 import { BiomeGround } from './biome-ground';
+
+/**
+ * A single chunk's cell box — the smallest viewport `useFogViewport`'s chunk-alignment ever
+ * produces, and the fastest a mounted `BiomeGround` reaches its first rendered mesh: one miss, one
+ * progressive-build tick.
+ */
+const ONE_CHUNK_VIEWPORT = { maxCX: CHUNK_SIZE - 1, maxCY: CHUNK_SIZE - 1, minCX: 0, minCY: 0 };
 
 test('it renders nothing until a seed and a viewport exist', async () => {
   const renderer = await ReactThreeTestRenderer.create(<BiomeGround />);
@@ -18,102 +24,73 @@ test('it renders nothing until a seed and a viewport exist', async () => {
   await renderer.unmount();
 });
 
-test('it builds a texture sized to the inflated viewport', async () => {
+test('it renders a chunk mesh once its tile finishes its progressive build', async () => {
+  onTestFinished(() => {
+    scatterBuildStats.buildMs = 0;
+  });
+
   setWorldRegion('avatar-a', 42, { edges: {}, nodes: {} }, null, new Set(), []);
-  setViewport({ maxCX: 2, maxCY: 2, minCX: -2, minCY: -2 });
+  setViewport(ONE_CHUNK_VIEWPORT);
 
   const renderer = await ReactThreeTestRenderer.create(<BiomeGround />);
 
-  expect(renderer.scene.children).toHaveLength(1);
+  await ReactThreeTestRenderer.waitFor(() => renderer.scene.children.length === 1);
 
   const plane = renderer.scene.children[0]!.instance;
 
-  invariant(isMesh(plane), 'the sole child is the biome ground plane');
+  invariant(isMesh(plane), 'the rendered child is the chunk tile mesh');
 
-  // one parallelogram quad — two triangles over four vertices — carries the whole field
+  // one parallelogram quad — two triangles over four vertices — carries the chunk's tile
   expect(plane.geometry.getAttribute('position').count).toBe(4);
   expect(plane.geometry.index?.count).toBe(6);
 
   const texture = getGroundTexture(plane);
-  const aligned = buildChunkAlignedViewport({ maxCX: 2, maxCY: 2, minCX: -2, minCY: -2 });
+  const expectedTexels = CHUNK_SIZE * 4;
 
-  expect(texture.image.width).toBe(buildExpectedCols(aligned));
-  expect(texture.image.height).toBe(buildExpectedRows(aligned));
-
-  await renderer.unmount();
-});
-
-test('it rewrites the texture bytes in place on a same-size pan', async () => {
-  setWorldRegion('avatar-a', 42, { edges: {}, nodes: {} }, null, new Set(), []);
-  setViewport({ maxCX: 2, maxCY: 2, minCX: -2, minCY: -2 });
-
-  const renderer = await ReactThreeTestRenderer.create(<BiomeGround />);
-
-  const plane = renderer.scene.children[0]!.instance;
-
-  invariant(isMesh(plane), 'the sole child is the biome ground plane');
-
-  const previousTexture = getGroundTexture(plane);
-  const previousData = previousTexture.image.data;
-
-  invariant(previousData, 'the ground texture carries a byte buffer');
-
-  const previousBytes = Uint8Array.from(previousData);
-
-  // translate by whole chunks so the aligned viewport moves without changing its span, keeping the
-  // byte buffers the same length for a content comparison
-  const shift = CHUNK_SIZE * 4;
-
-  await ReactThreeTestRenderer.act(() => {
-    setViewport({ maxCX: 2 + shift, maxCY: 2 + shift, minCX: -2 + shift, minCY: -2 + shift });
-
-    return Promise.resolve();
-  });
-
-  const nextTexture = getGroundTexture(plane);
-  const nextData = nextTexture.image.data;
-
-  invariant(nextData, 'the panned ground texture carries a byte buffer');
-
-  expect(nextTexture).toBe(previousTexture);
-
-  const nextBytes = Uint8Array.from(nextData);
-
-  expect(nextBytes).toHaveLength(previousBytes.length);
-  expect(nextBytes).not.toEqual(previousBytes);
+  expect(texture.image.width).toBe(expectedTexels);
+  expect(texture.image.height).toBe(expectedTexels);
 
   await renderer.unmount();
 });
 
-test('it keeps one mesh and one material across pans, rebuilding the texture to the new size', async () => {
+test('it drops a chunk mesh once a pan carries it out of view and streams in the entered chunk', async () => {
+  onTestFinished(() => {
+    scatterBuildStats.buildMs = 0;
+  });
+
   setWorldRegion('avatar-a', 42, { edges: {}, nodes: {} }, null, new Set(), []);
-  setViewport({ maxCX: 2, maxCY: 2, minCX: -2, minCY: -2 });
+  setViewport(ONE_CHUNK_VIEWPORT);
 
   const renderer = await ReactThreeTestRenderer.create(<BiomeGround />);
 
-  const plane = renderer.scene.children[0]!.instance;
+  await ReactThreeTestRenderer.waitFor(() => renderer.scene.children.length === 1);
 
-  invariant(isMesh(plane), 'the sole child is the biome ground plane');
+  const firstPlane = renderer.scene.children[0]!.instance;
 
-  const material = plane.material;
-  const previousTexture = getGroundTexture(plane);
-  const nextViewport: Viewport = { maxCX: 20, maxCY: 20, minCX: -20, minCY: -20 };
+  invariant(isMesh(firstPlane), 'the rendered child is the first chunk tile mesh');
+
+  // several chunks away — outside the predictive-prefetch strip — so the departed chunk is never
+  // still cached under the new viewport
+  const farChunkOrigin = CHUNK_SIZE * 10;
 
   await ReactThreeTestRenderer.act(() => {
-    setViewport(nextViewport);
+    setViewport({
+      maxCX: farChunkOrigin + CHUNK_SIZE - 1,
+      maxCY: farChunkOrigin + CHUNK_SIZE - 1,
+      minCX: farChunkOrigin,
+      minCY: farChunkOrigin,
+    });
 
     return Promise.resolve();
   });
 
-  expect(renderer.scene.children[0]!.instance).toBe(plane);
-  expect(plane.material).toBe(material);
+  await ReactThreeTestRenderer.waitFor(() => renderer.scene.children.length === 1);
 
-  const nextTexture = getGroundTexture(plane);
-  const nextAligned = buildChunkAlignedViewport(nextViewport);
+  const secondPlane = renderer.scene.children[0]!.instance;
 
-  expect(nextTexture.image.width).toBe(buildExpectedCols(nextAligned));
-  expect(nextTexture.image.height).toBe(buildExpectedRows(nextAligned));
-  expect(nextTexture).not.toBe(previousTexture);
+  invariant(isMesh(secondPlane), 'the rendered child is the entered chunk tile mesh');
+
+  expect(secondPlane).not.toBe(firstPlane);
 
   await renderer.unmount();
 });
@@ -143,21 +120,4 @@ function getGroundTexture(mesh: Mesh): DataTexture {
   invariant(value instanceof DataTexture, 'the ground plane material carries a live DataTexture');
 
   return value;
-}
-
-/**
- * Mirrors BiomeGround's own private `BIOME_TEXELS_PER_CELL` and `BIOME_VIEWPORT_MARGIN_CELLS`. The
- * dimension assertions above apply this inflation on top of `buildChunkAlignedViewport` — the same
- * chunk-rounding `useFogViewport` applies before BiomeGround ever sees a viewport — so the expected
- * texel counts match what the component actually builds from, not the raw store viewport.
- */
-const TEXELS_PER_CELL = 4;
-const VIEWPORT_MARGIN_CELLS = 2;
-
-function buildExpectedCols(viewport: Readonly<Viewport>): number {
-  return (viewport.maxCX - viewport.minCX + 1 + 2 * VIEWPORT_MARGIN_CELLS) * TEXELS_PER_CELL;
-}
-
-function buildExpectedRows(viewport: Readonly<Viewport>): number {
-  return (viewport.maxCY - viewport.minCY + 1 + 2 * VIEWPORT_MARGIN_CELLS) * TEXELS_PER_CELL;
 }

--- a/libs/game/worldmap-client/src/components-three/biome-ground.test.tsx
+++ b/libs/game/worldmap-client/src/components-three/biome-ground.test.tsx
@@ -19,9 +19,9 @@ const ONE_CHUNK_VIEWPORT = { maxCX: CHUNK_SIZE - 1, maxCY: CHUNK_SIZE - 1, minCX
 test('it renders nothing until a seed and a viewport exist', async () => {
   const renderer = await ReactThreeTestRenderer.create(<BiomeGround />);
 
-  expect(renderer.scene.children).toHaveLength(0);
+  onTestFinished(() => renderer.unmount());
 
-  await renderer.unmount();
+  expect(renderer.scene.children).toHaveLength(0);
 });
 
 test('it renders a chunk mesh once its tile finishes its progressive build', async () => {
@@ -33,6 +33,8 @@ test('it renders a chunk mesh once its tile finishes its progressive build', asy
   setViewport(ONE_CHUNK_VIEWPORT);
 
   const renderer = await ReactThreeTestRenderer.create(<BiomeGround />);
+
+  onTestFinished(() => renderer.unmount());
 
   await ReactThreeTestRenderer.waitFor(() => renderer.scene.children.length === 1);
 
@@ -49,8 +51,6 @@ test('it renders a chunk mesh once its tile finishes its progressive build', asy
 
   expect(texture.image.width).toBe(expectedTexels);
   expect(texture.image.height).toBe(expectedTexels);
-
-  await renderer.unmount();
 });
 
 test('it drops a chunk mesh once a pan carries it out of view and streams in the entered chunk', async () => {
@@ -62,6 +62,8 @@ test('it drops a chunk mesh once a pan carries it out of view and streams in the
   setViewport(ONE_CHUNK_VIEWPORT);
 
   const renderer = await ReactThreeTestRenderer.create(<BiomeGround />);
+
+  onTestFinished(() => renderer.unmount());
 
   await ReactThreeTestRenderer.waitFor(() => renderer.scene.children.length === 1);
 
@@ -91,8 +93,6 @@ test('it drops a chunk mesh once a pan carries it out of view and streams in the
   invariant(isMesh(secondPlane), 'the rendered child is the entered chunk tile mesh');
 
   expect(secondPlane).not.toBe(firstPlane);
-
-  await renderer.unmount();
 });
 
 /**

--- a/libs/game/worldmap-client/src/components-three/biome-ground.tsx
+++ b/libs/game/worldmap-client/src/components-three/biome-ground.tsx
@@ -1,7 +1,6 @@
 import { sceneColors } from '@vers/design-system';
 import type { BiomeField, Viewport } from '@vers/worldmap-core';
-import { BIOME_ROSTER, buildBiomeField, toHexPosition } from '@vers/worldmap-core';
-import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+import { BIOME_ROSTER, CHUNK_SIZE, buildBiomeField, toHexPosition } from '@vers/worldmap-core';
 import {
   BufferAttribute,
   BufferGeometry,
@@ -13,83 +12,26 @@ import {
 } from 'three';
 import { MeshBasicNodeMaterial } from 'three/webgpu';
 import invariant from 'tiny-invariant';
+import { buildChunkKey } from '../chunk-stream/build-chunk-key';
+import { useChunkStream } from '../chunk-stream/use-chunk-stream';
 import { NODE_POSITION_SCALING_FACTOR } from '../consts';
+import { scatterBuildStats } from '../scatter-build-stats';
 import { useFogViewport } from '../state/use-fog-viewport';
 import { useUserSeed } from '../state/use-user-seed';
-import type { TSLTextureNode } from './scene-tsl';
 import { sceneTSL } from './scene-tsl';
 
 /**
  * Biome texels per axial cell unit. Modest by design: each texel walks the full Worley/value-noise
- * sample, so the resolution trades border smoothness against per-pan rebuild cost.
+ * sample, so the resolution trades border smoothness against per-chunk build cost.
  */
 const BIOME_TEXELS_PER_CELL = 4;
 
 /**
- * Cells the ground quad extends past the chunk-aligned viewport, covering the screen edge between a
- * fast pan and the next chunk-boundary rebuild.
+ * Chunk tiles kept cached before evicting the least-recently-used one — several screens' worth of
+ * recently visited ground at the default zoom, small enough that a long free pan never grows the
+ * tab's GPU memory without bound.
  */
-const BIOME_VIEWPORT_MARGIN_CELLS = 2;
-
-/**
- * Draws the placeholder biome terrain tint over the world map: one viewport-covering plane whose
- * per-fragment color samples a CPU-mixed RGBA texture — the base biome blended toward its border
- * neighbour by `blendT`, with the modifier tint overlaid at low alpha where the modifier layer draws
- * non-`none`. Purely presentational flavour: it projects the biome field from the current region's
- * seed and stores nothing itself, rebuilding only when a pan crosses a chunk boundary. It renders
- * nothing until both a seed and a viewport exist.
- */
-export function BiomeGround() {
-  const userSeed = useUserSeed();
-  const viewport = useFogViewport();
-
-  const biome = useMemo(() => {
-    if (userSeed === null || viewport === null) {
-      return null;
-    }
-
-    const inflated: Viewport = {
-      maxCX: viewport.maxCX + BIOME_VIEWPORT_MARGIN_CELLS,
-      maxCY: viewport.maxCY + BIOME_VIEWPORT_MARGIN_CELLS,
-      minCX: viewport.minCX - BIOME_VIEWPORT_MARGIN_CELLS,
-      minCY: viewport.minCY - BIOME_VIEWPORT_MARGIN_CELLS,
-    };
-
-    return {
-      field: buildBiomeField(userSeed, inflated, { resolution: BIOME_TEXELS_PER_CELL }),
-      fieldViewport: inflated,
-    };
-  }, [userSeed, viewport]);
-
-  if (biome === null) {
-    return null;
-  }
-
-  return <BiomeGroundPlane field={biome.field} viewport={biome.fieldViewport} />;
-}
-
-interface BiomeGroundPlaneProps {
-  readonly field: BiomeField;
-  readonly viewport: Viewport;
-}
-
-/**
- * The byte buffer behind the live ground texture, kept beside its dimensions so a same-size rebuild
- * can rewrite the pixels in place.
- */
-interface GroundBuffer {
-  bytes: Uint8Array;
-  cols: number;
-  rows: number;
-}
-
-interface BiomeGroundResources {
-  applied: { field: BiomeField; viewport: Viewport };
-  readonly buffer: GroundBuffer;
-  readonly geometry: BufferGeometry;
-  readonly material: MeshBasicNodeMaterial;
-  readonly textureNode: TSLTextureNode;
-}
+const BIOME_CHUNK_CACHE_CAPACITY = 256;
 
 /**
  * The ground plane sits between the floor (`y = -0.1`) and the node/edge/fog plane (`y = 0`), inside
@@ -98,102 +40,90 @@ interface BiomeGroundResources {
 const BIOME_GROUND_ELEVATION = -0.05;
 
 /**
- * The geometry, material, and texture node live for the whole mount: a field change swaps the
- * texture node's value and rewrites the quad in place, never rebuilding the material — the same
- * discipline `FogOfWar` follows, for the same reason: a fresh material recompiles its shader
- * pipeline, and that churn is enough to lose the GPU context mid-pan.
+ * Streams the placeholder biome terrain tint over the world map as a chunk-keyed mosaic: each
+ * `CHUNK_SIZE`-cell chunk builds once — a quad whose per-fragment color samples a CPU-mixed RGBA
+ * texture, the base biome blended toward its border neighbour by `blendT`, with the modifier tint
+ * overlaid at low alpha where the modifier layer draws non-`none` — and persists in the chunk-stream
+ * cache so a pan across already-visited ground re-mounts the cached tiles instantly. It renders
+ * nothing until both a seed and a viewport exist.
  */
-function BiomeGroundPlane(props: Readonly<BiomeGroundPlaneProps>) {
-  const planeRef = useRef<BiomeGroundResources | null>(null);
-  const plane = (planeRef.current ??= buildBiomeGroundResources(props.field, props.viewport));
+export function BiomeGround() {
+  const userSeed = useUserSeed();
+  const viewport = useFogViewport();
 
-  useLayoutEffect(() => {
-    updateBiomeGroundPlane(plane, props.field, props.viewport);
-  }, [plane, props.field, props.viewport]);
-
-  useEffect(
-    () => () => {
-      plane.geometry.dispose();
-      plane.material.dispose();
-      plane.textureNode.value.dispose();
+  const entries = useChunkStream<BiomeChunkEntry>({
+    build: buildBiomeChunkEntry,
+    cacheCapacity: BIOME_CHUNK_CACHE_CAPACITY,
+    dispose: disposeBiomeChunkEntry,
+    onBuildTick: (buildMs) => {
+      scatterBuildStats.buildMs = buildMs;
     },
-    [plane],
-  );
+    userSeed,
+    viewport,
+  });
 
   return (
-    <mesh
-      geometry={plane.geometry}
-      material={plane.material}
-      position={[0, 0, BIOME_GROUND_ELEVATION]}
-    />
+    <>
+      {entries.map((entry) => (
+        <mesh
+          geometry={entry.geometry}
+          key={buildChunkKey(entry.chunkX, entry.chunkY)}
+          material={entry.material}
+          position={[0, 0, BIOME_GROUND_ELEVATION]}
+        />
+      ))}
+    </>
   );
-}
-
-function buildBiomeGroundResources(
-  field: BiomeField,
-  viewport: Readonly<Viewport>,
-): BiomeGroundResources {
-  const buffer: GroundBuffer = {
-    bytes: new Uint8Array(field.cols * field.rows * 4),
-    cols: field.cols,
-    rows: field.rows,
-  };
-
-  updateGroundBytes(buffer.bytes, field);
-
-  const textureNode = sceneTSL.texture(buildGroundTexture(buffer));
-
-  const material = new MeshBasicNodeMaterial();
-
-  material.colorNode = sceneTSL.toNode(textureNode);
-
-  return {
-    applied: { field, viewport },
-    buffer,
-    geometry: buildBiomeGroundGeometry(viewport),
-    material,
-    textureNode,
-  };
 }
 
 /**
- * A same-size field — every pan; only a zoom changes the texel dimensions — rewrites the live
- * texture's pixels in place: no new GPU texture, and no disposal of one a queued frame still binds.
- * Only a resize allocates a replacement, and the old texture is released only after the node stops
- * referencing it.
+ * One chunk's built ground content: the biome tint texture, its quad geometry, and the material
+ * binding them, sized and positioned to the chunk's own cell box. Built once and never mutated —
+ * unlike the single whole-viewport plane this layer replaced, a chunk tile never needs to rewrite
+ * itself in place, since a pan changes which chunks are on screen rather than any one chunk's
+ * content. `chunkX`/`chunkY` ride along so a rendered entry can key its mesh without re-deriving
+ * the coordinate the cache already resolved it by.
+ *
+ * A relief or scatter layer streamed from the same chunk grid extends this shape with its own
+ * fields — `useChunkStream`'s cache is generic over the entry type precisely so that extension
+ * needs no change here.
  */
-function updateBiomeGroundPlane(
-  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- the resources' buffer and texture-node value slot are mutable by design: rewriting them is how a rebuilt field reaches the live material
-  plane: BiomeGroundResources,
-  field: BiomeField,
-  viewport: Readonly<Viewport>,
-): void {
-  if (plane.applied.field === field && plane.applied.viewport === viewport) {
-    return;
-  }
+interface BiomeChunkEntry {
+  readonly chunkX: number;
+  readonly chunkY: number;
+  readonly geometry: BufferGeometry;
+  readonly material: MeshBasicNodeMaterial;
+  readonly texture: DataTexture;
+}
 
-  plane.applied = { field, viewport };
+function buildBiomeChunkEntry(userSeed: number, chunkX: number, chunkY: number): BiomeChunkEntry {
+  const box: Viewport = {
+    maxCX: chunkX * CHUNK_SIZE + CHUNK_SIZE - 1,
+    maxCY: chunkY * CHUNK_SIZE + CHUNK_SIZE - 1,
+    minCX: chunkX * CHUNK_SIZE,
+    minCY: chunkY * CHUNK_SIZE,
+  };
 
-  if (field.cols === plane.buffer.cols && field.rows === plane.buffer.rows) {
-    updateGroundBytes(plane.buffer.bytes, field);
+  const field = buildBiomeField(userSeed, box, { resolution: BIOME_TEXELS_PER_CELL });
+  const texture = buildGroundTexture(field);
 
-    plane.textureNode.value.needsUpdate = true;
-  } else {
-    plane.buffer.bytes = new Uint8Array(field.cols * field.rows * 4);
+  const material = new MeshBasicNodeMaterial();
 
-    plane.buffer.cols = field.cols;
-    plane.buffer.rows = field.rows;
+  material.colorNode = sceneTSL.toNode(sceneTSL.texture(texture));
 
-    updateGroundBytes(plane.buffer.bytes, field);
+  return {
+    chunkX,
+    chunkY,
+    geometry: buildBiomeChunkGeometry(box),
+    material,
+    texture,
+  };
+}
 
-    const previous = plane.textureNode.value;
-
-    plane.textureNode.value = buildGroundTexture(plane.buffer);
-
-    previous.dispose();
-  }
-
-  updateBiomeGroundGeometry(plane.geometry, viewport);
+function disposeBiomeChunkEntry(entry: Readonly<BiomeChunkEntry>): void {
+  entry.geometry.dispose();
+  entry.material.dispose();
+  entry.texture.dispose();
 }
 
 const BASE_TINT_HEXES: ReadonlyArray<string> = [
@@ -225,13 +155,27 @@ const MODIFIER_TINT = new Color(sceneColors.modifierOverlay);
  */
 const MODIFIER_OVERLAY_ALPHA = 0.35;
 
+function buildGroundTexture(field: Readonly<BiomeField>): DataTexture {
+  const bytes = new Uint8Array(field.cols * field.rows * 4);
+
+  updateGroundBytes(bytes, field);
+
+  const map = new DataTexture(bytes, field.cols, field.rows, RGBAFormat, UnsignedByteType);
+
+  map.magFilter = LinearFilter;
+  map.minFilter = LinearFilter;
+  map.needsUpdate = true;
+
+  return map;
+}
+
 /**
  * CPU-mixes each texel's RGBA byte: the base tint blended toward the border neighbour's tint by
  * half `blendT`, then the modifier tint overlaid at `MODIFIER_OVERLAY_ALPHA` where the modifier
  * layer drew non-`none`. Alpha is always opaque — the ground plane replaces the floor's color
  * within its footprint outright, it never shows the floor through.
  */
-function updateGroundBytes(bytes: Uint8Array, field: BiomeField): void {
+function updateGroundBytes(bytes: Uint8Array, field: Readonly<BiomeField>): void {
   const count = field.cols * field.rows;
 
   for (let index = 0; index < count; index++) {
@@ -265,53 +209,33 @@ function getBaseTint(id: number): Color {
   return tint;
 }
 
-// oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- the buffer is mutable by design: it backs the live texture's pixel storage
-function buildGroundTexture(buffer: GroundBuffer): DataTexture {
-  const map = new DataTexture(buffer.bytes, buffer.cols, buffer.rows, RGBAFormat, UnsignedByteType);
-
-  map.magFilter = LinearFilter;
-  map.minFilter = LinearFilter;
-  map.needsUpdate = true;
-
-  return map;
-}
-
 /**
- * One parallelogram quad whose attribute buffers live as long as the geometry: the position
- * attribute is rewritten in place on every later viewport change, since replacing an attribute
- * object strands its GPU buffer until the whole geometry is disposed.
+ * One parallelogram quad covering the chunk's cell box in scene space, the same axial-to-uv mapping
+ * `buildBiomeField` samples its texels from — built once, since a chunk entry's box never changes
+ * after the entry is built.
  */
-function buildBiomeGroundGeometry(viewport: Readonly<Viewport>): BufferGeometry {
-  const geometry = new BufferGeometry();
-
-  geometry.setAttribute('position', new BufferAttribute(new Float32Array(12), 3));
-  geometry.setAttribute('uv', new BufferAttribute(new Float32Array([0, 0, 1, 0, 0, 1, 1, 1]), 2));
-  geometry.setIndex([0, 1, 2, 2, 1, 3]);
-
-  updateBiomeGroundGeometry(geometry, viewport);
-
-  return geometry;
-}
-
-/**
- * Rewrites the quad's corners to cover the viewport's cell box in scene space, the same axial-to-uv
- * mapping `buildBiomeField` samples its texels from.
- */
-function updateBiomeGroundGeometry(geometry: BufferGeometry, viewport: Readonly<Viewport>): void {
+function buildBiomeChunkGeometry(box: Readonly<Viewport>): BufferGeometry {
   const corners = [
-    toHexPosition(viewport.minCX - 0.5, viewport.minCY - 0.5),
-    toHexPosition(viewport.maxCX + 0.5, viewport.minCY - 0.5),
-    toHexPosition(viewport.minCX - 0.5, viewport.maxCY + 0.5),
-    toHexPosition(viewport.maxCX + 0.5, viewport.maxCY + 0.5),
+    toHexPosition(box.minCX - 0.5, box.minCY - 0.5),
+    toHexPosition(box.maxCX + 0.5, box.minCY - 0.5),
+    toHexPosition(box.minCX - 0.5, box.maxCY + 0.5),
+    toHexPosition(box.maxCX + 0.5, box.maxCY + 0.5),
   ];
 
-  const position = geometry.getAttribute('position');
+  const positions = new Float32Array(12);
 
   for (const [index, [x, y]] of corners.entries()) {
-    position.setXYZ(index, x * NODE_POSITION_SCALING_FACTOR, y * NODE_POSITION_SCALING_FACTOR, 0);
+    positions[index * 3] = x * NODE_POSITION_SCALING_FACTOR;
+    positions[index * 3 + 1] = y * NODE_POSITION_SCALING_FACTOR;
+    positions[index * 3 + 2] = 0;
   }
 
-  position.needsUpdate = true;
+  const geometry = new BufferGeometry();
 
+  geometry.setAttribute('position', new BufferAttribute(positions, 3));
+  geometry.setAttribute('uv', new BufferAttribute(new Float32Array([0, 0, 1, 0, 0, 1, 1, 1]), 2));
+  geometry.setIndex([0, 1, 2, 2, 1, 3]);
   geometry.computeBoundingSphere();
+
+  return geometry;
 }

--- a/libs/game/worldmap-client/src/scatter-build-stats.ts
+++ b/libs/game/worldmap-client/src/scatter-build-stats.ts
@@ -1,10 +1,12 @@
 import type { ScatterBuildStats } from './types';
 
 /**
- * Mutable scatter-build telemetry the perf HUD samples from the frame loop. This stays out of the
- * Zustand store because of write cadence: the scatter build pipeline writes on every chunk rebuild
- * — not a React state transition — and the one consumer reads imperatively each frame, so a store
- * subscription would add churn without buying any reactivity.
+ * Mutable chunk-build telemetry the perf HUD samples from the frame loop. This stays out of the
+ * Zustand store because of write cadence: a chunk-stream layer writes on every progressive-build
+ * tick — not a React state transition — and the one consumer reads imperatively each frame, so a
+ * store subscription would add churn without buying any reactivity. `buildMs` carries whichever
+ * layer built most recently; `glowCount` and `partCount` stay at their default until a scatter
+ * layer streams instanced parts through the same chunk cache.
  */
 export const scatterBuildStats: ScatterBuildStats = {
   buildMs: 0,

--- a/libs/game/worldmap-client/src/utils/lru-map.test.ts
+++ b/libs/game/worldmap-client/src/utils/lru-map.test.ts
@@ -49,3 +49,74 @@ test('it overwrites an existing key without evicting another entry', () => {
   expect(map.get('b')).toBe(2);
   expect(map.size).toBe(2);
 });
+
+test('it calls onEvict with the value and key a capacity eviction drops', () => {
+  const evicted: Array<[string, number]> = [];
+
+  const map = new LRUMap<string, number>(2, (value, key) => {
+    evicted.push([key, value]);
+  });
+
+  map.set('a', 1);
+  map.set('b', 2);
+  map.set('c', 3);
+
+  expect(evicted).toStrictEqual([['a', 1]]);
+});
+
+test('it never calls onEvict for an overwrite of an existing key', () => {
+  const evicted: Array<[string, number]> = [];
+
+  const map = new LRUMap<string, number>(2, (value, key) => {
+    evicted.push([key, value]);
+  });
+
+  map.set('a', 1);
+  map.set('a', 2);
+
+  expect(evicted).toHaveLength(0);
+});
+
+test('it calls onEvict for every remaining entry when cleared', () => {
+  const evicted: Array<[string, number]> = [];
+
+  const map = new LRUMap<string, number>(4, (value, key) => {
+    evicted.push([key, value]);
+  });
+
+  map.set('a', 1);
+  map.set('b', 2);
+  map.clear();
+
+  expect(evicted).toIncludeSameMembers([
+    ['a', 1],
+    ['b', 2],
+  ]);
+
+  expect(map.size).toBe(0);
+});
+
+test('it calls onEvict when an entry is explicitly deleted', () => {
+  const evicted: Array<[string, number]> = [];
+
+  const map = new LRUMap<string, number>(4, (value, key) => {
+    evicted.push([key, value]);
+  });
+
+  map.set('a', 1);
+  map.delete('a');
+
+  expect(evicted).toStrictEqual([['a', 1]]);
+});
+
+test('it never calls onEvict for a delete that misses', () => {
+  const evicted: Array<[string, number]> = [];
+
+  const map = new LRUMap<string, number>(4, (value, key) => {
+    evicted.push([key, value]);
+  });
+
+  map.delete('missing');
+
+  expect(evicted).toHaveLength(0);
+});

--- a/libs/game/worldmap-client/src/utils/lru-map.ts
+++ b/libs/game/worldmap-client/src/utils/lru-map.ts
@@ -3,14 +3,23 @@
  * capacity removes the map's oldest entry, and a `get` hit re-inserts its entry so recently read
  * keys survive eviction. A stored `undefined` value is indistinguishable from a miss and gets no
  * recency refresh.
+ *
+ * An optional `onEvict` callback fires for every entry a caller loses access to through this map's
+ * own operations — a capacity eviction, an explicit `delete`, or a `clear` — so a map holding
+ * resources that must be released (a GPU texture, a subscription) never leaks one. It never fires
+ * for an overwrite: `set` on an existing key replaces its value without severing the map's hold on
+ * the key, so the caller decides whether the old value needs releasing.
  */
 export class LRUMap<K, V> extends Map<K, V> {
   readonly #capacity: number;
 
-  constructor(capacity: number) {
+  readonly #onEvict: ((value: V, key: K) => void) | undefined;
+
+  constructor(capacity: number, onEvict?: (value: V, key: K) => void) {
     super();
 
     this.#capacity = capacity;
+    this.#onEvict = onEvict;
   }
 
   override get(key: K): undefined | V {
@@ -30,13 +39,37 @@ export class LRUMap<K, V> extends Map<K, V> {
     if (super.has(key)) {
       super.delete(key);
     } else if (this.size >= this.#capacity) {
-      const oldestKey = super.keys().next().value;
+      const oldestEntry = super.entries().next().value;
 
-      if (oldestKey !== undefined) {
+      if (oldestEntry !== undefined) {
+        const [oldestKey, oldestValue] = oldestEntry;
+
         super.delete(oldestKey);
+        this.#onEvict?.(oldestValue, oldestKey);
       }
     }
 
     return super.set(key, value);
+  }
+
+  override delete(key: K): boolean {
+    const value = super.get(key);
+    const deleted = super.delete(key);
+
+    if (deleted && value !== undefined) {
+      this.#onEvict?.(value, key);
+    }
+
+    return deleted;
+  }
+
+  override clear(): void {
+    if (this.#onEvict) {
+      for (const [key, value] of super.entries()) {
+        this.#onEvict(value, key);
+      }
+    }
+
+    super.clear();
   }
 }

--- a/libs/game/worldmap-client/src/utils/lru-map.ts
+++ b/libs/game/worldmap-client/src/utils/lru-map.ts
@@ -4,11 +4,12 @@
  * keys survive eviction. A stored `undefined` value is indistinguishable from a miss and gets no
  * recency refresh.
  *
- * An optional `onEvict` callback fires for every entry a caller loses access to through this map's
- * own operations — a capacity eviction, an explicit `delete`, or a `clear` — so a map holding
- * resources that must be released (a GPU texture, a subscription) never leaks one. It never fires
- * for an overwrite: `set` on an existing key replaces its value without severing the map's hold on
- * the key, so the caller decides whether the old value needs releasing.
+ * An optional `onEvict` callback fires for every held entry a caller loses access to through this
+ * map's own operations — a capacity eviction, an explicit `delete`, or a `clear` — so a map holding
+ * resources that must be released (a GPU texture, a subscription) never leaks one. A stored
+ * `undefined` is not a held entry (it reads as a miss and takes no recency slot), so it never
+ * evicts. It never fires for an overwrite: `set` on an existing key replaces its value without
+ * severing the map's hold on the key, so the caller decides whether the old value needs releasing.
  */
 export class LRUMap<K, V> extends Map<K, V> {
   readonly #capacity: number;
@@ -52,6 +53,7 @@ export class LRUMap<K, V> extends Map<K, V> {
     return super.set(key, value);
   }
 
+  // oxlint-disable-next-line zgeoff/function-verb -- overrides Map.prototype.delete; the built-in name is the contract this subclass must keep
   override delete(key: K): boolean {
     const value = super.get(key);
     const deleted = super.delete(key);
@@ -63,6 +65,7 @@ export class LRUMap<K, V> extends Map<K, V> {
     return deleted;
   }
 
+  // oxlint-disable-next-line zgeoff/function-verb -- overrides Map.prototype.clear; the built-in name is the contract this subclass must keep
   override clear(): void {
     if (this.#onEvict) {
       for (const [key, value] of super.entries()) {


### PR DESCRIPTION
## Description

Closes #878

Adds a generic, LRU-evicted chunk-streaming framework (`libs/game/worldmap-client/src/chunk-stream/`) and migrates `BiomeGround` from a single whole-viewport plane onto per-chunk tiles streamed through it.

- `ChunkCache<TEntry>` wraps an extended `LRUMap` with capacity eviction and a `syncSeed` reset that disposes every entry on seed change (chunk keys don't carry the seed)
- `resolveChunkStream` resolves a viewport's cache hits/misses plus a one-chunk predictive-prefetch strip via a symmetric `Math.sign` movement check
- `useChunkStream` builds a bounded number of misses per animation frame, deferring the viewport with `useDeferredValue` and disposing the cache on unmount
- `LRUMap` gained an `onEvict` hook (capacity eviction, explicit `delete`, `clear`) so GPU-resource caches never leak
- `BiomeGround` now renders one mesh per cached chunk (`BiomeChunkEntry`: geometry + texture + material, built once); its build time feeds the existing `scatterBuildStats.buildMs`, now documented as general chunk-build telemetry
- Ground relief and scatter are out of scope; the framework and `BiomeChunkEntry` are generic enough for later issues to extend
- Added `dispose` and `sync` to the function-naming taxonomy; allow-listed `LRUMap`'s `delete`/`clear` overrides and `MeshBasicNodeMaterial` in `prefer-readonly-parameter-types`

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality

## Context

The #877 drag-pan Playwright benchmark was not run — it requires a real browser/GPU per its own doc comment, out of scope for this environment.
