### PR TITLE
docs: relocate comment mechanism to the line and drop narration

### DIFF
--- a/apps/web/src/lib/activity/build-optimistic-progression.ts
+++ b/apps/web/src/lib/activity/build-optimistic-progression.ts
@@ -39,20 +39,16 @@ interface OptimisticProgression {
 
 /**
  * Derives the level/xp a screen renders from the settled progression read: the settled total plus
- * every pending entry's delta, plus the live sim's own running delta on top — deduped by activity
- * id against the pending list so a just-terminal run's own entry, once its refetch lands, is never
- * counted twice. The live overlay is net of whatever the settled total already carries for that
- * same run, so a settled row that tracks a run in flight never double-counts its verified part;
- * checkpoints still queued client-side only widen that remainder, never invert it. The level is
- * recomputed from the resulting total whenever anything is projected — a pending entry can carry
- * xp from a run the live sim never drove, so only the aggregate total derives a trustworthy level;
- * the settled row's own level is exact only once nothing projects on top of it.
+ * every pending entry's delta, plus a live-sim overlay, net of whatever the settled total already
+ * carries for that run.
  */
 export function buildOptimisticProgression(
   input: Readonly<BuildOptimisticProgressionInput>,
 ): OptimisticProgression {
   const pendingXP = input.progression.pending.reduce((total, entry) => total + entry.xpDelta, 0);
 
+  // Dedupe by activity id: once a just-terminal run's own entry lands in the pending list via
+  // refetch, the overlay below must stop counting it, or it counts twice.
   const simIsPending = input.progression.pending.some(
     (entry) => entry.activityID === input.simActivity?.id,
   );
@@ -77,6 +73,10 @@ export function buildOptimisticProgression(
 
   return {
     isSettling,
+
+    // Recompute the level from the aggregate total whenever anything is projected: a pending
+    // entry can carry xp from a run the live sim never drove, so the settled row's own level is
+    // exact only once nothing projects on top of it.
     level: isSettling ? buildLevelFromXP(displayXP) : input.progression.level,
     xp: displayXP,
   };

--- a/apps/web/src/lib/metrics/record-service-call-failure.ts
+++ b/apps/web/src/lib/metrics/record-service-call-failure.ts
@@ -7,15 +7,15 @@ export type ServiceCallFailureReason = 'timeout' | 'transport';
  * Counts one outbound service call that never delivered — either every bounded attempt hit its own
  * per-attempt timeout, or the underlying transport failed outright with no timeout involved. Split
  * by `service` and `reason` so a suspended machine's resume window (`timeout`, self-healing once
- * the machine wakes) reads apart from a genuinely unreachable service (`transport`). The counter is
- * resolved through the global metrics API on every call — the SDK returns the same instrument for
- * an identical registration, and resolving late keeps it bound to whichever meter provider the
- * process registered at boot; without one it is the API's no-op.
+ * the machine wakes) reads apart from a genuinely unreachable service (`transport`).
  */
 export function recordServiceCallFailure(
   service: ServiceName,
   reason: ServiceCallFailureReason,
 ): void {
+  // Resolved through the global metrics API on every call: the SDK returns the same instrument for
+  // an identical registration, and resolving late keeps it bound to whichever meter provider the
+  // process registered at boot; without one it is the API's no-op.
   const counter = metrics.getMeter('@vers/web').createCounter('vers.web.service_call_failures', {
     description: 'outbound service calls that never delivered, by service and reason',
     unit: '{call}',

--- a/apps/web/src/lib/metrics/record-service-call-retry.ts
+++ b/apps/web/src/lib/metrics/record-service-call-retry.ts
@@ -4,11 +4,12 @@ import type { ServiceName } from '@vers/service-auth';
 /**
  * Counts one retry attempt against an outbound service call that failed its previous attempt — the
  * signal for how often a bounded service call recovers through retry rather than succeeding on its
- * first attempt. The counter is resolved through the global metrics API on every call — the SDK
- * returns the same instrument for an identical registration, and resolving late keeps it bound to
- * whichever meter provider the process registered at boot; without one it is the API's no-op.
+ * first attempt.
  */
 export function recordServiceCallRetry(service: ServiceName): void {
+  // Resolved on every call: the SDK returns the same instrument for an identical registration, and
+  // resolving late keeps it bound to whichever meter provider the process registered at boot;
+  // without one it is the API's no-op.
   const counter = metrics.getMeter('@vers/web').createCounter('vers.web.service_call_retries', {
     description: 'retry attempts against an outbound service call that failed its previous attempt',
     unit: '{retry}',

--- a/apps/web/src/lib/query/build-query-client.ts
+++ b/apps/web/src/lib/query/build-query-client.ts
@@ -9,8 +9,7 @@ import { MutationCache, QueryCache, QueryClient } from '@tanstack/react-query';
  * errors and 5xx — retry twice, and errors born in the client itself are reported once per error
  * at the cache layer, where no per-hook handler can shadow the report. On the browser it also wires
  * cross-tab cache sync over `BroadcastChannel`, so a cache change in one tab invalidates the same
- * query in every other open tab; this module also runs on the server during SSR, where
- * `BroadcastChannel` doesn't exist, so that wiring is guarded to the client only.
+ * query in every other open tab.
  */
 export function buildQueryClient(): QueryClient {
   const queryClient = new QueryClient({
@@ -21,6 +20,8 @@ export function buildQueryClient(): QueryClient {
     queryCache: new QueryCache({ onError: reportUnexpectedError }),
   });
 
+  // This module also runs on the server during SSR, where `BroadcastChannel` doesn't exist, so
+  // cross-tab sync is guarded to the client only.
   if (globalThis.window !== undefined && typeof BroadcastChannel !== 'undefined') {
     broadcastQueryClient({ broadcastChannel: 'vers-query', queryClient });
   }

--- a/apps/web/src/lib/rpc/service-dispatcher.ts
+++ b/apps/web/src/lib/rpc/service-dispatcher.ts
@@ -5,14 +5,18 @@ import { Agent } from 'undici';
  * machine autosuspends on a horizon far shorter than undici's own multi-minute idle default, so a
  * pooled socket left open past that horizon still looks usable while the machine underneath it is
  * gone — a request written onto it neither arrives nor triggers the machine's wake.
- * `keepAliveMaxTimeout` is the field that matters: it caps whatever `Keep-Alive` hint the origin
- * advertises, and `keepAliveTimeout` matches it as the default absent a hint. No connect timeout is
- * set: undici's own default sits well clear of the per-attempt bound an outbound call already
- * carries, leaving that bound the single budget a call answers to. A suspended machine whose resume
- * falls back to a cold start needs seconds before it accepts a connection, and a connect cap
- * shorter than the attempt bound would fail the call before that bound ever applied.
  */
 export const serviceDispatcher = new Agent({
+  // Caps whatever `Keep-Alive` hint the origin advertises, so a pooled socket never outlives the
+  // machine's autosuspend horizon.
   keepAliveMaxTimeout: 30_000,
+
+  // Matches keepAliveMaxTimeout as the default absent a `Keep-Alive` hint.
   keepAliveTimeout: 30_000,
+
+  // No connect timeout: undici's own default sits well clear of the per-attempt bound an outbound
+  // call already carries, leaving that bound the single budget a call answers to. A suspended
+  // machine whose resume falls back to a cold start needs seconds before it accepts a connection,
+  // and a connect cap shorter than the attempt bound would fail the call before that bound ever
+  // applied.
 });

--- a/apps/web/src/lib/scene/resolve-scene-state-for-location.ts
+++ b/apps/web/src/lib/scene/resolve-scene-state-for-location.ts
@@ -4,16 +4,17 @@ import type { SceneState } from '@vers/game-rendering';
 
 /**
  * Resolves the scene state a navigation to `location` would produce, without waiting for that
- * navigation to happen: `staticData` isn't reachable from the router's `types` view-transition
- * callback, which only receives locations, so this runs `matchRoutes` itself to recover the
- * matched branch and folds its root-first `scene`/`presentation` contributions against `previous`
- * the same way the live route-to-store sync folds the active match list.
+ * navigation to happen.
  */
 export function resolveSceneStateForLocation(
   router: AnyRouter,
   location: Readonly<Pick<ParsedLocation, 'pathname' | 'search'>>,
   previous: SceneState,
 ): SceneState {
+  // `staticData` isn't reachable from the router's `types` view-transition callback, which only
+  // receives locations, so this runs `matchRoutes` itself to recover the matched branch; the result
+  // folds its root-first `scene`/`presentation` contributions against `previous` the same way the
+  // live route-to-store sync folds the active match list.
   const matches = router.matchRoutes(location.pathname, location.search);
 
   return resolveSceneState(

--- a/apps/web/src/lib/worldmap/build-world-map-node-codex-query-options.ts
+++ b/apps/web/src/lib/worldmap/build-world-map-node-codex-query-options.ts
@@ -1,13 +1,12 @@
 import { getWorldMapNodeCodexFragment } from './get-world-map-node-codex-fragment';
 
-/**
- * RSC values need `structuralSharing: false`: Query's default deep-equality check can't run over
- * a Composite Component source.
- */
 export function buildWorldMapNodeCodexQueryOptions(difficulty: number) {
   return {
     queryFn: () => getWorldMapNodeCodexFragment({ data: { difficulty } }),
     queryKey: ['rsc', 'world-map-node-codex', difficulty],
+
+    // RSC values need this: Query's default deep-equality check can't run over a Composite
+    // Component source.
     structuralSharing: false,
   };
 }

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -10,11 +10,9 @@ import { resolveSceneStateForLocation } from './lib/scene/resolve-scene-state-fo
 import { routeTree } from './routeTree.gen';
 import { CSP_NONCE_HEADER } from './server/csp-nonce-header';
 
-/**
- * The secure-headers middleware stamps this onto the request before the SSR handler runs; reading
- * it back is the only way this isomorphic factory can recover a per-request value, since it has
- * no other channel into request middleware context.
- */
+// The secure-headers middleware stamps this onto the request before the SSR handler runs; reading
+// it back is the only way this isomorphic factory can recover a per-request value, since it has
+// no other channel into request middleware context.
 const getCSPNonce = createIsomorphicFn()
   .server(() => getRequestHeader(CSP_NONCE_HEADER))
   .client(() => {

--- a/apps/web/src/routes/-explore-current/explore-current-panel.tsx
+++ b/apps/web/src/routes/-explore-current/explore-current-panel.tsx
@@ -41,10 +41,7 @@ interface StartAttemptReport {
  * panel awaits the call directly and renders its own outcome, so another tab's run never reads as
  * this one's. A failed start renders a retry action.
  *
- * Once the start goes live the panel navigates to the engagement screen, once per activity —
- * latched in `@vers/idle-client`'s store rather than a component ref, so a remount (the browser
- * back button, re-drilling the same node) that re-fires the start call and finds the same
- * activity already live reads it as already engaged rather than bouncing the player back.
+ * Once the start goes live the panel navigates to the engagement screen, once per activity.
  *
  * Two rejections render a reload notice instead of the generic retry. A start refused because
  * the account's active avatar changed names the current avatar: the route's own data still names
@@ -180,6 +177,10 @@ export function ExploreCurrentPanel(props: Readonly<ExploreCurrentPanelProps>) {
     attemptScopeID === selectedNode?.id &&
     idleWorkerHandle.activity?.id === expectedActivityID;
 
+  // The engaged activity is latched in `@vers/idle-client`'s store rather than a component ref, so
+  // a remount (the browser back button, re-drilling the same node) that re-fires the start call
+  // and finds the same activity already live reads it as already engaged rather than bouncing the
+  // player back.
   useEffect(() => {
     if (!isActivityReady || expectedActivityID === engagedActivityID) {
       return;

--- a/apps/web/src/routes/-game/use-avatar-region-graph.ts
+++ b/apps/web/src/routes/-game/use-avatar-region-graph.ts
@@ -44,35 +44,16 @@ interface HeldCompletedNodeIDs {
  * Rebuilds the worldmap store's region graph from the active avatar's seed and the store's current
  * viewport, and resets the selection and viewport to the avatar's origin whenever the active
  * avatar itself changes — a fresh avatar or a switch between avatars — while otherwise leaving the
- * selection alone across a moved viewport, a re-render, or a remount. The graph is built from the
- * chunk-aligned viewport and kept by reference while that alignment holds, so the rendered node
- * and edge lists change only when a pan crosses a chunk boundary, not on every cell-granular
- * camera move. The region is keyed by the avatar id, not the seed: two avatars can share a seed,
- * and a switch between them must still reset the selection. A missing active avatar leaves the
- * store untouched rather than clearing it.
+ * selection alone across a moved viewport, a re-render, or a remount. The region is keyed by the
+ * avatar id, not the seed: two avatars can share a seed, and a switch between them must still
+ * reset the selection. A missing active avatar leaves the store untouched rather than clearing it.
  *
  * Alongside the graph, every region-touching update recomputes the store's two completed-set
  * projections: the selectable-node set — the origin, every completed node, and every node an edge
  * connects to a completed node, the same reachability rule the activity service gates starts
  * against — over the full topology, never over the viewport-filtered graph edges, so the client
  * and server always agree at a viewport boundary; and the reveal sources the fog-of-war renderer
- * projects the revealed region from. The recompute only runs when the region or the completed set
- * actually changes, not on every cell-granular viewport update the free camera reports while
- * panning.
- *
- * The completed set comes from the avatar's revealed-nodes query, which this hook alone subscribes
- * to. The query stays
- * disabled until the camera reports a viewport and the store's region belongs to the active avatar
- * — a viewport held by another avatar's region is that avatar's camera footprint, and the region
- * switch clears it before the incoming avatar may issue a request. The chunk-aligned viewport
- * keying the query is shrunk to the reveal cell cap so no canvas aspect can produce a request the
- * service would reject. The
- * completed set itself is viewport-independent, but the viewport-carrying key means a pan across a
- * chunk boundary re-keys the query and drops its data back to `undefined` for a moment, so the
- * last resolved set is held in state beside the avatar it belongs to and reused until the new
- * key's fetch lands, rather than collapsing selectability to the origin alone on every such
- * crossing. An avatar switch drops that held set immediately, so the incoming avatar never briefly
- * inherits the outgoing avatar's completed nodes.
+ * projects the revealed region from.
  *
  * Returns the fog-revealed node id set projected over the loaded region — the same reveal sources
  * published to the store, expanded to the individual node ids their discs cover inside the region
@@ -89,6 +70,12 @@ export function useAvatarRegionGraph(): ReadonlySet<string> {
   const previousViewportRef = useRef<null | Viewport>(null);
   const previousCompletedNodeIDsRef = useRef<null | ReadonlySet<string>>(null);
 
+  // The completed set is viewport-independent, but the viewport-carrying query key below means a
+  // pan across a chunk boundary re-keys the query and drops its data back to `undefined` for a
+  // moment. The last resolved set is held here beside the avatar it belongs to and reused until
+  // the new key's fetch lands, rather than collapsing selectability to the origin alone on every
+  // such crossing. An avatar switch drops the held set immediately, so the incoming avatar never
+  // briefly inherits the outgoing avatar's completed nodes.
   const [heldCompleted, setHeldCompleted] = useState<HeldCompletedNodeIDs>({
     avatarID: undefined,
     nodeIDs: EMPTY_NODE_ID_SET,
@@ -96,10 +83,16 @@ export function useAvatarRegionGraph(): ReadonlySet<string> {
 
   const [revealedNodeIDs, setRevealedNodeIDs] = useState<ReadonlySet<string>>(EMPTY_NODE_ID_SET);
 
+  // The chunk-aligned viewport keying the query is shrunk to the reveal cell cap so no canvas
+  // aspect can produce a request the service would reject.
   const revealedViewport = viewport
     ? buildChunkAlignedViewport(viewport, REVEAL_VIEWPORT_CELL_CAP)
     : null;
 
+  // This hook is the sole subscriber to the avatar's revealed-nodes query. It stays disabled
+  // until the camera reports a viewport and the store's region belongs to the active avatar — a
+  // viewport held by another avatar's region is that avatar's camera footprint, and the region
+  // switch clears it before the incoming avatar may issue a request.
   const revealedNodesQuery = useQuery({
     ...buildRevealedNodesQueryOptions(avatarID ?? '', revealedViewport ?? EMPTY_VIEWPORT),
     enabled: avatarID !== undefined && revealedViewport !== null && regionKey === avatarID,
@@ -133,12 +126,18 @@ export function useAvatarRegionGraph(): ReadonlySet<string> {
 
     previousAvatarIDRef.current = avatarID;
 
+    // The region rebuilds from the chunk-aligned viewport and is kept by reference while that
+    // alignment holds, so the rendered node and edge lists change only when a pan crosses a chunk
+    // boundary, not on every cell-granular camera move.
     const regionViewport =
       isAvatarSwitch || viewport === null ? INITIAL_VIEWPORT : buildChunkAlignedViewport(viewport);
 
     const regionUnchanged =
       !isAvatarSwitch && isSameViewport(previousViewportRef.current, regionViewport);
 
+    // When the region itself hasn't moved, only recompute the completed-set projections, and only
+    // when the completed set actually changed — not on every cell-granular viewport update the
+    // free camera reports while panning.
     if (regionUnchanged) {
       if (completedNodeIDs === previousCompletedNodeIDsRef.current) {
         return;

--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -49,10 +49,11 @@ const clientAssets = serveStatic({ dir: CLIENT_ASSETS_DIRECTORY });
 
 /**
  * Serves the built client assets, falling through to `next` for anything that isn't a file on
- * disk (every SSR page and server function). Wrapped so its srvx-flavored signature — which
- * permits a synchronous `Response` — normalizes to this file's own `Middleware` return type.
+ * disk (every SSR page and server function).
  */
 function serveClientAssets(request: Request, next: () => Promise<Response>): Promise<Response> {
+  // srvx's `clientAssets` permits a synchronous `Response`; wrapping normalizes its return to
+  // this file's own `Middleware` return type.
   return Promise.resolve(clientAssets(request, next));
 }
 

--- a/apps/web/src/server/make-request-logger.ts
+++ b/apps/web/src/server/make-request-logger.ts
@@ -15,10 +15,8 @@ interface RequestLoggerSink {
  * Builds the request-lifecycle logging middleware: one structured line per request on completion,
  * carrying method, path, status, and duration as queryable fields — data never rides in the
  * message text. The query string never reaches the line: query params carry emailed tokens and
- * auth codes, and a log stream is no place for either. Severity follows outcome: 5xx at error, 4xx
- * at warn, everything else at info — except a served static asset (a pathname with a file
- * extension), which logs at debug to keep asset traffic out of the shipped stream. A handler that
- * throws still logs, at error with the thrown value, before the throw continues to the runtime.
+ * auth codes, and a log stream is no place for either. A handler that throws still logs, at error
+ * with the thrown value, before the throw continues to the runtime.
  */
 export function makeRequestLogger(logger: RequestLoggerSink): Middleware {
   return async (request, next) => {

--- a/apps/web/src/server/make-umami-proxy.ts
+++ b/apps/web/src/server/make-umami-proxy.ts
@@ -61,10 +61,7 @@ interface RelayInit {
 const UPSTREAM_DEADLINE_MS = 15_000;
 
 /**
- * Fetches the upstream target and rewraps the result. fetch responses carry immutable headers,
- * which the server framework must still be able to finalize — and the body arrives already
- * decoded, so the upstream encoding headers no longer describe it. Copy entry by entry: passing
- * another runtime's Headers instance to the constructor can yield an empty copy.
+ * Fetches the upstream target and rewraps the result.
  */
 async function sendUpstream(target: URL, init?: RelayInit): Promise<Response> {
   let response: Response;
@@ -93,8 +90,12 @@ async function sendUpstream(target: URL, init?: RelayInit): Promise<Response> {
     clearTimeout(timer);
   }
 
+  // fetch responses carry immutable headers, which the server framework must still be able to
+  // finalize. Copy entry by entry: passing another runtime's Headers instance to the constructor
+  // can yield an empty copy.
   const headers = new Headers([...response.headers]);
 
+  // the body arrives already decoded, so the upstream encoding headers no longer describe it
   headers.delete('content-encoding');
   headers.delete('content-length');
 

--- a/apps/web/src/server/with-request-trace.ts
+++ b/apps/web/src/server/with-request-trace.ts
@@ -8,10 +8,7 @@ const ASSET_PATH_PATTERN = /\.[a-z0-9]+$/i;
  * Runs the request inside its W3C trace-context scope. A served static asset (a pathname with a
  * file extension) or the `/health` probe — the same paths logged only at debug level — skips
  * opening a span; every other request opens a SERVER span extracted from the inbound headers, a
- * no-op without a registered tracer provider. The stored `TraceContext` derives from that span when
- * it continued or started a real trace; otherwise (no span, or no tracer provider registered) it
- * falls back to parsing the inbound `traceparent` directly, or starts a fresh trace for this hop —
- * so a support report can always name the trace from `x-trace-id`, with or without OTel wired.
+ * no-op without a registered tracer provider.
  */
 export function withRequestTrace(
   request: Request,

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -91,15 +91,15 @@ function findNonEmptyEnv(name: string): string | undefined {
 
 /**
  * Starts the shared MSW server for `vite dev` only — `configureServer` never fires for
- * `vite build` — so dev boot runs entirely against the mock backend. Goes through `ssrLoadModule`
- * rather than a plain top-level import: this config file loads outside Vite's own resolver, and
- * this app's workspace packages (`@vers/contract-*`) are extensionless-TS source that only that
- * resolver handles.
+ * `vite build` — so dev boot runs entirely against the mock backend.
  */
 function buildMockBackendPlugin(): Plugin {
   return {
     name: 'vers:mock-backend',
     async configureServer(viteServer) {
+      // Goes through `ssrLoadModule` rather than a plain top-level import: this config file loads
+      // outside Vite's own resolver, and this app's workspace packages (`@vers/contract-*`) are
+      // extensionless-TS source that only that resolver handles.
       const mocks: Record<string, unknown> = await viteServer.ssrLoadModule('/src/mocks/node.ts');
 
       if (!isMockBackendServer(mocks['server'])) {

--- a/contracts/activity/src/build-start-hash.ts
+++ b/contracts/activity/src/build-start-hash.ts
@@ -1,10 +1,6 @@
 import { sha256 } from '@noble/hashes/sha2.js';
 import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils.js';
 
-/**
- * The frozen encounter params folded into the start hash: `difficulty` is always present, and any
- * further sealed field is a string or number so it serializes canonically.
- */
 interface HashedEncounterNode {
   readonly [key: string]: number | string | undefined;
   readonly difficulty: number;
@@ -19,14 +15,11 @@ interface BuildStartHashInput {
 }
 
 /**
- * The checkpoint hash chain's root: a sha256 hex digest over the canonical field order
- * `[seed, simVersion, contentVersion, keyVersion, encounterNode]`, seeding `last_hash` before the
- * first checkpoint links onto it. The activity's own id carries no cryptographic role and is
- * excluded: `(seed, versions, encounterNode)` already uniquely identifies the stream,
- * and the chain never needs the id to reproduce it — the client computes every continuation's seed
- * and hash from the appended chain alone, online and offline alike. `encounterNode` serializes
- * every defined key in sorted order, key insertion order irrelevant, so a richer descriptor can
- * extend it later without another format change.
+ * The checkpoint hash chain's root, seeding `last_hash` before the first checkpoint links onto it.
+ * The exact canonical field order is frozen and enforced by a golden test. The activity's own id
+ * carries no cryptographic role and is excluded: `(seed, versions, encounterNode)` already uniquely
+ * identifies the stream, and the chain never needs the id to reproduce it — the client computes
+ * every continuation's seed and hash from the appended chain alone, online and offline alike.
  */
 export function buildStartHash(input: Readonly<BuildStartHashInput>): string {
   const canonical = JSON.stringify([
@@ -40,12 +33,10 @@ export function buildStartHash(input: Readonly<BuildStartHashInput>): string {
   return bytesToHex(sha256(utf8ToBytes(canonical)));
 }
 
-/**
- * `Object.fromEntries` defines each key as an own property, so a node parsed from JSON with an own
- * `__proto__` key lands in the digest like any other field — plain assignment would invoke the
- * prototype setter and silently drop it.
- */
 function buildCanonicalEncounterNode(node: HashedEncounterNode): Record<string, unknown> {
+  // `Object.fromEntries` defines each key as an own property, so a node parsed from JSON with an
+  // own `__proto__` key lands in the digest like any other field — plain assignment would invoke
+  // the prototype setter and silently drop it.
   return Object.fromEntries(
     Object.keys(node)
       .filter((candidate) => node[candidate] !== undefined)

--- a/deploy.config.ts
+++ b/deploy.config.ts
@@ -13,13 +13,11 @@ const rpcUnauthorizedReply = z.object({
 
 /**
  * Fleet manifest for the deploy CLI (`bun run deploy`): which Fly apps exist,
- * what makes each one stale, and how a deploy is verified. Staleness compares
- * HEAD against the `GIT_SHA` each deploy stamps into machine env, so a
- * skipped or cancelled rollout self-heals on the next push. The anonymous RPC
- * probe must round-trip the contract's typed UNAUTHORIZED through
- * app-web → flycast → service-user, which no /health check can see.
+ * what makes each one stale, and how a deploy is verified.
  */
 export default defineDeployManifest({
+  // Staleness compares HEAD against the `GIT_SHA` each deploy stamps into machine env, so a
+  // skipped or cancelled rollout self-heals on the next push.
   apps: [
     {
       app: 'vers-service-activity',
@@ -99,6 +97,9 @@ export default defineDeployManifest({
       dockerfile: 'apps/web/Dockerfile',
       exposure: 'public',
       minStartedMachines: 1,
+
+      // The anonymous RPC probe must round-trip the contract's typed UNAUTHORIZED through
+      // app-web → flycast → service-user, which no /health check can see.
       probes: [
         { expectStatus: 200, kind: 'http', url: 'https://vers-app-web.fly.dev/health' },
         {

--- a/infra/axiom.ts
+++ b/infra/axiom.ts
@@ -127,12 +127,8 @@ const serverErrorsMonitor = new axiom.Monitor(
 );
 
 /**
- * Fleet-wide alarm for a hung or pathologically slow request, evaluated on the monitor's own
- * schedule rather than at span close, and independent of the per-request slow-request warn log a
- * service emits against its own configurable threshold. It fires on any non-probe server span past
- * a fixed ceiling regardless of which service or route it came from. Health-probe routes are
- * excluded: their latency tracks scale-to-zero machine wake, not request handling, so they would
- * fire the alarm continuously without indicating a real fault.
+ * Health-probe routes are excluded: their latency tracks scale-to-zero machine wake, not request
+ * handling, so they would fire the alarm continuously without indicating a real fault.
  */
 const slowRequestsMonitor = new axiom.Monitor(
   'vers-slow-requests',
@@ -154,12 +150,8 @@ const slowRequestsMonitor = new axiom.Monitor(
 );
 
 /**
- * alertOnNoData stays false: the counter emits only when a wake delivery
- * exhausts its retries, so a quiet dataset is the healthy default, never a
- * down exporter. The metric is an OTLP cumulative counter (the exporter sets no
- * delta temporality), so `map increase` reduces each window's aligned maximum to
- * the number of new failures inside it — the threshold fires when that climbs by
- * at least one.
+ * alertOnNoData stays false: the counter emits only when a wake delivery exhausts its retries, so a
+ * quiet dataset is the healthy default, never a down exporter.
  */
 const replayPokeFailedMonitor = new axiom.Monitor(
   'vers-replay-poke-failed',
@@ -168,6 +160,10 @@ const replayPokeFailedMonitor = new axiom.Monitor(
     type: 'Threshold',
     description:
       'A wake poke to service-replay exhausted its retries without delivering. The optimistic client hides verifier failure, so this counter is the explicit signal that the replay queue may go undrained despite an activity appending unverified work.',
+
+    // The metric is an OTLP cumulative counter (the exporter sets no delta temporality), so `map
+    // increase` reduces each window's aligned maximum to the number of new failures inside it —
+    // the threshold fires when that climbs by at least one.
     mplQuery:
       '`vers-metrics`:`vers.activity.replay_poke_failed` | align to 5m using max | group using max | map increase',
     intervalMinutes: 5,

--- a/infra/github.ts
+++ b/infra/github.ts
@@ -80,10 +80,6 @@ const labels = new github.IssueLabels(
   { protect: true },
 );
 
-/**
- * Branch protection for main: squash-only PRs gated on the aggregate `checks`
- * status, no deletions, no force pushes, no bypass actors.
- */
 const mainProtectionRuleset = new github.RepositoryRuleset('main-protection', {
   name: 'main protection',
   repository,

--- a/libs/core/email/src/render-email.ts
+++ b/libs/core/email/src/render-email.ts
@@ -21,15 +21,15 @@ interface EmailData {
 }
 
 /**
- * Renders an email component to its deliverable html and plain-text forms through react-dom
- * directly — `@react-email/render` cannot run inside a `bun build --compile` binary (the bundler
- * initializes its module body before the react binding it closes over exists, so the first render
- * throws), and the compiled service binaries are exactly where this runs. The doctype and
- * plain-text selectors match what `@react-email/render` produces, so delivered emails read the
- * same either way.
+ * Renders an email component to its deliverable html and plain-text forms, matching the doctype and
+ * plain-text selectors `@react-email/render` produces so delivered emails read the same either way.
  */
 // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- config wraps a React element tree (mutable props); no deep-readonly form
 export function renderEmail(config: EmailConfig): EmailData {
+  // Renders through react-dom directly rather than `@react-email/render`: that package cannot run
+  // inside a `bun build --compile` binary (the bundler initializes its module body before the react
+  // binding it closes over exists, so the first render throws), and the compiled service binaries
+  // are exactly where this runs.
   const markup = renderToStaticMarkup(config.component);
 
   return {

--- a/libs/data/db/migrations/1783900000002_generalize_chain_scope.ts
+++ b/libs/data/db/migrations/1783900000002_generalize_chain_scope.ts
@@ -3,10 +3,7 @@ import type { Kysely } from 'kysely';
 /**
  * Generalizes the seed chain's key from `(avatar, node)` to `(avatar, chain scope)`, a
  * `(scope_type, scope_id)` pair identifying a stable, returnable target; `world_map_node` is the
- * scope for world-map nodes. Renames `node_id` to `scope_id` on `activity_chains` and `activities`,
- * adds `scope_type` to both (backfilled to `world_map_node` for existing rows, NOT NULL with no
- * default thereafter), and re-keys `activity_chains`' primary key on
- * `(avatar_id, scope_type, scope_id)`.
+ * scope for world-map nodes.
  */
 export async function up(db: Kysely<unknown>): Promise<void> {
   await db.schema.alterTable('activity_chains').renameColumn('node_id', 'scope_id').execute();

--- a/libs/data/db/src/create-db.ts
+++ b/libs/data/db/src/create-db.ts
@@ -11,27 +11,8 @@ interface CreateDBConfig {
 }
 
 /**
- * Builds a `Kysely` client over the shared postgres.js dialect with
- * camelCase-mapped columns. Callers own env parsing — this never reads
- * `process.env` itself.
- *
- * Both session-level timeouts below bound how long a single statement or an
- * idle-in-transaction connection can hold a lock: no future code path that
- * opens a transaction can leave orphaned transaction state alive past 30s,
- * even across a serverless process kill.
- *
- * `idle_timeout` (seconds, unlike the millisecond session timeouts) closes a
- * pooled connection from the client side before the managed Postgres endpoint
- * suspends on its own idle timeout and drops the socket server-side. Without
- * it the pool hands a caller a connection the endpoint already closed, and the
- * first write fails with CONNECTION_CLOSED; the value stays under the
- * endpoint's suspend timeout so the client always closes first.
- *
- * `connect_timeout` (also seconds) bounds connection acquisition itself, a
- * phase neither `statement_timeout` nor `idle_timeout` covers: a suspended
- * managed Postgres endpoint that stalls on wake fails in 10s instead of
- * hanging for minutes, while 10s leaves headroom for a normal cold wake
- * (roughly 1-5s).
+ * Builds a `Kysely` client over the shared postgres.js dialect with camelCase-mapped columns.
+ * Callers own env parsing — this never reads `process.env` itself.
  */
 export function createDB(config: CreateDBConfig): Kysely<DB> {
   const sql = postgres(config.databaseURL, buildPostgresOptions(config));
@@ -50,12 +31,26 @@ export function createDB(config: CreateDBConfig): Kysely<DB> {
  */
 export function buildPostgresOptions(config: CreateDBConfig) {
   return {
+    // Bounds connection acquisition itself, a phase neither `statement_timeout` nor
+    // `idle_timeout` covers: a suspended managed Postgres endpoint that stalls on wake fails in
+    // 10s instead of hanging for minutes, while 10s leaves headroom for a normal cold wake
+    // (roughly 1-5s).
     connect_timeout: 10,
     connection: {
+      // Both session-level timeouts below bound how long a single statement or an
+      // idle-in-transaction connection can hold a lock: no future code path that opens a
+      // transaction can leave orphaned transaction state alive past 30s, even across a
+      // serverless process kill.
       idle_in_transaction_session_timeout: 30_000,
       statement_timeout: 30_000,
       ...(config.searchPath === undefined ? {} : { search_path: config.searchPath }),
     },
+
+    // Seconds, unlike the millisecond session timeouts above. Closes a pooled connection from
+    // the client side before the managed Postgres endpoint suspends on its own idle timeout and
+    // drops the socket server-side. Without it the pool hands a caller a connection the endpoint
+    // already closed, and the first write fails with CONNECTION_CLOSED; the value stays under
+    // the endpoint's suspend timeout so the client always closes first.
     idle_timeout: 240,
   };
 }

--- a/libs/data/sim-registry/src/update-expired-sim-versions.ts
+++ b/libs/data/sim-registry/src/update-expired-sim-versions.ts
@@ -4,28 +4,33 @@ import { sql } from 'kysely';
 import type { SimVersionRow } from './types';
 
 /**
- * Tombstones every `active` `sim_versions` row past its retention deadline in a single statement,
- * flipping `status` to `pruned` rather than deleting the row — dispatch tells a retained-but-expired
- * version (a pruned row: force a resync) apart from an unregistered one (no row: park the activity),
- * and deleting would collapse that distinction. Excludes the current version (the newest `active`
- * row by `deployedAt`) regardless of its own `retainedUntil`, so a lone active row is always
- * protected — the sweep never leaves the fleet with no valid replay target. The `active` guard also
- * keeps a repeat run from re-returning rows a prior sweep already pruned.
+ * Tombstones every active row past its retention deadline via status flip, excluding the current
+ * version so the fleet always keeps a valid replay target.
  */
 export function updateExpiredSimVersions(db: Kysely<DB>): Promise<Array<SimVersionRow>> {
-  return db
-    .updateTable('simVersions')
-    .set({ status: 'pruned' })
-    .where('status', '=', 'active')
-    .where('retainedUntil', '<', sql<Date>`now()`)
-    .where('engineHash', 'is distinct from', (eb) =>
-      eb
-        .selectFrom('simVersions')
-        .select('engineHash')
-        .where('status', '=', 'active')
-        .orderBy('deployedAt', 'desc')
-        .limit(1),
-    )
-    .returningAll()
-    .execute();
+  return (
+    db
+      .updateTable('simVersions')
+
+      // Flipping status to pruned rather than deleting the row lets dispatch tell a
+      // retained-but-expired version (a pruned row: force a resync) apart from an unregistered one
+      // (no row: park the activity).
+      .set({ status: 'pruned' })
+      .where('status', '=', 'active')
+      .where('retainedUntil', '<', sql<Date>`now()`)
+
+      // Excludes the current version (the newest active row by deployedAt) regardless of its own
+      // retainedUntil, so a lone active row is always protected. The active guard on both sides also
+      // keeps a repeat run from re-returning rows a prior sweep already pruned.
+      .where('engineHash', 'is distinct from', (eb) =>
+        eb
+          .selectFrom('simVersions')
+          .select('engineHash')
+          .where('status', '=', 'active')
+          .orderBy('deployedAt', 'desc')
+          .limit(1),
+      )
+      .returningAll()
+      .execute()
+  );
 }

--- a/libs/design/design-system/src/components/resource-bar/resource-bar.tsx
+++ b/libs/design/design-system/src/components/resource-bar/resource-bar.tsx
@@ -40,10 +40,8 @@ const fill = cva({
     left: '[0]',
     position: 'absolute',
     top: '[0]',
-    /**
-     * A vital only steps on discrete combat events, so easing the width change reads as the pool
-     * draining rather than teleporting.
-     */
+    // A vital only steps on discrete combat events, so easing the width change reads as the pool
+    // draining rather than teleporting.
     transition: '[width 120ms linear]',
   },
   variants: {

--- a/libs/game/game-utils/src/create-rng.ts
+++ b/libs/game/game-utils/src/create-rng.ts
@@ -4,12 +4,6 @@ import { decodeState } from './decode-state';
 import { encodeState } from './encode-state';
 import type { RNG } from './types';
 
-/**
- * thin wrapper around pure-rand as it's interface is verbose and we don't need
- * most of it
- *
- * @param state - the 128-bit xoroshiro128+ state to rehydrate, as a 32-character hex string
- */
 export function createRNG(state: string): RNG {
   const gen = xoroshiro128plusFromState(decodeState(state));
   const getInt = (min: number, max: number) => uniformInt(gen, min, max);

--- a/libs/game/idle-client/src/engagement-view.tsx
+++ b/libs/game/idle-client/src/engagement-view.tsx
@@ -14,10 +14,8 @@ const view = css({
   width: 'full',
 });
 
-/**
- * A wave holds at most six enemies, so each plate is capped at a sixth of the row (minus the five
- * gaps between six) and the group centres — a short wave stays plate-sized instead of stretching.
- */
+// A wave holds at most six enemies, so each plate is capped at a sixth of the row (minus the five
+// gaps between six) and the group centres — a short wave stays plate-sized instead of stretching.
 const encounterRow = css({
   '& > *': { flex: '1', maxWidth: '[calc((100% - 3.75rem) / 6)]', minWidth: '0' },
   alignItems: 'stretch',
@@ -35,11 +33,6 @@ interface EngagementViewProps {
   readonly onEndRun?: () => void;
 }
 
-/**
- * The engagement screen's live combat view: the mission header, the row of enemy plates for the
- * current wave, and the player's own plate. Enemies render in kill order so the next target reads
- * left-to-right.
- */
 export function EngagementView(props: Readonly<EngagementViewProps>) {
   const activity = useActivity();
   const avatar = useAvatar();
@@ -48,6 +41,7 @@ export function EngagementView(props: Readonly<EngagementViewProps>) {
     return <Spinner />;
   }
 
+  // Enemies render in kill order so the next target reads left-to-right.
   const enemies = activity.currentWave?.enemies.toReversed() ?? [];
 
   return (

--- a/libs/game/idle-client/src/resync/plan-offline-continuations.ts
+++ b/libs/game/idle-client/src/resync/plan-offline-continuations.ts
@@ -46,14 +46,10 @@ export interface PlanOfflineContinuationsResult {
 }
 
 /**
- * Simulates an entire offline gap locally: no network call, no submitter. Attempt by attempt, it
- * reconstructs the confirmed row's own remaining tail for free — the already-appended prefix
- * costs nothing against the budget. While budget remains and the failure policy allows it, each
- * further attempt's seed, client id, and predicted build snapshot derive from the chain position
- * alone, exactly as the server reproduces them when it applies the catch-up. Prediction depends
- * on the single-active-run invariant: no other scope accrues unsettled xp during the gap, so the
- * confirmed row's own snapshot is the correct baseline for every later attempt's fold, and the
- * only sources this loop must add are the gap's own continuations as they close.
+ * Simulates an entire offline gap locally: no network call, no submitter. While budget remains
+ * and the failure policy allows it, each further attempt's seed, client id, and predicted build
+ * snapshot derive from the chain position alone, exactly as the server reproduces them when it
+ * applies the catch-up.
  *
  * A failure under the abort policy stops planning after that continuation's own tail — the same
  * policy live play applies after a terminal checkpoint. The wire format still mints that
@@ -117,6 +113,8 @@ export async function planOfflineContinuations(
       return { planned, reason: 'budget-exhausted' };
     }
 
+    // Attempt by attempt, this reconstructs the confirmed row's own remaining tail for free — the
+    // already-appended prefix costs nothing against the budget.
     const tail = attempt.checkpoints.slice(appendedHead);
 
     if (tail.length === 0) {
@@ -142,6 +140,10 @@ export async function planOfflineContinuations(
       unverifiedDeltaSum: 0,
     });
 
+    // Prediction depends on the single-active-run invariant: no other scope accrues unsettled xp
+    // during the gap, so the confirmed row's own snapshot is the correct baseline for every later
+    // attempt's fold, and the only sources this loop must add are the gap's own continuations as
+    // they close.
     const optimistic = foldOptimisticBuild(baselineXP, localSources);
 
     const nextBuildSnapshot = {

--- a/libs/game/idle-client/src/submission/create-checkpoint-submitter.ts
+++ b/libs/game/idle-client/src/submission/create-checkpoint-submitter.ts
@@ -331,11 +331,6 @@ export function createCheckpointSubmitter(
     });
   };
 
-  /**
-   * Delivers an activity's queued checkpoints now, superseding its shared progress-window timer,
-   * by sending its child a `FLUSH_NOW` and waiting until it leaves `flushing` — out any attempt
-   * already in flight, then exactly one attempt of its own. A no-op for an unregistered activity.
-   */
   const flushNow = async (activityID: string): Promise<void> => {
     const child = findChild(activityID);
 

--- a/libs/game/idle-client/src/submission/read-cached-node-ids.ts
+++ b/libs/game/idle-client/src/submission/read-cached-node-ids.ts
@@ -4,12 +4,12 @@ import { resolveCheckpointQueueDB } from './resolve-checkpoint-queue-db';
 /**
  * Reads every node id this device already holds a genesis seed for under the given avatar, so a
  * caller can diff that avatar's revealed-frontier set down to only the nodes still needing a
- * reveal. The compound key is range-read over the avatar's bound alone, so another avatar's cached
- * nodes never leak into the result.
+ * reveal. Another avatar's cached nodes never leak into the result.
  */
 export async function readCachedNodeIDs(avatarID: string): Promise<ReadonlySet<string>> {
   const db = await resolveCheckpointQueueDB();
 
+  // the compound key is range-read over the avatar's bound alone
   const keys = await db.getAllKeys(
     NODE_SEEDS_STORE_NAME,
     IDBKeyRange.bound([avatarID], [avatarID, []]),

--- a/libs/game/idle-client/src/submission/read-start-stamps.ts
+++ b/libs/game/idle-client/src/submission/read-start-stamps.ts
@@ -3,12 +3,13 @@ import { resolveCheckpointQueueDB } from './resolve-checkpoint-queue-db';
 import type { StartStampsPreference } from './types';
 
 /**
- * Reads the cached `revealNodes` crypto stamps, narrowing past the other record shapes sharing the
- * preferences store; `undefined` when this device has never revealed a node for any avatar.
+ * Reads the cached `revealNodes` crypto stamps; `undefined` when this device has never revealed a
+ * node for any avatar.
  */
 export async function readStartStamps(): Promise<StartStampsPreference | undefined> {
   const db = await resolveCheckpointQueueDB();
   const record = await db.get(PREFERENCES_STORE_NAME, START_STAMPS_KEY);
 
+  // Narrows past the other record shapes sharing the preferences store.
   return record !== undefined && 'keyVersion' in record ? record : undefined;
 }

--- a/libs/game/idle-client/src/submission/resolve-checkpoint-queue-db.ts
+++ b/libs/game/idle-client/src/submission/resolve-checkpoint-queue-db.ts
@@ -7,12 +7,13 @@ import { upgradeCheckpointQueueDB } from './upgrade-checkpoint-queue-db';
 let queueDB: null | Promise<IDBPDatabase<CheckpointQueueSchema>> = null;
 
 /**
- * Lazily opens, and caches, the worker's durable IndexedDB database, creating its stores through
- * the shared upgrade callback so the open path and an upgrade-driving test exercise the same store
- * layout.
+ * Lazily opens, and caches, the worker's durable IndexedDB database — repeated calls share one
+ * connection.
  */
 export function resolveCheckpointQueueDB(): Promise<IDBPDatabase<CheckpointQueueSchema>> {
   queueDB ??= openDB<CheckpointQueueSchema>(CHECKPOINT_QUEUE_DB_NAME, CHECKPOINT_QUEUE_DB_VERSION, {
+    // Shared with the upgrade-driving test, so the open path and that test exercise the same store
+    // layout.
     upgrade: upgradeCheckpointQueueDB,
   });
 

--- a/libs/game/idle-client/src/submission/upgrade-checkpoint-queue-db.ts
+++ b/libs/game/idle-client/src/submission/upgrade-checkpoint-queue-db.ts
@@ -8,20 +8,13 @@ import {
 import type { CheckpointQueueSchema } from './types';
 
 /**
- * Creates every object store the worker's durable cache needs on a fresh open or a version upgrade:
- * `pending-checkpoints` keyed `[activityID, version]`, so an activity's rows sort in submission
- * order and a compound read/delete addresses either a single checkpoint or an activity's whole
- * range; `preferences` caches device-local settings — a SharedWorker has no `localStorage` — as the
- * offline outbox for a server source of truth; `content-documents` caches published content by
- * `contentVersion`; `node-seeds` caches a revealed world-map node's start inputs — genesis seed,
- * encounter, and content version — by its `[avatarID, nodeID]` pair. Each store is created only if
- * missing, so an upgrade from an earlier version adds the stores that version lacks without dropping
- * the ones it already holds or their rows.
- *
- * The one exception is `node-seeds`: an upgrade from a version predating v5 clears it. Its earlier
- * rows carried only a genesis seed, missing the encounter and content version a v5 row declares, so
- * clearing the rebuildable cache leaves only full-shape rows behind — the prefetch re-reveals and
- * repopulates them.
+ * Creates every object store the worker's durable cache needs on a fresh open or a version
+ * upgrade. Each store is created only if missing, so an upgrade from an earlier version adds the
+ * stores that version lacks without dropping the ones it already holds or their rows. The one
+ * exception is `node-seeds`: an upgrade from a version predating v5 clears it, since its earlier
+ * rows carried only a genesis seed and miss the encounter and content version a v5 row declares —
+ * clearing the rebuildable cache leaves only full-shape rows behind, and the prefetch re-reveals
+ * and repopulates them.
  */
 export function upgradeCheckpointQueueDB(
   database: IDBPDatabase<CheckpointQueueSchema>,
@@ -33,20 +26,28 @@ export function upgradeCheckpointQueueDB(
     'versionchange'
   >,
 ): void {
+  // `pending-checkpoints` keyed `[activityID, version]`, so an activity's rows sort in submission
+  // order and a compound read/delete addresses either a single checkpoint or an activity's whole
+  // range.
   if (!database.objectStoreNames.contains(CHECKPOINT_QUEUE_STORE_NAME)) {
     database.createObjectStore(CHECKPOINT_QUEUE_STORE_NAME, {
       keyPath: ['activityID', 'version'],
     });
   }
 
+  // `preferences` caches device-local settings — a SharedWorker has no `localStorage` — as the
+  // offline outbox for a server source of truth.
   if (!database.objectStoreNames.contains(PREFERENCES_STORE_NAME)) {
     database.createObjectStore(PREFERENCES_STORE_NAME);
   }
 
+  // `content-documents` caches published content by `contentVersion`.
   if (!database.objectStoreNames.contains(CONTENT_DOCUMENT_STORE_NAME)) {
     database.createObjectStore(CONTENT_DOCUMENT_STORE_NAME, { keyPath: 'contentVersion' });
   }
 
+  // `node-seeds` caches a revealed world-map node's start inputs — genesis seed, encounter, and
+  // content version — by its `[avatarID, nodeID]` pair.
   if (!database.objectStoreNames.contains(NODE_SEEDS_STORE_NAME)) {
     database.createObjectStore(NODE_SEEDS_STORE_NAME, { keyPath: ['avatarID', 'nodeID'] });
   } else if (oldVersion < 5) {

--- a/libs/game/idle-client/src/submission/write-start-stamps.ts
+++ b/libs/game/idle-client/src/submission/write-start-stamps.ts
@@ -4,16 +4,16 @@ import type { StartStampsPreference } from './types';
 
 /**
  * Persists `revealNodes`'s crypto stamps, dropping a write whose stamps are strictly older than the
- * cached ones. Overlapping reveal batches can settle out of order, so a late response may carry an
- * older pair than one already cached; comparing the incoming pair against the cached one —
- * `keyVersion` first, then `secretVersion` — inside a single read-compare-write transaction
- * serializes concurrent writers and keeps the newest pair. An equal-or-newer pair overwrites.
+ * cached ones. An equal-or-newer pair overwrites.
  */
 export async function writeStartStamps(stamps: Readonly<StartStampsPreference>): Promise<void> {
   const db = await resolveCheckpointQueueDB();
 
   const tx = db.transaction(PREFERENCES_STORE_NAME, 'readwrite');
 
+  // Overlapping reveal batches can settle out of order, so a late response may carry an older pair
+  // than one already cached. A single read-compare-write transaction serializes concurrent writers
+  // and keeps the newest pair.
   const cached = await tx.store.get(START_STAMPS_KEY);
 
   if (cached === undefined || !('keyVersion' in cached) || !isOlderThan(stamps, cached)) {
@@ -23,10 +23,6 @@ export async function writeStartStamps(stamps: Readonly<StartStampsPreference>):
   await tx.done;
 }
 
-/**
- * Whether `incoming` stamps are strictly older than `cached`: a lower `keyVersion`, or the same
- * `keyVersion` with a lower `secretVersion`. An equal-or-newer pair is not older, so it overwrites.
- */
 function isOlderThan(
   incoming: Readonly<StartStampsPreference>,
   cached: Readonly<StartStampsPreference>,

--- a/libs/game/idle-client/src/worker/create-worker-demux.ts
+++ b/libs/game/idle-client/src/worker/create-worker-demux.ts
@@ -42,13 +42,11 @@ const DEFAULT_EVICT_AFTER_MS = 5 * 60 * 1000;
 /**
  * Bridges every tab on the web-locks path to the runtime's router: no real `MessagePort` exists
  * between a tab and the elected writer, so each tab's frames — enveloped with its id by
- * `createBroadcastPort` — are demultiplexed onto a virtual port built the moment an unseen tab id
- * first appears. The virtual port delivers synchronously: `upgrade` registers the router's message
- * listener before this handler relays the same frame to it, so no buffering or `start()` concept
- * is needed for correct delivery ordering. Idle tabs are swept on a timer so a tab that never sends
- * an explicit disconnect — there is no such signal over `BroadcastChannel` — does not leak forever.
- * Removing a tab, by sweep or by its own disconnect, fires the virtual port's close listeners, so
- * the RPC handler aborts that tab's in-flight calls and drops its per-connection state.
+ * `createBroadcastPort` — are demultiplexed onto a virtual port per tab. Idle tabs are swept on a
+ * timer so a tab that never sends an explicit disconnect — there is no such signal over
+ * `BroadcastChannel` — does not leak forever. Removing a tab, by sweep or by its own disconnect,
+ * fires the virtual port's close listeners, so the RPC handler aborts that tab's in-flight calls
+ * and drops its per-connection state.
  */
 export function createWorkerDemux(options: Readonly<CreateWorkerDemuxOptions>): WorkerDemux {
   const evictAfterMs = options.evictAfterMs ?? DEFAULT_EVICT_AFTER_MS;
@@ -58,6 +56,10 @@ export function createWorkerDemux(options: Readonly<CreateWorkerDemuxOptions>): 
   const outgoing = new BroadcastChannel(RPC_WORKER_TO_CLIENT_CHANNEL);
   const tabs = new Map<string, Tab>();
 
+  // The returned virtual port is built the moment an unseen tab id first appears, and delivers
+  // synchronously: `upgrade` registers the router's message listener before the incoming-channel
+  // handler below relays the same frame to it, so no buffering or `start()` concept is needed for
+  // correct delivery ordering.
   const buildVirtualPort = (
     tabID: string,
 

--- a/libs/game/idle-client/src/worker/create-worker-router.ts
+++ b/libs/game/idle-client/src/worker/create-worker-router.ts
@@ -12,11 +12,7 @@ import { workerContract } from './worker-contract';
 const ACK = { ok: true as const };
 
 /**
- * Implements the worker contract against one runtime's context, closing every procedure over the
- * same domain state a raw client message used to route into by hand. `ready` gates every
- * procedure the same way every message handler used to: a call arriving before the device-local
- * failure-action cache finishes seeding waits for it, so it never plans against the enum's default
- * while the real cached preference is still in flight.
+ * Implements the worker contract, closing every procedure over one runtime's context.
  */
 export function createWorkerRouter(context: WorkerContext, ready: Readonly<Promise<void>>) {
   const os = implement(workerContract).$context<WorkerCallContext>();

--- a/libs/game/idle-client/src/worker/handle-disconnect-message.ts
+++ b/libs/game/idle-client/src/worker/handle-disconnect-message.ts
@@ -4,11 +4,11 @@ import type { WorkerCallContext } from './types';
  * Releases whatever the transport holds for the calling connection: the real port on the
  * `SharedWorker` path, this tab's entry in the web-locks demux's registry on the other. `RPCLink`
  * has no close-notify of its own, so a tab calls this from its `pagehide` handler as the only
- * reliable teardown signal every environment delivers. The release is deferred to a macrotask —
- * closing synchronously here would race this very call's own answer, which still has to go out
- * over the same connection.
+ * reliable teardown signal every environment delivers.
  */
 export function handleDisconnectMessage(callContext: WorkerCallContext): void {
+  // deferred to a macrotask — closing synchronously here would race this very call's own answer,
+  // which still has to go out over the same connection
   setTimeout(() => {
     callContext.close();
   }, 0);

--- a/libs/game/idle-client/src/worker/handle-set-failure-action-message.ts
+++ b/libs/game/idle-client/src/worker/handle-set-failure-action-message.ts
@@ -15,21 +15,19 @@ interface SetFailureActionOutput {
 }
 
 /**
- * Applies a tab's failure-action change, answering with the applied value. The synchronous
- * in-memory effects land first, before any await, so a slow persistence or push never delays them:
- * the context's in-session value updates, a live simulation adopts it directly, and every
- * connection hears the effective value — the caller's own tab included, since the broadcast is the
- * only echo it gets. The device-local cache then records it dirty as an offline outbox entry, and
- * finally the value is pushed to the server. The push is single-flight per worker: a change
- * arriving while a push runs coalesces onto it — the running loop re-reads the context and pushes
- * the newest value — so an older push's acknowledgement can never clear the dirty flag or cache a
- * value already superseded. Delivery is best-effort: a connectivity failure leaves the cache dirty
- * for the next resync's reconcile to retry.
+ * Applies a tab's failure-action change and answers with the applied value. Every connection
+ * hears the effective value through the broadcast — the caller's own tab included, since the
+ * broadcast is the only echo it gets. The push to the server is single-flight per worker: a
+ * change arriving while a push runs coalesces onto it, so an older push's acknowledgement can
+ * never clear the dirty flag or cache a value already superseded. Delivery is best-effort — a
+ * connectivity failure leaves the cache dirty for the next resync's reconcile to retry.
  */
 export async function handleSetFailureActionMessage(
   context: WorkerContext,
   input: Readonly<SetFailureActionInput>,
 ): Promise<SetFailureActionOutput> {
+  // Synchronous in-memory effects land first, before any await, so a slow persistence or push
+  // never delays them.
   context.setFailureAction(input.failureAction);
   context.setFailureActionDirty(true);
   context.getSimulation().setFailureAction(input.failureAction);
@@ -41,6 +39,7 @@ export async function handleSetFailureActionMessage(
 
   context.broadcast(statusMessage);
 
+  // The device-local cache records the change dirty as an offline outbox entry before the push.
   await writeFailureActionCache({
     avatarID: input.avatarID,
     dirty: true,
@@ -60,17 +59,12 @@ export async function handleSetFailureActionMessage(
   return { failureAction: input.failureAction };
 }
 
-/**
- * Delivers the context's current failure action to the server as the offline outbox's one entry,
- * looping until the value it confirmed still matches the context — a change that arrives mid-flight
- * is picked up and delivered again, so the dirty flag clears only for a value the server actually
- * holds. A delivery failure leaves the value dirty and ends the loop for the next resync's
- * reconcile to retry.
- */
 async function flushFailureAction(context: WorkerContext, avatarID: string): Promise<void> {
   let pushed = context.getFailureAction();
   let confirmed = false;
 
+  // A delivery failure ends the loop, leaving the value dirty for the next resync's reconcile to
+  // retry.
   while (!confirmed) {
     const [error] = await safe(
       context.getClient().updateFailureAction({ avatarID, failureAction: pushed }),

--- a/libs/game/idle-client/src/worker/handle-stop-activity-message.ts
+++ b/libs/game/idle-client/src/worker/handle-stop-activity-message.ts
@@ -11,9 +11,7 @@ interface StopActivityInput {
 }
 
 /**
- * Ends a run entirely inside the worker: the local halt lands first and needs no network — the
- * simulation stops, the runtime resets to its idle state, and every tab sees a cleared snapshot —
- * then the durable intent is written and its delivery attempted.
+ * Ends a run entirely inside the worker.
  */
 export async function handleStopActivityMessage(
   context: WorkerContext,
@@ -27,6 +25,8 @@ export async function handleStopActivityMessage(
     return;
   }
 
+  // The local halt lands first and needs no network — the simulation stops, the runtime resets to
+  // its idle state, and every tab sees a cleared snapshot.
   context.advanceStopScope();
   context.getSimulation().stopActivity();
 
@@ -41,6 +41,7 @@ export async function handleStopActivityMessage(
 
   context.broadcast(message);
 
+  // The durable intent is written and its delivery attempted only after the local halt completes.
   // unconditional: whatever continuation was outstanding died with the run the player ended
   await removePendingStartIntent();
   await submitStopIntent(context, { avatarID: input.avatarID, id: input.activityID });

--- a/libs/game/idle-client/src/worker/start-error-reporting.ts
+++ b/libs/game/idle-client/src/worker/start-error-reporting.ts
@@ -30,9 +30,7 @@ export interface StartErrorReportingOptions {
  * loads the SDK. Never rejects: a bootstrap failure leaves reporting off with a console warning,
  * since an unhandled rejection from the reporting path itself is the one fault nothing can
  * capture. The SDK's default global handlers stay on in production, netting any throw the
- * explicit capture sites miss. Tracing lives on the OpenTelemetry path; the error backend drops
- * transaction envelopes. Client reports are off: the error backend discards them, and their
- * periodic flush would keep an idle worker chattering.
+ * explicit capture sites miss.
  */
 export async function startErrorReporting(
   dsn: string | undefined,
@@ -52,7 +50,12 @@ export async function startErrorReporting(
       // HTTP body type — and a failed checkpoint submission's body carries the session token, so
       // body capture is switched off wholesale
       dataCollection: { httpBodies: [], userInfo: true },
+
+      // Tracing lives on the OpenTelemetry path; the error backend drops transaction envelopes.
       tracesSampleRate: 0,
+
+      // The error backend discards client reports, and their periodic flush would keep an idle
+      // worker chattering.
       sendClientReports: false,
       ...(options.beforeSend !== undefined && { beforeSend: options.beforeSend }),
       ...(options.disableDefaultIntegrations === true && { defaultIntegrations: false }),

--- a/libs/game/idle-core/src/core/run-simulation.ts
+++ b/libs/game/idle-core/src/core/run-simulation.ts
@@ -1,17 +1,23 @@
 import type { ActivityCheckpoint, ActivityInput, AvatarData } from '../types';
 import { createSimulationDriver } from './create-simulation-driver';
 
-/**
- * @property duration - derive from the checkpoint data submitted by the
- * cient, or if simulating offline progress the duration since the last checkpoint (if any)
- * @property expectedCheckpointCount - when the caller knows exactly how many checkpoints the run should
- * produce (a replay), the primary halt condition; `duration` is only the safety cap behind it.
- * @property stopAtState - if a final rng state is provided we will stop processing once we've reached it. useful for
- * verifying client progress.
- */
 interface SimulationConfig {
+  /**
+   * Derived from the checkpoint data submitted by the client, or — when simulating offline
+   * progress — the duration since the last checkpoint, if any.
+   */
   readonly duration: number;
+
+  /**
+   * When the caller knows exactly how many checkpoints the run should produce (a replay), the
+   * primary halt condition; `duration` is only the safety cap behind it.
+   */
   readonly expectedCheckpointCount?: number;
+
+  /**
+   * When a final rng state is provided, processing stops once it's reached — useful for verifying
+   * client progress.
+   */
   readonly stopAtState?: string;
 }
 

--- a/libs/game/idle-core/src/core/utils/create-wave.ts
+++ b/libs/game/idle-core/src/core/utils/create-wave.ts
@@ -2,16 +2,17 @@ import { createEnemy } from '../../entities/create-enemy';
 import type { EnemyData, SimulationContext, Wave, WaveSnapshot } from '../../types';
 
 /**
- * Builds a wave from its already-resolved enemy data verbatim — `index` names this wave's position
- * within its encounter's ordered wave list, giving each wave a stable, deterministic id. Each
- * enemy's id derives from that wave id plus its position within the wave, keeping enemy identity
- * deterministic too.
+ * Builds a wave from its already-resolved enemy data verbatim. `index` names this wave's position
+ * within its encounter's ordered wave list; each wave and enemy gets a stable, deterministic id,
+ * safe to rely on across ticks.
  */
 export function createWave(
   index: number,
   enemyData: ReadonlyArray<EnemyData>,
   ctx: SimulationContext,
 ): Wave {
+  // the wave id derives from its position; each enemy id derives from that wave id plus its
+  // position within the wave
   const id = `wave-${index}`;
 
   const enemies = enemyData.map((data, enemyIndex) =>

--- a/libs/game/idle-core/src/entities/create-avatar.ts
+++ b/libs/game/idle-core/src/entities/create-avatar.ts
@@ -159,10 +159,6 @@ function getInitialState(data: AvatarData): AvatarState {
   };
 }
 
-/**
- * Writes a behaviour's state into the serializable snapshot under its id, keeping the id and value
- * types aligned.
- */
 function updateBehaviourSnapshot<K extends BehaviourID>(
   state: AvatarBehaviourSnapshot,
   id: K,

--- a/libs/game/idle-core/src/progression/build-unsettled-xp.ts
+++ b/libs/game/idle-core/src/progression/build-unsettled-xp.ts
@@ -23,18 +23,18 @@ interface UnsettledXPInput {
 
 /**
  * The xp an activity has earned but not yet settled — what a display adds on top of the avatar's
- * settled row, and the exact inverse of what verification will pay for the same checkpoints. A
- * terminal tail carries the run's final total, so what remains is that total less whatever earlier
- * segments already settled; every other tail carries per-checkpoint deltas, so what remains is
- * their sum past the verified cursor. Reading the two rules apart is what keeps a run's displayed
- * total steady as verification advances underneath it.
+ * settled row, and the exact inverse of what verification will pay for the same checkpoints.
  */
 export function buildUnsettledXP(input: Readonly<UnsettledXPInput>): number {
   const terminalTotal = parseTerminalCheckpointXP(input.tailPayload);
 
   if (terminalTotal === undefined) {
+    // Every non-terminal tail carries per-checkpoint deltas, so what remains is their sum past
+    // the verified cursor.
     return input.unverifiedDeltaSum;
   }
 
+  // A terminal tail carries the run's final total, so what remains is that total less whatever
+  // earlier segments already settled.
   return terminalTotal - input.settledXP;
 }

--- a/libs/game/idle-core/src/types/combat.ts
+++ b/libs/game/idle-core/src/types/combat.ts
@@ -3,8 +3,6 @@ export interface ActivityExecutorSnapshot {
 }
 
 /**
- * The lifecycle every activity type's executor implements: report elapsed time,
- * project a serializable snapshot, reset for a fresh run, and advance by a delta.
  * Each activity type supplies its own executor — combat is the world map encounter's.
  */
 export interface ActivityExecutor {

--- a/libs/game/item-gen/src/build-affix-pool.ts
+++ b/libs/game/item-gen/src/build-affix-pool.ts
@@ -2,10 +2,8 @@ import invariant from 'tiny-invariant';
 import type { AffixConstraints, AffixDef, AffixPool } from './types';
 
 /**
- * Applies a constraint set to an affix table in the canonical order — occupancy and protection
- * filters, then reweights (factor 0 removes; an id absent from the pool is a no-op), then a sort
- * by affix id — so equal inputs always yield an identical pool. Forced affixes bypass the filters;
- * only their existence in the table is asserted.
+ * Applies a constraint set to an affix table so equal inputs always yield an identical pool.
+ * Forced affixes bypass the filters; only their existence in the table is asserted.
  */
 export function buildAffixPool(
   affixes: ReadonlyArray<AffixDef>,
@@ -17,11 +15,17 @@ export function buildAffixPool(
   const reweights = constraints.reweights ?? {};
 
   const entries = affixes
+
+    // excludes occupied-group affixes when the constraint requests it
     .filter(
       (affix) =>
         !(constraints.excludeOccupiedGroups === true && occupiedGroupIDs.has(affix.groupID)),
     )
+
+    // excludes protected groups
     .filter((affix) => !protectedGroupIDs.has(affix.groupID))
+
+    // reweights: an id absent from the pool is a no-op
     .map((affix) => {
       const factor = Object.hasOwn(reweights, affix.id) ? reweights[affix.id] : undefined;
 
@@ -42,7 +46,11 @@ export function buildAffixPool(
         valueMax: affix.valueMax,
       };
     })
+
+    // factor 0 removes the affix from the pool
     .filter((affix) => affix.weight > 0)
+
+    // sorts by affix id for a canonical, order-independent pool
     .toSorted((a, b) => (a.id < b.id ? -1 : 1));
 
   const forced = (constraints.forceAffixIDs ?? []).toSorted().map((affixID) => {

--- a/libs/game/roll-crypto/src/build-roll-stream.ts
+++ b/libs/game/roll-crypto/src/build-roll-stream.ts
@@ -7,15 +7,11 @@ import type { RollStream, WeightedEntry } from './types';
 const BLOCK_SIZE = 32;
 
 /**
- * Builds a roll stream over a lazily unbounded byte tape: block `i` is
- * `HKDF-SHA256(ikm: seed, salt: none, info: utf8('${domain}|${i}'), 32)`, so the tape has no
- * length ceiling and every draw derives from `(seed, domain)` alone. The expansion layout and each
- * draw's byte consumption are frozen — changing either forks every consumer's outcomes.
- *
- * `rollRange` is unbiased via rejection sampling over the smallest big-endian byte width covering
- * the span (span ≤ 2^32, so number arithmetic stays exact); a degenerate range returns `min`
- * consuming no bytes. `pickWeighted` draws one `rollRange` over the total weight and walks the
- * entries in given order — callers own deterministic entry ordering.
+ * Builds a roll stream over a lazily unbounded byte tape: every draw derives from `(seed, domain)`
+ * alone, with no limit on how many draws the stream can serve. The expansion layout and each draw's
+ * byte consumption are frozen — changing either forks every consumer's outcomes; the exact
+ * HKDF-SHA256 expansion formula is pinned by `build-roll-stream.test.ts`'s golden snapshots.
+ * `pickWeighted` walks its entries in the order given — callers own deterministic entry ordering.
  */
 export function buildRollStream(seed: Uint8Array, domain: string): RollStream {
   // Snapshot the seed so a caller mutating its array cannot fork draws already promised.
@@ -52,9 +48,12 @@ export function buildRollStream(seed: Uint8Array, domain: string): RollStream {
     invariant(span <= 2 ** 32, 'range span must not exceed 2^32');
 
     if (span === 1) {
+      // A degenerate range returns min consuming no bytes.
       return min;
     }
 
+    // Rejection-sample over the smallest big-endian byte width covering the span (span <= 2^32,
+    // so number arithmetic stays exact).
     let width = 1;
 
     while (256 ** width < span) {

--- a/libs/game/worldmap-client/src/chunk-stream/resolve-chunk-stream.ts
+++ b/libs/game/worldmap-client/src/chunk-stream/resolve-chunk-stream.ts
@@ -100,11 +100,7 @@ export function collectCachedEntries<TEntry>(
 
 /**
  * Collects the chunk strip one step beyond whichever edge the range advanced past since
- * `previousRange`, per axis, skipping a chunk the main scan above already queued. The range's own
- * minimum corner is the movement signal: a genuine pan holds the range's span constant while both
- * corners shift together, so a change on the minimum alone unambiguously names the direction: a
- * span change with no shift (a zoom) reports no movement on that axis and collects no strip, since
- * the zoom's own newly visible area already came from the main scan above.
+ * `previousRange`, per axis, skipping a chunk the main scan above already queued.
  */
 function collectLeadingEdgeMisses<TEntry>(
   cache: Readonly<ChunkCache<TEntry>>,
@@ -112,6 +108,12 @@ function collectLeadingEdgeMisses<TEntry>(
   previousRange: Readonly<ChunkRange>,
 ): Array<string> {
   const misses: Array<string> = [];
+
+  // The range's own minimum corner is the movement signal: a genuine pan holds the range's span
+  // constant while both corners shift together, so a change on the minimum alone unambiguously
+  // names the direction. A span change with no shift (a zoom) reports no movement on that axis and
+  // collects no strip, since the zoom's own newly visible area already came from the main scan
+  // above.
   const movedX = Math.sign(range.minChunkX - previousRange.minChunkX);
   const movedY = Math.sign(range.minChunkY - previousRange.minChunkY);
 

--- a/libs/game/worldmap-client/src/chunk-stream/use-chunk-stream.ts
+++ b/libs/game/worldmap-client/src/chunk-stream/use-chunk-stream.ts
@@ -48,14 +48,6 @@ const BUILDS_PER_TICK = 1;
  * stalls, and the strip one chunk beyond the pan's leading edge prefetches ahead of the viewport
  * that will need it. `viewport` is wrapped in `useDeferredValue` here, once, so every layer this
  * hook drives gets an interruptible transition on a chunk-crossing pan without wrapping it itself.
- *
- * The render body only reads the cache — it shows whatever chunks are already built and touches no
- * shared state, so a concurrent render React starts and abandons never disposes or queues against
- * the committed scene. Every write — invalidating the cache on a seed change, recording the range
- * the prefetch compares against, queuing the misses to build — happens in a committed effect, which
- * also keeps the predictive prefetch working under React's development double-render. Newly built
- * chunks reach the returned array through the progressive builder's own re-renders: a memo keyed on
- * the viewport would never observe a build that lands without the viewport changing.
  */
 export function useChunkStream<TEntry>(
   options: Readonly<UseChunkStreamOptions<TEntry>>,

--- a/libs/game/worldmap-client/src/components-three/biome-ground.tsx
+++ b/libs/game/worldmap-client/src/components-three/biome-ground.tsx
@@ -41,11 +41,9 @@ const BIOME_GROUND_ELEVATION = -0.05;
 
 /**
  * Streams the placeholder biome terrain tint over the world map as a chunk-keyed mosaic: each
- * `CHUNK_SIZE`-cell chunk builds once — a quad whose per-fragment color samples a CPU-mixed RGBA
- * texture, the base biome blended toward its border neighbour by `blendT`, with the modifier tint
- * overlaid at low alpha where the modifier layer draws non-`none` — and persists in the chunk-stream
- * cache so a pan across already-visited ground re-mounts the cached tiles instantly. It renders
- * nothing until both a seed and a viewport exist.
+ * `CHUNK_SIZE`-cell chunk builds once and persists in the chunk-stream cache, so a pan across
+ * already-visited ground re-mounts the cached tiles instantly. It renders nothing until both a
+ * seed and a viewport exist.
  */
 export function BiomeGround() {
   const userSeed = useUserSeed();
@@ -170,10 +168,8 @@ function buildGroundTexture(field: Readonly<BiomeField>): DataTexture {
 }
 
 /**
- * CPU-mixes each texel's RGBA byte: the base tint blended toward the border neighbour's tint by
- * half `blendT`, then the modifier tint overlaid at `MODIFIER_OVERLAY_ALPHA` where the modifier
- * layer drew non-`none`. Alpha is always opaque — the ground plane replaces the floor's color
- * within its footprint outright, it never shows the floor through.
+ * CPU-mixes each texel's RGBA byte. Alpha is always opaque — the ground plane replaces the floor's
+ * color within its footprint outright, it never shows the floor through.
  */
 function updateGroundBytes(bytes: Uint8Array, field: Readonly<BiomeField>): void {
   const count = field.cols * field.rows;
@@ -182,11 +178,13 @@ function updateGroundBytes(bytes: Uint8Array, field: Readonly<BiomeField>): void
     const base = getBaseTint(field.baseIDs[index] ?? 0);
     const neighbour = getBaseTint(field.neighbourBaseIDs[index] ?? 0);
     const mixT = 0.5 * (field.blendTs[index] ?? 0);
+    // The base tint blends toward the border neighbour's tint by half `blendT`.
     let r = base.r + (neighbour.r - base.r) * mixT;
     let g = base.g + (neighbour.g - base.g) * mixT;
     let b = base.b + (neighbour.b - base.b) * mixT;
 
     if ((field.modifierIDs[index] ?? 0) !== 0) {
+      // The modifier tint overlays at `MODIFIER_OVERLAY_ALPHA` where the modifier layer drew non-`none`.
       r += (MODIFIER_TINT.r - r) * MODIFIER_OVERLAY_ALPHA;
       g += (MODIFIER_TINT.g - g) * MODIFIER_OVERLAY_ALPHA;
       b += (MODIFIER_TINT.b - b) * MODIFIER_OVERLAY_ALPHA;

--- a/libs/game/worldmap-client/src/components-three/fog-of-war.tsx
+++ b/libs/game/worldmap-client/src/components-three/fog-of-war.tsx
@@ -61,12 +61,9 @@ const FOG_BILLOW_EDGE = 0.35;
 const FOG_BILLOW_DEEP = 0.08;
 
 /**
- * Draws soft fog of war over the world map: one viewport-covering plane whose per-fragment opacity
- * samples a fog-density texture — the smootherstep-eased euclidean distance to the nearest reveal
- * disc, 0 over revealed ground and 1 a falloff past the frontier — modulated by drifting billow
- * noise. Purely presentational: it projects the density field from the store's reveal sources and
- * stores nothing itself, rebuilding only when a pan crosses a chunk boundary. It renders nothing
- * until both a viewport and reveal sources exist.
+ * Draws soft fog of war over the world map. Purely presentational: it projects the density field
+ * from the store's reveal sources and stores nothing itself, rebuilding only when a pan crosses a
+ * chunk boundary. It renders nothing until both a viewport and reveal sources exist.
  */
 export function FogOfWar() {
   const revealSources = useRevealSources();
@@ -107,12 +104,12 @@ interface FogPlaneProps {
 
 /**
  * The geometry, material, and texture node live for the whole mount: a field change swaps the
- * texture node's value and rewrites the quad in place, never rebuilding the material. A fresh
- * material per change would recompile its shader pipeline on every rebuild, and that churn is
- * enough to lose the GPU context mid-pan — the canvas goes irrecoverably blank.
+ * texture node's value and rewrites the quad in place, never rebuilding the material.
  */
 function FogPlane(props: Readonly<FogPlaneProps>) {
   const planeRef = useRef<FogPlaneResources | null>(null);
+  // a fresh material per change would recompile its shader pipeline on every rebuild, and that
+  // churn is enough to lose the GPU context mid-pan — the canvas goes irrecoverably blank
   const plane = (planeRef.current ??= buildFogPlaneResources(props.field, props.viewport));
 
   useLayoutEffect(() => {
@@ -161,6 +158,9 @@ function buildFogPlaneResources(
 
   updateDensityBytes(density.bytes, field);
 
+  // the density texture's red channel is the smootherstep-eased euclidean distance to the
+  // nearest reveal disc — 0 over revealed ground, 1 a falloff past the frontier; the opacity
+  // node samples it and modulates the result with drifting billow noise
   const textureNode = sceneTSL.texture(buildDensityTexture(density));
 
   const material = new MeshBasicNodeMaterial({
@@ -181,11 +181,9 @@ function buildFogPlaneResources(
 }
 
 /**
- * A same-size field — every pan; only a zoom changes the texel dimensions — rewrites the live
- * texture's pixels in place: no new GPU texture and, above all, no disposal, since destroying a
- * texture a queued frame still binds is a device loss on the WebGPU backend and a silently blank
- * canvas. Only a resize allocates a replacement, and the old texture is released only after the
- * node stops referencing it.
+ * Never dispose a texture a queued frame still binds — destroying it is a device loss on the
+ * WebGPU backend and a silently blank canvas. Only a resize allocates a replacement, and the old
+ * texture is released only after the node stops referencing it.
  */
 function updateFogPlane(
   // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- the resources' density buffer and texture-node value slot are mutable by design: rewriting them is how a rebuilt field reaches the live material
@@ -201,10 +199,14 @@ function updateFogPlane(
   plane.applied = { field, viewport };
 
   if (field.cols === plane.density.cols && field.rows === plane.density.rows) {
+    // a pan without a zoom keeps the texel dimensions — rewrite the live texture's pixels in
+    // place, no new GPU texture
     updateDensityBytes(plane.density.bytes, field);
 
     plane.textureNode.value.needsUpdate = true;
   } else {
+    // a zoom changes the texel dimensions — allocate a replacement texture and release the old
+    // one only once the node stops referencing it
     plane.density.bytes = new Uint8Array(field.values.length);
 
     plane.density.cols = field.cols;
@@ -293,23 +295,22 @@ function updateFogPlaneGeometry(geometry: BufferGeometry, viewport: Readonly<Vie
   geometry.computeBoundingSphere();
 }
 
-/**
- * Two octaves of world-anchored noise drifting in opposite directions, so the fog reads as a
- * living volume rather than a static gradient. The billow is strongest in the frontier band —
- * `density * (1 - density)` peaks mid-gradient and vanishes at both ends — with a small
- * density-proportional term so deep fog keeps a faint internal churn; clamping restores the 0..1
- * opacity range. Noise coordinates come from world position, not uv, so drifting the camera never
- * drags the billow along with the quad; the time term broadcast onto both axes blows the noise
- * field diagonally, like wind.
- */
 function buildBillowedOpacity(density: TSLMathNode): TSLMathNode {
   const ground = sceneTSL.positionWorld.xz;
   const clock = sceneTSL.time;
+  // strongest in the frontier band: `density * (1 - density)` peaks mid-gradient and vanishes at
+  // both ends
   const band = density.mul(density.oneMinus()).mul(4);
+  // noise coordinates come from world position, not uv, so drifting the camera never drags the
+  // billow along with the quad
   const drift = ground.mul(FOG_BILLOW_SCALE);
   const coarse = sceneTSL.mx_noise_float(drift.add(clock.mul(0.24)));
+  // two octaves drifting in opposite directions, with the time term broadcast onto both axes
+  // blowing the noise field diagonally, like wind
   const fine = sceneTSL.mx_noise_float(drift.mul(2.3).sub(clock.mul(0.31)));
   const billow = coarse.mul(0.7).add(fine.mul(0.3));
+  // a small density-proportional term added to the band term so deep fog keeps a faint internal
+  // churn
   const amplitude = band.mul(FOG_BILLOW_EDGE).add(density.mul(FOG_BILLOW_DEEP));
 
   return density.add(billow.mul(amplitude)).clamp(0, 1);

--- a/libs/game/worldmap-client/src/components-three/perf-probe.tsx
+++ b/libs/game/worldmap-client/src/components-three/perf-probe.tsx
@@ -33,15 +33,6 @@ interface RollingFrameWindow {
  * the dev tools panel's perf HUD. Every read happens inside `useFrame`, never a memo — concurrent
  * rendering can interrupt and replay a memo, which would misreport the elapsed time between two
  * unrelated renders as a frame duration.
- *
- * three's own internal animation loop would reset `info.render` on its own rAF cadence, but that
- * loop races R3F's separate `requestAnimationFrame` loop, which is what actually drives
- * `renderer.render()` here — a reset on the wrong cadence would zero counts between this probe's
- * read and the frame they describe. While mounted, this probe takes ownership of the reset
- * instead: reading each tick's counts one frame after the render they describe, then zeroing them
- * so the next read covers only the frame after that. The renderer persists across scene swaps, so
- * the effect restores `autoReset` on cleanup — otherwise every other scene would keep accumulating
- * counts three's own loop never gets a chance to clear.
  */
 export function PerfProbe() {
   const renderer = useRenderer();
@@ -50,6 +41,14 @@ export function PerfProbe() {
   useEffect(() => {
     const previousAutoReset = renderer.info.autoReset;
 
+    // three's own internal animation loop would reset `info.render` on its own rAF cadence, but
+    // that loop races R3F's separate `requestAnimationFrame` loop, which is what actually drives
+    // `renderer.render()` here — a reset on the wrong cadence would zero counts between this
+    // probe's read and the frame they describe. While mounted, this probe takes ownership of the
+    // reset instead, reading each tick's counts one frame after the render they describe and then
+    // zeroing them itself (below) so the next read covers only the frame after that. The renderer
+    // persists across scene swaps, so this effect restores `autoReset` on cleanup — otherwise every
+    // other scene would keep accumulating counts three's own loop never gets a chance to clear.
     renderer.info.autoReset = false;
 
     return () => {
@@ -63,6 +62,8 @@ export function PerfProbe() {
     const drawCalls = render.drawCalls ?? render.calls ?? 0;
     const triangleCount = render.triangles ?? 0;
 
+    // Zeroes the counts this probe just read, so the next read covers only the frame after this
+    // one — see the ownership note on the mount effect above.
     renderer.info.reset();
 
     const rolling = frameWindow.current;

--- a/libs/game/worldmap-client/src/utils/build-chunk-aligned-viewport.ts
+++ b/libs/game/worldmap-client/src/utils/build-chunk-aligned-viewport.ts
@@ -5,9 +5,8 @@ import { CHUNK_SIZE, WORLD_COORD_MAX, WORLD_COORD_MIN } from '@vers/worldmap-cor
  * Rounds a viewport out to the generation-chunk grid it overlaps, so a pan that stays inside the
  * same chunks keeps requesting the identical reveal-query viewport instead of a new one every cell.
  * Clamped back to the lattice's encodable range, since rounding outward can push past it near the
- * world's rim. An optional `cellCap` then shrinks the aligned box symmetrically around its center —
- * one chunk off each end of the longer axis at a time — until its cell area fits the cap, so a
- * pathological canvas aspect can never push a capped caller past its per-request bound; callers
+ * world's rim. An optional `cellCap` then shrinks the aligned box until its cell area fits the cap,
+ * so a pathological canvas aspect can never push a capped caller past its per-request bound; callers
  * aligning for geometry pass no cap.
  */
 export function buildChunkAlignedViewport(viewport: Viewport, cellCap?: number): Viewport {

--- a/libs/game/worldmap-client/src/utils/create-style-context.tsx
+++ b/libs/game/worldmap-client/src/utils/create-style-context.tsx
@@ -9,14 +9,6 @@ type StyleSlotRecipe<R extends StyleRecipe> = ReturnType<R>;
 
 type StyleSlot<R extends StyleRecipe> = keyof ReturnType<R>;
 
-/**
- * Creates a style context for a given slot recipe and returns a pair of HOCs for
- * applying slot styles to a component. Useful for creating slot-based compound
- * components.
- *
- * @param recipe - The recipe to create a style context for.
- * @returns An object with two functions: `withContext` and `withProvider`.
- */
 export function createStyleContext<R extends StyleRecipe>(recipe: R) {
   const StyleContext = React.createContext<null | StyleSlotRecipe<R>>(null);
 

--- a/libs/game/worldmap-content/src/derive-worldmap-descriptor.ts
+++ b/libs/game/worldmap-content/src/derive-worldmap-descriptor.ts
@@ -15,9 +15,7 @@ export interface DeriveWorldmapDescriptorInput {
  * always yields an identical descriptor, and it is uncorrelated with public node geometry — no
  * client can reproduce it without the scope secret.
  *
- * The `v1` segment is scheme versioning, frozen alongside the byte layout. The coordinate and user
- * seed are decimal-formatted before joining, so distinct integers can never collide through digit
- * concatenation.
+ * The exact byte layout is frozen and enforced by the golden-descriptor test.
  */
 export function deriveWorldmapDescriptor(
   input: Readonly<DeriveWorldmapDescriptorInput>,

--- a/libs/game/worldmap-core/src/build-biome-field.ts
+++ b/libs/game/worldmap-core/src/build-biome-field.ts
@@ -20,11 +20,6 @@ export interface BuildBiomeFieldOptions {
  * border. Node jitter stays within its own cell, so the texel at a cell's own coordinate always
  * agrees with `getBiome` on that cell.
  *
- * Texels are laid out row-major over the viewport's cell box inflated by half a cell on each side,
- * the same convention `buildRevealDistanceField` uses: texel `(i, j)` samples axial `(minCX - 0.5 +
- * (i + 0.5) / resolution, minCY - 0.5 + (j + 0.5) / resolution)`, the mapping a quad spanning that
- * box with corner-anchored uvs interpolates.
- *
  * `blendTs` carries cross-territory border proximity: 0 through a patch interior — including every
  * internal territory boundary between same-biome nodes — ramping to 1 where two differently-biomed
  * territories meet, over `BIOME_TERRITORY_BLEND_BAND` scene units. `neighbourBaseIDs` names the
@@ -81,6 +76,10 @@ export function buildBiomeField(
     return position;
   };
 
+  // Texels are laid out row-major over the viewport's cell box inflated by half a cell on each
+  // side, the same convention `buildRevealDistanceField` uses: texel `(i, j)` samples axial
+  // `(minCX - 0.5 + (i + 0.5) / resolution, minCY - 0.5 + (j + 0.5) / resolution)`, the mapping
+  // a quad spanning that box with corner-anchored uvs interpolates.
   for (let j = 0; j < rows; j++) {
     const cy = viewport.minCY - 0.5 + (j + 0.5) / options.resolution;
 

--- a/libs/game/worldmap-core/src/build-reveal-distance-field.ts
+++ b/libs/game/worldmap-core/src/build-reveal-distance-field.ts
@@ -33,10 +33,6 @@ export interface RevealFieldOptions {
  * A disc's clear radius is its hex-hop radius times √3 — the farthest scene distance of any cell
  * inside its hex disc — plus the jitter margin, so every genuinely revealed cell sits fully inside
  * the clear region even when its node is jittered outward, and fog never hides opened ground.
- *
- * Texels are laid out row-major over the viewport's cell box inflated by half a cell on each side:
- * texel `(i, j)` samples axial `(minCX - 0.5 + (i + 0.5) / resolution, minCY - 0.5 + (j + 0.5) /
- * resolution)`, the same mapping a quad spanning that box with corner-anchored uvs interpolates.
  */
 export function buildRevealDistanceField(
   sources: ReadonlyArray<RevealSource>,
@@ -50,6 +46,10 @@ export function buildRevealDistanceField(
 
   const discs = collectReachingDiscs(sources, viewport, options.falloff);
 
+  // Texels are laid out row-major over the viewport's cell box inflated by half a cell on each
+  // side: texel (i, j) samples axial (minCX - 0.5 + (i + 0.5) / resolution, minCY - 0.5 + (j +
+  // 0.5) / resolution), the same mapping a quad spanning that box with corner-anchored uvs
+  // interpolates.
   for (let j = 0; j < rows; j++) {
     const b = viewport.minCY - 0.5 + (j + 0.5) / options.resolution;
 

--- a/libs/game/worldmap-core/src/consts.ts
+++ b/libs/game/worldmap-core/src/consts.ts
@@ -122,10 +122,7 @@ export const BIOME_TERRITORY_BLEND_BAND = 0.75;
 /**
  * Base-biome alternatives and their distance-banded rarity, placeholder and tunable. Every name is
  * dev-facing flavour text — it must never reach a contract schema, an analytics event, or a DB
- * column. `biome_1` is common at every distance; `biome_2` is absent until distance ~20 and fades
- * in by ~80; `biome_3` is deep-only, absent until distance ~60 and fading in by ~140; `biome_4` is
- * common near the origin and rarer far out. Every curve converges to a roughly equal weight by
- * distance 200.
+ * column.
  */
 export const BIOME_ROSTER: ReadonlyArray<BiomeRosterEntry> = [
   {

--- a/libs/game/worldmap-core/src/encode-morton-key.ts
+++ b/libs/game/worldmap-core/src/encode-morton-key.ts
@@ -10,9 +10,6 @@ import { MORTON_AXIS_BITS } from './consts';
  *
  * A coordinate outside the packable range, or one carrying a fractional axis, is a caller bug:
  * callers holding unbounded coordinates filter them out before packing.
- *
- * Built from plain arithmetic rather than bitwise operators, since JS's bitwise operators truncate
- * to 32 bits and the interleaved result runs past that width.
  */
 export function encodeMortonKey(coord: readonly [number, number]): number {
   invariant(
@@ -24,6 +21,8 @@ export function encodeMortonKey(coord: readonly [number, number]): number {
   const zy = toZigzag(coord[1]);
   let key = 0;
 
+  // Built from plain arithmetic rather than bitwise operators, since JS's bitwise operators
+  // truncate to 32 bits and the interleaved result runs past that width.
   for (let bit = 0; bit < MORTON_AXIS_BITS; bit++) {
     const xBit = Math.floor(zx / 2 ** bit) % 2;
     const yBit = Math.floor(zy / 2 ** bit) % 2;

--- a/libs/game/worldmap-core/src/get-biome.ts
+++ b/libs/game/worldmap-core/src/get-biome.ts
@@ -23,9 +23,6 @@ import type { BiomeRosterEntry, BiomeSample } from './types';
  * derives the identical sample from the same seed and position, and `cx`/`cy` may be any real
  * number, not only an integer cell coordinate, so a texel field can sample between cell centers.
  *
- * The base layer reads its nearest and second-nearest feature point for `blendT` and
- * `neighbourBaseID`; the modifier layer's border blend is never read, so it reads only its nearest.
- *
  * A hidden per-node reward that clusters by biome is permanently forbidden — it would turn
  * client-visible terrain into a treasure map for sealed loot, the exact sniping fog exists to deny.
  * Biome may only ever touch reward through a public, biome-uniform function of the public biome id,
@@ -40,6 +37,8 @@ export function getBiome(userSeed: number, cx: number, cy: number): BiomeSample 
   const warpedX = hexX + BIOME_EDGE_WOBBLE_AMPLITUDE * (wobbleX - 0.5);
   const warpedY = hexY + BIOME_EDGE_WOBBLE_AMPLITUDE * (wobbleY - 0.5);
 
+  // Reads both nearest and second-nearest feature points: blendT and neighbourBaseID need the
+  // second-nearest for the border blend.
   const base = buildNearestFeaturePoints(
     userSeed,
     warpedX,
@@ -49,6 +48,7 @@ export function getBiome(userSeed: number, cx: number, cy: number): BiomeSample 
     HASH_CHANNEL.worleyFeatureY,
   );
 
+  // The modifier layer has no border blend, so only its nearest feature point is read.
   const modifier = buildNearestFeaturePoints(
     userSeed,
     warpedX,
@@ -102,16 +102,6 @@ interface NearestFeaturePoints {
   readonly secondDistance: number;
 }
 
-/**
- * Scatters one jittered feature point per coarse cell of `patchSize` and scans the 5×5
- * neighbourhood around `(x, y)` for the nearest and second-nearest, the Worley step behind the
- * border blend. Feature points jitter anywhere inside their cell, so a sample near a cell corner
- * can sit closer to a feature two rings out than to every feature in the 3×3 window. 5×5 is always
- * enough: the sample's own cell and its corner-adjacent cell each hold a candidate within √2 patch
- * units, while every cell three or more rings out lies at least 2 patch units away, so both winners
- * fall inside the window. Candidate coordinates and feature points stay plain numbers throughout
- * the scan — nothing is allocated per candidate.
- */
 function buildNearestFeaturePoints(
   userSeed: number,
   x: number,
@@ -129,6 +119,12 @@ function buildNearestFeaturePoints(
   let secondCellX = baseCellX;
   let secondCellY = baseCellY;
 
+  // Scatters one jittered feature point per coarse cell of patchSize and scans the 5×5
+  // neighbourhood around (x, y) for the nearest and second-nearest. Feature points jitter anywhere
+  // inside their cell, so a sample near a cell corner can sit closer to a feature two rings out
+  // than to every feature in the 3×3 window. 5×5 is always enough: the sample's own cell and its
+  // corner-adjacent cell each hold a candidate within √2 patch units, while every cell three or
+  // more rings out lies at least 2 patch units away, so both winners fall inside the window.
   for (let dy = -2; dy <= 2; dy++) {
     for (let dx = -2; dx <= 2; dx++) {
       const cellX = baseCellX + dx;

--- a/libs/service/jobs/src/create-job-queue.ts
+++ b/libs/service/jobs/src/create-job-queue.ts
@@ -122,8 +122,7 @@ const DEAD_LETTER_SUFFIX = '.dead';
 
 /**
  * Idempotent: `pg-boss`'s `createQueue` upserts, so calling `start` again against an already
- * migrated database is safe. A dead-letter queue is created before the queue that references it,
- * since pg-boss enforces the reference with a foreign key.
+ * migrated database is safe.
  */
 async function startQueues(boss: PgBoss, defs: JobDefs): Promise<void> {
   await boss.start();
@@ -131,6 +130,8 @@ async function startQueues(boss: PgBoss, defs: JobDefs): Promise<void> {
   for (const [name, def] of Object.entries(defs)) {
     const deadLetterName = def.deadLetter === true ? `${name}${DEAD_LETTER_SUFFIX}` : undefined;
 
+    // pg-boss enforces the dead-letter reference with a foreign key, so the referenced queue
+    // must exist before the queue that points at it is created.
     if (deadLetterName !== undefined) {
       await boss.createQueue(deadLetterName);
     }
@@ -176,10 +177,6 @@ interface FetchedJob {
   readonly retryLimit: number;
 }
 
-/**
- * One-shot fetch/handle/complete loop: batches until a queue is empty, then moves to the next
- * queue.
- */
 async function drainJobs(
   boss: PgBoss,
   defs: JobDefs,

--- a/libs/service/product-analytics/src/metrics/record-delivery-failure.ts
+++ b/libs/service/product-analytics/src/metrics/record-delivery-failure.ts
@@ -6,12 +6,12 @@ export type DeliveryFailureReason = 'quarantined' | 'rejected' | 'unreachable';
  * Counts one product event that never landed in the Tinybird data source, split by reason:
  * `rejected` covers a non-2xx response from the Events API, `quarantined` covers a row the API
  * accepted but failed schema validation on, and `unreachable` covers a network failure or the
- * upstream deadline tripping. The counter is resolved through the global metrics API on every
- * call — the SDK returns the same instrument for an identical registration, and resolving late
- * keeps the counter bound to whichever meter provider the process registered at boot; without one
- * it is the API's no-op.
+ * upstream deadline tripping.
  */
 export function recordDeliveryFailure(reason: DeliveryFailureReason): void {
+  // Resolved through the global metrics API on every call — the SDK returns the same instrument
+  // for an identical registration, and resolving late keeps the counter bound to whichever meter
+  // provider the process registered at boot; without one it is the API's no-op.
   const counter = metrics
     .getMeter('@vers/product-analytics')
     .createCounter('vers.analytics.delivery_failures', {

--- a/libs/service/service-utils/src/orpc/build-tracing-interceptor.ts
+++ b/libs/service/service-utils/src/orpc/build-tracing-interceptor.ts
@@ -9,9 +9,7 @@ import { findTraceContext } from '../trace/find-trace-context';
 
 /**
  * Builds an `RPCLink` `clientInterceptors` entry that mints a CLIENT span per call (named by the
- * procedure's path) and injects the outbound `traceparent`: from the span when a tracer provider
- * is registered, falling back to the ambient request's trace context, and minting fresh only when
- * neither exists (background work with no request scope). A 5xx response or a thrown transport
+ * procedure's path) and injects the outbound `traceparent`. A 5xx response or a thrown transport
  * failure marks the span failed before it rethrows.
  */
 export function buildTracingInterceptor<T extends ClientContext = ClientContext>(): Interceptor<
@@ -25,6 +23,8 @@ export function buildTracingInterceptor<T extends ClientContext = ClientContext>
       options.path.join('.'),
       { kind: SpanKind.CLIENT },
       async (span) => {
+        // Prefers the span's own trace context, falls back to the ambient request's, and mints
+        // fresh only when neither exists (background work with no request scope).
         const outboundTrace = findSpanTraceContext() ?? findTraceContext() ?? createTraceContext();
 
         options.request.headers['traceparent'] = buildTraceparent(outboundTrace);

--- a/libs/service/service-utils/src/trace/get-trace-storage.ts
+++ b/libs/service/service-utils/src/trace/get-trace-storage.ts
@@ -9,14 +9,12 @@ let storage: asyncHooks.AsyncLocalStorage<TraceContext> | undefined;
  * only by `withTraceContext`; read anywhere via `findTraceContext` — including pino mixins, so
  * every log line inside a request carries its trace id without threading it through call
  * signatures.
- *
- * Construction is deferred to the call site, and the binding it constructs from is read through
- * a namespace import rather than a named one, so that importing this module — or anything that
- * re-exports it, like the `orpc` barrel — never touches `node:async_hooks` on its own. A
- * bundler that externalizes the builtin for the browser only throws when a property on it is
- * actually read; a browser bundle that never calls into a request scope never reads one.
  */
 export function getTraceStorage(): asyncHooks.AsyncLocalStorage<TraceContext> {
+  // construction is deferred to this call site, and read through the namespace import above,
+  // so importing this module — or anything that re-exports it, like the `orpc` barrel — never
+  // touches `node:async_hooks` on its own; a bundler that externalizes the builtin for the
+  // browser only throws when a property on it is actually read
   storage ??= new asyncHooks.AsyncLocalStorage<TraceContext>();
 
   return storage;

--- a/libs/testing/client-test-utils/src/register-zustand-reset.ts
+++ b/libs/testing/client-test-utils/src/register-zustand-reset.ts
@@ -4,13 +4,13 @@ import * as actualZustand from 'zustand';
 /**
  * Wires automatic zustand store resets into the current bun-test run: wraps zustand's `create` so
  * every store built through it registers a reset to its initial state, replayed in a global
- * `afterEach`. Call once from a bunfig preload, as early as possible — `bun test` runs every file
- * in one process with no per-file isolation, so a store mutated in one file otherwise leaks into
- * the next, and the wrapping must be installed before any module under test imports `zustand`.
- * `mock.module` swaps the live `zustand` namespace binding retroactively, so the real `create` is
- * captured into a const before it runs, or calling it from inside the wrapper recurses.
+ * `afterEach`. Call once from a bunfig preload, before any module under test imports `zustand` —
+ * `bun test` runs every file in one process with no per-file isolation, so a store mutated in one
+ * file otherwise leaks into the next.
  */
 export function registerZustandReset(): void {
+  // Captured before mock.module swaps the live `zustand` namespace binding; calling
+  // actualZustand.create from inside the wrapper below would recurse.
   const actualCreate = actualZustand.create;
 
   const storeResetFns = new Set<() => void>();
@@ -33,6 +33,8 @@ export function registerZustandReset(): void {
       : createTrackedStore;
   }) as typeof actualZustand.create;
 
+  // Swaps the live `zustand` namespace binding retroactively, so every already-imported consumer
+  // picks up the tracked `create`.
   void mock.module('zustand', () => ({ ...actualZustand, create }));
 
   afterEach(() => {

--- a/libs/testing/mock-services/src/activity/reveal-nodes.ts
+++ b/libs/testing/mock-services/src/activity/reveal-nodes.ts
@@ -17,13 +17,13 @@ const MOCK_SECRET_REF = 'worldmap';
 const MOCK_SECRET_VERSION = 1;
 
 /**
- * Mints a genesis seed per requested node, hashed from the avatar and node id so the same pair
- * always reveals to the same seed across calls — mirroring the real service's idempotent reveal
- * without a persisted chain collection to key off of. Each node's encounter mirrors
- * `startActivity`'s own mock derivation: difficulty from its coordinate alone, no sealed pool
- * pick. Mirrors the real handler's other checks: NODE_UNKNOWN for a scope id that doesn't resolve
- * to a world-map node, and admission gated to the account's active avatar, adopting an absent
- * selection unless a different avatar already holds a live run.
+ * Mints a genesis seed per requested node so the same avatar-and-node pair always reveals to the
+ * same seed across calls — mirroring the real service's idempotent reveal without a persisted
+ * chain collection to key off of. Each node's encounter mirrors `startActivity`'s own mock
+ * derivation: difficulty from its coordinate alone, no sealed pool pick. Mirrors the real
+ * handler's other checks: NODE_UNKNOWN for a scope id that doesn't resolve to a world-map node,
+ * and admission gated to the account's active avatar, adopting an absent selection unless a
+ * different avatar already holds a live run.
  */
 export const revealNodes = os.revealNodes.handler(async (opts) => {
   const actingUserId = opts.context.actingUserId;
@@ -71,6 +71,7 @@ export const revealNodes = os.revealNodes.handler(async (opts) => {
   }
 
   const nodes = opts.input.nodeIDs.map((nodeID) => {
+    // Hashed from the avatar and node id, so the same pair always derives the same seed.
     const hash = sha256(utf8ToBytes(`vers-mock-genesis|${opts.input.avatarID}|${nodeID}`));
     const encounterNode = resolveEncounterNode('world_map_node', nodeID);
 

--- a/libs/testing/service-test-utils/src/bun/setup-bun-test-db.ts
+++ b/libs/testing/service-test-utils/src/bun/setup-bun-test-db.ts
@@ -13,11 +13,8 @@ const TEST_CONTAINER_PORT = 32_999;
  * Publishes the shared postgres test container's connection details as
  * `TEST_DB_URI`/`TEST_TEMPLATE_DB` env vars for bun-test files to read (a
  * bun-test file's preload runs once per file's process, so `inject`-style
- * handoff isn't available). Starts (or attaches to) the reused container —
- * short-circuiting whenever the container is already reachable, since CI
- * always starts it with `pg:test-container:start` first and testcontainers
- * under bun is otherwise unproven — then provisions this worktree's
- * branch-scoped template.
+ * handoff isn't available). Starts (or attaches to) the reused container,
+ * then provisions this worktree's branch-scoped template.
  */
 export async function setupBunTestDB(): Promise<void> {
   if (process.env['TEST_DB_URI'] !== undefined) {
@@ -28,6 +25,8 @@ export async function setupBunTestDB(): Promise<void> {
 
   let baseURI: string;
 
+  // Short-circuits whenever the container is already reachable, since CI always starts it with
+  // `pg:test-container:start` first and testcontainers under bun is otherwise unproven.
   if (containerReachable) {
     baseURI = `postgres://test:test@localhost:${TEST_CONTAINER_PORT}`;
   } else {

--- a/libs/testing/test-utils/src/bun/register-happy-dom.ts
+++ b/libs/testing/test-utils/src/bun/register-happy-dom.ts
@@ -2,11 +2,7 @@ import { GlobalRegistrator } from '@happy-dom/global-registrator';
 
 /**
  * Registers happy-dom's globals for a bun-test preload, then restores bun's native fetch stack
- * (fetch, Request, Response, Headers, Blob, AbortController, AbortSignal, and the web-stream
- * classes) over happy-dom's replacements. The two implementations fail when mixed: bun's
- * ReadableStream.pipeTo rejects happy-dom's WritableStream, MSW's node interception reads a
- * Request's signal and a Response's body stream, and a happy-dom `AbortSignal` fails Bun's
- * `Request` constructor's own instance check, so the whole set must come from one implementation.
+ * over happy-dom's replacements, since the two implementations aren't interoperable.
  */
 export function registerHappyDOM(): void {
   const nativeFetchStack = {
@@ -23,5 +19,10 @@ export function registerHappyDOM(): void {
   };
 
   GlobalRegistrator.register();
+
+  // bun's ReadableStream.pipeTo rejects happy-dom's WritableStream, MSW's node interception reads
+  // a Request's signal and a Response's body stream, and a happy-dom AbortSignal fails Bun's
+  // Request constructor's own instance check — the whole fetch stack must come from one
+  // implementation.
   Object.assign(globalThis, nativeFetchStack);
 }

--- a/scripts/src/bin/deploy.ts
+++ b/scripts/src/bin/deploy.ts
@@ -305,13 +305,9 @@ async function withReleaseDB(run: (db: Kysely<DB>) => Promise<void>): Promise<vo
 
 /**
  * One rollout from an already-built image (null for targets that deploy their fly.toml stock
- * image): sweep any machines stranded on a second image by an aborted rollout, ensure the target's
- * IP posture, cut the fleet over, reconcile, probe. Probes passing records the release as the app's
- * next rollback target; probes failing rolls the fleet back to the previous recorded release and
- * leaves the run red either way, so the failure ships forward on a later push instead of a broken
- * release serving meanwhile. A sweep the planner can't resolve unambiguously fails the leg before
- * flyctl ever runs, rather than let its own "found multiple image versions" preflight fail it with
- * no path to recovery but a manual machine destroy.
+ * image). Probes passing records the release as the app's next rollback target; probes failing
+ * rolls the fleet back to the previous recorded release and leaves the run red either way, so the
+ * failure ships forward on a later push instead of a broken release serving meanwhile.
  */
 async function runRollout(
   db: Kysely<DB>,
@@ -325,6 +321,9 @@ async function runRollout(
   const recordedRelease = previous === undefined ? null : { gitSHA: previous.gitSha };
   const sweepPlan = planMachineSweep(fleet.machines, recordedRelease);
 
+  // A sweep the planner can't resolve unambiguously fails the leg before flyctl ever runs, rather
+  // than let its own "found multiple image versions" preflight fail it with no path to recovery but
+  // a manual machine destroy.
   if (sweepPlan.kind === 'ambiguous') {
     console.error(`✗ ${target.app} — ${sweepPlan.reason}`);
     console.error(formatMachineTable(fleet.machines));

--- a/scripts/src/bin/issue-hygiene.ts
+++ b/scripts/src/bin/issue-hygiene.ts
@@ -40,10 +40,8 @@ const repo = process.env['GITHUB_REPOSITORY'] ?? repoResult.trim();
 
 const existingCommentID = await findStickyCommentID(repo, issueNumber);
 
-/**
- * A clean issue that never earned a sticky comment needs none — only issues the bot has already
- * commented on get their comment flipped to the all-clear rendering.
- */
+// a clean issue that never earned a sticky comment needs none — only issues the bot has already
+// commented on get their comment flipped to the all-clear rendering
 if (findings.length === 0 && existingCommentID === null) {
   console.log(`#${issueNumber} is clean`);
   process.exit(0);

--- a/scripts/src/postgres/refresh-dev-base.ts
+++ b/scripts/src/postgres/refresh-dev-base.ts
@@ -5,20 +5,15 @@ import postgres from 'postgres';
 import { buildDevDSN } from './build-dev-dsn';
 
 /**
- * Rebuilds dev_base from nothing: forced drop, create, migrate, seed, then
- * lock. The seed step shells out to @vers/db's kysely-ctl script because
- * seeds are a kysely-ctl feature with no library entrypoint. Existing
- * per-worktree clones are untouched — they pick up new migrations on their
- * next session. The finished template refuses connections (like template0):
- * cloning fails while any session exists on the source, and Neon parks
- * invisible backends on recently connected databases for minutes — so the
- * only connections dev_base ever sees are this rebuild's own, and those are
- * terminated once it's locked.
+ * Rebuilds dev_base from nothing: forced drop, create, migrate, seed, then lock. Existing
+ * per-worktree clones are untouched — they pick up new migrations on their next session. The
+ * finished template refuses connections (like template0).
  */
 export async function refreshDevBase(maintenanceDSN: string, repoRoot: string): Promise<void> {
   const pg = postgres(maintenanceDSN, { max: 1 });
 
   try {
+    // FORCE drops the database even while other sessions still hold connections to it.
     await pg.unsafe('DROP DATABASE IF EXISTS dev_base WITH (FORCE)');
     await pg.unsafe('CREATE DATABASE dev_base');
   } finally {
@@ -35,6 +30,8 @@ export async function refreshDevBase(maintenanceDSN: string, repoRoot: string): 
       : new Error('dev_base migration failed', { cause: result.error });
   }
 
+  // Shells out to @vers/db's kysely-ctl script because seeds are a kysely-ctl feature with no
+  // library entrypoint.
   await execa('bun', ['run', 'db:seed'], {
     cwd: join(repoRoot, 'libs/data/db'),
     env: { DATABASE_URL: devBaseDSN },
@@ -44,6 +41,9 @@ export async function refreshDevBase(maintenanceDSN: string, repoRoot: string): 
   const lock = postgres(maintenanceDSN, { max: 1 });
 
   try {
+    // Cloning fails while any session exists on the source, and Neon parks invisible backends on
+    // recently connected databases for minutes, so dev_base is locked against new connections and
+    // its own are terminated below — leaving it clonable.
     await lock.unsafe('ALTER DATABASE dev_base WITH ALLOW_CONNECTIONS false');
 
     await lock`

--- a/scripts/src/postgres/sweep-dev-dbs.ts
+++ b/scripts/src/postgres/sweep-dev-dbs.ts
@@ -9,8 +9,6 @@ interface SweepConfig {
 
 /**
  * Drops this machine's orphaned dev databases and returns their names.
- * DROP ... WITH (FORCE) disconnects lingering sessions first, so a sweep
- * never fails on a stale connection left by a closed agent session.
  */
 export async function sweepDevDBs(config: Readonly<SweepConfig>): Promise<Array<string>> {
   const pg = postgres(config.maintenanceDSN, { max: 1 });
@@ -29,6 +27,8 @@ export async function sweepDevDBs(config: Readonly<SweepConfig>): Promise<Array<
     });
 
     for (const name of orphans) {
+      // WITH (FORCE) disconnects lingering sessions first, so the drop never fails on a stale
+      // connection left by a closed agent session.
       await pg.unsafe(`DROP DATABASE ${name} WITH (FORCE)`);
     }
 

--- a/scripts/src/postgres/sweep-test-templates.ts
+++ b/scripts/src/postgres/sweep-test-templates.ts
@@ -11,8 +11,7 @@ interface SweepTestTemplatesConfig {
  * Drops the local test container's orphaned branch-scoped test-template
  * databases and returns their names, or `null` when the container isn't
  * reachable — a sweep is a no-op on a machine with no running test
- * container. `DROP ... WITH (FORCE)` disconnects lingering sessions first,
- * so a sweep never fails on a connection a closed test run left open.
+ * container.
  */
 export async function sweepTestTemplates(
   config: Readonly<SweepTestTemplatesConfig>,
@@ -34,6 +33,8 @@ export async function sweepTestTemplates(
     });
 
     for (const name of orphans) {
+      // WITH (FORCE) disconnects lingering sessions first, so a drop never fails on a connection
+      // a closed test run left open.
       await pg.unsafe(`DROP DATABASE "${name}" WITH (FORCE)`);
     }
 

--- a/services/activity/src/build-router.ts
+++ b/services/activity/src/build-router.ts
@@ -32,12 +32,6 @@ interface BuildActivityRouterDeps {
   readonly simTimeCapMs: number;
 }
 
-/**
- * Assembles the activities service's oRPC router, closing each handler over the shared db client
- * (and, for `startActivity`, the memoized content-document loader new activities are minted
- * against, the key version, the keys origin, s2s signing key, and scope secret ref/version its
- * sealed content read uses; for `trackActivityProgress`, the offline-progress budget ceiling).
- */
 export function buildActivityRouter(deps: BuildActivityRouterDeps) {
   const os = implement(activityContract).$context<ServiceContext>();
 

--- a/services/activity/src/env-shape.ts
+++ b/services/activity/src/env-shape.ts
@@ -1,10 +1,5 @@
 import * as z from 'zod';
 
-/**
- * Environment the activity service needs beyond the base service env: the checkpoint-store
- * database, the replay origin committed appends poke, the keys origin a start reads its scope
- * secret from, and the key its wake-poke and s2s tokens are signed with.
- */
 export const envShape = {
   DATABASE_URL: z.string().describe('Postgres connection string for the activity checkpoint store'),
   KEYS_SERVICE_URL: z

--- a/services/activity/src/get-optimistic-build.ts
+++ b/services/activity/src/get-optimistic-build.ts
@@ -10,13 +10,14 @@ import invariant from 'tiny-invariant';
  * every activity that ended and still awaits its verifier — beside the runs that xp came from. A
  * `parked` or `quarantined` activity is left out: both are holds with no path back to verification
  * on their own, so counting them would stamp xp that never settles into this run's snapshot and
- * every later one's. One statement reads the settled row and the unsettled set together, so a
- * concurrent verifier commit can't land its delta between two separate reads.
+ * every later one's.
  */
 export async function getOptimisticBuild(
   trx: Kysely<DB>,
   avatarID: string,
 ): Promise<OptimisticBuild> {
+  // One statement reads the settled row and the unsettled set together, so a concurrent verifier
+  // commit can't land its delta between two separate reads.
   const rows = await trx
     .selectFrom('avatars')
     .leftJoin('activities', (join) =>

--- a/services/activity/src/handlers/advance-activity.ts
+++ b/services/activity/src/handlers/advance-activity.ts
@@ -78,12 +78,6 @@ interface AdvanceActivityOpts {
  * simulation was pinned to, and every minted row stays eligible for the replay verifier's
  * descriptor check.
  *
- * Each continuation is its own transaction: append, then — on terminal — mint, through the same
- * head compare-and-swap, meter debit, terminal anchor advance, chain-seed read, and provenance
- * recording as live play. A rejection at either step unwinds the whole transaction, so the
- * confirmed head reported on any bail is always the last fully committed continuation's — never a
- * partial append with no successor.
- *
  * The mint authors `buildSnapshot` itself server-side; the entry's own `buildSnapshot` is only a
  * cross-check hint, and a mismatch bails with `CHECKPOINT_INVALID`. A client-supplied snapshot
  * the server stored as-is would be direct xp inflation.
@@ -323,19 +317,18 @@ interface RunContinuationInput {
 
 /**
  * Runs one continuation: append its tail onto the target row, then — because every tail ends
- * terminal by construction — mint its own id as the next row. The target read and its structural
- * validation run outside any transaction, matching `trackActivityProgress`'s own shape, so a
- * rejection found there needs no rollback. The cap decision and the append-and-mint each open
- * their own top-level transaction. A cap commits on its own: its terminal transition is honest
- * progress independent of this continuation's fate, exactly as `trackActivityProgress` commits it
- * apart from the append it rejects. An append and its following mint share one transaction, so a
- * rejected mint rolls the append back with it.
+ * terminal by construction — mint its own id as the next row. The cap decision and the
+ * append-and-mint each open their own top-level transaction. A cap commits on its own: its
+ * terminal transition is honest progress independent of this continuation's fate. An append and
+ * its following mint share one transaction, so a rejected mint rolls the append back with it.
  */
 async function runContinuation(
   deps: AdvanceActivityDeps,
   pinned: Readonly<PinnedActivityContext>,
   input: Readonly<RunContinuationInput>,
 ): Promise<MintedContinuation> {
+  // The target read and its structural validation run outside any transaction, matching
+  // trackActivityProgress's own shape, so a rejection found here needs no rollback.
   const target = await deps.db
     .selectFrom('activities')
     .innerJoin('avatars', 'avatars.id', 'activities.avatarId')

--- a/services/activity/src/handlers/get-avatar-progression.ts
+++ b/services/activity/src/handlers/get-avatar-progression.ts
@@ -130,10 +130,6 @@ interface PendingCandidateRow {
   readonly settledXp: null | number;
 }
 
-/**
- * Builds a pending entry from a candidate row, or nothing when the row carries no pending activity
- * — a null activity id from the left join, or an activity whose unsettled xp comes to nothing.
- */
 function findPendingEntry(row: Readonly<PendingCandidateRow>): Array<PendingXPEntry> {
   if (row.id === null) {
     return [];

--- a/services/activity/src/handlers/resume-activity.ts
+++ b/services/activity/src/handlers/resume-activity.ts
@@ -24,9 +24,8 @@ interface ResumeActivityOpts {
  * Takes over as an active activity's writer session: after this call the acting session is the
  * only one whose appends are accepted, and the displaced writer's in-flight submissions
  * fail fatally. Taking the writer is the whole of resuming server-side — the caller rebuilds its
- * simulation from the verified anchor and appends from the current head. The ownership check
- * folds into the same statement, so a foreign or missing activity is the same NOT_FOUND as a
- * terminal one.
+ * simulation from the verified anchor and appends from the current head. A foreign, missing, or
+ * terminal activity all fail the same NOT_FOUND.
  */
 export async function resumeActivity(
   db: Kysely<DB>,
@@ -44,6 +43,9 @@ export async function resumeActivity(
     .set({ writerSessionId: actingSessionID })
     .where('id', '=', opts.input.activityID)
     .where('status', '=', 'active')
+
+    // the ownership check folds into this statement, so a foreign activity fails the same
+    // NOT_FOUND path as a missing or terminal one
     .where('avatarId', 'in', (subquery) =>
       subquery.selectFrom('avatars').select('id').where('userId', '=', actingUserID),
     )

--- a/services/activity/src/handlers/reveal-nodes.ts
+++ b/services/activity/src/handlers/reveal-nodes.ts
@@ -13,11 +13,6 @@ import { requireActiveAvatar } from '../require-active-avatar';
 import { resolveEncounterNode } from '../resolve-encounter-node';
 import type { AvatarNotActivePayload, EmptyErrorPayload, MissingSessionPayload } from '../types';
 
-/**
- * Db handle plus the memoized content-document loader, the key version every revealed node's
- * encounter is stamped against, and the keys dispatch a reveal reads its scope secret over — the
- * same encounter-derivation inputs `startActivity` closes over.
- */
 interface RevealNodesDeps {
   readonly db: Kysely<DB>;
   readonly keysServiceURL: string;
@@ -194,11 +189,6 @@ interface EncounterInputs {
   readonly scopeSecret: Uint8Array;
 }
 
-/**
- * Loads the current content document and the avatar's scope secret, after the mint transaction has
- * run its active-avatar gate — an owned-but-inactive avatar rejects before this reveal contacts the
- * content registry or the keys service, and pays for neither round trip.
- */
 async function loadEncounterInputs(
   deps: RevealNodesDeps,
   avatarID: string,

--- a/services/activity/src/handlers/stop-activity.ts
+++ b/services/activity/src/handlers/stop-activity.ts
@@ -35,8 +35,7 @@ interface StopActivityOpts {
  * `NOT_FOUND` means the row doesn't exist for this caller — so a stop delivered late or twice
  * from a durable client queue can neither fail spuriously nor kill a newer run. A still-active
  * row whose stamped writer is another session rejects with SESSION_EVICTED: the stop intent
- * predates a writer take-over, and honoring it would kill the run the new writer is driving. The
- * ownership check folds into each statement — a foreign or missing avatar matches no row.
+ * predates a writer take-over, and honoring it would kill the run the new writer is driving.
  */
 export async function stopActivity(
   deps: StopActivityDeps,
@@ -58,6 +57,8 @@ export async function stopActivity(
       .selectFrom('activities')
       .selectAll()
       .where('avatarId', '=', opts.input.avatarID)
+
+      // Folds the ownership check into the query: a foreign or missing avatar matches no row.
       .where('avatarId', 'in', (subquery) =>
         subquery.selectFrom('avatars').select('id').where('userId', '=', actingUserID),
       );

--- a/services/activity/src/metrics/record-advance-bailout.ts
+++ b/services/activity/src/metrics/record-advance-bailout.ts
@@ -12,12 +12,12 @@ export type AdvanceBailoutReason =
  * Counts one `advanceActivity` request that bailed before processing every requested
  * continuation, split by the rejection that stopped it. A bailout always leaves the confirmed head
  * advanced past the committed prefix, so a rising count here tracks how often an offline catch-up's
- * outer resync must re-plan, not lost progress. The counter is resolved through the global metrics
- * API on every call — the SDK returns the same instrument for an identical registration, and
- * resolving late keeps the counter bound to whichever meter provider the process registered at
- * boot; without one it is the API's no-op.
+ * outer resync must re-plan, not lost progress.
  */
 export function recordAdvanceBailout(reason: AdvanceBailoutReason): void {
+  // Resolved through the global metrics API on every call: the SDK returns the same instrument for
+  // an identical registration, and resolving late keeps the counter bound to whichever meter
+  // provider the process registered at boot; without one it is the API's no-op.
   const counter = metrics
     .getMeter('@vers/service-activity')
     .createCounter('vers.activity.advance_bailouts', {

--- a/services/activity/src/metrics/record-advance-continuation.ts
+++ b/services/activity/src/metrics/record-advance-continuation.ts
@@ -5,12 +5,12 @@ export type AdvanceContinuationOutcome = 'converged' | 'minted';
 /**
  * Counts one `advanceActivity` continuation processed, split by whether its mint step landed a
  * fresh row (`minted`) or converged on a row a prior, partially committed request already minted
- * at the same client id (`converged`). The counter is resolved through the global metrics API on
- * every call — the SDK returns the same instrument for an identical registration, and resolving
- * late keeps the counter bound to whichever meter provider the process registered at boot; without
- * one it is the API's no-op.
+ * at the same client id (`converged`).
  */
 export function recordAdvanceContinuation(outcome: AdvanceContinuationOutcome): void {
+  // Resolved through the global metrics API on every call: the SDK returns the same instrument
+  // for an identical registration, and resolving late keeps the counter bound to whichever meter
+  // provider the process registered at boot; without one it is the API's no-op.
   const counter = metrics
     .getMeter('@vers/service-activity')
     .createCounter('vers.activity.advance_continuations', {

--- a/services/activity/src/metrics/record-avatar-not-active-rejection.ts
+++ b/services/activity/src/metrics/record-avatar-not-active-rejection.ts
@@ -2,12 +2,12 @@ import { metrics } from '@opentelemetry/api';
 
 /**
  * Counts one `startActivity` call rejected because the starting avatar is not the account's
- * active one. Attribute-free — the rejection has no dimension worth splitting on. The counter is
- * resolved through the global metrics API on every call — the SDK returns the same instrument for
- * an identical registration, and resolving late keeps the counter bound to whichever meter
- * provider the process registered at boot; without one it is the API's no-op.
+ * active one. Attribute-free — the rejection has no dimension worth splitting on.
  */
 export function recordAvatarNotActiveRejection(): void {
+  // Resolved through the global metrics API on every call: the SDK returns the same instrument for
+  // an identical registration, and resolving late keeps the counter bound to whichever meter
+  // provider the process registered at boot; without one it is the API's no-op.
   const counter = metrics
     .getMeter('@vers/service-activity')
     .createCounter('vers.activity.avatar_not_active_rejections', {

--- a/services/activity/src/metrics/record-content-incompatible-rejection.ts
+++ b/services/activity/src/metrics/record-content-incompatible-rejection.ts
@@ -6,12 +6,12 @@ export type ContentIncompatiblePath = 'fallback' | 'requested';
  * Counts one `startActivity` call rejected because the resolved engine's `maxContentVersion` falls
  * behind the content version the request would stamp, split by which resolution path found the
  * mismatch: `requested` covers a client-sent hash, `fallback` covers the registry-current version
- * the transitional hash-less path resolves. The counter is resolved through the global metrics API
- * on every call — the SDK returns the same instrument for an identical registration, and resolving
- * late keeps the counter bound to whichever meter provider the process registered at boot; without
- * one it is the API's no-op.
+ * the transitional hash-less path resolves.
  */
 export function recordContentIncompatibleRejection(path: ContentIncompatiblePath): void {
+  // Resolved through the global metrics API on every call: the SDK returns the same instrument for
+  // an identical registration, and resolving late keeps the counter bound to whichever meter
+  // provider the process registered at boot; without one it is the API's no-op.
   const counter = metrics
     .getMeter('@vers/service-activity')
     .createCounter('vers.activity.content_incompatible_rejections', {

--- a/services/activity/src/metrics/record-node-unreachable-rejection.ts
+++ b/services/activity/src/metrics/record-node-unreachable-rejection.ts
@@ -2,12 +2,12 @@ import { metrics } from '@opentelemetry/api';
 
 /**
  * Counts one `startActivity` call rejected because the requested scope node sits outside the
- * avatar's selectable set. Attribute-free — the rejection has no dimension worth splitting on. The
- * counter is resolved through the global metrics API on every call — the SDK returns the same
- * instrument for an identical registration, and resolving late keeps the counter bound to whichever
- * meter provider the process registered at boot; without one it is the API's no-op.
+ * avatar's selectable set. Attribute-free — the rejection has no dimension worth splitting on.
  */
 export function recordNodeUnreachableRejection(): void {
+  // resolved through the global metrics API on every call — the SDK returns the same instrument
+  // for an identical registration, and resolving late keeps the counter bound to whichever meter
+  // provider the process registered at boot; without one it is the API's no-op
   const counter = metrics
     .getMeter('@vers/service-activity')
     .createCounter('vers.activity.node_unreachable_rejections', {

--- a/services/activity/src/metrics/record-replay-poke-failed.ts
+++ b/services/activity/src/metrics/record-replay-poke-failed.ts
@@ -3,12 +3,12 @@ import { metrics } from '@opentelemetry/api';
 /**
  * Counts one replay wake poke that never delivered after exhausting its retries — the explicit
  * stall signal for the replay queue: an activity progress append landed, but no verifier machine
- * ever learned there was work to drain. The counter is resolved through the global metrics API on
- * every call — the SDK returns the same instrument for an identical registration, and resolving
- * late keeps it bound to whichever meter provider the process registered at boot; without one it is
- * the API's no-op.
+ * ever learned there was work to drain.
  */
 export function recordReplayPokeFailed(): void {
+  // The SDK returns the same instrument for an identical registration, and resolving late keeps it
+  // bound to whichever meter provider the process registered at boot; without one it is the API's
+  // no-op.
   const counter = metrics
     .getMeter('@vers/service-activity')
     .createCounter('vers.activity.replay_poke_failed', {

--- a/services/activity/src/metrics/record-reveal-mint.ts
+++ b/services/activity/src/metrics/record-reveal-mint.ts
@@ -2,12 +2,12 @@ import { metrics } from '@opentelemetry/api';
 
 /**
  * Counts activity-chain rows a `revealNodes` call minted or re-affirmed, one recording per call
- * carrying the number of distinct nodes it processed. Resolved through the global metrics API on
- * every call — the SDK returns the same instrument for an identical registration, and resolving
- * late keeps it bound to whichever meter provider the process registered at boot; without one it is
- * the API's no-op.
+ * carrying the number of distinct nodes it processed.
  */
 export function recordRevealMint(nodeCount: number): void {
+  // Resolved through the global metrics API on every call — the SDK returns the same instrument
+  // for an identical registration, and resolving late keeps it bound to whichever meter provider
+  // the process registered at boot; without one it is the API's no-op.
   const counter = metrics
     .getMeter('@vers/service-activity')
     .createCounter('vers.activity.reveal_mints', {

--- a/services/activity/src/metrics/record-reveal-query.ts
+++ b/services/activity/src/metrics/record-reveal-query.ts
@@ -8,12 +8,12 @@ interface RevealQueryFanOut {
 /**
  * Records one reveal query's fan-out: how many first-clear grant rows the query scanned for reveal
  * sources, and how many revealed cells the projection returned for the queried viewport.
- * Event-recorded, so both histograms emit only while a reveal query actually runs. Resolved through
- * the global metrics API on every call — the SDK returns the same instrument for an identical
- * registration, and resolving late keeps them bound to whichever meter provider the process
- * registered at boot; without one they are the API's no-op.
+ * Event-recorded, so both histograms emit only while a reveal query actually runs.
  */
 export function recordRevealQuery(fanOut: RevealQueryFanOut): void {
+  // Resolved through the global metrics API on every call: the SDK returns the same instrument for
+  // an identical registration, and resolving late keeps it bound to whichever meter provider the
+  // process registered at boot; without one it's the API's no-op.
   const meter = metrics.getMeter('@vers/service-activity');
 
   meter

--- a/services/activity/src/metrics/record-terminal-transition.ts
+++ b/services/activity/src/metrics/record-terminal-transition.ts
@@ -5,12 +5,12 @@ export type TerminalTransitionStatus = 'capped' | 'stopped';
 /**
  * Counts one activity that claimed a terminal transition, split by status: `stopped` covers a
  * completed or failed last checkpoint, `capped` covers a batch rejected whole because it exceeded
- * the avatar's accrued simulated-time budget. The counter is resolved through the global metrics
- * API on every call — the SDK returns the same instrument for an identical registration, and
- * resolving late keeps the counter bound to whichever meter provider the process registered at
- * boot; without one it is the API's no-op.
+ * the avatar's accrued simulated-time budget.
  */
 export function recordTerminalTransition(status: TerminalTransitionStatus): void {
+  // resolved through the global metrics API on every call — the SDK returns the same instrument
+  // for an identical registration, and resolving late keeps the counter bound to whichever meter
+  // provider the process registered at boot; without one it is the API's no-op
   const counter = metrics
     .getMeter('@vers/service-activity')
     .createCounter('vers.activity.terminal_transitions', {

--- a/services/activity/src/metrics/record-writer-takeover.ts
+++ b/services/activity/src/metrics/record-writer-takeover.ts
@@ -3,12 +3,12 @@ import { metrics } from '@opentelemetry/api';
 /**
  * Counts one successful writer claim on an active activity — a take-over of another session's
  * stream, a claim of an unstamped one, or a same-session re-claim alike; the claim statement
- * cannot tell them apart. The counter is resolved through the global metrics API on every call —
- * the SDK returns the same instrument for an identical registration, and resolving late keeps the
- * counter bound to whichever meter provider the process registered at boot; without one it is the
- * API's no-op.
+ * cannot tell them apart.
  */
 export function recordWriterTakeover(): void {
+  // Resolved through the global metrics API on every call: the SDK returns the same instrument
+  // for an identical registration, and resolving late keeps the counter bound to whichever meter
+  // provider the process registered at boot; without one it is the API's no-op.
   const counter = metrics
     .getMeter('@vers/service-activity')
     .createCounter('vers.activity.writer_takeovers', {

--- a/services/activity/src/pick-checkpoint-batch-race-outcome.ts
+++ b/services/activity/src/pick-checkpoint-batch-race-outcome.ts
@@ -62,10 +62,8 @@ interface SettledTailRow {
 
 /**
  * Reports whether a checkpoint batch, replayed from scratch, recomputes onto a settled activity's
- * recorded tail: the last entry's version lands on `settled.appendedHead`, and every entry's hash —
- * recomputed from each payload, never trusted from the submitted `hash` field — chains onto
- * the previous entry's rebuilt hash and the final one reproduces `settled.lastHash`. A match proves
- * the recorded tail is this exact batch: the original submit landed and only the ack was lost.
+ * recorded tail. A match proves the recorded tail is this exact batch: the original submit landed
+ * and only the ack was lost.
  */
 function isSettledResubmit(
   checkpoints: ReadonlyArray<CheckpointBatchEntry>,
@@ -73,12 +71,15 @@ function isSettledResubmit(
 ): boolean {
   const lastCheckpoint = checkpoints.at(-1);
 
+  // The last entry's version must land on `settled.appendedHead`.
   if (lastCheckpoint === undefined || lastCheckpoint.version !== settled.appendedHead) {
     return false;
   }
 
   let previousHash: string | undefined;
 
+  // Every entry's hash is recomputed from its payload, never trusted from the submitted `hash`
+  // field, and must chain onto the previous entry's rebuilt hash.
   for (const checkpoint of checkpoints) {
     if (previousHash !== undefined && checkpoint.prevHash !== previousHash) {
       return false;
@@ -87,5 +88,6 @@ function isSettledResubmit(
     previousHash = buildCheckpointHashFromEntry(checkpoint);
   }
 
+  // The final rebuilt hash must reproduce `settled.lastHash`.
   return previousHash === settled.lastHash;
 }

--- a/services/avatar/src/env-shape.ts
+++ b/services/avatar/src/env-shape.ts
@@ -1,9 +1,5 @@
 import * as z from 'zod';
 
-/**
- * Environment the avatar service needs beyond the base service env: a database connection for the
- * avatar and progression tables.
- */
 export const envShape = {
   DATABASE_URL: z
     .string()

--- a/services/avatar/src/handlers/create-avatar.ts
+++ b/services/avatar/src/handlers/create-avatar.ts
@@ -33,9 +33,8 @@ interface CreateAvatarOpts {
  * Creates an avatar owned by the acting user and makes it the active one, unless a live activity
  * holds the selection — then the new avatar lands unselected, since taking the slot would steal
  * it from the running avatar. Throws CONFLICT when the name is already taken and LIMIT_REACHED at
- * the per-mode cap; the per-user advisory lock serializes the count against concurrent creates
- * (a row lock can't fence inserts that don't exist yet). Runs inside the caller's transaction
- * when given one, or opens its own otherwise.
+ * the per-mode cap. Runs inside the caller's transaction when given one, or opens its own
+ * otherwise.
  */
 export async function createAvatar(db: Kysely<DB>, opts: CreateAvatarOpts): Promise<AvatarData> {
   const actingUserId = opts.context.actingUserId;
@@ -62,6 +61,8 @@ async function runCreateWrites(
   actingUserId: string,
   opts: CreateAvatarOpts,
 ): Promise<AvatarData> {
+  // the per-user advisory lock serializes the count against concurrent creates; a row lock can't
+  // apply to inserts that don't exist yet
   await sql`select pg_advisory_xact_lock(hashtext(${actingUserId}))`.execute(trx);
 
   const counted = await trx

--- a/services/email/src/env-shape.ts
+++ b/services/email/src/env-shape.ts
@@ -1,10 +1,5 @@
 import * as z from 'zod';
 
-/**
- * Environment the email service needs beyond the base service env: a database connection for the
- * job queue's default pg-boss pool, and the Resend credentials for the client jobs deliver
- * through.
- */
 export const envShape = {
   DATABASE_URL: z.string().describe('Postgres connection string backing the pg-boss job queue'),
   EMAIL_FROM: z.string().describe('From address on delivered transactional email'),

--- a/services/email/src/metrics/record-delivery-failure.ts
+++ b/services/email/src/metrics/record-delivery-failure.ts
@@ -1,12 +1,12 @@
 import { metrics } from '@opentelemetry/api';
 
 /**
- * Counts one email that failed to deliver: a job whose handler or completion step failed. The
- * counter is resolved through the global metrics API on every call — the SDK returns the same
- * instrument for an identical registration, and resolving late keeps the counter bound to
- * whichever meter provider the process registered at boot; without one it is the API's no-op.
+ * Counts one email that failed to deliver: a job whose handler or completion step failed.
  */
 export function recordDeliveryFailure(): void {
+  // Resolved through the global metrics API on every call: the SDK returns the same instrument for
+  // an identical registration, and resolving late keeps the counter bound to whichever meter
+  // provider the process registered at boot; without one it is the API's no-op.
   const counter = metrics
     .getMeter('@vers/service-email')
     .createCounter('vers.email.delivery_failures', {

--- a/services/keys/src/metrics/record-derive-rejection.ts
+++ b/services/keys/src/metrics/record-derive-rejection.ts
@@ -4,12 +4,12 @@ export type DeriveRejectionReason = 'unknown-key-version' | 'unknown-scope-secre
 
 /**
  * Counts one derivation call — an avatar roll key or a scope secret — that refused to derive,
- * split by reason. The counter is resolved through the global metrics API on every call — the SDK
- * returns the same instrument for an identical registration, and resolving late keeps the counter
- * bound to whichever meter provider the process registered at boot; without one it is the API's
- * no-op.
+ * split by reason.
  */
 export function recordDeriveRejection(reason: DeriveRejectionReason): void {
+  // Resolved through the global metrics API on every call: the SDK returns the same instrument
+  // for an identical registration, and resolving late keeps the counter bound to whichever meter
+  // provider the process registered at boot; without one it is the API's no-op.
   const counter = metrics
     .getMeter('@vers/service-keys')
     .createCounter('vers.keys.derive_rejections', {

--- a/services/replay/src/metrics/record-backlog-claimed.ts
+++ b/services/replay/src/metrics/record-backlog-claimed.ts
@@ -2,11 +2,11 @@ import { metrics } from '@opentelemetry/api';
 
 /**
  * Records how many chains one drain cycle claimed and adjudicated before finding the queue empty.
- * The histogram is resolved through the global metrics API on every call — the SDK returns the
- * same instrument for an identical registration, and resolving late keeps it bound to whichever
- * meter provider the process registered at boot; without one it is the API's no-op.
  */
 export function recordBacklogClaimed(chainCount: number): void {
+  // The histogram is resolved through the global metrics API on every call: the SDK returns the
+  // same instrument for an identical registration, and resolving late keeps it bound to whichever
+  // meter provider the process registered at boot; without one it is the API's no-op.
   const histogram = metrics
     .getMeter('@vers/service-replay')
     .createHistogram('vers.replay.backlog_claimed', {

--- a/services/replay/src/metrics/record-clamped-settlement.ts
+++ b/services/replay/src/metrics/record-clamped-settlement.ts
@@ -5,12 +5,12 @@ import { metrics } from '@opentelemetry/api';
  * at zero and paid less than the segment recorded against the activity. The engine clamps a
  * failure penalty to the progress made into the current level, so this should never fire — it
  * exists because the shortfall is otherwise silent, and a non-zero count means the penalty and the
- * settled total are being computed against different bases. The counter is resolved through the
- * global metrics API on every call — the SDK returns the same instrument for an identical
- * registration, and resolving late keeps it bound to whichever meter provider the process
- * registered at boot; without one it is the API's no-op.
+ * settled total are being computed against different bases.
  */
 export function recordClampedSettlement(): void {
+  // Resolved through the global metrics API on every call: the SDK returns the same instrument for
+  // an identical registration, and resolving late keeps it bound to whichever meter provider the
+  // process registered at boot; without one it is the API's no-op.
   const counter = metrics
     .getMeter('@vers/service-replay')
     .createCounter('vers.replay.clamped_settlements', {

--- a/services/replay/src/metrics/record-drain-duration.ts
+++ b/services/replay/src/metrics/record-drain-duration.ts
@@ -2,12 +2,12 @@ import { metrics } from '@opentelemetry/api';
 
 /**
  * Records how long one drain cycle held the `/wake` request open, from its first claim attempt
- * through finding the queue empty. The histogram is resolved through the global metrics API on
- * every call — the SDK returns the same instrument for an identical registration, and resolving
- * late keeps it bound to whichever meter provider the process registered at boot; without one it is
- * the API's no-op.
+ * through finding the queue empty.
  */
 export function recordDrainDuration(durationSeconds: number): void {
+  // resolved through the global metrics API on every call — the SDK returns the same instrument
+  // for an identical registration, and resolving late keeps it bound to whichever meter provider
+  // the process registered at boot; without one it is the API's no-op
   const histogram = metrics
     .getMeter('@vers/service-replay')
     .createHistogram('vers.replay.drain_duration', {

--- a/services/replay/src/metrics/record-iteration-failure.ts
+++ b/services/replay/src/metrics/record-iteration-failure.ts
@@ -5,12 +5,12 @@ export type IterationFailureOutcome = 'errored' | 'quarantined';
 /**
  * Counts one drain iteration that failed to replay a claimed chain, split by outcome:
  * `quarantined` covers an activity that exhausted its replay attempts, `errored` covers every
- * other failed attempt (including one the drain loop itself never got a frontier for). The
- * counter is resolved through the global metrics API on every call — the SDK returns the same
- * instrument for an identical registration, and resolving late keeps the counter bound to
- * whichever meter provider the process registered at boot; without one it is the API's no-op.
+ * other failed attempt (including one the drain loop itself never got a frontier for).
  */
 export function recordIterationFailure(outcome: IterationFailureOutcome): void {
+  // The SDK returns the same instrument for an identical registration, and resolving late keeps
+  // the counter bound to whichever meter provider the process registered at boot; without one it
+  // is the API's no-op.
   const counter = metrics
     .getMeter('@vers/service-replay')
     .createCounter('vers.replay.iteration_failures', {

--- a/services/replay/src/metrics/record-rejection.ts
+++ b/services/replay/src/metrics/record-rejection.ts
@@ -15,12 +15,12 @@ export type RejectionReason =
  * version-registry holds (unknown or retention-expired sim versions), `elapsed-time` covers
  * duration-cap trips, `provider-unavailable` covers a cross-version dispatch whose provider timed
  * out, refused the connection, or answered with an undefined error, and `unbacked-snapshot` covers
- * a build snapshot that borrowed xp from a run since rejected. The counter is resolved through the
- * global metrics API on every call — the SDK returns the same instrument for an identical
- * registration, and resolving late keeps the counter bound to whichever meter provider the process
- * registered at boot; without one it is the API's no-op.
+ * a build snapshot that borrowed xp from a run since rejected.
  */
 export function recordRejection(reason: RejectionReason): void {
+  // Resolved through the global metrics API on every call — the SDK returns the same instrument
+  // for an identical registration, and resolving late keeps the counter bound to whichever meter
+  // provider the process registered at boot; without one it is the API's no-op.
   const counter = metrics
     .getMeter('@vers/service-replay')
     .createCounter('vers.verification.rejections', {

--- a/services/replay/src/metrics/record-settled-xp.ts
+++ b/services/replay/src/metrics/record-settled-xp.ts
@@ -11,12 +11,12 @@ type SettlementSource = 'progress' | 'terminal';
  * Records one verified segment's xp movement, split by how the amount was derived. An up-down
  * counter rather than a histogram because the measure is signed — a failed run's terminal settles
  * the death penalty as a negative, and a histogram discards negative recordings, which would hide
- * exactly the sign and ordering defects this instrument exists to catch. The counter is resolved
- * through the global metrics API on every call — the SDK returns the same instrument for an
- * identical registration, and resolving late keeps it bound to whichever meter provider the
- * process registered at boot; without one it is the API's no-op.
+ * exactly the sign and ordering defects this instrument exists to catch.
  */
 export function recordSettledXP(xpDelta: number, source: SettlementSource): void {
+  // Resolved through the global metrics API on every call: the SDK returns the same instrument for
+  // an identical registration, and resolving late keeps it bound to whichever meter provider the
+  // process registered at boot; without one it's the API's no-op.
   const counter = metrics
     .getMeter('@vers/service-replay')
     .createUpDownCounter('vers.replay.settled_xp', {

--- a/services/replay/src/metrics/record-verification-lag.ts
+++ b/services/replay/src/metrics/record-verification-lag.ts
@@ -3,12 +3,12 @@ import { metrics } from '@opentelemetry/api';
 /**
  * Records how long one newly verified append sat unverified, from its own appended timestamp to
  * the moment a drain cycle confirmed it. Event-recorded, so it emits only while a drain is
- * actually verifying appends — an idle machine reports nothing. The histogram is resolved through
- * the global metrics API on every call — the SDK returns the same instrument for an identical
- * registration, and resolving late keeps it bound to whichever meter provider the process
- * registered at boot; without one it is the API's no-op.
+ * actually verifying appends — an idle machine reports nothing.
  */
 export function recordVerificationLag(lagSeconds: number): void {
+  // resolved through the global metrics API on every call — the SDK returns the same instrument
+  // for an identical registration, and resolving late keeps it bound to whichever meter provider
+  // the process registered at boot; without one it is the API's no-op
   const histogram = metrics
     .getMeter('@vers/service-replay')
     .createHistogram('vers.replay.verification_lag', {

--- a/services/replay/src/metrics/record-wake.ts
+++ b/services/replay/src/metrics/record-wake.ts
@@ -2,12 +2,12 @@ import { metrics } from '@opentelemetry/api';
 
 /**
  * Counts one `/wake` request received, before it collapses onto an already-running drain or starts
- * a new one — the poke-rate signal, silent whenever the queue never needs waking. The counter is
- * resolved through the global metrics API on every call — the SDK returns the same instrument for
- * an identical registration, and resolving late keeps the counter bound to whichever meter provider
- * the process registered at boot; without one it is the API's no-op.
+ * a new one — the poke-rate signal, silent whenever the queue never needs waking.
  */
 export function recordWake(): void {
+  // Resolved through the global metrics API on every call: the SDK returns the same instrument
+  // for an identical registration, and resolving late keeps the counter bound to whichever meter
+  // provider the process registered at boot; without one it is the API's no-op.
   const counter = metrics.getMeter('@vers/service-replay').createCounter('vers.replay.wake', {
     description: 'wake requests received',
     unit: '{wake}',

--- a/services/replay/src/test-utils/create-provider-process.ts
+++ b/services/replay/src/test-utils/create-provider-process.ts
@@ -18,12 +18,6 @@ interface ProviderProcess {
  * full ambient env and mask a missing env-wiring bug, which is the regression this fixture exists
  * to catch. `PORT=0` binds an OS-assigned port, read back from the boot log; the process is killed
  * via `onTestFinished`.
- *
- * Readiness is event-driven, not polled: the boot resolves on the log's bound-port announcement,
- * and a process that exits first rejects immediately with its captured output, so a crashing boot
- * reports its real error instead of running out the clock. The deadline only catches a boot that
- * hangs without exiting. Both pipes keep draining for the process's whole life so a full pipe can
- * never block the child.
  */
 export async function createProviderProcess(engineHash: string): Promise<ProviderProcess> {
   const keyPair = await getTestServiceKeyPair();

--- a/services/session/src/env-shape.ts
+++ b/services/session/src/env-shape.ts
@@ -1,9 +1,5 @@
 import * as z from 'zod';
 
-/**
- * Environment the session service needs beyond the base service env: the session and step-up
- * tables' database, plus the identity and key its user tokens are signed with.
- */
 export const envShape = {
   API_IDENTIFIER: z.string().describe('Issuer and audience stamped into signed user tokens'),
   DATABASE_URL: z

--- a/services/session/src/handlers/record-failed-attempt.ts
+++ b/services/session/src/handlers/record-failed-attempt.ts
@@ -17,12 +17,7 @@ interface RecordFailedAttemptOpts {
 
 /**
  * Records a failed step-up verification attempt — called only after a failed verification, never
- * before one, so a pre-verify tracking call can't purge attempts ahead of the real check. A
- * pending transaction must never be observable sitting at the attempt cap, so this deletes the row
- * directly once it has reached the cap-1 attempt rather than incrementing into the cap and
- * deleting as a separate step. The two conditional statements (delete-at-cap, then
- * increment-below-cap) each re-validate their predicate against the row under its row lock, so
- * concurrent failures on the same transaction serialize instead of racing a read-then-write.
+ * before one, so a pre-verify tracking call can't purge attempts ahead of the real check.
  */
 export async function recordFailedAttempt(
   db: Kysely<DB>,
@@ -30,12 +25,18 @@ export async function recordFailedAttempt(
 ): Promise<{ attemptsRemaining: number }> {
   recordFailedAttemptMetric();
 
+  // a pending transaction must never be observable sitting at the attempt cap, so this deletes
+  // the row directly once it has reached the cap-1 attempt rather than incrementing into the cap
+  // and deleting as a separate step
   const removedAtCap = await removeIfAtCap(db, opts.input.id);
 
   if (removedAtCap) {
     return { attemptsRemaining: 0 };
   }
 
+  // this update and the delete-at-cap above each re-validate their predicate against the row
+  // under its row lock, so concurrent failures on the same transaction serialize instead of
+  // racing a read-then-write
   const incremented = await db
     .updateTable('pendingTransactions')
     .set({ attempts: sql`attempts + 1` })

--- a/services/session/src/handlers/verify-session.ts
+++ b/services/session/src/handlers/verify-session.ts
@@ -63,17 +63,15 @@ export async function verifySession(
   return { accessToken: tokenPair[1], refreshToken: tokenPair[0] };
 }
 
-/**
- * Runs the verify-and-evict statement, retrying once on a deadlock. Two different pending
- * sessions of the same user verifying concurrently can deadlock (SQLSTATE 40P01: each statement's
- * update locks its own row while its delete waits on the other's); the retry's update finds its
- * row already evicted by the winner and fails cleanly into an empty result, never a raw 500.
- */
 async function runVerifyAndEvict(
   db: Kysely<DB>,
   sessionId: string,
   refreshToken: string,
 ): Promise<Array<{ readonly id: string }>> {
+  // Two different pending sessions of the same user verifying concurrently can deadlock
+  // (SQLSTATE 40P01: each statement's update locks its own row while its delete waits on the
+  // other's). The retry's update finds its row already evicted by the winner and fails cleanly
+  // into an empty result, never a raw 500.
   try {
     return await runVerifyAndEvictStatement(db, sessionId, refreshToken);
   } catch (error: unknown) {

--- a/services/session/src/metrics/record-failed-attempt.ts
+++ b/services/session/src/metrics/record-failed-attempt.ts
@@ -1,12 +1,12 @@
 import { metrics } from '@opentelemetry/api';
 
 /**
- * Counts one failed step-up verification attempt. The counter is resolved through the global
- * metrics API on every call — the SDK returns the same instrument for an identical registration,
- * and resolving late keeps the counter bound to whichever meter provider the process registered at
- * boot; without one it is the API's no-op.
+ * Counts one failed step-up verification attempt.
  */
 export function recordFailedAttempt(): void {
+  // Resolved through the global metrics API on every call: the SDK returns the same instrument for
+  // an identical registration, and resolving late keeps the counter bound to whichever meter
+  // provider the process registered at boot; without one it is the API's no-op.
   const counter = metrics
     .getMeter('@vers/service-session')
     .createCounter('vers.session.failed_attempts', {

--- a/services/user/src/env-shape.ts
+++ b/services/user/src/env-shape.ts
@@ -1,9 +1,5 @@
 import * as z from 'zod';
 
-/**
- * Environment the user service needs beyond the base service env: a database connection for the
- * account and credential tables.
- */
 export const envShape = {
   DATABASE_URL: z
     .string()

--- a/services/verification/src/env-shape.ts
+++ b/services/verification/src/env-shape.ts
@@ -1,9 +1,5 @@
 import * as z from 'zod';
 
-/**
- * Environment the verification service needs beyond the base service env: a database connection
- * for the verification rows.
- */
 export const envShape = {
   DATABASE_URL: z.string().describe('Postgres connection string for the verification rows'),
 };


### PR DESCRIPTION
## Description

Applies the new comment-placement policy to existing comments — the audit's 125 mechanical fixes across 111 files. Comment-only: typecheck and lint pass, no logic changed. Stacked on #900; retarget to `main` once that merges.

- `split` (96): the caller contract stays as the JSDoc block; the mechanism moves to a `//` at the line it explains.
- `move-to-line` (12): a JSDoc block that only justified one statement becomes a `//` above it.
- `delete-narration` (17): removed where the signature or code already conveys it.

A full-repo audit classified 1,473 blocks (4+ lines); 91% were correctly-placed caller contracts and stay untouched. The 6 enforceable-form items (one type union, five golden-test pointers) are excluded here — they are code changes, tracked separately.

## Testing

- [x] `bun run typecheck` passes (56/56)
- [x] `bun run lint` passes
- [ ] `bun run test` — comment-only, no behaviour touched
- [ ] New tests added for new functionality

## Context

Stacked on `docs/readable-voice-sweep` (#900), which carries the register sweep and the comment policy this applies. WIP — expected to merge after #900.
