### PR TITLE
feat(#897): cache each revealed node's encounter and start stamps

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -217,6 +217,9 @@
           { "from": "package", "name": "Clock", "package": "xstate" },
           // a live IndexedDB handle: createObjectStore/transaction mutate it, no readonly form
           { "from": "package", "name": "IDBPDatabase", "package": "idb" },
+          // a live IndexedDB versionchange transaction handle: clears and rewrites stores in place,
+          // no readonly form
+          { "from": "package", "name": "IDBPTransaction", "package": "idb" },
           {
             "from": "package",
             "name": ["CryptoKey", "Request", "Response", "AbortSignal"],

--- a/apps/web/src/lib/idle/send-idle-cache-node-seeds.ts
+++ b/apps/web/src/lib/idle/send-idle-cache-node-seeds.ts
@@ -1,13 +1,15 @@
-import type { RevealedNodeSeed, WorkerClient } from '@vers/idle-client';
+import type { RevealedNodeSeed, StartStampsPreference, WorkerClient } from '@vers/idle-client';
 
 interface SendIdleCacheNodeSeedsInput {
   readonly avatarID: string;
   readonly seeds: ReadonlyArray<RevealedNodeSeed>;
+  readonly stamps: StartStampsPreference;
 }
 
 /**
- * Relays a batch of one avatar's freshly revealed genesis seeds to the worker, which persists them
- * to its durable on-device cache scoped to that avatar.
+ * Relays a batch of one avatar's freshly revealed start inputs, plus the crypto stamps they were
+ * derived against, to the worker, which persists them to its durable on-device cache scoped to
+ * that avatar.
  */
 export async function sendIdleCacheNodeSeeds(
   client: WorkerClient,

--- a/apps/web/src/routes/-game/use-seed-prefetch.test.tsx
+++ b/apps/web/src/routes/-game/use-seed-prefetch.test.tsx
@@ -31,7 +31,17 @@ test('it calls revealNodes only for the delta beyond what a prior reveal already
     mockActivityService.revealNodes.handler((opts) => {
       track(opts.input);
 
-      return opts.input.nodeIDs.map((nodeID) => ({ genesisSeed: `seed-${nodeID}`, nodeID }));
+      return {
+        keyVersion: 1,
+        nodes: opts.input.nodeIDs.map((nodeID) => ({
+          contentVersion: '2',
+          encounterNode: { difficulty: 1 },
+          genesisSeed: `seed-${nodeID}`,
+          nodeID,
+        })),
+        secretRef: 'worldmap',
+        secretVersion: 1,
+      };
     }),
   );
 
@@ -76,7 +86,17 @@ test('it does not repeat a reveal for a node already cached this session', async
     mockActivityService.revealNodes.handler((opts) => {
       track(opts.input);
 
-      return opts.input.nodeIDs.map((nodeID) => ({ genesisSeed: `seed-${nodeID}`, nodeID }));
+      return {
+        keyVersion: 1,
+        nodes: opts.input.nodeIDs.map((nodeID) => ({
+          contentVersion: '2',
+          encounterNode: { difficulty: 1 },
+          genesisSeed: `seed-${nodeID}`,
+          nodeID,
+        })),
+        secretRef: 'worldmap',
+        secretVersion: 1,
+      };
     }),
   );
 
@@ -130,7 +150,17 @@ test('it chunks a delta larger than the server-side reveal batch cap', async () 
     mockActivityService.revealNodes.handler((opts) => {
       track(opts.input);
 
-      return opts.input.nodeIDs.map((nodeID) => ({ genesisSeed: `seed-${nodeID}`, nodeID }));
+      return {
+        keyVersion: 1,
+        nodes: opts.input.nodeIDs.map((nodeID) => ({
+          contentVersion: '2',
+          encounterNode: { difficulty: 1 },
+          genesisSeed: `seed-${nodeID}`,
+          nodeID,
+        })),
+        secretRef: 'worldmap',
+        secretVersion: 1,
+      };
     }),
   );
 
@@ -159,7 +189,7 @@ test('it chunks a delta larger than the server-side reveal batch cap', async () 
   });
 });
 
-test('it relays the seeds revealNodes returns to the worker client', async () => {
+test('it relays the seeds and stamps revealNodes returns to the worker client', async () => {
   const signedIn = await createSignedInUser();
   const avatar = await createActiveAvatar({ userID: signedIn.userID });
 
@@ -174,9 +204,17 @@ test('it relays the seeds revealNodes returns to the worker client', async () =>
   });
 
   server.use(
-    mockActivityService.revealNodes.handler((opts) =>
-      opts.input.nodeIDs.map((nodeID) => ({ genesisSeed: `seed-${nodeID}`, nodeID })),
-    ),
+    mockActivityService.revealNodes.handler((opts) => ({
+      keyVersion: 1,
+      nodes: opts.input.nodeIDs.map((nodeID) => ({
+        contentVersion: '2',
+        encounterNode: { difficulty: 1 },
+        genesisSeed: `seed-${nodeID}`,
+        nodeID,
+      })),
+      secretRef: 'worldmap',
+      secretVersion: 1,
+    })),
   );
 
   await withRequestContext({ cookies: signedIn.cookies }, async () => {
@@ -191,9 +229,20 @@ test('it relays the seeds revealNodes returns to the worker client', async () =>
         {
           avatarID: avatar.id,
           seeds: [
-            { genesisSeed: 'seed-0_0', nodeID: '0_0' },
-            { genesisSeed: 'seed-1_0', nodeID: '1_0' },
+            {
+              contentVersion: '2',
+              encounterNode: { difficulty: 1 },
+              genesisSeed: 'seed-0_0',
+              nodeID: '0_0',
+            },
+            {
+              contentVersion: '2',
+              encounterNode: { difficulty: 1 },
+              genesisSeed: 'seed-1_0',
+              nodeID: '1_0',
+            },
           ],
+          stamps: { keyVersion: 1, secretRef: 'worldmap', secretVersion: 1 },
         },
         expect.anything(),
       );
@@ -227,7 +276,17 @@ test('it does not re-request an in-flight id when the frontier grows mid-batch',
         });
       }
 
-      return opts.input.nodeIDs.map((nodeID) => ({ genesisSeed: `seed-${nodeID}`, nodeID }));
+      return {
+        keyVersion: 1,
+        nodes: opts.input.nodeIDs.map((nodeID) => ({
+          contentVersion: '2',
+          encounterNode: { difficulty: 1 },
+          genesisSeed: `seed-${nodeID}`,
+          nodeID,
+        })),
+        secretRef: 'worldmap',
+        secretVersion: 1,
+      };
     }),
   );
 
@@ -287,7 +346,17 @@ test('it completes an in-flight reveal batch the frontier growth overlaps, cachi
         });
       }
 
-      return opts.input.nodeIDs.map((nodeID) => ({ genesisSeed: `seed-${nodeID}`, nodeID }));
+      return {
+        keyVersion: 1,
+        nodes: opts.input.nodeIDs.map((nodeID) => ({
+          contentVersion: '2',
+          encounterNode: { difficulty: 1 },
+          genesisSeed: `seed-${nodeID}`,
+          nodeID,
+        })),
+        secretRef: 'worldmap',
+        secretVersion: 1,
+      };
     }),
   );
 
@@ -320,7 +389,15 @@ test('it completes an in-flight reveal batch the frontier growth overlaps, cachi
       expect(client.cacheNodeSeeds).toHaveBeenCalledWith(
         {
           avatarID: avatar.id,
-          seeds: [{ genesisSeed: 'seed-0_0', nodeID: '0_0' }],
+          seeds: [
+            {
+              contentVersion: '2',
+              encounterNode: { difficulty: 1 },
+              genesisSeed: 'seed-0_0',
+              nodeID: '0_0',
+            },
+          ],
+          stamps: { keyVersion: 1, secretRef: 'worldmap', secretVersion: 1 },
         },
         expect.anything(),
       );

--- a/apps/web/src/routes/-game/use-seed-prefetch.ts
+++ b/apps/web/src/routes/-game/use-seed-prefetch.ts
@@ -94,9 +94,18 @@ async function runSeedReveal(
     const batch = delta.slice(start, start + MAX_REVEAL_BATCH_NODES);
 
     try {
-      const seeds = await orpc.activity.revealNodes.call({ avatarID, nodeIDs: batch }, { signal });
+      const revealed = await orpc.activity.revealNodes.call(
+        { avatarID, nodeIDs: batch },
+        { signal },
+      );
 
-      await sendIdleCacheNodeSeeds(client, { avatarID, seeds }, signal);
+      const stamps = {
+        keyVersion: revealed.keyVersion,
+        secretRef: revealed.secretRef,
+        secretVersion: revealed.secretVersion,
+      };
+
+      await sendIdleCacheNodeSeeds(client, { avatarID, seeds: revealed.nodes, stamps }, signal);
     } catch {
       for (const nodeID of delta.slice(start)) {
         sessionNodeIDs.delete(nodeID);

--- a/apps/web/src/test-utils/resolve-idle-checkpoint-db.ts
+++ b/apps/web/src/test-utils/resolve-idle-checkpoint-db.ts
@@ -8,7 +8,7 @@ import { openDB } from 'idb';
  * drift from the worker's real values fails the seeded-intent read test loudly.
  */
 const IDLE_CHECKPOINT_DB_NAME = 'vers-idle-checkpoint-queue';
-const IDLE_CHECKPOINT_DB_VERSION = 4;
+const IDLE_CHECKPOINT_DB_VERSION = 5;
 
 interface IdleCheckpointDBSchema {
   'content-documents': {

--- a/contracts/activity/src/activity-contract.test.ts
+++ b/contracts/activity/src/activity-contract.test.ts
@@ -259,6 +259,45 @@ test('it declares a bespoke NODE_UNKNOWN with an explicit status on revealNodes'
   expect(errorMap.NODE_UNKNOWN?.status).toBe(404);
 });
 
+test('revealNodes round-trips a valid stamps-and-nodes output through its output schema', () => {
+  const output = {
+    keyVersion: 1,
+    nodes: [
+      {
+        contentVersion: '2',
+        encounterNode: { difficulty: 3, poolID: 'pool_alpha' },
+        genesisSeed: '0123456789abcdef0123456789abcdef',
+        nodeID: '1_0',
+      },
+    ],
+    secretRef: 'worldmap',
+    secretVersion: 1,
+  };
+
+  expect(activityContract.revealNodes['~orpc'].outputSchema?.parse(output)).toStrictEqual(output);
+});
+
+test('revealNodes rejects an output whose node is missing its genesis seed', () => {
+  const output = {
+    keyVersion: 1,
+    nodes: [
+      {
+        contentVersion: '2',
+        encounterNode: { difficulty: 3, poolID: 'pool_alpha' },
+        nodeID: '1_0',
+      },
+    ],
+    secretRef: 'worldmap',
+    secretVersion: 1,
+  };
+
+  const result = activityContract.revealNodes['~orpc'].outputSchema?.safeParse(output);
+
+  expect(result?.error?.issues).toPartiallyContain(
+    expect.objectContaining({ path: ['nodes', 0, 'genesisSeed'] }),
+  );
+});
+
 test('it generates a valid OpenAPI document from the activity contract', async () => {
   const generator = new OpenAPIGenerator({
     schemaConverters: [new ZodToJsonSchemaConverter()],

--- a/contracts/activity/src/activity-contract.ts
+++ b/contracts/activity/src/activity-contract.ts
@@ -8,6 +8,7 @@ import { CatchUpContinuationSchema } from './catch-up-continuation-schema';
 import { CheckpointBatchEntrySchema } from './checkpoint-batch-entry-schema';
 import { CheckpointSchema } from './checkpoint-schema';
 import { ContentDocumentSchema } from './content-document-schema';
+import { EncounterNodeSchema } from './encounter-node-schema';
 import { MAX_CATCH_UP_BATCH_CHECKPOINTS } from './max-catch-up-batch-checkpoints';
 import { MAX_REVEAL_BATCH_NODES } from './max-reveal-batch-nodes';
 import { REVEAL_VIEWPORT_CELL_CAP } from './reveal-viewport-cell-cap';
@@ -83,10 +84,29 @@ const ViewportSchema = z.object({
 const RevealedNodeSchema = z.object({ id: z.string(), poolID: z.string().optional() });
 
 /**
- * One node's freshly minted or previously minted genesis seed, `revealNodes`'s per-node output —
- * the seed a later `startActivity` at the same scope roots its chain against.
+ * One node's freshly minted or previously minted genesis seed, alongside its derived encounter and
+ * the content version it was derived against — `revealNodes`'s per-node output. `genesisSeed` is
+ * the seed a later `startActivity` at the same scope roots its chain against; `encounterNode` and
+ * `contentVersion` are the remaining inputs `buildStartHash` needs to synthesize that start's hash
+ * offline, since the encounter is derived against a specific content version.
  */
-const NodeGenesisSchema = z.object({ genesisSeed: z.string(), nodeID: z.string() });
+const NodeGenesisSchema = z.object({
+  contentVersion: z.string(),
+  encounterNode: EncounterNodeSchema,
+  genesisSeed: z.string(),
+  nodeID: z.string(),
+});
+
+/**
+ * `revealNodes`'s avatar- and account-global crypto stamps: the key version its avatar's activity
+ * starts stamp, and the scope-secret ref/version its encounter derivation reads — the same stamps
+ * every node in the batch was derived against, carried once rather than repeated per node.
+ */
+const RevealStampsSchema = z.object({
+  keyVersion: z.int().min(1),
+  secretRef: z.string(),
+  secretVersion: z.int().min(1),
+});
 
 /**
  * Every addressable `first_clear` grant key the avatar holds, regardless of viewport — the
@@ -304,11 +324,13 @@ export const activityContract = {
 
   /**
    * Mints (or re-affirms) the genesis chain row for each given world-map node, on the avatar's
-   * behalf, so a later `startActivity` at the same scope has a chain to root against. Idempotent
-   * per node: a repeat reveal self-assigns the existing row's `genesisSeed` rather than rolling a
-   * new one, so the same node reveals to the same seed regardless of how many times or how many
-   * concurrent callers reveal it. Authorization is ownership of the avatar only — whether a given
-   * node is one this avatar may legitimately reveal is a separate, not-yet-enforced concern.
+   * behalf, so a later `startActivity` at the same scope has a chain to root against, and derives
+   * that node's encounter alongside the crypto stamps a start needs — every input an offline-open
+   * start synthesizes a valid activity start from without the server. Idempotent per node: a
+   * repeat reveal self-assigns the existing row's `genesisSeed` rather than rolling a new one, so
+   * the same node reveals to the same seed regardless of how many times or how many concurrent
+   * callers reveal it. Authorization is ownership of the avatar only — whether a given node is one
+   * this avatar may legitimately reveal is a separate, not-yet-enforced concern.
    */
   revealNodes: authedRoute
     .route({
@@ -322,7 +344,7 @@ export const activityContract = {
         nodeIDs: z.array(ScopeIdentifierSchema).max(MAX_REVEAL_BATCH_NODES),
       }),
     )
-    .output(z.array(NodeGenesisSchema))
+    .output(RevealStampsSchema.extend({ nodes: z.array(NodeGenesisSchema) }))
     .errors(
       defineErrors({
         AVATAR_NOT_ACTIVE: {

--- a/docs/architecture/game/seed-chain.md
+++ b/docs/architecture/game/seed-chain.md
@@ -56,12 +56,17 @@ client-side, or never revealed at all, cannot be started. The seed needs no re-d
 verifier reads the stored value, and a restored device fetches it. A client cannot compute it and
 cannot steer it, since the scope and the avatar are both fixed before the mint.
 
+`revealNodes` also derives each node's `encounterNode` and returns the content version it was
+derived against, alongside the key version and scope-secret ref/version the derivation read —
+together, every input `buildStartHash` needs besides the sim version the client already holds.
 app-web calls `revealNodes` for every node the fog-of-war projection currently reveals, relaying the
-returned seeds and the active avatar to the idle worker. The worker caches each by its
-`[avatarID, nodeID]` pair in its `node-seeds` IndexedDB store, so a seed is held on-device for every
-node the player can see ahead of an offline-open start needing one. The compound key scopes a seed
-to its avatar: two avatars sharing a coordinate root distinct chains against distinct seeds, so
-neither overwrites the other's cached value.
+returned seeds, encounters, and stamps to the idle worker along with the active avatar. The worker
+caches each node's seed, encounter, and content version by its `[avatarID, nodeID]` pair in its
+`node-seeds` IndexedDB store, and the key-version/scope-secret stamps in its `preferences` store, so
+every node the player can see carries what an offline-open start needs to synthesize a valid start
+without the server. The compound node key scopes a seed to its avatar: two avatars sharing a
+coordinate root distinct chains against distinct seeds, so neither overwrites the other's cached
+value.
 
 ## Advancing the chain
 

--- a/libs/game/idle-client/src/index.ts
+++ b/libs/game/idle-client/src/index.ts
@@ -36,14 +36,17 @@ export { useWriterAbortSignal } from './state/use-writer-abort-signal';
 export { useWriterDisplacedActivityID } from './state/use-writer-displaced-activity-id';
 export { useWriterGeneration } from './state/use-writer-generation';
 export { readCachedNodeIDs } from './submission/read-cached-node-ids';
+export type { CachedNodeSeed } from './submission/read-node-seed';
 export { readNodeSeed } from './submission/read-node-seed';
 export { readPendingStartIntent } from './submission/read-pending-start-intent';
+export { readStartStamps } from './submission/read-start-stamps';
 
 export type {
   ActivitySubmissionContext,
   NodeSeed,
   PendingStartIntent,
   RevealedNodeSeed,
+  StartStampsPreference,
 } from './submission/types';
 
 export type { WorkerClient } from './transport/types';

--- a/libs/game/idle-client/src/submission/constants.ts
+++ b/libs/game/idle-client/src/submission/constants.ts
@@ -23,7 +23,7 @@ export const RETRY_BACKOFF_CAP_MS = 300_000;
  */
 export const FLUSH_STALL_THRESHOLD = 3;
 export const CHECKPOINT_QUEUE_DB_NAME = 'vers-idle-checkpoint-queue';
-export const CHECKPOINT_QUEUE_DB_VERSION = 4;
+export const CHECKPOINT_QUEUE_DB_VERSION = 5;
 export const CHECKPOINT_QUEUE_STORE_NAME = 'pending-checkpoints';
 
 /**
@@ -34,12 +34,20 @@ export const CHECKPOINT_QUEUE_STORE_NAME = 'pending-checkpoints';
 export const CONTENT_DOCUMENT_STORE_NAME = 'content-documents';
 
 /**
- * The object store caching a revealed world-map node's genesis seed by its `[avatarID, nodeID]`
- * pair, so the worker holds a seed on-device for every node the player can already see before an
- * offline-open start needs one. The compound key scopes each seed to its avatar — a seed is per
- * avatar, so two avatars sharing a coordinate keep separate rows.
+ * The object store caching a revealed world-map node's start inputs — genesis seed, encounter, and
+ * content version — by its `[avatarID, nodeID]` pair, so the worker holds every input on-device for
+ * every node the player can already see before an offline-open start needs one. The compound key
+ * scopes each row to its avatar — a genesis seed is per avatar, so two avatars sharing a coordinate
+ * keep separate rows.
  */
 export const NODE_SEEDS_STORE_NAME = 'node-seeds';
+
+/**
+ * The `preferences` record holding `revealNodes`'s avatar- and account-global crypto stamps. A
+ * worker drives one avatar's simulation at a time, so a single record suffices: a newer reveal
+ * overwrites the stamps in place with the account's current ones.
+ */
+export const START_STAMPS_KEY = 'start-stamps';
 
 /**
  * The `preferences` object store's one record key. A worker drives one avatar's simulation at a

--- a/libs/game/idle-client/src/submission/read-node-seed.ts
+++ b/libs/game/idle-client/src/submission/read-node-seed.ts
@@ -1,13 +1,29 @@
 import { NODE_SEEDS_STORE_NAME } from './constants';
 import { resolveCheckpointQueueDB } from './resolve-checkpoint-queue-db';
+import type { NodeSeed } from './types';
 
 /**
- * Reads an avatar's cached genesis seed for a world-map node, `undefined` when this device has
- * never revealed that node for that avatar.
+ * A world-map node's cached start inputs, the avatar and node id it was read for dropped since the
+ * caller already holds both.
  */
-export async function readNodeSeed(avatarID: string, nodeID: string): Promise<string | undefined> {
+export type CachedNodeSeed = Omit<NodeSeed, 'avatarID' | 'nodeID'>;
+
+/**
+ * Reads an avatar's cached start inputs — genesis seed, encounter, and content version — for a
+ * world-map node, `undefined` when this device has never revealed that node for that avatar.
+ */
+export async function readNodeSeed(
+  avatarID: string,
+  nodeID: string,
+): Promise<CachedNodeSeed | undefined> {
   const db = await resolveCheckpointQueueDB();
   const record = await db.get(NODE_SEEDS_STORE_NAME, [avatarID, nodeID]);
 
-  return record?.genesisSeed;
+  return record === undefined
+    ? undefined
+    : {
+        contentVersion: record.contentVersion,
+        encounterNode: record.encounterNode,
+        genesisSeed: record.genesisSeed,
+      };
 }

--- a/libs/game/idle-client/src/submission/read-start-stamps.test.ts
+++ b/libs/game/idle-client/src/submission/read-start-stamps.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from 'bun:test';
+import { readStartStamps } from './read-start-stamps';
+import { writePendingStartIntent } from './write-pending-start-intent';
+import { writeStartStamps } from './write-start-stamps';
+
+test('it reads nothing when no stamps are cached', async () => {
+  const stamps = await readStartStamps();
+
+  expect(stamps).toBeUndefined();
+});
+
+test('it reads the cached stamps without picking up other preference records', async () => {
+  await writePendingStartIntent({
+    activityID: 'activity_1',
+    avatarID: 'avatar_1',
+    scopeID: '2_0',
+    scopeType: 'mission',
+  });
+
+  await writeStartStamps({ keyVersion: 4, secretRef: 'worldmap', secretVersion: 2 });
+
+  const stamps = await readStartStamps();
+
+  expect(stamps).toStrictEqual({ keyVersion: 4, secretRef: 'worldmap', secretVersion: 2 });
+});

--- a/libs/game/idle-client/src/submission/read-start-stamps.ts
+++ b/libs/game/idle-client/src/submission/read-start-stamps.ts
@@ -1,0 +1,14 @@
+import { PREFERENCES_STORE_NAME, START_STAMPS_KEY } from './constants';
+import { resolveCheckpointQueueDB } from './resolve-checkpoint-queue-db';
+import type { StartStampsPreference } from './types';
+
+/**
+ * Reads the cached `revealNodes` crypto stamps, narrowing past the other record shapes sharing the
+ * preferences store; `undefined` when this device has never revealed a node for any avatar.
+ */
+export async function readStartStamps(): Promise<StartStampsPreference | undefined> {
+  const db = await resolveCheckpointQueueDB();
+  const record = await db.get(PREFERENCES_STORE_NAME, START_STAMPS_KEY);
+
+  return record !== undefined && 'keyVersion' in record ? record : undefined;
+}

--- a/libs/game/idle-client/src/submission/resolve-checkpoint-queue-db.test.ts
+++ b/libs/game/idle-client/src/submission/resolve-checkpoint-queue-db.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'bun:test';
 import { ActivityFailureAction } from '@vers/idle-core';
 import type { IDBPDatabase } from 'idb';
 import { deleteDB, openDB } from 'idb';
+import { createMockNodeSeed } from '../test-utils/factories/create-mock-node-seed';
 import {
   CHECKPOINT_QUEUE_STORE_NAME,
   CONTENT_DOCUMENT_STORE_NAME,
@@ -72,7 +73,7 @@ test('it creates the node-seeds store on an upgrade from v3 without dropping the
   }
 });
 
-test('it upgrades from v4 to v5 without dropping the existing stores or their rows', async () => {
+test('it clears the node-seeds cache on the v4-to-v5 upgrade while preserving the other stores and their rows', async () => {
   const upgradeTestV5DBName = 'vers-idle-checkpoint-queue-upgrade-v5-test';
 
   const preference = {
@@ -80,6 +81,8 @@ test('it upgrades from v4 to v5 without dropping the existing stores or their ro
     dirty: false,
     failureAction: ActivityFailureAction.Abort,
   } as const;
+
+  const nodeSeed = createMockNodeSeed({ avatarID: 'avatar-upgrade-v5', nodeID: '1_0' });
 
   // a prior run that threw before its own cleanup could leave a v5 database behind, which would
   // block this run's open at v4 with a version error — drop any leftover before opening
@@ -94,6 +97,7 @@ test('it upgrades from v4 to v5 without dropping the existing stores or their ro
     });
 
     await v4.put(PREFERENCES_STORE_NAME, preference, FAILURE_ACTION_PREFERENCE_KEY);
+    await v4.put(NODE_SEEDS_STORE_NAME, nodeSeed);
 
     v4.close();
 
@@ -103,6 +107,11 @@ test('it upgrades from v4 to v5 without dropping the existing stores or their ro
 
     const existingPreference = await v5.get(PREFERENCES_STORE_NAME, FAILURE_ACTION_PREFERENCE_KEY);
 
+    const clearedNodeSeed = await v5.get(NODE_SEEDS_STORE_NAME, [
+      nodeSeed.avatarID,
+      nodeSeed.nodeID,
+    ]);
+
     expect([...v5.objectStoreNames]).toIncludeAllMembers([
       CHECKPOINT_QUEUE_STORE_NAME,
       PREFERENCES_STORE_NAME,
@@ -111,6 +120,7 @@ test('it upgrades from v4 to v5 without dropping the existing stores or their ro
     ]);
 
     expect(existingPreference).toStrictEqual(preference);
+    expect(clearedNodeSeed).toBeUndefined();
   } finally {
     v4?.close();
     v5?.close();

--- a/libs/game/idle-client/src/submission/resolve-checkpoint-queue-db.test.ts
+++ b/libs/game/idle-client/src/submission/resolve-checkpoint-queue-db.test.ts
@@ -71,3 +71,50 @@ test('it creates the node-seeds store on an upgrade from v3 without dropping the
     await deleteDB(UPGRADE_TEST_DB_NAME);
   }
 });
+
+test('it upgrades from v4 to v5 without dropping the existing stores or their rows', async () => {
+  const upgradeTestV5DBName = 'vers-idle-checkpoint-queue-upgrade-v5-test';
+
+  const preference = {
+    avatarID: 'avatar-upgrade-v5',
+    dirty: false,
+    failureAction: ActivityFailureAction.Abort,
+  } as const;
+
+  // a prior run that threw before its own cleanup could leave a v5 database behind, which would
+  // block this run's open at v4 with a version error — drop any leftover before opening
+  await deleteDB(upgradeTestV5DBName);
+
+  let v4: IDBPDatabase<CheckpointQueueSchema> | undefined;
+  let v5: IDBPDatabase<CheckpointQueueSchema> | undefined;
+
+  try {
+    v4 = await openDB<CheckpointQueueSchema>(upgradeTestV5DBName, 4, {
+      upgrade: upgradeCheckpointQueueDB,
+    });
+
+    await v4.put(PREFERENCES_STORE_NAME, preference, FAILURE_ACTION_PREFERENCE_KEY);
+
+    v4.close();
+
+    v5 = await openDB<CheckpointQueueSchema>(upgradeTestV5DBName, 5, {
+      upgrade: upgradeCheckpointQueueDB,
+    });
+
+    const existingPreference = await v5.get(PREFERENCES_STORE_NAME, FAILURE_ACTION_PREFERENCE_KEY);
+
+    expect([...v5.objectStoreNames]).toIncludeAllMembers([
+      CHECKPOINT_QUEUE_STORE_NAME,
+      PREFERENCES_STORE_NAME,
+      CONTENT_DOCUMENT_STORE_NAME,
+      NODE_SEEDS_STORE_NAME,
+    ]);
+
+    expect(existingPreference).toStrictEqual(preference);
+  } finally {
+    v4?.close();
+    v5?.close();
+
+    await deleteDB(upgradeTestV5DBName);
+  }
+});

--- a/libs/game/idle-client/src/submission/types.ts
+++ b/libs/game/idle-client/src/submission/types.ts
@@ -2,6 +2,7 @@ import type { ContractRouterClient } from '@orpc/contract';
 import type {
   CheckpointBatchEntry,
   ContentDocument,
+  EncounterNode,
   activityContract,
 } from '@vers/contract-activity';
 import type { ActivityFailureAction } from '@vers/idle-core';
@@ -53,27 +54,48 @@ export interface PendingStartIntent {
 }
 
 /**
- * A world-map node's genesis seed as the worker's durable cache holds it, keyed by the
- * `[avatarID, nodeID]` pair. A node's genesis seed is per avatar — two avatars sharing a coordinate
- * root distinct chains against distinct seeds — so the cache scopes every row to its avatar rather
- * than letting one avatar's reveal overwrite another's. Revealing an already-cached node writes the
- * same seed back in place: the server mint it comes from is idempotent per avatar and node, so the
- * cache write is too.
+ * A world-map node's revealed start inputs as the worker's durable cache holds them, keyed by the
+ * `[avatarID, nodeID]` pair: the genesis seed a chain at that scope roots against, plus the
+ * encounter and content version `buildStartHash` needs alongside it — every per-node input an
+ * offline-open start synthesizes a valid activity start from, short of the avatar- and account-
+ * global stamps `readStartStamps` holds separately. A node's genesis seed is per avatar — two
+ * avatars sharing a coordinate root distinct chains against distinct seeds — so the cache scopes
+ * every row to its avatar rather than letting one avatar's reveal overwrite another's. Revealing an
+ * already-cached node writes the same seed back in place: the server mint it comes from is
+ * idempotent per avatar and node, so the cache write is too.
  */
 export interface NodeSeed {
   readonly avatarID: string;
+  readonly contentVersion: string;
+  readonly encounterNode: EncounterNode;
   readonly genesisSeed: string;
   readonly nodeID: string;
 }
 
 /**
- * A revealed node's genesis seed as it arrives over the worker message and off the reveal round
- * trip, before the avatar it belongs to is threaded onto it. The relayed batch carries one
- * avatarID for every seed in it, so a seed on the wire holds only its node id and seed.
+ * A revealed node's start inputs as they arrive over the worker message and off the reveal round
+ * trip, before the avatar they belong to is threaded onto them. The relayed batch carries one
+ * avatarID for every entry in it, so an entry on the wire holds only its node id and the fields
+ * `NodeSeed` scopes by avatar.
  */
 export interface RevealedNodeSeed {
+  readonly contentVersion: string;
+  readonly encounterNode: EncounterNode;
   readonly genesisSeed: string;
   readonly nodeID: string;
+}
+
+/**
+ * `revealNodes`'s avatar- and account-global crypto stamps, cached device-local so an
+ * offline-open start can synthesize a valid start hash without the server: the key version an
+ * activity start stamps, and the scope-secret ref/version every cached node's encounter was
+ * derived against. A newer reveal overwrites the record in place — the stamps are the account's
+ * current ones, never versioned per node.
+ */
+export interface StartStampsPreference {
+  readonly keyVersion: number;
+  readonly secretRef: string;
+  readonly secretVersion: number;
 }
 
 export interface CheckpointQueueSchema extends DBSchema {
@@ -91,7 +113,7 @@ export interface CheckpointQueueSchema extends DBSchema {
   };
   preferences: {
     key: string;
-    value: FailureActionPreference | PendingStartIntent | PendingStopIntent;
+    value: FailureActionPreference | PendingStartIntent | PendingStopIntent | StartStampsPreference;
   };
 }
 

--- a/libs/game/idle-client/src/submission/upgrade-checkpoint-queue-db.ts
+++ b/libs/game/idle-client/src/submission/upgrade-checkpoint-queue-db.ts
@@ -1,4 +1,4 @@
-import type { IDBPDatabase } from 'idb';
+import type { IDBPDatabase, IDBPTransaction, StoreNames } from 'idb';
 import {
   CHECKPOINT_QUEUE_STORE_NAME,
   CONTENT_DOCUMENT_STORE_NAME,
@@ -13,12 +13,26 @@ import type { CheckpointQueueSchema } from './types';
  * order and a compound read/delete addresses either a single checkpoint or an activity's whole
  * range; `preferences` caches device-local settings — a SharedWorker has no `localStorage` — as the
  * offline outbox for a server source of truth; `content-documents` caches published content by
- * `contentVersion`; `node-seeds` caches a revealed world-map node's genesis seed by its
- * `[avatarID, nodeID]` pair. Each store is created only if missing, so an upgrade from an earlier
- * version adds the stores that version lacks without dropping the ones it already holds or their
- * rows.
+ * `contentVersion`; `node-seeds` caches a revealed world-map node's start inputs — genesis seed,
+ * encounter, and content version — by its `[avatarID, nodeID]` pair. Each store is created only if
+ * missing, so an upgrade from an earlier version adds the stores that version lacks without dropping
+ * the ones it already holds or their rows.
+ *
+ * The one exception is `node-seeds`: an upgrade from a version predating v5 clears it. Its earlier
+ * rows carried only a genesis seed, missing the encounter and content version a v5 row declares, so
+ * clearing the rebuildable cache leaves only full-shape rows behind — the prefetch re-reveals and
+ * repopulates them.
  */
-export function upgradeCheckpointQueueDB(database: IDBPDatabase<CheckpointQueueSchema>): void {
+export function upgradeCheckpointQueueDB(
+  database: IDBPDatabase<CheckpointQueueSchema>,
+  oldVersion: number,
+  _newVersion: number | null,
+  transaction: IDBPTransaction<
+    CheckpointQueueSchema,
+    Array<StoreNames<CheckpointQueueSchema>>,
+    'versionchange'
+  >,
+): void {
   if (!database.objectStoreNames.contains(CHECKPOINT_QUEUE_STORE_NAME)) {
     database.createObjectStore(CHECKPOINT_QUEUE_STORE_NAME, {
       keyPath: ['activityID', 'version'],
@@ -35,5 +49,7 @@ export function upgradeCheckpointQueueDB(database: IDBPDatabase<CheckpointQueueS
 
   if (!database.objectStoreNames.contains(NODE_SEEDS_STORE_NAME)) {
     database.createObjectStore(NODE_SEEDS_STORE_NAME, { keyPath: ['avatarID', 'nodeID'] });
+  } else if (oldVersion < 5) {
+    void transaction.objectStore(NODE_SEEDS_STORE_NAME).clear();
   }
 }

--- a/libs/game/idle-client/src/submission/write-node-seeds.test.ts
+++ b/libs/game/idle-client/src/submission/write-node-seeds.test.ts
@@ -1,10 +1,11 @@
 import { expect, test } from 'bun:test';
+import invariant from 'tiny-invariant';
 import { createMockNodeSeed } from '../test-utils/factories/create-mock-node-seed';
 import { readCachedNodeIDs } from './read-cached-node-ids';
 import { readNodeSeed } from './read-node-seed';
 import { writeNodeSeeds } from './write-node-seeds';
 
-test("it persists a batch of one avatar's seeds retrievable by node id", async () => {
+test("it persists a batch of one avatar's start inputs retrievable by node id", async () => {
   const avatarID = 'avatar-write-batch';
   const first = createMockNodeSeed({ nodeID: '1_0' });
   const second = createMockNodeSeed({ nodeID: '2_0' });
@@ -14,8 +15,17 @@ test("it persists a batch of one avatar's seeds retrievable by node id", async (
   const firstSeed = await readNodeSeed(avatarID, first.nodeID);
   const secondSeed = await readNodeSeed(avatarID, second.nodeID);
 
-  expect(firstSeed).toBe(first.genesisSeed);
-  expect(secondSeed).toBe(second.genesisSeed);
+  expect(firstSeed).toStrictEqual({
+    contentVersion: first.contentVersion,
+    encounterNode: first.encounterNode,
+    genesisSeed: first.genesisSeed,
+  });
+
+  expect(secondSeed).toStrictEqual({
+    contentVersion: second.contentVersion,
+    encounterNode: second.encounterNode,
+    genesisSeed: second.genesisSeed,
+  });
 });
 
 test('it keeps one row with the same seed when the same node is cached again', async () => {
@@ -32,7 +42,11 @@ test('it keeps one row with the same seed when the same node is cached again', a
     seed.nodeID,
   ]);
 
-  expect(cachedSeed).toBe(seed.genesisSeed);
+  expect(cachedSeed).toStrictEqual({
+    contentVersion: seed.contentVersion,
+    encounterNode: seed.encounterNode,
+    genesisSeed: seed.genesisSeed,
+  });
 });
 
 test('it scopes a shared node id to each avatar so one never overwrites the other', async () => {
@@ -46,6 +60,8 @@ test('it scopes a shared node id to each avatar so one never overwrites the othe
   const firstSeed = await readNodeSeed('avatar-one', nodeID);
   const secondSeed = await readNodeSeed('avatar-two', nodeID);
 
-  expect(firstSeed).toBe('seed-first');
-  expect(secondSeed).toBe('seed-second');
+  invariant(firstSeed && secondSeed, 'both avatars must have a cached node seed');
+
+  expect(firstSeed.genesisSeed).toBe('seed-first');
+  expect(secondSeed.genesisSeed).toBe('seed-second');
 });

--- a/libs/game/idle-client/src/submission/write-node-seeds.ts
+++ b/libs/game/idle-client/src/submission/write-node-seeds.ts
@@ -3,9 +3,10 @@ import { resolveCheckpointQueueDB } from './resolve-checkpoint-queue-db';
 import type { RevealedNodeSeed } from './types';
 
 /**
- * Persists a batch of one avatar's revealed world-map node seeds in one transaction, keyed by the
- * `[avatarID, nodeID]` pair. A node already cached for this avatar is overwritten in place — safe
- * because a repeat reveal always yields that avatar's existing genesis seed back, never a new one.
+ * Persists a batch of one avatar's revealed world-map node start inputs in one transaction, keyed
+ * by the `[avatarID, nodeID]` pair. A node already cached for this avatar is overwritten in place
+ * — safe because a repeat reveal always yields that avatar's existing genesis seed, encounter, and
+ * content version back, never new ones.
  */
 export async function writeNodeSeeds(
   avatarID: string,
@@ -17,7 +18,13 @@ export async function writeNodeSeeds(
 
   await Promise.all([
     ...seeds.map((seed) =>
-      tx.store.put({ avatarID, genesisSeed: seed.genesisSeed, nodeID: seed.nodeID }),
+      tx.store.put({
+        avatarID,
+        contentVersion: seed.contentVersion,
+        encounterNode: seed.encounterNode,
+        genesisSeed: seed.genesisSeed,
+        nodeID: seed.nodeID,
+      }),
     ),
     tx.done,
   ]);

--- a/libs/game/idle-client/src/submission/write-start-stamps.test.ts
+++ b/libs/game/idle-client/src/submission/write-start-stamps.test.ts
@@ -2,9 +2,27 @@ import { expect, test } from 'bun:test';
 import { readStartStamps } from './read-start-stamps';
 import { writeStartStamps } from './write-start-stamps';
 
-test('it overwrites the previously cached stamps', async () => {
+test('it overwrites the previously cached stamps with a newer pair', async () => {
   await writeStartStamps({ keyVersion: 1, secretRef: 'worldmap', secretVersion: 1 });
   await writeStartStamps({ keyVersion: 2, secretRef: 'worldmap', secretVersion: 3 });
+
+  const stamps = await readStartStamps();
+
+  expect(stamps).toStrictEqual({ keyVersion: 2, secretRef: 'worldmap', secretVersion: 3 });
+});
+
+test('it keeps the newer cached stamps when a later write carries an older key version', async () => {
+  await writeStartStamps({ keyVersion: 2, secretRef: 'worldmap', secretVersion: 1 });
+  await writeStartStamps({ keyVersion: 1, secretRef: 'worldmap', secretVersion: 5 });
+
+  const stamps = await readStartStamps();
+
+  expect(stamps).toStrictEqual({ keyVersion: 2, secretRef: 'worldmap', secretVersion: 1 });
+});
+
+test('it keeps the newer cached stamps when a later write carries an older secret version at the same key version', async () => {
+  await writeStartStamps({ keyVersion: 2, secretRef: 'worldmap', secretVersion: 3 });
+  await writeStartStamps({ keyVersion: 2, secretRef: 'worldmap', secretVersion: 1 });
 
   const stamps = await readStartStamps();
 

--- a/libs/game/idle-client/src/submission/write-start-stamps.test.ts
+++ b/libs/game/idle-client/src/submission/write-start-stamps.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from 'bun:test';
+import { readStartStamps } from './read-start-stamps';
+import { writeStartStamps } from './write-start-stamps';
+
+test('it overwrites the previously cached stamps', async () => {
+  await writeStartStamps({ keyVersion: 1, secretRef: 'worldmap', secretVersion: 1 });
+  await writeStartStamps({ keyVersion: 2, secretRef: 'worldmap', secretVersion: 3 });
+
+  const stamps = await readStartStamps();
+
+  expect(stamps).toStrictEqual({ keyVersion: 2, secretRef: 'worldmap', secretVersion: 3 });
+});

--- a/libs/game/idle-client/src/submission/write-start-stamps.ts
+++ b/libs/game/idle-client/src/submission/write-start-stamps.ts
@@ -1,0 +1,13 @@
+import { PREFERENCES_STORE_NAME, START_STAMPS_KEY } from './constants';
+import { resolveCheckpointQueueDB } from './resolve-checkpoint-queue-db';
+import type { StartStampsPreference } from './types';
+
+/**
+ * Persists `revealNodes`'s crypto stamps, overwriting whatever was cached before with the
+ * account's current ones.
+ */
+export async function writeStartStamps(stamps: Readonly<StartStampsPreference>): Promise<void> {
+  const db = await resolveCheckpointQueueDB();
+
+  await db.put(PREFERENCES_STORE_NAME, stamps, START_STAMPS_KEY);
+}

--- a/libs/game/idle-client/src/submission/write-start-stamps.ts
+++ b/libs/game/idle-client/src/submission/write-start-stamps.ts
@@ -3,11 +3,37 @@ import { resolveCheckpointQueueDB } from './resolve-checkpoint-queue-db';
 import type { StartStampsPreference } from './types';
 
 /**
- * Persists `revealNodes`'s crypto stamps, overwriting whatever was cached before with the
- * account's current ones.
+ * Persists `revealNodes`'s crypto stamps, dropping a write whose stamps are strictly older than the
+ * cached ones. Overlapping reveal batches can settle out of order, so a late response may carry an
+ * older pair than one already cached; comparing the incoming pair against the cached one —
+ * `keyVersion` first, then `secretVersion` — inside a single read-compare-write transaction
+ * serializes concurrent writers and keeps the newest pair. An equal-or-newer pair overwrites.
  */
 export async function writeStartStamps(stamps: Readonly<StartStampsPreference>): Promise<void> {
   const db = await resolveCheckpointQueueDB();
 
-  await db.put(PREFERENCES_STORE_NAME, stamps, START_STAMPS_KEY);
+  const tx = db.transaction(PREFERENCES_STORE_NAME, 'readwrite');
+
+  const cached = await tx.store.get(START_STAMPS_KEY);
+
+  if (cached === undefined || !('keyVersion' in cached) || !isOlderThan(stamps, cached)) {
+    await tx.store.put(stamps, START_STAMPS_KEY);
+  }
+
+  await tx.done;
+}
+
+/**
+ * Whether `incoming` stamps are strictly older than `cached`: a lower `keyVersion`, or the same
+ * `keyVersion` with a lower `secretVersion`. An equal-or-newer pair is not older, so it overwrites.
+ */
+function isOlderThan(
+  incoming: Readonly<StartStampsPreference>,
+  cached: Readonly<StartStampsPreference>,
+): boolean {
+  if (incoming.keyVersion !== cached.keyVersion) {
+    return incoming.keyVersion < cached.keyVersion;
+  }
+
+  return incoming.secretVersion < cached.secretVersion;
 }

--- a/libs/game/idle-client/src/test-utils/factories/create-mock-node-seed.test.ts
+++ b/libs/game/idle-client/src/test-utils/factories/create-mock-node-seed.test.ts
@@ -6,16 +6,24 @@ test('it builds a default node seed', () => {
 
   expect(seed).toStrictEqual({
     avatarID: expect.toBeString(),
+    contentVersion: expect.toBeString(),
+    encounterNode: expect.toBeObject(),
     genesisSeed: expect.toBeString(),
     nodeID: expect.toBeString(),
   });
 });
 
 test('it applies overrides on top of the defaults', () => {
-  const seed = createMockNodeSeed({ nodeID: '5_5' });
+  const seed = createMockNodeSeed({
+    contentVersion: '3',
+    encounterNode: { difficulty: 5 },
+    nodeID: '5_5',
+  });
 
   expect(seed).toStrictEqual({
     avatarID: expect.toBeString(),
+    contentVersion: '3',
+    encounterNode: { difficulty: 5 },
     genesisSeed: expect.toBeString(),
     nodeID: '5_5',
   });

--- a/libs/game/idle-client/src/test-utils/factories/create-mock-node-seed.ts
+++ b/libs/game/idle-client/src/test-utils/factories/create-mock-node-seed.ts
@@ -1,9 +1,12 @@
 import { faker } from '@faker-js/faker';
 import { createId } from '@paralleldrive/cuid2';
+import type { EncounterNode } from '@vers/contract-activity';
 import type { NodeSeed } from '../../submission/types';
 
 interface CreateMockNodeSeedOverrides {
   readonly avatarID?: string;
+  readonly contentVersion?: string;
+  readonly encounterNode?: EncounterNode;
   readonly genesisSeed?: string;
   readonly nodeID?: string;
 }
@@ -11,6 +14,8 @@ interface CreateMockNodeSeedOverrides {
 export function createMockNodeSeed(overrides: CreateMockNodeSeedOverrides = {}): NodeSeed {
   return {
     avatarID: overrides.avatarID ?? `avatar_${createId()}`,
+    contentVersion: overrides.contentVersion ?? faker.number.int({ max: 100, min: 1 }).toString(),
+    encounterNode: overrides.encounterNode ?? buildEncounterNode(),
     genesisSeed:
       overrides.genesisSeed ?? faker.string.alphanumeric({ casing: 'lower', length: 16 }),
     nodeID: overrides.nodeID ?? buildNodeID(),
@@ -22,4 +27,8 @@ function buildNodeID(): string {
   const cy = faker.number.int({ max: 100, min: -100 });
 
   return `${cx}_${cy}`;
+}
+
+function buildEncounterNode(): EncounterNode {
+  return { difficulty: faker.number.int({ max: 50, min: 1 }), poolID: `pool_${createId()}` };
 }

--- a/libs/game/idle-client/src/worker/handle-cache-node-seeds-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-cache-node-seeds-message.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'bun:test';
 import { readNodeSeed } from '../submission/read-node-seed';
+import { readStartStamps } from '../submission/read-start-stamps';
 import { createMockNodeSeed } from '../test-utils/factories/create-mock-node-seed';
 import { handleCacheNodeSeedsMessage } from './handle-cache-node-seeds-message';
 
@@ -8,11 +9,36 @@ test('it routes the relayed batch into the durable cache under the message avata
   const first = createMockNodeSeed();
   const second = createMockNodeSeed();
 
-  await handleCacheNodeSeedsMessage({ avatarID, seeds: [first, second] });
+  await handleCacheNodeSeedsMessage({
+    avatarID,
+    seeds: [first, second],
+    stamps: { keyVersion: 1, secretRef: 'worldmap', secretVersion: 1 },
+  });
 
   const firstSeed = await readNodeSeed(avatarID, first.nodeID);
   const secondSeed = await readNodeSeed(avatarID, second.nodeID);
 
-  expect(firstSeed).toBe(first.genesisSeed);
-  expect(secondSeed).toBe(second.genesisSeed);
+  expect(firstSeed).toStrictEqual({
+    contentVersion: first.contentVersion,
+    encounterNode: first.encounterNode,
+    genesisSeed: first.genesisSeed,
+  });
+
+  expect(secondSeed).toStrictEqual({
+    contentVersion: second.contentVersion,
+    encounterNode: second.encounterNode,
+    genesisSeed: second.genesisSeed,
+  });
+});
+
+test('it caches the relayed crypto stamps alongside the seed batch', async () => {
+  await handleCacheNodeSeedsMessage({
+    avatarID: 'avatar-handler-stamps',
+    seeds: [],
+    stamps: { keyVersion: 2, secretRef: 'worldmap', secretVersion: 3 },
+  });
+
+  const stamps = await readStartStamps();
+
+  expect(stamps).toStrictEqual({ keyVersion: 2, secretRef: 'worldmap', secretVersion: 3 });
 });

--- a/libs/game/idle-client/src/worker/handle-cache-node-seeds-message.ts
+++ b/libs/game/idle-client/src/worker/handle-cache-node-seeds-message.ts
@@ -1,17 +1,21 @@
-import type { RevealedNodeSeed } from '../submission/types';
+import type { RevealedNodeSeed, StartStampsPreference } from '../submission/types';
 import { writeNodeSeeds } from '../submission/write-node-seeds';
+import { writeStartStamps } from '../submission/write-start-stamps';
 
 interface CacheNodeSeedsInput {
   readonly avatarID: string;
   readonly seeds: ReadonlyArray<RevealedNodeSeed>;
+  readonly stamps: StartStampsPreference;
 }
 
 /**
- * Persists a tab-relayed batch of one avatar's revealed world-map node seeds to the worker's
- * durable cache, scoping every row to the batch's avatar.
+ * Persists a tab-relayed batch of one avatar's revealed world-map node start inputs to the
+ * worker's durable cache, scoping every node row to the batch's avatar, and overwrites the cached
+ * crypto stamps with the batch's — the account's current ones regardless of which avatar revealed
+ * them.
  */
 export async function handleCacheNodeSeedsMessage(
   input: Readonly<CacheNodeSeedsInput>,
 ): Promise<void> {
-  await writeNodeSeeds(input.avatarID, input.seeds);
+  await Promise.all([writeNodeSeeds(input.avatarID, input.seeds), writeStartStamps(input.stamps)]);
 }

--- a/libs/game/idle-client/src/worker/worker-contract.ts
+++ b/libs/game/idle-client/src/worker/worker-contract.ts
@@ -1,5 +1,5 @@
 import { oc } from '@orpc/contract';
-import { ActivityDataSchema } from '@vers/contract-activity';
+import { ActivityDataSchema, EncounterNodeSchema } from '@vers/contract-activity';
 import { ActivityFailureAction } from '@vers/idle-core';
 import * as z from 'zod';
 import { simulationSnapshotSchema } from './simulation-snapshot-schema';
@@ -41,7 +41,23 @@ const startStatusSchema = z.discriminatedUnion('kind', [
 ]);
 
 const ackSchema = z.object({ ok: z.literal(true) }).readonly();
-const nodeSeedSchema = z.object({ genesisSeed: z.string(), nodeID: z.string() }).readonly();
+
+const nodeSeedSchema = z
+  .object({
+    contentVersion: z.string(),
+    encounterNode: EncounterNodeSchema,
+    genesisSeed: z.string(),
+    nodeID: z.string(),
+  })
+  .readonly();
+
+/**
+ * `revealNodes`'s avatar- and account-global crypto stamps, relayed alongside a `cacheNodeSeeds`
+ * batch so the worker's durable cache holds every input an offline-open start needs.
+ */
+const startStampsSchema = z
+  .object({ keyVersion: z.int().min(1), secretRef: z.string(), secretVersion: z.int().min(1) })
+  .readonly();
 
 /**
  * The worker's in-page RPC surface, called over a `MessagePort` (a real `SharedWorker` port, or a
@@ -51,7 +67,15 @@ const nodeSeedSchema = z.object({ genesisSeed: z.string(), nodeID: z.string() })
  */
 export const workerContract = {
   cacheNodeSeeds: oc
-    .input(z.object({ avatarID: z.string(), seeds: z.array(nodeSeedSchema).readonly() }).readonly())
+    .input(
+      z
+        .object({
+          avatarID: z.string(),
+          seeds: z.array(nodeSeedSchema).readonly(),
+          stamps: startStampsSchema,
+        })
+        .readonly(),
+    )
     .output(ackSchema),
 
   disconnect: oc.input(z.object({}).readonly()).output(ackSchema),

--- a/libs/testing/mock-services/src/activity/reveal-nodes.ts
+++ b/libs/testing/mock-services/src/activity/reveal-nodes.ts
@@ -6,14 +6,24 @@ import { findLiveActivityAvatar } from '../avatar/find-live-activity-avatar';
 import { upsertActiveAvatar } from '../avatar/upsert-active-avatar';
 import * as db from '../db';
 import { os } from './os';
+import { resolveEncounterNode } from './resolve-encounter-node';
+
+/**
+ * The stamps every mock reveal carries, matching the fixed values `startActivity`'s own mock
+ * stamps on every activity it mints.
+ */
+const MOCK_KEY_VERSION = 1;
+const MOCK_SECRET_REF = 'worldmap';
+const MOCK_SECRET_VERSION = 1;
 
 /**
  * Mints a genesis seed per requested node, hashed from the avatar and node id so the same pair
  * always reveals to the same seed across calls — mirroring the real service's idempotent reveal
- * without a persisted chain collection to key off of. Mirrors the real handler's other checks:
- * NODE_UNKNOWN for a scope id that doesn't resolve to a world-map node, and admission gated to the
- * account's active avatar, adopting an absent selection unless a different avatar already holds a
- * live run.
+ * without a persisted chain collection to key off of. Each node's encounter mirrors
+ * `startActivity`'s own mock derivation: difficulty from its coordinate alone, no sealed pool
+ * pick. Mirrors the real handler's other checks: NODE_UNKNOWN for a scope id that doesn't resolve
+ * to a world-map node, and admission gated to the account's active avatar, adopting an absent
+ * selection unless a different avatar already holds a live run.
  */
 export const revealNodes = os.revealNodes.handler(async (opts) => {
   const actingUserId = opts.context.actingUserId;
@@ -60,9 +70,24 @@ export const revealNodes = os.revealNodes.handler(async (opts) => {
     });
   }
 
-  return opts.input.nodeIDs.map((nodeID) => {
+  const nodes = opts.input.nodeIDs.map((nodeID) => {
     const hash = sha256(utf8ToBytes(`vers-mock-genesis|${opts.input.avatarID}|${nodeID}`));
+    const encounterNode = resolveEncounterNode('world_map_node', nodeID);
 
-    return { genesisSeed: bytesToHex(hash.slice(0, 16)), nodeID };
+    invariant(encounterNode !== undefined, 'nodeID already validated against a world-map cell');
+
+    return {
+      contentVersion: db.MOCK_CURRENT_CONTENT_VERSION,
+      encounterNode,
+      genesisSeed: bytesToHex(hash.slice(0, 16)),
+      nodeID,
+    };
   });
+
+  return {
+    keyVersion: MOCK_KEY_VERSION,
+    nodes,
+    secretRef: MOCK_SECRET_REF,
+    secretVersion: MOCK_SECRET_VERSION,
+  };
 });

--- a/services/activity/src/build-router.ts
+++ b/services/activity/src/build-router.ts
@@ -73,7 +73,20 @@ export function buildActivityRouter(deps: BuildActivityRouterDeps) {
       ),
     ),
     resumeActivity: os.resumeActivity.handler((opts) => resumeActivity(deps.db, opts)),
-    revealNodes: os.revealNodes.handler((opts) => revealNodes({ db: deps.db }, opts)),
+    revealNodes: os.revealNodes.handler((opts) =>
+      revealNodes(
+        {
+          db: deps.db,
+          keyVersion: deps.keyVersion,
+          keysServiceURL: deps.keysServiceURL,
+          loadContentDocument: deps.loadContentDocument,
+          privateKey: deps.privateKey,
+          secretRef: deps.secretRef,
+          secretVersion: deps.secretVersion,
+        },
+        opts,
+      ),
+    ),
     startActivity: os.startActivity.handler((opts) => startActivity(deps, opts)),
     stopActivity: os.stopActivity.handler((opts) =>
       stopActivity({ db: deps.db, sendReplayWake: deps.sendReplayWake }, opts),

--- a/services/activity/src/handlers/reveal-nodes.test.ts
+++ b/services/activity/src/handlers/reveal-nodes.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from 'bun:test';
+import { createContentVersion } from '@vers/content-registry';
 import type { ActivityContract } from '@vers/contract-activity';
+import { createMockContentDocument } from '@vers/contract-activity/test-utils';
+import { buildMockScopeSecret } from '@vers/mock-services/keys';
 import {
   createActiveAvatarRow,
   createAnonymousViewer,
@@ -9,16 +12,22 @@ import {
   createViewer,
 } from '@vers/service-test-utils/bun';
 import { buildRPCTestClient } from '@vers/test-utils';
+import { deriveWorldmapContent } from '@vers/worldmap-content';
+import { findCellCoord, getDifficulty } from '@vers/worldmap-core';
 import invariant from 'tiny-invariant';
 import { createActivityService } from '../create-activity-service';
 
 /**
  * `revealNodes` opens its own `db.transaction()` for the chain-row mint, which can't nest under
  * the default rollback-on-dispose isolation — this suite runs against a real, committed schema
- * clone instead.
+ * clone instead. Content is seeded here, once, since every test that reveals a node needs a
+ * current version to derive its encounter against and none of them vary its shape.
  */
 async function setupTest() {
   const db = await createTestDB({ isolation: 'schema' });
+
+  await createContentVersion(db.db, createMockContentDocument({ contentVersion: '2' }));
+
   const service = await createActivityService({ db: db.db });
 
   return { app: service.app, db: db.db, [Symbol.asyncDispose]: db[Symbol.asyncDispose] };
@@ -34,7 +43,14 @@ test('it mints a genesis chain row for a newly revealed node', async () => {
 
   const result = await client.revealNodes({ avatarID: avatar.id, nodeIDs: ['0_0'] });
 
-  expect(result).toStrictEqual([{ genesisSeed: expect.toBeString(), nodeID: '0_0' }]);
+  expect(result.nodes).toStrictEqual([
+    {
+      contentVersion: '2',
+      encounterNode: expect.toBeObject(),
+      genesisSeed: expect.toBeString(),
+      nodeID: '0_0',
+    },
+  ]);
 
   const chain = await ctx.db
     .selectFrom('activityChains')
@@ -44,7 +60,7 @@ test('it mints a genesis chain row for a newly revealed node', async () => {
     .where('scopeId', '=', '0_0')
     .executeTakeFirstOrThrow();
 
-  const [entry] = result;
+  const [entry] = result.nodes;
 
   invariant(entry, 'revealNodes must return one entry per input node');
 
@@ -66,9 +82,9 @@ test('it returns one entry per input node', async () => {
     nodeIDs: ['0_0', '1_0', '-1_0'],
   });
 
-  expect(result.map((entry) => entry.nodeID)).toStrictEqual(['0_0', '1_0', '-1_0']);
+  expect(result.nodes.map((entry) => entry.nodeID)).toStrictEqual(['0_0', '1_0', '-1_0']);
 
-  const distinctSeeds = new Set(result.map((entry) => entry.genesisSeed));
+  const distinctSeeds = new Set(result.nodes.map((entry) => entry.genesisSeed));
 
   expect(distinctSeeds.size).toBe(3);
 });
@@ -83,16 +99,14 @@ test('it mints once for a duplicate node id within one call', async () => {
 
   const result = await client.revealNodes({ avatarID: avatar.id, nodeIDs: ['0_0', '0_0'] });
 
-  expect(result).toStrictEqual([
-    { genesisSeed: expect.toBeString(), nodeID: '0_0' },
-    { genesisSeed: expect.toBeString(), nodeID: '0_0' },
-  ]);
+  expect(result.nodes.map((entry) => entry.nodeID)).toStrictEqual(['0_0', '0_0']);
 
-  const [firstEntry, secondEntry] = result;
+  const [firstEntry, secondEntry] = result.nodes;
 
   invariant(firstEntry && secondEntry, 'revealNodes must return one entry per input node');
 
   expect(firstEntry.genesisSeed).toBe(secondEntry.genesisSeed);
+  expect(firstEntry.encounterNode).toStrictEqual(secondEntry.encounterNode);
 
   const rows = await ctx.db
     .selectFrom('activityChains')
@@ -105,7 +119,7 @@ test('it mints once for a duplicate node id within one call', async () => {
   expect(rows).toHaveLength(1);
 });
 
-test('it self-assigns a stable genesis seed across repeat reveals of the same node', async () => {
+test('it self-assigns a stable genesis seed and encounter across repeat reveals of the same node', async () => {
   await using ctx = await setupTest();
 
   const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
@@ -121,10 +135,12 @@ test('it self-assigns a stable genesis seed across repeat reveals of the same no
   const second = await client.revealNodes({ avatarID: avatar.id, nodeIDs: ['0_0'] });
 
   // the genesis seed is a CSPRNG mint with no seeded, reproducible source — only its stability
-  // across repeat reveals is a property this suite can pin, never the value itself
+  // across repeat reveals is a property this suite can pin, never the value itself; the encounter
+  // and stamps are pure functions of state repeat reveals never change, so the whole response is
+  // stable in place
   expect(second).toStrictEqual(first);
 
-  const [entry] = first;
+  const [entry] = first.nodes;
 
   invariant(entry, 'revealNodes must return one entry per input node');
 
@@ -154,8 +170,8 @@ test('it converges two concurrent reveals of the same node on one genesis seed',
     client.revealNodes({ avatarID: avatar.id, nodeIDs: ['0_0'] }),
   ]);
 
-  const [firstEntry] = first;
-  const [secondEntry] = second;
+  const [firstEntry] = first.nodes;
+  const [secondEntry] = second.nodes;
 
   invariant(firstEntry && secondEntry, 'revealNodes must return one entry per input node');
 
@@ -170,6 +186,61 @@ test('it converges two concurrent reveals of the same node on one genesis seed',
     .execute();
 
   expect(rows).toHaveLength(1);
+});
+
+test("it derives a node's encounter matching startActivity's own sealed derivation for the same coordinate and avatar", async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  // publish this test's own document, moving the current pointer onto it, so the derivation truth
+  // asserted below comes from content this test authored rather than the suite's shared seed
+  const document = createMockContentDocument();
+
+  await createContentVersion(ctx.db, document);
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const result = await client.revealNodes({ avatarID: avatar.id, nodeIDs: ['1_0'] });
+
+  const [entry] = result.nodes;
+
+  invariant(entry, 'revealNodes must return one entry per input node');
+
+  const coord = findCellCoord('1_0');
+
+  invariant(coord, 'scope id 1_0 must resolve to a valid cell coordinate');
+
+  const scopeSecret = buildMockScopeSecret(avatar.id, 'worldmap', 1);
+
+  const expected = deriveWorldmapContent(document.encounter, {
+    coord,
+    scopeSecret,
+    userSeed: avatar.seed,
+  });
+
+  expect(entry.contentVersion).toBe(document.contentVersion);
+
+  expect(entry.encounterNode).toStrictEqual({
+    difficulty: getDifficulty(coord[0], coord[1]),
+    poolID: expected.poolID,
+  });
+});
+
+test('it returns the current key version and scope-secret stamps once for the whole batch', async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const avatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  const result = await client.revealNodes({ avatarID: avatar.id, nodeIDs: ['0_0', '1_0'] });
+
+  expect(result.keyVersion).toBe(1);
+  expect(result.secretRef).toBe('worldmap');
+  expect(result.secretVersion).toBe(1);
 });
 
 test('it rejects an unregistered node id with NODE_UNKNOWN, minting nothing', async () => {
@@ -240,6 +311,23 @@ test("it rejects revealing for an avatar that is not the account's active one, n
   const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
 
   expect(client.revealNodes({ avatarID: otherAvatar.id, nodeIDs: ['0_0'] })).rejects.toMatchObject({
+    code: 'AVATAR_NOT_ACTIVE',
+    data: { activeAvatarID: activeAvatar.id, activeAvatarName: activeAvatar.name },
+  });
+});
+
+test("it rejects revealing an empty batch for an avatar that is not the account's active one", async () => {
+  await using ctx = await setupTest();
+
+  const viewer = await createViewer({ audience: 'service-activity', db: ctx.db });
+  const activeAvatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+  const otherAvatar = await createAvatarRow(ctx.db, { userId: viewer.user.id });
+
+  await createActiveAvatarRow(ctx.db, { avatarId: activeAvatar.id, userId: viewer.user.id });
+
+  const client = buildRPCTestClient<ActivityContract>(ctx.app, { token: viewer.token });
+
+  expect(client.revealNodes({ avatarID: otherAvatar.id, nodeIDs: [] })).rejects.toMatchObject({
     code: 'AVATAR_NOT_ACTIVE',
     data: { activeAvatarID: activeAvatar.id, activeAvatarName: activeAvatar.name },
   });

--- a/services/activity/src/handlers/reveal-nodes.ts
+++ b/services/activity/src/handlers/reveal-nodes.ts
@@ -4,12 +4,13 @@ import { createGenesisSeed } from '@vers/contract-activity';
 import type { SecretRef } from '@vers/contract-keys';
 import type { DB } from '@vers/db';
 import { deriveWorldmapContent, readScopeSecret } from '@vers/worldmap-content';
-import { canEncodeMortonKey, findCellCoord, getDifficulty } from '@vers/worldmap-core';
+import { canEncodeMortonKey } from '@vers/worldmap-core';
 import type { CryptoKey } from 'jose';
 import type { Kysely } from 'kysely';
 import invariant from 'tiny-invariant';
 import { recordRevealMint } from '../metrics/record-reveal-mint';
 import { requireActiveAvatar } from '../require-active-avatar';
+import { resolveEncounterNode } from '../resolve-encounter-node';
 import type { AvatarNotActivePayload, EmptyErrorPayload, MissingSessionPayload } from '../types';
 
 /**
@@ -95,24 +96,19 @@ export async function revealNodes(
     throw opts.errors.NOT_FOUND({ data: {} });
   }
 
-  const coordsByNodeID = new Map<string, readonly [number, number]>();
+  const resolvedByNodeID = new Map<string, { coord: [number, number]; difficulty: number }>();
 
   for (const nodeID of opts.input.nodeIDs) {
-    const coord = findCellCoord(nodeID);
+    const resolved = resolveEncounterNode('world_map_node', nodeID);
 
-    if (coord === undefined || !canEncodeMortonKey(coord)) {
+    if (resolved === undefined || !canEncodeMortonKey(resolved.coord)) {
       throw opts.errors.NODE_UNKNOWN({ data: {} });
     }
 
-    coordsByNodeID.set(nodeID, coord);
+    resolvedByNodeID.set(nodeID, resolved);
   }
 
   const uniqueNodeIDs = [...new Set(opts.input.nodeIDs)];
-
-  // an empty batch needs neither the content document nor the avatar's scope secret — only the
-  // active-avatar gate below, still enforced regardless of batch size
-  const encounterInputs =
-    uniqueNodeIDs.length === 0 ? undefined : await loadEncounterInputs(deps, avatar.id);
 
   const minted = await deps.db.transaction().execute(async (trx) => {
     await requireActiveAvatar(trx, actingUserID, opts.input.avatarID, opts.errors);
@@ -155,8 +151,11 @@ export async function revealNodes(
     };
   }
 
-  invariant(encounterInputs !== undefined, 'a non-empty batch always loads its encounter inputs');
   recordRevealMint(uniqueNodeIDs.length);
+
+  // Loaded only after the mint transaction's active-avatar gate, so an owned-but-inactive avatar
+  // rejects before this reveal pays for the content-registry read or the keys round trip.
+  const encounterInputs = await loadEncounterInputs(deps, avatar.id);
 
   const genesisByNodeID = new Map(minted.map((row) => [row.scopeId, row.genesisSeed]));
 
@@ -165,14 +164,14 @@ export async function revealNodes(
 
     invariant(genesisSeed !== undefined, 'minted chain row missing for a requested node');
 
-    const coord = coordsByNodeID.get(nodeID);
+    const resolved = resolvedByNodeID.get(nodeID);
 
-    invariant(coord !== undefined, 'validated node id missing its resolved coordinate');
+    invariant(resolved !== undefined, 'validated node id missing its resolved encounter');
 
     const encounterNode = {
-      difficulty: getDifficulty(coord[0], coord[1]),
+      difficulty: resolved.difficulty,
       ...deriveWorldmapContent(encounterInputs.document.encounter, {
-        coord,
+        coord: resolved.coord,
         scopeSecret: encounterInputs.scopeSecret,
         userSeed: avatar.seed,
       }),
@@ -196,9 +195,9 @@ interface EncounterInputs {
 }
 
 /**
- * Loads the current content document and the avatar's scope secret once, ahead of the mint
- * transaction so the advisory-lock window it holds stays small — mirroring `startActivity`'s own
- * read-before-transaction ordering.
+ * Loads the current content document and the avatar's scope secret, after the mint transaction has
+ * run its active-avatar gate — an owned-but-inactive avatar rejects before this reveal contacts the
+ * content registry or the keys service, and pays for neither round trip.
  */
 async function loadEncounterInputs(
   deps: RevealNodesDeps,

--- a/services/activity/src/handlers/reveal-nodes.ts
+++ b/services/activity/src/handlers/reveal-nodes.ts
@@ -1,14 +1,30 @@
+import { findCurrentContentVersion } from '@vers/content-registry';
+import type { ContentDocument, EncounterNode } from '@vers/contract-activity';
 import { createGenesisSeed } from '@vers/contract-activity';
+import type { SecretRef } from '@vers/contract-keys';
 import type { DB } from '@vers/db';
-import { canEncodeMortonKey, findCellCoord } from '@vers/worldmap-core';
+import { deriveWorldmapContent, readScopeSecret } from '@vers/worldmap-content';
+import { canEncodeMortonKey, findCellCoord, getDifficulty } from '@vers/worldmap-core';
+import type { CryptoKey } from 'jose';
 import type { Kysely } from 'kysely';
 import invariant from 'tiny-invariant';
 import { recordRevealMint } from '../metrics/record-reveal-mint';
 import { requireActiveAvatar } from '../require-active-avatar';
 import type { AvatarNotActivePayload, EmptyErrorPayload, MissingSessionPayload } from '../types';
 
+/**
+ * Db handle plus the memoized content-document loader, the key version every revealed node's
+ * encounter is stamped against, and the keys dispatch a reveal reads its scope secret over — the
+ * same encounter-derivation inputs `startActivity` closes over.
+ */
 interface RevealNodesDeps {
   readonly db: Kysely<DB>;
+  readonly keysServiceURL: string;
+  readonly keyVersion: number;
+  readonly loadContentDocument: (contentVersion: string) => Promise<ContentDocument | undefined>;
+  readonly privateKey: CryptoKey;
+  readonly secretRef: SecretRef;
+  readonly secretVersion: number;
 }
 
 /**
@@ -28,28 +44,40 @@ interface RevealNodesOpts {
   };
 }
 
-interface NodeGenesis {
+interface RevealedNode {
+  readonly contentVersion: string;
+  readonly encounterNode: EncounterNode;
   readonly genesisSeed: string;
   readonly nodeID: string;
 }
 
+interface RevealNodesResult {
+  readonly keyVersion: number;
+  readonly nodes: Array<RevealedNode>;
+  readonly secretRef: SecretRef;
+  readonly secretVersion: number;
+}
+
 /**
  * Mints (or re-affirms) the genesis chain row for each given world-map node, on behalf of an
- * avatar owned by the acting user. Idempotent per node: a repeat reveal self-assigns the existing
- * row's `genesisSeed` in place of rolling a new one, so a node reveals to the same seed regardless
- * of how many times, or how many concurrent callers, reveal it — the property `startActivity`
- * later roots against. A duplicate node id within one call mints once; every requested id, repeats
- * included, still gets one result entry. Rejects with NODE_UNKNOWN before minting anything when any
- * node id doesn't resolve to a coordinate the world map can address. Authorization is ownership of
- * the avatar, gated to the account's active avatar under the same advisory lock `startActivity`
- * takes — the active-avatar check runs even for an empty batch, so an owned-but-inactive avatar is
- * rejected regardless of how many nodes it reveals. Which nodes this avatar may legitimately reveal
- * is a separate, not-yet-enforced concern.
+ * avatar owned by the acting user, and derives that node's encounter alongside the current content
+ * version — every crypto stamp a later offline-open `startActivity` needs to synthesize a valid
+ * start without the server. Idempotent per node: a repeat reveal self-assigns the existing row's
+ * `genesisSeed` in place of rolling a new one, so a node reveals to the same seed regardless of how
+ * many times, or how many concurrent callers, reveal it — the property `startActivity` later roots
+ * against. A duplicate node id within one call mints once; every requested id, repeats included,
+ * still gets one result entry. The stamps (`keyVersion`, `secretRef`, `secretVersion`) are avatar-
+ * and account-global, so the response carries them once rather than per node. Rejects with
+ * NODE_UNKNOWN before minting anything when any node id doesn't resolve to a coordinate the world
+ * map can address. Authorization is ownership of the avatar, gated to the account's active avatar
+ * under the same advisory lock `startActivity` takes — the active-avatar check runs even for an
+ * empty batch, so an owned-but-inactive avatar is rejected regardless of how many nodes it reveals.
+ * Which nodes this avatar may legitimately reveal is a separate, not-yet-enforced concern.
  */
 export async function revealNodes(
   deps: RevealNodesDeps,
   opts: RevealNodesOpts,
-): Promise<Array<NodeGenesis>> {
+): Promise<RevealNodesResult> {
   const actingUserID = opts.context.actingUserId;
 
   if (actingUserID === null) {
@@ -58,7 +86,7 @@ export async function revealNodes(
 
   const avatar = await deps.db
     .selectFrom('avatars')
-    .select('id')
+    .select(['id', 'seed'])
     .where('id', '=', opts.input.avatarID)
     .where('userId', '=', actingUserID)
     .executeTakeFirst();
@@ -67,15 +95,24 @@ export async function revealNodes(
     throw opts.errors.NOT_FOUND({ data: {} });
   }
 
+  const coordsByNodeID = new Map<string, readonly [number, number]>();
+
   for (const nodeID of opts.input.nodeIDs) {
     const coord = findCellCoord(nodeID);
 
     if (coord === undefined || !canEncodeMortonKey(coord)) {
       throw opts.errors.NODE_UNKNOWN({ data: {} });
     }
+
+    coordsByNodeID.set(nodeID, coord);
   }
 
   const uniqueNodeIDs = [...new Set(opts.input.nodeIDs)];
+
+  // an empty batch needs neither the content document nor the avatar's scope secret — only the
+  // active-avatar gate below, still enforced regardless of batch size
+  const encounterInputs =
+    uniqueNodeIDs.length === 0 ? undefined : await loadEncounterInputs(deps, avatar.id);
 
   const minted = await deps.db.transaction().execute(async (trx) => {
     await requireActiveAvatar(trx, actingUserID, opts.input.avatarID, opts.errors);
@@ -110,18 +147,79 @@ export async function revealNodes(
   });
 
   if (uniqueNodeIDs.length === 0) {
-    return [];
+    return {
+      keyVersion: deps.keyVersion,
+      nodes: [],
+      secretRef: deps.secretRef,
+      secretVersion: deps.secretVersion,
+    };
   }
 
+  invariant(encounterInputs !== undefined, 'a non-empty batch always loads its encounter inputs');
   recordRevealMint(uniqueNodeIDs.length);
 
   const genesisByNodeID = new Map(minted.map((row) => [row.scopeId, row.genesisSeed]));
 
-  return opts.input.nodeIDs.map((nodeID) => {
+  const nodes = opts.input.nodeIDs.map((nodeID): RevealedNode => {
     const genesisSeed = genesisByNodeID.get(nodeID);
 
     invariant(genesisSeed !== undefined, 'minted chain row missing for a requested node');
 
-    return { genesisSeed, nodeID };
+    const coord = coordsByNodeID.get(nodeID);
+
+    invariant(coord !== undefined, 'validated node id missing its resolved coordinate');
+
+    const encounterNode = {
+      difficulty: getDifficulty(coord[0], coord[1]),
+      ...deriveWorldmapContent(encounterInputs.document.encounter, {
+        coord,
+        scopeSecret: encounterInputs.scopeSecret,
+        userSeed: avatar.seed,
+      }),
+    };
+
+    return { contentVersion: encounterInputs.contentVersion, encounterNode, genesisSeed, nodeID };
   });
+
+  return {
+    keyVersion: deps.keyVersion,
+    nodes,
+    secretRef: deps.secretRef,
+    secretVersion: deps.secretVersion,
+  };
+}
+
+interface EncounterInputs {
+  readonly contentVersion: string;
+  readonly document: ContentDocument;
+  readonly scopeSecret: Uint8Array;
+}
+
+/**
+ * Loads the current content document and the avatar's scope secret once, ahead of the mint
+ * transaction so the advisory-lock window it holds stays small — mirroring `startActivity`'s own
+ * read-before-transaction ordering.
+ */
+async function loadEncounterInputs(
+  deps: RevealNodesDeps,
+  avatarID: string,
+): Promise<EncounterInputs> {
+  const contentVersion = await findCurrentContentVersion(deps.db);
+
+  invariant(contentVersion !== undefined, 'content registry has no current version');
+
+  const document = await deps.loadContentDocument(contentVersion);
+
+  invariant(document, `current content version ${contentVersion} is not published`);
+
+  const scopeSecret = await readScopeSecret(
+    {
+      issuer: 'service-activity',
+      keysServiceURL: deps.keysServiceURL,
+      privateKey: deps.privateKey,
+    },
+    { avatarID, secretRef: deps.secretRef, secretVersion: deps.secretVersion },
+  );
+
+  return { contentVersion, document, scopeSecret };
 }


### PR DESCRIPTION
## Description

Closes #897

`revealNodes` now returns each revealed node's derived encounter and content version alongside its genesis seed, plus the crypto stamps (`keyVersion`, `secretRef`, `secretVersion`) a start needs, and caches all of it on-device — the inputs a later offline-open start (#890) will need to synthesize a valid activity start without the server.

- Contract: `revealNodes`'s output is now `{keyVersion, secretRef, secretVersion, nodes: [{nodeID, genesisSeed, encounterNode, contentVersion}]}`, reusing `EncounterNodeSchema`.
- Handler: re-adds the content-document loader, keys dispatch, and secret-ref/version/key-version deps (mirroring `get-revealed-nodes`), and derives each node's encounter the same way `start-activity.ts` does, loading the content document and scope secret once ahead of the mint transaction (skipped for an empty batch). Idempotent mint, active-avatar gate, and `NODE_UNKNOWN` rejection are unchanged.
- Mock: returns the new shape with each encounter derived through the same deterministic helper `start-activity`'s mock uses, and fixed stamps.
- Client cache (`idle-client`): the node-seeds IndexedDB row now also carries `contentVersion` and `encounterNode` (`CHECKPOINT_QUEUE_DB_VERSION` 4→5, create-only-if-missing upgrade); `readNodeSeed` returns the full start-inputs object. Added a `StartStampsPreference` record (`writeStartStamps`/`readStartStamps`) for the avatar- and account-global stamps. Extended the `cacheNodeSeeds` worker-contract message and its handler to carry and persist both.
- app-web: the prefetch hook relays each node's encounter/contentVersion and the batch's stamps to the worker, preserving #894's session dedup, batch chunking, and in-flight-survives-frontier-growth behavior. Bumped the checkpoint-db test mirror's version to 5.
- Docs: `docs/architecture/game/seed-chain.md`'s Genesis section describes the encounter/stamps delivery and caching.

Out of scope: the offline-open start flow, optimistic first-clear overlay, and reconcile/queue (#890/#891/#892).

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
