### PR TITLE
docs: readable-register doc sweep and comment-placement policy

### DIFF
--- a/.claude/skills/docs-writing/SKILL.md
+++ b/.claude/skills/docs-writing/SKILL.md
@@ -9,20 +9,20 @@ description:
 
 Write for a cold reader: someone with none of the conversation, ticket, or diff that produced the
 doc, reading every sentence as if it had always existed. When a sentence needs that missing context
-to resolve, it fails review however clean it reads to you — as the author, your resolved mental model
-binds every referent, so the failure is invisible from the writing seat and you check for it
+to resolve, it fails review however clean it reads to you — as the author, your resolved mental
+model binds every referent, so the failure is invisible from the writing seat and you check for it
 deliberately.
 
 Aim for plain sentences with actors and verbs. Not telegraphic — keep the articles and the
 connective clauses — and not florid. The rules below make that register checkable. When a sentence
 fails one, redraft it from the facts it contains rather than patching it word by word; patching
-preserves the failed structure. The same holds at doc scale: when a doc fails, list what each section
-must say and rewrite the sections fresh.
+preserves the failed structure. The same holds at doc scale: when a doc fails, list what each
+section must say and rewrite the sections fresh.
 
 > **Note:** these docs are written by AI and read by humans. The rules are written to be executable
-> by the writer, so some phrasing is more precise than a human reader needs — line budgets, greppable
-> patterns, exact placeholder shapes. That precision is what makes a rule checkable rather than
-> aspirational.
+> by the writer, so some phrasing is more precise than a human reader needs — line budgets,
+> greppable patterns, exact placeholder shapes. That precision is what makes a rule checkable rather
+> than aspirational.
 
 Two passes govern every doc. **Selection** decides which points the doc makes; it is ruthless.
 **Rendering** decides how a surviving point is written — its sentences, its words, its shape, its
@@ -104,8 +104,8 @@ knife.
   State the abstraction alone only when no single instance can carry it.
 - **Address the reader in how-to prose.** Instructions say "you" and use imperatives ("seed it
   yourself", "call `seed()` if you'd rather not create data per test"). A how-to written without a
-  reader reads as a spec. Reference and design prose stay declarative — there the doc states what the
-  system is, not what the reader does.
+  reader reads as a spec. Reference and design prose stay declarative — there the doc states what
+  the system is, not what the reader does.
 - **Name the actor.** "The sweep drops each stranded machine and records the set removed", not
   "stranded machines are dropped and the removed set is recorded". Two shapes hide the actor: the
   passive — append "by monkeys" and a sentence that still parses is passive — and the disguised
@@ -193,8 +193,8 @@ knife.
 - **Delta-framing.** "Also", "as well as", "in addition", "now", "still" assert an addition or a
   change against a baseline. With the baseline stated in the same doc the framing is legal; with the
   baseline in the conversation, a prior draft, or the diff, the sentence documents the edit instead
-  of the system — write the resulting state. "New" qualifying a component ("the new endpoint") is the
-  word-scale form: it stales the moment the change merges, so name the component.
+  of the system — write the resulting state. "New" qualifying a component ("the new endpoint") is
+  the word-scale form: it stales the moment the change merges, so name the component.
 - **Banned words.** The AGENTS.md banned-words list applies to all prose; fix a violation on sight.
 
 ## Structure — the shape points take

--- a/.claude/skills/docs-writing/SKILL.md
+++ b/.claude/skills/docs-writing/SKILL.md
@@ -7,8 +7,22 @@ description:
 
 # Docs writing
 
-Write every sentence as if it had always existed, for a reader who saw none of the work that
-produced it.
+Write for a cold reader: someone with none of the conversation, ticket, or diff that produced the
+doc, reading every sentence as if it had always existed. When a sentence needs that missing context
+to resolve, it fails review however clean it reads to you — as the author, your resolved mental model
+binds every referent, so the failure is invisible from the writing seat and you check for it
+deliberately.
+
+Aim for plain sentences with actors and verbs. Not telegraphic — keep the articles and the
+connective clauses — and not florid. The rules below make that register checkable. When a sentence
+fails one, redraft it from the facts it contains rather than patching it word by word; patching
+preserves the failed structure. The same holds at doc scale: when a doc fails, list what each section
+must say and rewrite the sections fresh.
+
+> **Note:** these docs are written by AI and read by humans. The rules are written to be executable
+> by the writer, so some phrasing is more precise than a human reader needs — line budgets, greppable
+> patterns, exact placeholder shapes. That precision is what makes a rule checkable rather than
+> aspirational.
 
 Two passes govern every doc. **Selection** decides which points the doc makes; it is ruthless.
 **Rendering** decides how a surviving point is written — its sentences, its words, its shape, its
@@ -82,10 +96,23 @@ knife.
   sentence supports that point, and a sentence starting a new point starts a new paragraph. The
   test: reading only first sentences yields a correct coarse version of the doc.
 - **Lead with the fact.** The answer first, framing never — "Reuses the existing bucket", not "What
-  we want to do here is…".
-- **Active over passive.** "The sweep drops each stranded machine and records the set removed", not
-  "stranded machines are dropped and the removed set is recorded". The test: append "by monkeys" — a
-  sentence that still parses is passive.
+  we want to do here is…". An orientation clause ("To detect a stale artifact, …") is not
+  throat-clearing — it tells the reader where they are before the payload lands, so it stays.
+- **Show the rule in an instance.** When one concrete example carries a general rule, lead with the
+  example: "a request to `/admin/api/2026-07/graphql.json` is intercepted even though the schema is
+  pinned to `2026-01`" beats "handlers match any version segment and answer from the pinned schema".
+  State the abstraction alone only when no single instance can carry it.
+- **Address the reader in how-to prose.** Instructions say "you" and use imperatives ("seed it
+  yourself", "call `seed()` if you'd rather not create data per test"). A how-to written without a
+  reader reads as a spec. Reference and design prose stay declarative — there the doc states what the
+  system is, not what the reader does.
+- **Name the actor.** "The sweep drops each stranded machine and records the set removed", not
+  "stranded machines are dropped and the removed set is recorded". Two shapes hide the actor: the
+  passive — append "by monkeys" and a sentence that still parses is passive — and the disguised
+  activity, a copular sentence whose subject is really a verb someone performs ("a voice review is a
+  redraft" hides "when you review voice, you redraft"). A sentence stating a state or definition
+  ("the field is optional", "a point is a fact plus its rationale") has no actor — the copula is
+  correct there.
 - **Decisions read as decisions.** A made call never reads "may", "should", or "might" — hedged
   modals mark genuinely open options only. A conditional that defines criteria ("a change may be
   treated as standard-risk when…") is a definition, not a hedge.
@@ -114,6 +141,14 @@ knife.
   not "no drain delivers entries out of order" — a negated subject garden-paths. Noun stacks
   garden-path too: three bare nouns in a row unstack. A reduced relative clause appended after a
   dash takes "that" or "which".
+- **Unstack abstract nouns.** A chain of abstract nouns with nobody doing anything ("the escalation
+  path for consumers on diverging versions") stays opaque however precise it is. Rewrite it as a
+  clause with a subject and a verb ("what to do when a consuming repo needs a version the mock isn't
+  on").
+- **One verb per mechanism.** Joining unlike things under one vague verb ("carries", "handles",
+  "covers") makes them read as a matched pair sharing one mechanism, and the reader goes looking for
+  it. Where two things act differently, give each its own clause and verb: "the worker drops the
+  machine and records the removal", never "the worker handles the machine and the removal".
 - **Attribution takes a verb.** Name the owning doc or component as the subject: "the overview owns
   the boundaries", never "the boundaries are the overview's". A possessive on a markdown link ("the
   [sweep](url)'s seven readers") garden-paths twice over — put the link in a prepositional phrase
@@ -155,6 +190,11 @@ knife.
   - Template framing not specific to this doc ("The question most teams face is…").
   - Rhetorical questions setting up the answer the next sentence gives ("So why not cache it?
     Because…"). State the point.
+- **Delta-framing.** "Also", "as well as", "in addition", "now", "still" assert an addition or a
+  change against a baseline. With the baseline stated in the same doc the framing is legal; with the
+  baseline in the conversation, a prior draft, or the diff, the sentence documents the edit instead
+  of the system — write the resulting state. "New" qualifying a component ("the new endpoint") is the
+  word-scale form: it stales the moment the change merges, so name the component.
 - **Banned words.** The AGENTS.md banned-words list applies to all prose; fix a violation on sight.
 
 ## Structure — the shape points take

--- a/.claude/skills/verifier-service-socket/SKILL.md
+++ b/.claude/skills/verifier-service-socket/SKILL.md
@@ -50,9 +50,9 @@ issuer's public key under an issuer-named `kid` (`app-web`, `service-activity`, 
 Mint a throwaway keypair + tokens with a scratchpad script using `jose`: `generateKeyPair('EdDSA')`
 → `exportJWK`, wrap as `{"keys":[{...jwk, kid: "app-web"}]}`, then `SignJWT` with protected header
 `{ alg: 'EdDSA', kid: 'app-web' }`, issuer equal to the `kid`, audience = service name
-(`service-user`), and `sub` for an acting user (omit `sub` for anonymous). A token whose `iss` isn't
-a registered issuer, doesn't equal its `kid`, or is signed by a different issuer's key is rejected
-with a 401.
+(`service-user`), and `sub` for an acting user (omit `sub` for anonymous). The service rejects a
+token with a 401 when its `iss` isn't a registered issuer, doesn't equal its `kid`, or a different
+issuer's key signs it.
 
 ## Boot and drive
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,17 +194,17 @@ it.
 - Prefer the enforceable form. Before writing a comment, put the fact where a machine holds it:
   encode an outcome set as a discriminated union, a bound as a named constant, a caller rule as a
   type; protect a frozen wire or draw layout with a golden test. Comment only the residue neither a
-  type nor a test can hold, and where a test enforces an invariant, point at it rather than restating
-  the consequence.
+  type nor a test can hold, and where a test enforces an invariant, point at it rather than
+  restating the consequence.
 - Comment the decision, not the code. A comment states an invariant, cross-file or runtime behavior,
-  or why a non-obvious choice was made. One that restates the name, the signature, or the next line's
-  mechanics is a defect — delete it.
+  or why a non-obvious choice was made. One that restates the name, the signature, or the next
+  line's mechanics is a defect — delete it.
 - A long JSDoc block is a placement smell, not a prose exercise. When a declaration's comment runs
   long because it narrates the body, relocate: the mechanism to `//` at the lines, the enforceable
   parts into types or tests, leaving the block at the contract. A genuinely irreducible multi-point
-  contract stays — render it as structured prose (one point per paragraph, led by its topic sentence;
-  one fact per sentence; an outcome map or state-to-action table as a bullet list) and load the
-  `docs-writing` skill for its wording.
+  contract stays — render it as structured prose (one point per paragraph, led by its topic
+  sentence; one fact per sentence; an outcome map or state-to-action table as a bullet list) and
+  load the `docs-writing` skill for its wording.
 - JSDoc blocks are always multi-line (`/**` alone, one `*`-prefixed line per point, `*/` alone —
   never single-line `/** … */`), attached directly to the declaration they describe.
 - Comments describe the code as it is now — no history ("previously", "now uses"), no project state

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,20 +184,34 @@ Project-level additions to the shared function-naming taxonomy, under the same r
 
 ## Comments
 
-- Comments that document a declaration are JSDoc blocks, always multi-line (`/**` alone, one
-  `*`-prefixed line per point, `*/` alone — never single-line `/** … */`), attached directly to the
-  declaration they describe; `//` is for statement-level commentary inside bodies.
-- Comment a declaration only for what the file doesn't already show — an invariant, cross-file or
-  runtime behavior, or why the choice is necessary. A comment that restates the name or signature is
-  a defect — delete it.
+Two comment jobs, two locations. A JSDoc block on a declaration carries the caller-facing contract:
+what a reader needs to use the thing without opening its body — the guarantee, the invariants a
+caller must uphold, the failure modes. A `//` at a statement carries the implementation note: why
+that line does the non-obvious thing. A body's mechanism — how the algorithm walks, which step does
+what — is never narrated from the top; it lives at the lines, or nowhere when the code already shows
+it.
+
+- Prefer the enforceable form. Before writing a comment, put the fact where a machine holds it:
+  encode an outcome set as a discriminated union, a bound as a named constant, a caller rule as a
+  type; protect a frozen wire or draw layout with a golden test. Comment only the residue neither a
+  type nor a test can hold, and where a test enforces an invariant, point at it rather than restating
+  the consequence.
+- Comment the decision, not the code. A comment states an invariant, cross-file or runtime behavior,
+  or why a non-obvious choice was made. One that restates the name, the signature, or the next line's
+  mechanics is a defect — delete it.
+- A long JSDoc block is a placement smell, not a prose exercise. When a declaration's comment runs
+  long because it narrates the body, relocate: the mechanism to `//` at the lines, the enforceable
+  parts into types or tests, leaving the block at the contract. A genuinely irreducible multi-point
+  contract stays — render it as structured prose (one point per paragraph, led by its topic sentence;
+  one fact per sentence; an outcome map or state-to-action table as a bullet list) and load the
+  `docs-writing` skill for its wording.
+- JSDoc blocks are always multi-line (`/**` alone, one `*`-prefixed line per point, `*/` alone —
+  never single-line `/** … */`), attached directly to the declaration they describe.
 - Comments describe the code as it is now — no history ("previously", "now uses"), no project state
   (issue numbers, phase labels, "not wired yet"); those live in the commit message.
 - Comments don't name other declarations — renames strand the reference. State the contract instead:
   "callers must pass edits sorted last-to-first", not "(buildEditsFromAST's contract)". A
   declaration's own parameters and signature types are fine to name.
-- A comment past a few lines is structured prose: one point per paragraph, led by its topic
-  sentence; one fact per sentence; enumeration-shaped content (an outcome map, a state-to-action
-  table) as a bullet list. Load the `docs-writing` skill before writing or reworking one.
 
 ## Golden values in tests
 

--- a/agents/project.md
+++ b/agents/project.md
@@ -36,20 +36,34 @@ Project-level additions to the shared function-naming taxonomy, under the same r
 
 ## Comments
 
-- Comments that document a declaration are JSDoc blocks, always multi-line (`/**` alone, one
-  `*`-prefixed line per point, `*/` alone — never single-line `/** … */`), attached directly to the
-  declaration they describe; `//` is for statement-level commentary inside bodies.
-- Comment a declaration only for what the file doesn't already show — an invariant, cross-file or
-  runtime behavior, or why the choice is necessary. A comment that restates the name or signature is
-  a defect — delete it.
+Two comment jobs, two locations. A JSDoc block on a declaration carries the caller-facing contract:
+what a reader needs to use the thing without opening its body — the guarantee, the invariants a
+caller must uphold, the failure modes. A `//` at a statement carries the implementation note: why
+that line does the non-obvious thing. A body's mechanism — how the algorithm walks, which step does
+what — is never narrated from the top; it lives at the lines, or nowhere when the code already shows
+it.
+
+- Prefer the enforceable form. Before writing a comment, put the fact where a machine holds it:
+  encode an outcome set as a discriminated union, a bound as a named constant, a caller rule as a
+  type; protect a frozen wire or draw layout with a golden test. Comment only the residue neither a
+  type nor a test can hold, and where a test enforces an invariant, point at it rather than restating
+  the consequence.
+- Comment the decision, not the code. A comment states an invariant, cross-file or runtime behavior,
+  or why a non-obvious choice was made. One that restates the name, the signature, or the next line's
+  mechanics is a defect — delete it.
+- A long JSDoc block is a placement smell, not a prose exercise. When a declaration's comment runs
+  long because it narrates the body, relocate: the mechanism to `//` at the lines, the enforceable
+  parts into types or tests, leaving the block at the contract. A genuinely irreducible multi-point
+  contract stays — render it as structured prose (one point per paragraph, led by its topic sentence;
+  one fact per sentence; an outcome map or state-to-action table as a bullet list) and load the
+  `docs-writing` skill for its wording.
+- JSDoc blocks are always multi-line (`/**` alone, one `*`-prefixed line per point, `*/` alone —
+  never single-line `/** … */`), attached directly to the declaration they describe.
 - Comments describe the code as it is now — no history ("previously", "now uses"), no project state
   (issue numbers, phase labels, "not wired yet"); those live in the commit message.
 - Comments don't name other declarations — renames strand the reference. State the contract instead:
   "callers must pass edits sorted last-to-first", not "(buildEditsFromAST's contract)". A
   declaration's own parameters and signature types are fine to name.
-- A comment past a few lines is structured prose: one point per paragraph, led by its topic
-  sentence; one fact per sentence; enumeration-shaped content (an outcome map, a state-to-action
-  table) as a bullet list. Load the `docs-writing` skill before writing or reworking one.
 
 ## Golden values in tests
 

--- a/agents/project.md
+++ b/agents/project.md
@@ -46,17 +46,17 @@ it.
 - Prefer the enforceable form. Before writing a comment, put the fact where a machine holds it:
   encode an outcome set as a discriminated union, a bound as a named constant, a caller rule as a
   type; protect a frozen wire or draw layout with a golden test. Comment only the residue neither a
-  type nor a test can hold, and where a test enforces an invariant, point at it rather than restating
-  the consequence.
+  type nor a test can hold, and where a test enforces an invariant, point at it rather than
+  restating the consequence.
 - Comment the decision, not the code. A comment states an invariant, cross-file or runtime behavior,
-  or why a non-obvious choice was made. One that restates the name, the signature, or the next line's
-  mechanics is a defect — delete it.
+  or why a non-obvious choice was made. One that restates the name, the signature, or the next
+  line's mechanics is a defect — delete it.
 - A long JSDoc block is a placement smell, not a prose exercise. When a declaration's comment runs
   long because it narrates the body, relocate: the mechanism to `//` at the lines, the enforceable
   parts into types or tests, leaving the block at the contract. A genuinely irreducible multi-point
-  contract stays — render it as structured prose (one point per paragraph, led by its topic sentence;
-  one fact per sentence; an outcome map or state-to-action table as a bullet list) and load the
-  `docs-writing` skill for its wording.
+  contract stays — render it as structured prose (one point per paragraph, led by its topic
+  sentence; one fact per sentence; an outcome map or state-to-action table as a bullet list) and
+  load the `docs-writing` skill for its wording.
 - JSDoc blocks are always multi-line (`/**` alone, one `*`-prefixed line per point, `*/` alone —
   never single-line `/** … */`), attached directly to the declaration they describe.
 - Comments describe the code as it is now — no history ("previously", "now uses"), no project state

--- a/apps/bugsink/README.md
+++ b/apps/bugsink/README.md
@@ -47,8 +47,8 @@ webhook added in its settings. No outgoing email is configured — alerting is w
 per-project alert toggles live in each Bugsink project's settings.
 
 Bugsink's Discord messaging service renders a fixed body the app doesn't template, so these alerts
-keep their own shape rather than the structured embed the CI path posts to the same channel
-(`docs/architecture/platform/observability.md` § Alarms channel).
+keep their own shape rather than the structured embed the CI path posts to the same channel (see
+[Alarms channel](../../docs/architecture/platform/observability.md#alarms-channel)).
 
 ## Housekeeping
 

--- a/docs/architecture/game/game-entropy.md
+++ b/docs/architecture/game/game-entropy.md
@@ -12,8 +12,8 @@ and the [economy modes note](../../game-design/economy-modes.md) owns the reward
 
 The client is untrusted and holds the complete simulation. Any entropy the client can compute, the
 player can peek: simulate the future, inspect the outcome, and choose whether and where to play it.
-Look-ahead cannot be prevented in a deterministic client-simulated game: anything the client can
-describe, it can pre-compute. The design denies look-ahead its payoff instead of chasing it.
+A deterministic client-simulated game cannot prevent look-ahead: anything the client can describe,
+it can pre-compute. The design denies look-ahead its payoff instead of chasing it.
 
 A scanner does not play the average future. It simulates the future on every reachable node, across
 the whole offline window, and plays only the best one. Out of twenty thousand simulated futures the
@@ -44,7 +44,7 @@ the edge a re-attempt buys is bounded by the cost of reaching the position rathe
 The peek is free; the position is not:
 
 - An entry-gated target burns a non-refundable entry on every attempt, abandons included, so walking
-  the chain toward a favorable seed is paid for in resources.
+  the chain toward a favorable seed costs real resources.
 - A second competitive avatar is a full endgame build's worth of investment.
 - The counted attempt is always played in full.
 
@@ -94,8 +94,8 @@ positions — is [item generation](./item-generation.md).
 
 Key custody is the economy boundary:
 
-- **Server-held key** (trade avatars): the key never leaves the server, and a coordinate's content
-  is revealed only once the verifier settles its checkpoint, never at bare append
+- **Server-held key** (trade avatars): the key never leaves the server, and the verifier reveals a
+  coordinate's content only once it settles the checkpoint, never at bare append
   ([seed chain](./seed-chain.md)). A synced-but-unverified roll holds client-side as pending until
   then. Connected play settles a kill's rewards within a batch cadence; a return from offline
   settles the window's at once. No connectivity state changes what a committed reward is worth.
@@ -127,9 +127,9 @@ this design has.
 
 ### Version pinning
 
-Every roll is pinned by its activity's `Started` snapshot. `keyVersion` is stamped there beside the
-engine and content versions, and `f` resolves content under the pinned versions rather than the live
-deploy. So reveal, replay, and mint agree across deploys and root rotations.
+The activity's `Started` snapshot pins every roll, stamping `keyVersion` there beside the engine and
+content versions, and `f` resolves content under the pinned versions rather than the live deploy. So
+reveal, replay, and mint agree across deploys and root rotations.
 
 ## Sealed pre-commit salt
 
@@ -146,9 +146,9 @@ bounds how much the projection may reveal. Every decision happens against this m
 client never holds computable entropy while a decision is open.
 
 **Release.** The server resolves the outcome under the salt and returns the result; under server
-custody the salt itself never reaches the client. Release is commitment: a released position the
-client never resolves is force-resolved as forfeited — the bundle is lost — at a server-side
-deadline inside the replay-retention window.
+custody the salt itself never reaches the client. Release is commitment: at a server-side deadline
+inside the replay-retention window, the server force-resolves as forfeited any released position the
+client never resolves, and the bundle is lost.
 
 ### Keeping the seal honest
 
@@ -157,9 +157,9 @@ Three rules keep the seal honest, independent of what consumes it:
 - The salt's keying material is a server-held secret. Domain-separation labels alone are
   insufficient: salt derived from client-visible state under a different label is still
   client-computable, and the sealing property collapses.
-- Salt is minted once per position and re-fetch is idempotent. A client that loses the response
-  retries and receives the same salt, so a lost packet cannot fork the timeline; until the release
-  arrives, nothing resolves.
+- The server mints salt once per position, and re-fetch is idempotent. A client that loses the
+  response retries and receives the same salt, so a lost packet cannot fork the timeline; until the
+  release arrives, nothing resolves.
 - Every input the outcome depends on pins at mint, so deferring resolution cannot improve it.
 
 ### What the seal admits

--- a/docs/architecture/game/game-rendering.md
+++ b/docs/architecture/game/game-rendering.md
@@ -85,8 +85,8 @@ R3F is pinned to the v9 line, and three of its edges are walled off:
   container strands the children under React 19.
 
 drei and tunnel-rat are reference material, not dependencies. drei trails R3F majors and carries
-GLSL-era helpers the fallback can't run, and tunnel-rat is unmaintained. The project vendors or reimplements a helper worth
-keeping. Camera controls come from `yomotsu/camera-controls` directly.
+GLSL-era helpers the fallback can't run, and tunnel-rat is unmaintained. The project vendors or
+reimplements a helper worth keeping. Camera controls come from `yomotsu/camera-controls` directly.
 
 ## Scene ↔ DOM bridge
 

--- a/docs/architecture/game/game-rendering.md
+++ b/docs/architecture/game/game-rendering.md
@@ -85,8 +85,8 @@ R3F is pinned to the v9 line, and three of its edges are walled off:
   container strands the children under React 19.
 
 drei and tunnel-rat are reference material, not dependencies. drei trails R3F majors and carries
-GLSL-era helpers the fallback can't run, and tunnel-rat is unmaintained. A helper that earns its
-keep is vendored or reimplemented. Camera controls come from `yomotsu/camera-controls` directly.
+GLSL-era helpers the fallback can't run, and tunnel-rat is unmaintained. The project vendors or reimplements a helper worth
+keeping. Camera controls come from `yomotsu/camera-controls` directly.
 
 ## Scene ↔ DOM bridge
 

--- a/docs/architecture/game/worldmap.md
+++ b/docs/architecture/game/worldmap.md
@@ -95,8 +95,8 @@ grant table `(avatarId, landmarkId)`.
   result, but the completion table stays the source of truth.
 - Reveal discloses only after the predecessor completion verifies, never on optimistic completion.
   Disclosure carries expected-value-flat descriptor metadata alone — never salt or drops — and the
-  server caps its fan-out independent of node degree. An on-demand priority bump keeps the online path
-  responsive.
+  server caps its fan-out independent of node degree. An on-demand priority bump keeps the online
+  path responsive.
 
 ## Selection and the offline horizon
 

--- a/docs/architecture/game/worldmap.md
+++ b/docs/architecture/game/worldmap.md
@@ -47,7 +47,7 @@ that owns it.
   straight from its coordinates without generating any neighbour first, so regions load in any
   order. Nothing is baked; nothing is read from disk.
 - **Placement** — a hex grid carries one jittered node per cell. Every cell holds a node; visible
-  sparseness is a rendering choice, not an absence. Probabilistic existence is rejected: it
+  sparseness is a rendering choice, not an absence. The design rejects probabilistic existence: it
   reintroduces "does this id exist?" ambiguity and risks a fragmented graph.
 - **Connectivity** — a distance-capped [Gabriel graph](https://en.wikipedia.org/wiki/Gabriel_graph).
   Both sides of a chunk border evaluate the same predicate from the same hash inputs, so borders
@@ -94,8 +94,8 @@ grant table `(avatarId, landmarkId)`.
   sort order, so a 2D box reads as one 1D range. A per-chunk run-length reveal bitmask may cache the
   result, but the completion table stays the source of truth.
 - Reveal discloses only after the predecessor completion verifies, never on optimistic completion.
-  Disclosure carries expected-value-flat descriptor metadata alone — never salt or drops — and its
-  fan-out is capped independent of node degree. An on-demand priority bump keeps the online path
+  Disclosure carries expected-value-flat descriptor metadata alone — never salt or drops — and the
+  server caps its fan-out independent of node degree. An on-demand priority bump keeps the online path
   responsive.
 
 ## Selection and the offline horizon
@@ -167,9 +167,10 @@ assigns each node's biome; node jitter alone gives the drawn borders their organ
 - **Public biome-uniform term only** — biome touches reward only through a pure function of the
   public biome id, constant across every node in the biome, computable by every client. Biome may
   set a mean, publicly; it never rides hidden per-node variance.
-- **No hidden per-node reward** — a hidden per-node reward that clusters by biome is forbidden, and
-  the ban carries a permanent code comment. It would make client-visible terrain a treasure map for
-  sealed loot — the exact sniping fog prevents — and it is the cheapest form to build, so it tempts.
+- **No hidden per-node reward** — the design forbids a hidden per-node reward that clusters by
+  biome, and the ban carries a permanent code comment. It would make client-visible terrain a
+  treasure map for sealed loot — the exact sniping fog prevents — and it is the cheapest form to
+  build, so it tempts.
 - **Reroll defeated by progression cost** — the seed-selection attack (rerolling `userSeed` or
   spinning throwaway avatars for a favourable layout) is defeated by progression cost, not
   expected-value neutrality: a rerolled character starts at level 1, and using a fished

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -78,7 +78,7 @@ seals each node's content behind a per-avatar secret, so map shape reveals nothi
   carries a short-lived signed service token minted at the edge with the acting user's ID, and the
   runtime plugin in `@vers/service-runtime` verifies it before any handler runs
   ([auth](./services/auth.md)).
-- **Contracts** — each service's API is declared in its own `@vers/contract-*` package, oRPC
+- **Contracts** — each service declares its API in its own `@vers/contract-*` package, oRPC
   contract-first with Zod schemas owned by the declaring contract
   ([service contracts](./services/service-contracts.md)).
 - **Atomic release** — contracts are unversioned workspace source packages, and the repo deploys as
@@ -86,8 +86,8 @@ seals each node's content behind a per-avatar secret, so map shape reveals nothi
   divergence cannot land on `main`. There is no version matrix; the monorepo is the compatibility
   mechanism ([deployment](./platform/deployment.md)).
 - **Observability** — OpenTelemetry sends traces and logs to Axiom; the Sentry SDK sends errors to
-  Bugsink. Both are wired into every service by `@vers/service-runtime`, and request IDs propagate
-  from edge to service ([observability](./platform/observability.md)).
+  Bugsink. `@vers/service-runtime` wires both into every service, and request IDs propagate from
+  edge to service ([observability](./platform/observability.md)).
 
 ## Core technology
 

--- a/docs/architecture/platform/database.md
+++ b/docs/architecture/platform/database.md
@@ -17,10 +17,10 @@ connection after a suspend pays a resume cost.
 | Compute         | autoscaling 0.25–8 CU, scale-to-zero          |
 | Suspend timeout | 300s (Neon's default; `suspend_timeout` 0)    |
 
-The project, branches, compute endpoints, and roles are declared in the vers-infra Pulumi program
-(`infra/neon.ts`), applied with `pulumi up` from `infra/` and drift-checked by the infra-drift
-workflow. Databases, schemas, and migrations stay with the migration pipeline, and each role's
-in-database grants are SQL — the Neon API models role existence, not privileges.
+The vers-infra Pulumi program (`infra/neon.ts`) declares the project, branches, compute endpoints,
+and roles; `pulumi up` from `infra/` applies them, and the infra-drift workflow drift-checks them.
+Databases, schemas, and migrations stay with the migration pipeline, and each role's in-database
+grants are SQL — the Neon API models role existence, not privileges.
 
 Idle compute resumes on the next connection. A resume runs ~0.6–1.1s, observed from a Fly Sydney
 machine; once warm, queries run ~2ms and fresh connections ~55–70ms. Fly's idle-stop timing must not
@@ -103,7 +103,7 @@ A branch is a full copy-on-write postgres. Run migrations against it, introspect
 
 The `postgres` entry in `.mcp.json` runs `scripts/src/bin/pg-mcp-launch.ts`. That launcher renders a
 per-session dbhub config — DSNs read from 1Password, the dev source pinned to the worktree's
-database — and hands stdio to `@zgeoff/dbhub`. Both sources are lazy: a session that never queries
+database — and passes stdio to `@zgeoff/dbhub`. Both sources are lazy: a session that never queries
 postgres never opens a connection, and Neon stays suspended.
 
 - The `prod` source queries `vers` on the `main` branch as `mcp_ro`. Read-only holds at two

--- a/docs/architecture/platform/queues.md
+++ b/docs/architecture/platform/queues.md
@@ -12,8 +12,8 @@ consumer.
 it.
 
 - `defineJobs` declares a record mapping each job name to its
-  `{ schema, retryLimit, retryDelay, retryBackoff, deadLetter }`. The schema is a zod schema, and the
-  job name doubles as the queue name.
+  `{ schema, retryLimit, retryDelay, retryBackoff, deadLetter }`. The schema is a zod schema, and
+  the job name doubles as the queue name.
 - `createJobQueue(defs, config)` returns `start`, `stop`, `send`, and `drain`. The `config` carries
   the connection string, the per-job `handlers`, and optional `onError` and `onJobFailed` reporting
   callbacks. Every defined job needs a handler, and the handler receives the schema-parsed payload
@@ -23,8 +23,8 @@ it.
   rolls back with the domain write it belongs to.
 - `drain(name?)` runs one fetch/handle/complete loop and returns `{ completed, failed }`. When a
   stored payload no longer parses, the drain fails it without ever reaching the handler.
-- pg-boss owns the `pgboss` schema in the shared database and migrates it itself at `start()`, so the
-  `@vers/db` migrations never touch it.
+- pg-boss owns the `pgboss` schema in the shared database and migrates it itself at `start()`, so
+  the `@vers/db` migrations never touch it.
 
 ## Delivery model: drains, not resident workers
 

--- a/docs/architecture/platform/queues.md
+++ b/docs/architecture/platform/queues.md
@@ -8,21 +8,22 @@ consumer.
 
 ## The wrapper
 
-`@vers/jobs` is the only module that imports pg-boss.
+`@vers/jobs` is the only module that imports pg-boss, so every other package reaches queues through
+it.
 
-- `defineJobs` declares a record of job name →
-  `{ schema, retryLimit, retryDelay, retryBackoff, deadLetter }`. The schema is zod. The job name
-  doubles as the queue name.
-- `createJobQueue(defs, config)` returns `start`, `stop`, `send`, and `drain`. `config` carries the
-  connection string, the per-job `handlers`, and optional `onError` and `onJobFailed` reporting
-  callbacks. Every defined job requires a handler, which receives the schema-parsed payload and a
-  `{ jobID }` context.
-- `send` validates the payload before enqueue and returns the pg-boss job id. Its `trx` option
-  routes the insert through the caller's Kysely transaction, so job creation commits or rolls back
-  with the domain write it belongs to.
-- `drain(name?)` is a one-shot fetch/handle/complete loop returning `{ completed, failed }`. A
-  stored payload that no longer parses is failed without reaching the handler.
-- pg-boss owns the `pgboss` schema in the shared database and migrates it itself at `start()`.
+- `defineJobs` declares a record mapping each job name to its
+  `{ schema, retryLimit, retryDelay, retryBackoff, deadLetter }`. The schema is a zod schema, and the
+  job name doubles as the queue name.
+- `createJobQueue(defs, config)` returns `start`, `stop`, `send`, and `drain`. The `config` carries
+  the connection string, the per-job `handlers`, and optional `onError` and `onJobFailed` reporting
+  callbacks. Every defined job needs a handler, and the handler receives the schema-parsed payload
+  alongside a `{ jobID }` context.
+- `send` validates the payload before it enqueues and returns the pg-boss job id. Pass its `trx`
+  option to route the insert through the caller's Kysely transaction, so job creation commits or
+  rolls back with the domain write it belongs to.
+- `drain(name?)` runs one fetch/handle/complete loop and returns `{ completed, failed }`. When a
+  stored payload no longer parses, the drain fails it without ever reaching the handler.
+- pg-boss owns the `pgboss` schema in the shared database and migrates it itself at `start()`, so the
   `@vers/db` migrations never touch it.
 
 ## Delivery model: drains, not resident workers

--- a/docs/architecture/services/auth.md
+++ b/docs/architecture/services/auth.md
@@ -40,23 +40,22 @@ valid, unused transaction token on the resubmission, the mutation proceeds. Othe
 creates a pending transaction and challenges the caller for a code.
 
 The challenge submits to `verifyStepUpHandler`, shared by every gated mutation. `verifyCode` checks
-the submitted TOTP. An invalid code counts a failed attempt against the pending transaction, and the
-transaction is abandoned after 5 (`recordFailedAttempt`). A valid code atomically consumes the
-pending transaction and mints a transaction token.
+the submitted TOTP. An invalid code counts a failed attempt against the pending transaction, and
+`recordFailedAttempt` abandons it after 5. A valid code atomically consumes the pending transaction
+and mints a transaction token.
 
 State that outlives a request lives in postgres, in the `pending_transactions` table. A pending
-transaction holds its action, target, IP, and owning session, cascade-deleted with the session, and
-expires after 5 minutes. `consumePendingTransaction` rejects a request whose action, IP, session, or
-target does not match the stored row.
+transaction holds its action, target, IP, and owning session; postgres cascade-deletes it with the
+session, and it expires after 5 minutes. `consumePendingTransaction` rejects a request whose action,
+IP, session, or target does not match the stored row.
 
 The transaction token is an RS256 JWT minted and verified only inside the edge process
 (`create-step-up-transaction-token.ts`). It is proof a code check passed, redeemable once by the
 mutation it names. It carries `action`, `target`, `sessionID`, and a `jti`, and lives 5 minutes. It
-signs against a per-process in-memory keypair, since it never leaves the process that issued it.
-Single use is enforced by the `consumed_transaction_tokens` ledger: `consumeTransactionToken`
-records the `jti`, and a token whose `jti` is already recorded is rejected. `checkStepUp` also
-matches the token's `sessionID` before consuming it, so a token minted under one session cannot
-redeem under another.
+signs against a per-process in-memory keypair, since it never leaves the process that issued it. The
+`consumed_transaction_tokens` ledger enforces single use: `consumeTransactionToken` records the
+`jti` and rejects a token whose `jti` is already recorded. `checkStepUp` also matches the token's
+`sessionID` before consuming it, so a token minted under one session cannot redeem under another.
 
 ## TOTP verification
 
@@ -64,17 +63,17 @@ redeem under another.
 target and type (`2fa`, `2fa-setup`, `change-email`, `onboarding`):
 
 - `createVerification` generates a code and returns the OTP.
-- `verifyCode` checks it. `change-email` and `onboarding` codes are consumed on success and the row
-  deleted; `2fa` and `2fa-setup` codes stay, marked verified, each guarded so a replay matches zero
+- `verifyCode` checks it, consuming `change-email` and `onboarding` codes on success and deleting
+  the row; `2fa` and `2fa-setup` codes stay, marked verified, each guarded so a replay matches zero
   rows.
 - `get2FAVerificationURI` returns the authenticator-app URI for a pending 2FA setup.
 
 ## Password reset
 
 `service-user` owns the credential path: `verifyPassword` gates login, while `changePassword` and
-`resetPassword` rewrite the hash and sign the user out of every session. A reset token is stored as
-its sha256 hash and reaches the user only through the URL in the reset email. `resetPassword`
-matches it in constant time.
+`resetPassword` rewrite the hash and sign the user out of every session. `service-user` stores a
+reset token as its sha256 hash, and the token reaches the user only through the URL in the reset
+email. `resetPassword` matches it in constant time.
 
 ## Service-to-service tokens
 
@@ -94,4 +93,5 @@ Each service verifies inbound tokens in its runtime middleware before any handle
 `SERVICE_AUTH_JWKS` — a JWKS registering every issuer's public key under its `kid`. A token's
 claimed `iss` must be a known issuer and equal its `kid`, and the signature only validates against
 that issuer's registered key, so a leaked minting key lets its holder impersonate only that one
-service. A bad token is rejected with a plain 401 ([service contracts](./service-contracts.md)).
+service. Each service rejects a bad token with a plain 401
+([service contracts](./service-contracts.md)).

--- a/docs/architecture/services/error-handling.md
+++ b/docs/architecture/services/error-handling.md
@@ -49,8 +49,8 @@ Clients narrow on `code` (via `isDefinedError`/`safe`) and `data`, never on `mes
 
 ### Registry
 
-Every bespoke code in the system, its status, and its meaning. A new bespoke code lands with its row
-in this table in the same PR.
+This table lists every bespoke code in the system, its status, and its meaning. A new bespoke code
+lands with its row in this table in the same PR.
 
 Status assignment follows the failure's nature:
 
@@ -93,12 +93,12 @@ Status assignment follows the failure's nature:
   runs. The response is not contract-shaped by design ([service contracts](./service-contracts.md)).
 - **Central error interceptor.** One `onError` client-interceptor on the RPC handler classifies
   everything a procedure throws. A defined contract error or any 4xx passes through untouched: no
-  log, no report, it is the caller's outcome. Everything else is logged at error level with the
-  trace id and captured to the error backend, then encoded by oRPC as a bare
+  log, no report, it is the caller's outcome. For everything else, the interceptor logs at error
+  level with the trace id, captures it to the error backend, then oRPC encodes it as a bare
   `INTERNAL_SERVER_ERROR`. Internals never reach the wire.
 - **Wire protocol.** Services speak the oRPC RPC protocol at `/rpc` only. Contracts keep their
-  `.route()` metadata and stay OpenAPI-generatable, which the conformance suite asserts. No OpenAPI
-  endpoint is served.
+  `.route()` metadata and stay OpenAPI-generatable, which the conformance suite asserts. Services
+  serve no OpenAPI endpoint.
 
 ## Reporting
 
@@ -153,8 +153,8 @@ trace. The RPC path reports exactly once per unexpected throw.
 One W3C trace id follows a request from the browser through app-web into whichever service it lands
 on, and shows up in three places: every pino log line the request writes, the Bugsink event if one
 fires, and the `x-trace-id` header on every service response. The log-line mixin and the response
-header are telemetry the [observability](../platform/observability.md) doc owns. A trace id from an
-error screen or a support report greps straight to the logs and the event.
+header are telemetry the [observability](../platform/observability.md) doc owns. Grepping a trace id
+from an error screen or a support report finds it directly in the logs and the event.
 
 - The browser mints a fresh `traceparent` per RPC call from the `@vers/trace` primitives.
 - app-web's server-side service links continue the ambient request's trace when it carries one, and

--- a/docs/architecture/services/service-contracts.md
+++ b/docs/architecture/services/service-contracts.md
@@ -83,7 +83,7 @@ const os = implement(userContract).$context<ServiceContext>();
 
 const getCurrentUser = os.getCurrentUser.handler(({ context, errors }) => {
   if (context.actingUserId === null) {
-    throw errors.UNAUTHORIZED({ data: { reason: 'missing-session' } });
+    throw errors.UNAUTHORIZED({ data: { reason: "missing-session" } });
   }
   // …
 });
@@ -104,7 +104,7 @@ Clients are typed by a single annotation against the contract:
 
 ```ts
 export const userClient: ContractRouterClient<typeof userContract, ServiceLinkContext> =
-  createORPCClient(buildServiceLink('user'));
+  createORPCClient(buildServiceLink("user"));
 ```
 
 In app-web the link is isomorphic (`buildServiceLink`). On the server it mints a short-lived
@@ -145,8 +145,8 @@ runtime's per-request infrastructure ([error handling](./error-handling.md#trace
 
 When a session expires, the edge itself replies with the contract-shaped
 `UNAUTHORIZED { reason: 'expired-session' }` without calling the service at all. Services themselves
-only ever throw `missing-session`, as defense in depth when an authed procedure is reached without
-an acting user. The shared enum is caller-facing vocabulary, not an inventory of who throws what.
+only ever throw `missing-session`, as defense in depth when a caller reaches an authed procedure
+without an acting user. The shared enum is caller-facing vocabulary, not an inventory of who throws what.
 
 `FORBIDDEN` is declared with an empty `data` payload: no permission model exists, and any fields a
 permission model needs arrive additively.
@@ -165,9 +165,10 @@ Two layers cover a contract, per the repo's mock-free testing rules:
 
 - **Conformance** (generic, one call per service). `collectConformanceCases` (`@vers/test-utils`)
   walks a contract and runs the mechanical cases every procedure must satisfy against the real
-  Elysia app in-process via `app.handle(request)` — no network, no mocks. Malformed input is
-  rejected with `BAD_REQUEST`, an anonymous call to an authed procedure is rejected with
-  `UNAUTHORIZED { reason: 'missing-session' }`, and the contract generates a valid OpenAPI document.
+  Elysia app in-process via `app.handle(request)` — no network, no mocks. The app rejects malformed
+  input with `BAD_REQUEST`, rejects an anonymous call to an authed procedure with
+  `UNAUTHORIZED { reason: 'missing-session' }`, and generates a valid OpenAPI document from the
+  contract.
 - **Behavioural** (hand-written, per service): what the service actually does, with test data
   declared inline.
 

--- a/docs/architecture/services/service-contracts.md
+++ b/docs/architecture/services/service-contracts.md
@@ -83,7 +83,7 @@ const os = implement(userContract).$context<ServiceContext>();
 
 const getCurrentUser = os.getCurrentUser.handler(({ context, errors }) => {
   if (context.actingUserId === null) {
-    throw errors.UNAUTHORIZED({ data: { reason: "missing-session" } });
+    throw errors.UNAUTHORIZED({ data: { reason: 'missing-session' } });
   }
   // …
 });
@@ -104,7 +104,7 @@ Clients are typed by a single annotation against the contract:
 
 ```ts
 export const userClient: ContractRouterClient<typeof userContract, ServiceLinkContext> =
-  createORPCClient(buildServiceLink("user"));
+  createORPCClient(buildServiceLink('user'));
 ```
 
 In app-web the link is isomorphic (`buildServiceLink`). On the server it mints a short-lived
@@ -146,7 +146,8 @@ runtime's per-request infrastructure ([error handling](./error-handling.md#trace
 When a session expires, the edge itself replies with the contract-shaped
 `UNAUTHORIZED { reason: 'expired-session' }` without calling the service at all. Services themselves
 only ever throw `missing-session`, as defense in depth when a caller reaches an authed procedure
-without an acting user. The shared enum is caller-facing vocabulary, not an inventory of who throws what.
+without an acting user. The shared enum is caller-facing vocabulary, not an inventory of who throws
+what.
 
 `FORBIDDEN` is declared with an empty `data` payload: no permission model exists, and any fields a
 permission model needs arrive additively.

--- a/docs/game-design/attributes-damage-model.md
+++ b/docs/game-design/attributes-damage-model.md
@@ -41,7 +41,7 @@ memory pressure, and other effects that harm through thought, control, or unders
 ### Null
 
 Null damage is absence and impossibility: entropy, erasure, unreality, and forces that do not fit
-cleanly into the known material systems.
+into the known material systems.
 
 ## Damage Events
 
@@ -66,7 +66,7 @@ an investable defensive answer — circumstantial heavy crits are designed threa
 preparing for them.
 
 Baseline content is tuned so an unattended avatar's defeat is predictable from its build rather than
-from unlucky sequences — max-hit ceilings against expected defensive pools, not hard caps. Players
+from unlucky sequences — max-hit limits against expected defensive pools, not hard caps. Players
 who juice an instance deliberately trade that safety for yield; the appetite to go deeper should
 never hit a wall. Exact numbers belong to the progression and enemy notes.
 

--- a/docs/game-design/attributes-damage-model.md
+++ b/docs/game-design/attributes-damage-model.md
@@ -66,9 +66,9 @@ an investable defensive answer — circumstantial heavy crits are designed threa
 preparing for them.
 
 Baseline content is tuned so an unattended avatar's defeat is predictable from its build rather than
-from unlucky sequences — max-hit limits against expected defensive pools, not hard caps. Players
-who juice an instance deliberately trade that safety for yield; the appetite to go deeper should
-never hit a wall. Exact numbers belong to the progression and enemy notes.
+from unlucky sequences — max-hit limits against expected defensive pools, not hard caps. Players who
+juice an instance deliberately trade that safety for yield; the appetite to go deeper should never
+hit a wall. Exact numbers belong to the progression and enemy notes.
 
 ### Persistent Damage
 

--- a/docs/game-design/base-classes.md
+++ b/docs/game-design/base-classes.md
@@ -87,7 +87,7 @@ output. That resource, how it accrues, and what it amplifies are the entire base
 on its own.
 
 One of its specializations routes that resource through another universal system. Each of its three
-tiers is a fork: at one tier the avatar takes either a passive that scales the resource's ceiling
+tiers is a fork: at one tier the avatar takes either a passive that scales the resource's cap
 with the coupled system or a passive that converts the coupled system's recovery into resource gain
 — passives that pull toward different builds, so the pick commits a direction rather than stacking a
 number. Later tiers deepen that direction without deleting the earlier passive.

--- a/docs/game-design/base-classes.md
+++ b/docs/game-design/base-classes.md
@@ -87,9 +87,9 @@ output. That resource, how it accrues, and what it amplifies are the entire base
 on its own.
 
 One of its specializations routes that resource through another universal system. Each of its three
-tiers is a fork: at one tier the avatar takes either a passive that scales the resource's cap
-with the coupled system or a passive that converts the coupled system's recovery into resource gain
-— passives that pull toward different builds, so the pick commits a direction rather than stacking a
+tiers is a fork: at one tier the avatar takes either a passive that scales the resource's cap with
+the coupled system or a passive that converts the coupled system's recovery into resource gain —
+passives that pull toward different builds, so the pick commits a direction rather than stacking a
 number. Later tiers deepen that direction without deleting the earlier passive.
 
 Its sibling specializations express the same resource differently — routing it through other

--- a/docs/game-design/core-themes-world-fiction.md
+++ b/docs/game-design/core-themes-world-fiction.md
@@ -9,7 +9,7 @@ notes inherit.
 Vers is an idle ARPG/MMO where you shape your avatar, send them into dangerous regions, turn loot
 into power, and push farther into harder, stranger parts of the world.
 
-Shape your avatar. Send them into the world. Recover power. Push deeper. Compete.
+Shape your avatar, send them into the world, recover power, push deeper, and compete.
 
 ## Decisions
 
@@ -32,8 +32,8 @@ regions that most people cannot safely enter.
 The world was never destroyed; it stopped answering. Civilization built on itself for so long that
 most of the world now runs on its own accumulated logic — infrastructure that no longer recognizes
 anyone's authority, ecologies that were designed once and have since gone their own way, and human
-societies that broke from Respite and became something stranger. Respite is simply the largest place
-that still answers to the people living inside it. A region's danger is a measure of how far it has
+societies that broke from Respite and became something stranger. Respite is the largest place that
+still answers to the people living inside it. A region's danger is a measure of how far it has
 drifted — mechanical, ecological, or human; its value is what it still produces, protects, or knows.
 
 Those regions are the world map: real places and systems that can be entered, cleared, revisited,
@@ -57,7 +57,7 @@ An avatar is an enhanced human shaped by the player and capable of entering regi
 people cannot survive. "Avatar" is the worn remnant of a longer phrase — avatar _of_ something — and
 what filled the blank is lost; rival accounts contest what it was. What is known: the capacity is
 inborn, appearing by chance in some and not others, and no institution can manufacture it. The
-player-facing fantasy stays simple: shape your avatar, send them into danger, recover power, push
+player-facing fantasy stays direct: shape your avatar, send them into danger, recover power, push
 deeper — the contract, embodied in one person.
 
 Avatars are embodied people, not disposable drones. They can be augmented, equipped, specialized,
@@ -122,8 +122,8 @@ recovered, never permanently lost.
 Defeat costs progress, not the avatar: experience toward the next level is lost but levels are never
 removed; yield from the run that was not already extracted is lost; and any investment in the
 activity instance is lost — the instance resets to baseline. Extraction is the player's mid-run
-banking decision: yield stays at risk until it is pulled out. Extraction is set as policy, not
-performed by hand — automated rules (extract at a yield threshold, or when defenses degrade) let
+banking decision: yield stays at risk until it is pulled out. The player sets extraction as policy,
+not by hand — automated rules (extract at a yield threshold, or when defenses degrade) let
 unattended runs bank deliberately.
 
 Exact loss rates, floors, and extraction mechanics belong to the progression and economy notes.

--- a/docs/game-design/defensive-archetypes.md
+++ b/docs/game-design/defensive-archetypes.md
@@ -81,7 +81,7 @@ Interception spends a charge to reduce a connecting hit. **Block** intercepts st
 Both forms draw on one shared charge pool. Pool capacity and refill rate are shared investment;
 trigger chance and the amount mitigated are invested per form. Trigger chance is smoothed like
 avoidance, and a charge is consumed only when interception triggers — an eligible hit that passes
-untriggered spends nothing. Interception reduces at baseline — full negation is the ceiling of deep
+untriggered spends nothing. Interception reduces at baseline — full negation is the upper bound of deep
 investment, not the default.
 
 Charge supply bounds interception without a cap: refill rate against enemy hit rate limits how much
@@ -94,19 +94,19 @@ charge per intercept, so refill remains the binding limit.
 ## Armour
 
 Armour is Physical mitigation. Its reduction scales inversely with the size of the incoming hit:
-small hits are mostly absorbed, massive hits punch through. Armour erases chaff and fades against
+Armour mostly absorbs small hits, and massive hits punch through it. Armour erases chaff and fades against
 giants — the mirror of interception, and the pairing that lets a committed defender cover the full
 hit-size spectrum.
 
 ## Resistances
 
-Resistances are the six type-specific mitigations, capped, specced against a region's damage mix.
+Resistances are the six type-specific mitigations, capped and specced against a region's damage mix.
 Armour, Resistances, and Life are the dependable core: baseline content is tuned so they alone
 survive it, and every avoidance and interception stat is extra safety a build chooses. Direct and
 area hits are answered here.
 
-The hardest case is a large Physical area hit — nothing avoids or intercepts it, no resistance
-applies, and Armour fades against it. Max-hit tuning is bound by that case.
+The hardest case is a large Physical area hit — avoidance and interception do not apply to it, no
+resistance applies, and Armour fades against it. Max-hit tuning is bound by that case.
 
 ## Barrier
 

--- a/docs/game-design/defensive-archetypes.md
+++ b/docs/game-design/defensive-archetypes.md
@@ -81,8 +81,8 @@ Interception spends a charge to reduce a connecting hit. **Block** intercepts st
 Both forms draw on one shared charge pool. Pool capacity and refill rate are shared investment;
 trigger chance and the amount mitigated are invested per form. Trigger chance is smoothed like
 avoidance, and a charge is consumed only when interception triggers — an eligible hit that passes
-untriggered spends nothing. Interception reduces at baseline — full negation is the upper bound of deep
-investment, not the default.
+untriggered spends nothing. Interception reduces at baseline — full negation is the upper bound of
+deep investment, not the default.
 
 Charge supply bounds interception without a cap: refill rate against enemy hit rate limits how much
 of a stream can be intercepted. Sparse heavy hitters meet a charge on every swing; dense fast
@@ -94,9 +94,9 @@ charge per intercept, so refill remains the binding limit.
 ## Armour
 
 Armour is Physical mitigation. Its reduction scales inversely with the size of the incoming hit:
-Armour mostly absorbs small hits, and massive hits punch through it. Armour erases chaff and fades against
-giants — the mirror of interception, and the pairing that lets a committed defender cover the full
-hit-size spectrum.
+Armour mostly absorbs small hits, and massive hits punch through it. Armour erases chaff and fades
+against giants — the mirror of interception, and the pairing that lets a committed defender cover
+the full hit-size spectrum.
 
 ## Resistances
 

--- a/docs/game-design/economy-modes.md
+++ b/docs/game-design/economy-modes.md
@@ -53,9 +53,9 @@ a list of today's features:
 - No container crosses the boundary — stashes, banks, prize pools — including between one account's
   own avatars.
 - Self-found ladders rank on server-verifiable play — depth, level, clear speed. Those outcomes are
-  gear-influenced, and a device-held key rolls that gear locally, so self-found standing leans harder
-  on reroll detection than a trade avatar's. The same appended, verified record defends it, though
-  the design does not treat that record as tamper-proof.
+  gear-influenced, and a device-held key rolls that gear locally, so self-found standing leans
+  harder on reroll detection than a trade avatar's. The same appended, verified record defends it,
+  though the design does not treat that record as tamper-proof.
 - Avatars are league-scoped, so league resets contain self-found holdings with no extra rule.
 
 ## Reward Classes
@@ -97,14 +97,13 @@ while players sleep. The economy-loop note owns both.
 Juice is spending to modify an activity. Where its randomness lives follows the tail rule, not the
 mechanic:
 
-- **Tiers and activity modifiers** — the player chooses a tier, then rolls and rerolls the activity's
-  flavour modifiers before locking them in. The chosen tier sets any modifier that scales a
-  market-grade quantity — yield, roll or pack count — at a published scalar, never rolled, so it
-  reveals nothing to select.
-  The modifiers that may be rolled are normalized: bounded scalars, no jackpot combinations, never
-  coupled to a reward tail. A tail-free distribution is client-trustable and works anywhere, offline
-  included, rerolls and all. Keeping rolled modifiers tail-free is a standing content constraint,
-  the same obligation as roll density.
+- **Tiers and activity modifiers** — the player chooses a tier, then rolls and rerolls the
+  activity's flavour modifiers before locking them in. The chosen tier sets any modifier that scales
+  a market-grade quantity — yield, roll or pack count — at a published scalar, never rolled, so it
+  reveals nothing to select. The modifiers that may be rolled are normalized: bounded scalars, no
+  jackpot combinations, never coupled to a reward tail. A tail-free distribution is client-trustable
+  and works anywhere, offline included, rerolls and all. Keeping rolled modifiers tail-free is a
+  standing content constraint, the same obligation as roll density.
 - **Item crafting** — affix rolls are the tail; shaping items is the point. Crafting rolls draw
   sealed server entropy behind the preview flow, online. Self-found avatars craft against their own
   key — nothing is sealed from them, and nothing they make can leave.

--- a/docs/game-design/economy-modes.md
+++ b/docs/game-design/economy-modes.md
@@ -50,12 +50,12 @@ avatar's haul is off the books, never assayed, kept in its own hands.
 Mode partitions every economic container and every reward-bearing space — a standing invariant, not
 a list of today's features:
 
-- No container is shared across the boundary — stashes, banks, prize pools — including between one
-  account's own avatars.
+- No container crosses the boundary — stashes, banks, prize pools — including between one account's
+  own avatars.
 - Self-found ladders rank on server-verifiable play — depth, level, clear speed. Those outcomes are
-  gear-influenced and a device-held key rolls that gear locally, so self-found standing leans harder
-  on reroll detection than a trade avatar's; the same appended, verified record defends it, and it
-  is not held to be tamper-proof.
+  gear-influenced, and a device-held key rolls that gear locally, so self-found standing leans harder
+  on reroll detection than a trade avatar's. The same appended, verified record defends it, though
+  the design does not treat that record as tamper-proof.
 - Avatars are league-scoped, so league resets contain self-found holdings with no extra rule.
 
 ## Reward Classes
@@ -97,9 +97,10 @@ while players sleep. The economy-loop note owns both.
 Juice is spending to modify an activity. Where its randomness lives follows the tail rule, not the
 mechanic:
 
-- **Tiers and activity modifiers** — choose a tier, then roll and reroll the activity's flavour
-  modifiers, lock in. Any modifier that scales a market-grade quantity — yield, roll or pack count —
-  is set by the chosen tier at a published scalar, never rolled, so it reveals nothing to select.
+- **Tiers and activity modifiers** — the player chooses a tier, then rolls and rerolls the activity's
+  flavour modifiers before locking them in. The chosen tier sets any modifier that scales a
+  market-grade quantity — yield, roll or pack count — at a published scalar, never rolled, so it
+  reveals nothing to select.
   The modifiers that may be rolled are normalized: bounded scalars, no jackpot combinations, never
   coupled to a reward tail. A tail-free distribution is client-trustable and works anywhere, offline
   included, rerolls and all. Keeping rolled modifiers tail-free is a standing content constraint,

--- a/infra/README.md
+++ b/infra/README.md
@@ -10,20 +10,20 @@ resolve from 1Password at run time, so nothing sensitive lives on disk.
 - `axiom.ts` — the Axiom resource set: the `vers-*` datasets, the ingest and query API tokens, the
   threshold monitors, the Discord alarms notifier, and the dashboards; the registries in
   `docs/architecture/platform/observability.md` describe what the monitors and instruments watch.
-  Token secret values live in 1Password, out of code (stack state holds sensitive outputs encrypted)
-  — any change to a token's arguments regenerates its secret, so a scope edit means updating the
-  vault item and dependent Fly secrets within the 48-hour rotation grace window. The provider's own
+  Token secret values live in 1Password, out of code; stack state holds sensitive outputs encrypted.
+  Any change to a token's arguments regenerates its secret, so a scope edit means updating the vault
+  item and dependent Fly secrets within the 48-hour rotation grace window. The provider's own
   credential is console-managed: a token cannot rotate itself without invalidating the session doing
   the rotating.
 - `github.ts` — the zgeoff/vers repo configuration: the authoritative label set (the registry the
   issue-hygiene rules point at), the `main protection` branch ruleset, the `production` environment,
   the Actions variables (repo- and environment-scoped; the service-auth public key value comes from
-  encrypted stack config, the rest sit in code), and the Actions secrets (values resolve from the
-  `vers-ci` vault as environment variables at run time — GitHub cannot return a secret's value, so
-  the program pushes and the vault stays the source of truth). Console-managed and therefore not
-  drift: milestones and the delivery board (delivery state, not schema — and Projects v2 lacks
+  encrypted stack config, the rest sit in code), and the Actions secrets. Secret values resolve from
+  the `vers-ci` vault as environment variables at run time — GitHub cannot return a secret's value,
+  so the program pushes and the vault stays the source of truth. Console-managed and therefore not
+  drift: milestones and the delivery board (delivery state, not schema; Projects v2 also lacks
   mature provider support), the `OP_SERVICE_ACCOUNT_TOKEN` secret (the credential the resolution
-  itself authenticates with), and the provider's own PAT, for the same reason the Axiom token is — a
+  itself authenticates with), and the provider's own PAT, for the same reason as the Axiom token: a
   token cannot rotate itself without invalidating the session doing the rotating.
 - `sdks/axiom/` — committed TypeScript SDK generated from the bridged Terraform provider
   (`pulumi package add terraform-provider axiomhq/axiom 1.6.2` regenerates it; the version is pinned


### PR DESCRIPTION
## Description

Rewrites committed docs into a more readable register and recasts the comment policy so future agents place comments correctly. Prose only — no code or behaviour touched.

- Extends the `docs-writing` skill with the readability rules from the pipelabs writing-guideline rewrite: cold-reader framing, a plain-register statement, and six rules (show-the-instance, address-the-reader, name-the-actor, unstack-abstract-nouns, one-verb-per-mechanism, delta-framing).
- Rewrites 16 architecture and game-design docs plus two skills — passive and nominalised voice named to its actor, telegraphic fragments joined, banned figurative jargon replaced. No facts, headings, links, or code changed.
- Recasts the AGENTS comment policy around contract-on-the-declaration vs mechanism-at-the-line, enforceable-first (types and golden tests before prose), and long-block-as-a-placement-smell. Regenerates AGENTS.md.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [ ] New tests added for new functionality

## Context

A stacked branch applies the comment policy to existing comments (a classification audit found 131 actionable blocks of 1,473; the mechanical relocations sweep next). This PR is the register + policy base and can merge while that work is WIP.
