### PR TITLE
docs(testing): ban test-file functions other than setupTest

### DIFF
--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -31,7 +31,9 @@ The rules below decide most situations; where they don't, these do:
   private helper, restructuring a loop — breaks no test.
 - Every mock is a divergence from reality: mock only what is genuinely out of reach, and keep it
   high-fidelity — correct codes, realistic shapes, shared types.
-- Test utilities are production code, extracted and tested with the same rigour.
+- Test utilities are production code: anything a test file would grow beyond a local `setupTest()`
+  moves to `test-utils/` with its own test, or it doesn't exist — an untested helper inside a test
+  file can be wrong in a way no test reports.
 - Assertions are the contract: one loose assertion makes the rest of the test theatre.
 
 ## Everywhere
@@ -73,8 +75,14 @@ The rules below decide most situations; where they don't, these do:
   a payload invalid for any reason passes the bare boolean.
 - An input that is neither a domain object nor a DTO — a plain argument, an options bag, a config —
   is written inline at the call site, even when tests repeat the literal; repeated data reads, an
-  opaque baseline doesn't. Test files declare no baseline-builder helpers and no module-level
-  fixtures shared between tests.
+  opaque baseline doesn't.
+- A test file declares no function other than a local `setupTest()`. Any other helper — a data or
+  baseline builder, an assertion wrapper, a render or mount wrapper — is inlined at the call site,
+  replaced by a registered matcher, or extracted to `test-utils/` with its own test. A shared mount
+  goes through the project render utils (`render`/`renderHook`), never a per-file `render<Thing>`; a
+  hook whose reactive input changes between renders is driven by a closure over a mutable local
+  re-passed to the project `renderHook` with a no-arg `hook.rerender()`, not a bespoke wrapper that
+  reaches for RTL `initialProps`.
 - A factory is called in the test that uses its value, never through a helper that pre-configures
   overrides — a second layer of defaults is a shadow factory the test site can't see.
 - `test-utils/factories/` holds only faker-defaulted plain-data `create-mock-*` factories. Runtime

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -78,13 +78,12 @@ The rules below decide most situations; where they don't, these do:
   opaque baseline doesn't.
 - A test file declares no function other than a local `setupTest()`, and no module-level fixture or
   baseline shared between tests. Any other helper — a data or baseline builder, an assertion
-  wrapper, a render or mount wrapper — is inlined at the call site, replaced by a registered matcher,
-  or extracted to `test-utils/` with its own test; shared data is written inline at each call site,
-  not hoisted to a module const. A shared mount
-  goes through the project render utils (`render`/`renderHook`), never a per-file `render<Thing>`; a
-  hook whose reactive input changes between renders is driven by a closure over a mutable local
-  re-passed to the project `renderHook` with a no-arg `hook.rerender()`, not a bespoke wrapper that
-  reaches for RTL `initialProps`.
+  wrapper, a render or mount wrapper — is inlined at the call site, replaced by a registered
+  matcher, or extracted to `test-utils/` with its own test; shared data is written inline at each
+  call site, not hoisted to a module const. A shared mount goes through the project render utils
+  (`render`/`renderHook`), never a per-file `render<Thing>`; a hook whose reactive input changes
+  between renders is driven by a closure over a mutable local re-passed to the project `renderHook`
+  with a no-arg `hook.rerender()`, not a bespoke wrapper that reaches for RTL `initialProps`.
 - A factory is called in the test that uses its value, never through a helper that pre-configures
   overrides — a second layer of defaults is a shadow factory the test site can't see.
 - `test-utils/factories/` holds only faker-defaulted plain-data `create-mock-*` factories. Runtime

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -76,9 +76,11 @@ The rules below decide most situations; where they don't, these do:
 - An input that is neither a domain object nor a DTO — a plain argument, an options bag, a config —
   is written inline at the call site, even when tests repeat the literal; repeated data reads, an
   opaque baseline doesn't.
-- A test file declares no function other than a local `setupTest()`. Any other helper — a data or
-  baseline builder, an assertion wrapper, a render or mount wrapper — is inlined at the call site,
-  replaced by a registered matcher, or extracted to `test-utils/` with its own test. A shared mount
+- A test file declares no function other than a local `setupTest()`, and no module-level fixture or
+  baseline shared between tests. Any other helper — a data or baseline builder, an assertion
+  wrapper, a render or mount wrapper — is inlined at the call site, replaced by a registered matcher,
+  or extracted to `test-utils/` with its own test; shared data is written inline at each call site,
+  not hoisted to a module const. A shared mount
   goes through the project render utils (`render`/`renderHook`), never a per-file `render<Thing>`; a
   hook whose reactive input changes between renders is driven by a closure over a mutable local
   re-passed to the project `renderHook` with a no-arg `hook.rerender()`, not a bespoke wrapper that


### PR DESCRIPTION
## Summary

Tightens the testing skill so a test file may declare no function other than a local `setupTest()` — closing the gap that let a per-file `render*` wrapper slip past the narrower "no baseline-builder helpers" wording.

- Generalizes the principle: anything a test would grow beyond `setupTest()` moves to `test-utils/` with its own test, or doesn't exist.
- Adds the bright-line rule, naming the render/mount case: shared mounts go through the project `render`/`renderHook`; a reactive hook input is driven by a closure + no-arg `hook.rerender()`, never a bespoke wrapper reaching for RTL `initialProps`.

Mirrors the canonical rule from pipelabs-docs (#40). Docs-only.

## Test plan

- [x] `bun run format:check` clean