### PR TITLE
feat(#890): start a selectable node's activity chain locally while offline

### DIFF
--- a/apps/web/src/test-utils/resolve-idle-checkpoint-db.ts
+++ b/apps/web/src/test-utils/resolve-idle-checkpoint-db.ts
@@ -8,7 +8,7 @@ import { openDB } from 'idb';
  * drift from the worker's real values fails the seeded-intent read test loudly.
  */
 const IDLE_CHECKPOINT_DB_NAME = 'vers-idle-checkpoint-queue';
-const IDLE_CHECKPOINT_DB_VERSION = 5;
+const IDLE_CHECKPOINT_DB_VERSION = 6;
 
 interface IdleCheckpointDBSchema {
   'content-documents': {
@@ -17,6 +17,10 @@ interface IdleCheckpointDBSchema {
   };
   'node-seeds': {
     key: [string, string];
+    value: unknown;
+  };
+  'offline-starts': {
+    key: string;
     value: unknown;
   };
   'pending-checkpoints': {
@@ -58,6 +62,10 @@ export async function resolveIdleCheckpointDB(): Promise<IDBPDatabase<IdleCheckp
 
         if (!database.objectStoreNames.contains('node-seeds')) {
           database.createObjectStore('node-seeds', { keyPath: ['avatarID', 'nodeID'] });
+        }
+
+        if (!database.objectStoreNames.contains('offline-starts')) {
+          database.createObjectStore('offline-starts', { keyPath: 'id' });
         }
       },
     },

--- a/docs/architecture/game/seed-chain.md
+++ b/docs/architecture/game/seed-chain.md
@@ -68,6 +68,15 @@ without the server. The compound node key scopes a seed to its avatar: two avata
 coordinate root distinct chains against distinct seeds, so neither overwrites the other's cached
 value.
 
+An offline-open start — the game open, the server unreachable — mints an activity root entirely from
+this cache, computing the same `buildStartHash` the server would have stamped from the cached seed,
+encounter, content version, and stamps, then installing the row through the same path a
+server-authored one takes. The worker persists the synthesized row in its own `offline-starts`
+IndexedDB store, keyed by the activity's id, before installing it, so a crash between mint and
+install still leaves a recoverable root. `buildSnapshot` is a settled-xp guess sourced from the last
+activity row the worker installed for the avatar: a hint a later reconcile re-authors against the
+server's own record, never an attempt to reproduce the server's optimistic total.
+
 ## Advancing the chain
 
 The chain advances on an activity's transition out of `active`. Which cursor moves depends on

--- a/libs/game/idle-client/src/submission/constants.ts
+++ b/libs/game/idle-client/src/submission/constants.ts
@@ -23,7 +23,7 @@ export const RETRY_BACKOFF_CAP_MS = 300_000;
  */
 export const FLUSH_STALL_THRESHOLD = 3;
 export const CHECKPOINT_QUEUE_DB_NAME = 'vers-idle-checkpoint-queue';
-export const CHECKPOINT_QUEUE_DB_VERSION = 5;
+export const CHECKPOINT_QUEUE_DB_VERSION = 6;
 export const CHECKPOINT_QUEUE_STORE_NAME = 'pending-checkpoints';
 
 /**
@@ -41,6 +41,14 @@ export const CONTENT_DOCUMENT_STORE_NAME = 'content-documents';
  * keep separate rows.
  */
 export const NODE_SEEDS_STORE_NAME = 'node-seeds';
+
+/**
+ * The object store holding the full `ActivityData` an offline-open start mints locally, keyed by
+ * its own `id`. This is the client-minted root row a later reconcile drains and verifies against
+ * the server; it is written durably before the row installs, so a crash between mint and install
+ * still leaves a recoverable root.
+ */
+export const OFFLINE_STARTS_STORE_NAME = 'offline-starts';
 
 /**
  * The `preferences` record holding `revealNodes`'s avatar- and account-global crypto stamps. A

--- a/libs/game/idle-client/src/submission/read-all-offline-start-rows.test.ts
+++ b/libs/game/idle-client/src/submission/read-all-offline-start-rows.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from 'bun:test';
+import { createMockActivityData } from '@vers/contract-activity/test-utils';
+import { readAllOfflineStartRows } from './read-all-offline-start-rows';
+import { writeOfflineStartRow } from './write-offline-start-row';
+
+test('it reads every offline-start row across avatars', async () => {
+  const first = createMockActivityData();
+  const second = createMockActivityData();
+
+  await writeOfflineStartRow(first);
+  await writeOfflineStartRow(second);
+
+  const rows = await readAllOfflineStartRows();
+
+  expect(rows).toIncludeSameMembers([first, second]);
+});
+
+test('it reads nothing when no offline-start row is cached', async () => {
+  const rows = await readAllOfflineStartRows();
+
+  expect(rows).toStrictEqual([]);
+});

--- a/libs/game/idle-client/src/submission/read-all-offline-start-rows.ts
+++ b/libs/game/idle-client/src/submission/read-all-offline-start-rows.ts
@@ -1,0 +1,13 @@
+import type { ActivityData } from '@vers/contract-activity';
+import { OFFLINE_STARTS_STORE_NAME } from './constants';
+import { resolveCheckpointQueueDB } from './resolve-checkpoint-queue-db';
+
+/**
+ * Reads every offline-open start row this device holds, across every avatar and activity — a
+ * later reconcile's drain surface.
+ */
+export async function readAllOfflineStartRows(): Promise<ReadonlyArray<ActivityData>> {
+  const db = await resolveCheckpointQueueDB();
+
+  return db.getAll(OFFLINE_STARTS_STORE_NAME);
+}

--- a/libs/game/idle-client/src/submission/read-offline-start-row.test.ts
+++ b/libs/game/idle-client/src/submission/read-offline-start-row.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from 'bun:test';
+import { readOfflineStartRow } from './read-offline-start-row';
+
+test('it returns undefined for an activity id this device holds no offline-start row for', async () => {
+  const row = await readOfflineStartRow('act_read_offline_start_row_never_written');
+
+  expect(row).toBeUndefined();
+});

--- a/libs/game/idle-client/src/submission/read-offline-start-row.ts
+++ b/libs/game/idle-client/src/submission/read-offline-start-row.ts
@@ -1,0 +1,13 @@
+import type { ActivityData } from '@vers/contract-activity';
+import { OFFLINE_STARTS_STORE_NAME } from './constants';
+import { resolveCheckpointQueueDB } from './resolve-checkpoint-queue-db';
+
+/**
+ * Reads one offline-open start's client-minted root row by its activity id, `undefined` when this
+ * device holds no such row.
+ */
+export async function readOfflineStartRow(activityID: string): Promise<ActivityData | undefined> {
+  const db = await resolveCheckpointQueueDB();
+
+  return db.get(OFFLINE_STARTS_STORE_NAME, activityID);
+}

--- a/libs/game/idle-client/src/submission/resolve-checkpoint-queue-db.test.ts
+++ b/libs/game/idle-client/src/submission/resolve-checkpoint-queue-db.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'bun:test';
+import { createMockActivityData } from '@vers/contract-activity/test-utils';
 import { ActivityFailureAction } from '@vers/idle-core';
 import type { IDBPDatabase } from 'idb';
 import { deleteDB, openDB } from 'idb';
@@ -8,6 +9,7 @@ import {
   CONTENT_DOCUMENT_STORE_NAME,
   FAILURE_ACTION_PREFERENCE_KEY,
   NODE_SEEDS_STORE_NAME,
+  OFFLINE_STARTS_STORE_NAME,
   PREFERENCES_STORE_NAME,
 } from './constants';
 import type { CheckpointQueueSchema } from './types';
@@ -126,5 +128,59 @@ test('it clears the node-seeds cache on the v4-to-v5 upgrade while preserving th
     v5?.close();
 
     await deleteDB(upgradeTestV5DBName);
+  }
+});
+
+test('it adds the offline-starts store on the v5-to-v6 upgrade without dropping the existing stores or their rows', async () => {
+  const upgradeTestV6DBName = 'vers-idle-checkpoint-queue-upgrade-v6-test';
+
+  const preference = {
+    avatarID: 'avatar-upgrade-v6',
+    dirty: false,
+    failureAction: ActivityFailureAction.Abort,
+  } as const;
+
+  const offlineStart = createMockActivityData();
+
+  // a prior run that threw before its own cleanup could leave a v6 database behind, which would
+  // block this run's open at v5 with a version error — drop any leftover before opening
+  await deleteDB(upgradeTestV6DBName);
+
+  let v5: IDBPDatabase<CheckpointQueueSchema> | undefined;
+  let v6: IDBPDatabase<CheckpointQueueSchema> | undefined;
+
+  try {
+    v5 = await openDB<CheckpointQueueSchema>(upgradeTestV6DBName, 5, {
+      upgrade: upgradeCheckpointQueueDB,
+    });
+
+    await v5.put(PREFERENCES_STORE_NAME, preference, FAILURE_ACTION_PREFERENCE_KEY);
+
+    v5.close();
+
+    v6 = await openDB<CheckpointQueueSchema>(upgradeTestV6DBName, 6, {
+      upgrade: upgradeCheckpointQueueDB,
+    });
+
+    await v6.put(OFFLINE_STARTS_STORE_NAME, offlineStart);
+
+    const existingPreference = await v6.get(PREFERENCES_STORE_NAME, FAILURE_ACTION_PREFERENCE_KEY);
+    const storedOfflineStart = await v6.get(OFFLINE_STARTS_STORE_NAME, offlineStart.id);
+
+    expect([...v6.objectStoreNames]).toIncludeAllMembers([
+      CHECKPOINT_QUEUE_STORE_NAME,
+      PREFERENCES_STORE_NAME,
+      CONTENT_DOCUMENT_STORE_NAME,
+      NODE_SEEDS_STORE_NAME,
+      OFFLINE_STARTS_STORE_NAME,
+    ]);
+
+    expect(existingPreference).toStrictEqual(preference);
+    expect(storedOfflineStart).toStrictEqual(offlineStart);
+  } finally {
+    v5?.close();
+    v6?.close();
+
+    await deleteDB(upgradeTestV6DBName);
   }
 });

--- a/libs/game/idle-client/src/submission/types.ts
+++ b/libs/game/idle-client/src/submission/types.ts
@@ -1,5 +1,6 @@
 import type { ContractRouterClient } from '@orpc/contract';
 import type {
+  ActivityData,
   CheckpointBatchEntry,
   ContentDocument,
   EncounterNode,
@@ -106,6 +107,10 @@ export interface CheckpointQueueSchema extends DBSchema {
   'node-seeds': {
     key: [string, string];
     value: NodeSeed;
+  };
+  'offline-starts': {
+    key: string;
+    value: ActivityData;
   };
   'pending-checkpoints': {
     key: [string, number];

--- a/libs/game/idle-client/src/submission/upgrade-checkpoint-queue-db.ts
+++ b/libs/game/idle-client/src/submission/upgrade-checkpoint-queue-db.ts
@@ -3,6 +3,7 @@ import {
   CHECKPOINT_QUEUE_STORE_NAME,
   CONTENT_DOCUMENT_STORE_NAME,
   NODE_SEEDS_STORE_NAME,
+  OFFLINE_STARTS_STORE_NAME,
   PREFERENCES_STORE_NAME,
 } from './constants';
 import type { CheckpointQueueSchema } from './types';
@@ -52,5 +53,11 @@ export function upgradeCheckpointQueueDB(
     database.createObjectStore(NODE_SEEDS_STORE_NAME, { keyPath: ['avatarID', 'nodeID'] });
   } else if (oldVersion < 5) {
     void transaction.objectStore(NODE_SEEDS_STORE_NAME).clear();
+  }
+
+  // `offline-starts` caches the full `ActivityData` an offline-open start mints locally, keyed by
+  // its own `id`.
+  if (!database.objectStoreNames.contains(OFFLINE_STARTS_STORE_NAME)) {
+    database.createObjectStore(OFFLINE_STARTS_STORE_NAME, { keyPath: 'id' });
   }
 }

--- a/libs/game/idle-client/src/submission/write-offline-start-row.test.ts
+++ b/libs/game/idle-client/src/submission/write-offline-start-row.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from 'bun:test';
+import { createMockActivityData } from '@vers/contract-activity/test-utils';
+import { readOfflineStartRow } from './read-offline-start-row';
+import { writeOfflineStartRow } from './write-offline-start-row';
+
+test('it persists a row retrievable by its own id', async () => {
+  const row = createMockActivityData();
+
+  await writeOfflineStartRow(row);
+
+  const stored = await readOfflineStartRow(row.id);
+
+  expect(stored).toStrictEqual(row);
+});
+
+test('it overwrites an existing row with the same id', async () => {
+  const row = createMockActivityData({ id: 'act_write_offline_start_row' });
+  const updated = createMockActivityData({ ...row, status: 'stopped' });
+
+  await writeOfflineStartRow(row);
+  await writeOfflineStartRow(updated);
+
+  const stored = await readOfflineStartRow(row.id);
+
+  expect(stored).toStrictEqual(updated);
+});

--- a/libs/game/idle-client/src/submission/write-offline-start-row.ts
+++ b/libs/game/idle-client/src/submission/write-offline-start-row.ts
@@ -1,0 +1,14 @@
+import type { ActivityData } from '@vers/contract-activity';
+import { OFFLINE_STARTS_STORE_NAME } from './constants';
+import { resolveCheckpointQueueDB } from './resolve-checkpoint-queue-db';
+
+/**
+ * Persists an offline-open start's client-minted root row, keyed by its own `id`. Called before
+ * the row installs onto the live simulation, so a crash between mint and install still leaves a
+ * recoverable root for a later reconcile to drain.
+ */
+export async function writeOfflineStartRow(row: Readonly<ActivityData>): Promise<void> {
+  const db = await resolveCheckpointQueueDB();
+
+  await db.put(OFFLINE_STARTS_STORE_NAME, row);
+}

--- a/libs/game/idle-client/src/test-utils/create-stub-worker-context.test.ts
+++ b/libs/game/idle-client/src/test-utils/create-stub-worker-context.test.ts
@@ -55,6 +55,16 @@ test('it returns the injected submitter', () => {
   expect(context.getSubmitter()).toBe(submitter);
 });
 
+test('it reflects updateConnectivity on getConnectivity', () => {
+  const context = createStubWorkerContext();
+
+  expect(context.getConnectivity()).toBeTrue();
+
+  context.updateConnectivity(false);
+
+  expect(context.getConnectivity()).toBeFalse();
+});
+
 test('it reflects an externally aborted shutdown controller on the cancel signal', () => {
   const shutdownController = new AbortController();
 

--- a/libs/game/idle-client/src/test-utils/create-stub-worker-context.ts
+++ b/libs/game/idle-client/src/test-utils/create-stub-worker-context.ts
@@ -93,6 +93,7 @@ export function createStubWorkerContext(
     getBundledEngineHash: () => options.bundledEngineHash,
     getCancelSignal: () => cancelSignal,
     getClient: () => client,
+    getConnectivity: () => connectivityOnline,
     getConnectivityOnline: () => connectivityOnline,
     getFailureAction: () => failureAction,
     getRemainingBudgetMs: () => options.remainingBudgetMs ?? Number.MAX_SAFE_INTEGER,

--- a/libs/game/idle-client/src/worker/build-offline-start-row.test.ts
+++ b/libs/game/idle-client/src/worker/build-offline-start-row.test.ts
@@ -1,7 +1,11 @@
 import { expect, test } from 'bun:test';
 import { buildStartHash } from '@vers/contract-activity';
-import { createMockActivityData } from '@vers/contract-activity/test-utils';
+import {
+  createMockActivityData,
+  createMockContentDocument,
+} from '@vers/contract-activity/test-utils';
 import invariant from 'tiny-invariant';
+import { writeContentDocumentCache } from '../content/write-content-document-cache';
 import { writeNodeSeeds } from '../submission/write-node-seeds';
 import { writeStartStamps } from '../submission/write-start-stamps';
 import { createStubWorkerContext } from '../test-utils/create-stub-worker-context';
@@ -13,6 +17,10 @@ test('it synthesizes a row whose start hash matches buildStartHash for the same 
 
   await writeNodeSeeds(seed.avatarID, [seed]);
   await writeStartStamps({ keyVersion: 4, secretRef: 'worldmap', secretVersion: 2 });
+
+  await writeContentDocumentCache(
+    createMockContentDocument({ contentVersion: seed.contentVersion }),
+  );
 
   const context = createStubWorkerContext({ bundledEngineHash: 'engine_hash_1' });
 
@@ -80,6 +88,10 @@ test('it returns null when no start stamps are cached', async () => {
 
   await writeNodeSeeds(seed.avatarID, [seed]);
 
+  await writeContentDocumentCache(
+    createMockContentDocument({ contentVersion: seed.contentVersion }),
+  );
+
   const context = createStubWorkerContext({ bundledEngineHash: 'engine_hash_1' });
 
   const row = await buildOfflineStartRow(context, {
@@ -98,7 +110,29 @@ test('it returns null when the build carries no bundled engine hash', async () =
   await writeNodeSeeds(seed.avatarID, [seed]);
   await writeStartStamps({ keyVersion: 1, secretRef: 'worldmap', secretVersion: 1 });
 
+  await writeContentDocumentCache(
+    createMockContentDocument({ contentVersion: seed.contentVersion }),
+  );
+
   const context = createStubWorkerContext();
+
+  const row = await buildOfflineStartRow(context, {
+    avatarID: seed.avatarID,
+    scopeID: seed.nodeID,
+    scopeType: 'world_map_node',
+    startKey: 'start_key_1',
+  });
+
+  expect(row).toBeNull();
+});
+
+test('it returns null when the content document is not cached', async () => {
+  const seed = createMockNodeSeed({ avatarID: 'avatar_no_content_doc', nodeID: '1_0' });
+
+  await writeNodeSeeds(seed.avatarID, [seed]);
+  await writeStartStamps({ keyVersion: 1, secretRef: 'worldmap', secretVersion: 1 });
+
+  const context = createStubWorkerContext({ bundledEngineHash: 'engine_hash_1' });
 
   const row = await buildOfflineStartRow(context, {
     avatarID: seed.avatarID,
@@ -115,6 +149,10 @@ test('it sources the build snapshot from the last activity this worker installed
 
   await writeNodeSeeds(seed.avatarID, [seed]);
   await writeStartStamps({ keyVersion: 1, secretRef: 'worldmap', secretVersion: 1 });
+
+  await writeContentDocumentCache(
+    createMockContentDocument({ contentVersion: seed.contentVersion }),
+  );
 
   const context = createStubWorkerContext({ bundledEngineHash: 'engine_hash_1' });
 
@@ -139,6 +177,10 @@ test("it starts a fresh avatar's build snapshot at zero xp when the worker holds
 
   await writeNodeSeeds(seed.avatarID, [seed]);
   await writeStartStamps({ keyVersion: 1, secretRef: 'worldmap', secretVersion: 1 });
+
+  await writeContentDocumentCache(
+    createMockContentDocument({ contentVersion: seed.contentVersion }),
+  );
 
   const context = createStubWorkerContext({ bundledEngineHash: 'engine_hash_1' });
 

--- a/libs/game/idle-client/src/worker/build-offline-start-row.test.ts
+++ b/libs/game/idle-client/src/worker/build-offline-start-row.test.ts
@@ -1,0 +1,157 @@
+import { expect, test } from 'bun:test';
+import { buildStartHash } from '@vers/contract-activity';
+import { createMockActivityData } from '@vers/contract-activity/test-utils';
+import invariant from 'tiny-invariant';
+import { writeNodeSeeds } from '../submission/write-node-seeds';
+import { writeStartStamps } from '../submission/write-start-stamps';
+import { createStubWorkerContext } from '../test-utils/create-stub-worker-context';
+import { createMockNodeSeed } from '../test-utils/factories/create-mock-node-seed';
+import { buildOfflineStartRow } from './build-offline-start-row';
+
+test('it synthesizes a row whose start hash matches buildStartHash for the same cached inputs', async () => {
+  const seed = createMockNodeSeed({ avatarID: 'avatar_1', nodeID: '3_2' });
+
+  await writeNodeSeeds(seed.avatarID, [seed]);
+  await writeStartStamps({ keyVersion: 4, secretRef: 'worldmap', secretVersion: 2 });
+
+  const context = createStubWorkerContext({ bundledEngineHash: 'engine_hash_1' });
+
+  const row = await buildOfflineStartRow(context, {
+    avatarID: seed.avatarID,
+    scopeID: seed.nodeID,
+    scopeType: 'world_map_node',
+    startKey: 'start_key_1',
+  });
+
+  invariant(row !== null, 'expected the cached inputs to synthesize a row');
+
+  const expectedHash = buildStartHash({
+    contentVersion: seed.contentVersion,
+    encounterNode: seed.encounterNode,
+    keyVersion: 4,
+    seed: seed.genesisSeed,
+    simVersion: 'engine_hash_1',
+  });
+
+  expect(row).toStrictEqual({
+    appendedAt: null,
+    appendedHead: 0,
+    avatarID: seed.avatarID,
+    buildSnapshot: { level: 1, xp: 0 },
+    contentVersion: seed.contentVersion,
+    createdAt: expect.toBeValidDate(),
+    encounterNode: seed.encounterNode,
+    id: expect.toStartWith('act_'),
+    keyVersion: 4,
+    lastHash: expectedHash,
+    scopeID: seed.nodeID,
+    scopeType: 'world_map_node',
+    secretRef: 'worldmap',
+    secretVersion: 2,
+    seed: seed.genesisSeed,
+    simVersion: 'engine_hash_1',
+    startChainIndex: 0,
+    startHash: expectedHash,
+    startKey: 'start_key_1',
+    startedAt: expect.toBeValidDate(),
+    status: 'active',
+    stoppedAt: null,
+    updatedAt: expect.toBeValidDate(),
+    verifiedAt: null,
+    verifiedHead: 0,
+  });
+});
+
+test('it returns null when the scope was never cached for the avatar', async () => {
+  const context = createStubWorkerContext({ bundledEngineHash: 'engine_hash_1' });
+
+  const row = await buildOfflineStartRow(context, {
+    avatarID: 'avatar_never_cached',
+    scopeID: '0_0',
+    scopeType: 'world_map_node',
+    startKey: 'start_key_1',
+  });
+
+  expect(row).toBeNull();
+});
+
+test('it returns null when no start stamps are cached', async () => {
+  const seed = createMockNodeSeed({ avatarID: 'avatar_no_stamps', nodeID: '1_0' });
+
+  await writeNodeSeeds(seed.avatarID, [seed]);
+
+  const context = createStubWorkerContext({ bundledEngineHash: 'engine_hash_1' });
+
+  const row = await buildOfflineStartRow(context, {
+    avatarID: seed.avatarID,
+    scopeID: seed.nodeID,
+    scopeType: 'world_map_node',
+    startKey: 'start_key_1',
+  });
+
+  expect(row).toBeNull();
+});
+
+test('it returns null when the build carries no bundled engine hash', async () => {
+  const seed = createMockNodeSeed({ avatarID: 'avatar_no_hash', nodeID: '1_0' });
+
+  await writeNodeSeeds(seed.avatarID, [seed]);
+  await writeStartStamps({ keyVersion: 1, secretRef: 'worldmap', secretVersion: 1 });
+
+  const context = createStubWorkerContext();
+
+  const row = await buildOfflineStartRow(context, {
+    avatarID: seed.avatarID,
+    scopeID: seed.nodeID,
+    scopeType: 'world_map_node',
+    startKey: 'start_key_1',
+  });
+
+  expect(row).toBeNull();
+});
+
+test('it sources the build snapshot from the last activity this worker installed for the avatar', async () => {
+  const seed = createMockNodeSeed({ avatarID: 'avatar_with_history', nodeID: '1_0' });
+
+  await writeNodeSeeds(seed.avatarID, [seed]);
+  await writeStartStamps({ keyVersion: 1, secretRef: 'worldmap', secretVersion: 1 });
+
+  const context = createStubWorkerContext({ bundledEngineHash: 'engine_hash_1' });
+
+  context.setActivity(
+    createMockActivityData({ avatarID: seed.avatarID, buildSnapshot: { level: 7, xp: 8450 } }),
+  );
+
+  const row = await buildOfflineStartRow(context, {
+    avatarID: seed.avatarID,
+    scopeID: seed.nodeID,
+    scopeType: 'world_map_node',
+    startKey: 'start_key_1',
+  });
+
+  invariant(row !== null, 'expected the cached inputs to synthesize a row');
+
+  expect(row.buildSnapshot).toStrictEqual({ level: 7, xp: 8450 });
+});
+
+test("it starts a fresh avatar's build snapshot at zero xp when the worker holds no prior activity row for it", async () => {
+  const seed = createMockNodeSeed({ avatarID: 'avatar_fresh', nodeID: '1_0' });
+
+  await writeNodeSeeds(seed.avatarID, [seed]);
+  await writeStartStamps({ keyVersion: 1, secretRef: 'worldmap', secretVersion: 1 });
+
+  const context = createStubWorkerContext({ bundledEngineHash: 'engine_hash_1' });
+
+  context.setActivity(createMockActivityData({ avatarID: 'a-different-avatar' }));
+
+  const row = await buildOfflineStartRow(context, {
+    avatarID: seed.avatarID,
+    scopeID: seed.nodeID,
+    scopeType: 'world_map_node',
+    startKey: 'start_key_1',
+  });
+
+  invariant(row !== null, 'expected the cached inputs to synthesize a row');
+
+  expect(row.buildSnapshot).toStrictEqual({ level: 1, xp: 0 });
+});

--- a/libs/game/idle-client/src/worker/build-offline-start-row.ts
+++ b/libs/game/idle-client/src/worker/build-offline-start-row.ts
@@ -2,6 +2,7 @@ import { createId } from '@paralleldrive/cuid2';
 import type { ActivityData } from '@vers/contract-activity';
 import { buildStartHash } from '@vers/contract-activity';
 import { buildLevelFromXP } from '@vers/idle-core';
+import { findCachedContentDocument } from '../content/find-cached-content-document';
 import { readNodeSeed } from '../submission/read-node-seed';
 import { readStartStamps } from '../submission/read-start-stamps';
 import type { WorkerContext } from './types';
@@ -17,12 +18,13 @@ interface BuildOfflineStartRowInput {
  * Synthesizes a full `ActivityData` root row for an offline-open start, entirely from this
  * device's cached start inputs — `null` when any of them is missing, since no local start is
  * possible without every one: the scope's cached genesis seed and encounter (never revealed on
- * this device, or revealed for a different avatar), the account's cached crypto stamps, or the
- * build's bundled engine hash (undefined in dev builds, which start against the registry's
- * current stamp instead — unavailable offline). `buildSnapshot` is a settled-xp guess sourced from
- * the last activity row this worker installed for the avatar, `{ level: 1, xp: 0 }` when it holds
- * none — a deliberate hint the server reconcile re-authors, never an attempt to reproduce the
- * server's optimistic total.
+ * this device, or revealed for a different avatar), the scope's content document (cached only
+ * once an activity has installed at that content version on this device), the account's cached
+ * crypto stamps, or the build's bundled engine hash (undefined in dev builds, which start against
+ * the registry's current stamp instead — unavailable offline). `buildSnapshot` is a settled-xp
+ * guess sourced from the last activity row this worker installed for the avatar, `{ level: 1, xp:
+ * 0 }` when it holds none — a deliberate hint the server reconcile re-authors, never an attempt to
+ * reproduce the server's optimistic total.
  */
 export async function buildOfflineStartRow(
   context: WorkerContext,
@@ -31,6 +33,12 @@ export async function buildOfflineStartRow(
   const nodeSeed = await readNodeSeed(input.avatarID, input.scopeID);
 
   if (nodeSeed === undefined) {
+    return null;
+  }
+
+  // resolved from cache only: an offline start with an uncached content document has no way to
+  // install, and must fail here rather than let the install's own load reach the network
+  if ((await findCachedContentDocument(nodeSeed.contentVersion)) === undefined) {
     return null;
   }
 

--- a/libs/game/idle-client/src/worker/build-offline-start-row.ts
+++ b/libs/game/idle-client/src/worker/build-offline-start-row.ts
@@ -1,0 +1,99 @@
+import { createId } from '@paralleldrive/cuid2';
+import type { ActivityData } from '@vers/contract-activity';
+import { buildStartHash } from '@vers/contract-activity';
+import { buildLevelFromXP } from '@vers/idle-core';
+import { readNodeSeed } from '../submission/read-node-seed';
+import { readStartStamps } from '../submission/read-start-stamps';
+import type { WorkerContext } from './types';
+
+interface BuildOfflineStartRowInput {
+  readonly avatarID: string;
+  readonly scopeID: string;
+  readonly scopeType: string;
+  readonly startKey: string;
+}
+
+/**
+ * Synthesizes a full `ActivityData` root row for an offline-open start, entirely from this
+ * device's cached start inputs — `null` when any of them is missing, since no local start is
+ * possible without every one: the scope's cached genesis seed and encounter (never revealed on
+ * this device, or revealed for a different avatar), the account's cached crypto stamps, or the
+ * build's bundled engine hash (undefined in dev builds, which start against the registry's
+ * current stamp instead — unavailable offline). `buildSnapshot` is a settled-xp guess sourced from
+ * the last activity row this worker installed for the avatar, `{ level: 1, xp: 0 }` when it holds
+ * none — a deliberate hint the server reconcile re-authors, never an attempt to reproduce the
+ * server's optimistic total.
+ */
+export async function buildOfflineStartRow(
+  context: WorkerContext,
+  input: Readonly<BuildOfflineStartRowInput>,
+): Promise<ActivityData | null> {
+  const nodeSeed = await readNodeSeed(input.avatarID, input.scopeID);
+
+  if (nodeSeed === undefined) {
+    return null;
+  }
+
+  const stamps = await readStartStamps();
+
+  if (stamps === undefined) {
+    return null;
+  }
+
+  const simVersion = context.getBundledEngineHash();
+
+  if (simVersion === undefined) {
+    return null;
+  }
+
+  const startHash = buildStartHash({
+    contentVersion: nodeSeed.contentVersion,
+    encounterNode: nodeSeed.encounterNode,
+    keyVersion: stamps.keyVersion,
+    seed: nodeSeed.genesisSeed,
+    simVersion,
+  });
+
+  const now = new Date();
+
+  return {
+    appendedAt: null,
+    appendedHead: 0,
+    avatarID: input.avatarID,
+    buildSnapshot: buildOfflineBuildSnapshot(context, input.avatarID),
+    contentVersion: nodeSeed.contentVersion,
+    createdAt: now,
+    encounterNode: nodeSeed.encounterNode,
+    id: `act_${createId()}`,
+    keyVersion: stamps.keyVersion,
+    lastHash: startHash,
+    scopeID: input.scopeID,
+    scopeType: input.scopeType,
+    secretRef: stamps.secretRef,
+    secretVersion: stamps.secretVersion,
+    seed: nodeSeed.genesisSeed,
+    simVersion,
+    startChainIndex: 0,
+    startHash,
+    startKey: input.startKey,
+    startedAt: now,
+    status: 'active',
+    stoppedAt: null,
+    updatedAt: now,
+    verifiedAt: null,
+    verifiedHead: 0,
+  };
+}
+
+function buildOfflineBuildSnapshot(
+  context: WorkerContext,
+  avatarID: string,
+): { level: number; xp: number } {
+  const lastActivity = context.getActivity();
+
+  if (lastActivity !== null && lastActivity.avatarID === avatarID) {
+    return lastActivity.buildSnapshot;
+  }
+
+  return { level: buildLevelFromXP(0), xp: 0 };
+}

--- a/libs/game/idle-client/src/worker/create-worker-runtime.ts
+++ b/libs/game/idle-client/src/worker/create-worker-runtime.ts
@@ -216,6 +216,7 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
     getBundledEngineHash: () => options.bundledEngineHash ?? BUNDLED_ENGINE_HASH,
     getCancelSignal: () => cancelSignal,
     getClient: () => client,
+    getConnectivity: () => connectivityOnline,
     getFailureAction: () => failureAction,
     getRemainingBudgetMs: () => OFFLINE_PROGRESS_CAP_MS - (Date.now() - lastAckAt),
     getResyncAvatarID: () => resyncAvatarID,

--- a/libs/game/idle-client/src/worker/handle-start-activity-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-start-activity-message.test.ts
@@ -774,6 +774,55 @@ test('it answers failed and persists nothing when offline and the build carries 
   expect(rows).toStrictEqual([]);
 });
 
+test('it answers failed without reporting a fault when offline and the content document is not cached', async () => {
+  const previousHandle = sentryHandle.current;
+  const recorded: Array<Readonly<ErrorEvent>> = [];
+
+  onTestFinished(() => {
+    sentryHandle.current = previousHandle;
+  });
+
+  await startErrorReporting('https://testpublickey@o0.ingest.sentry.io/1', {
+    beforeSend: (event) => {
+      recorded.push(event);
+
+      return null;
+    },
+    disableDefaultIntegrations: true,
+  });
+
+  const context = createStubWorkerContext({
+    bundledEngineHash: 'engine_hash_offline_no_doc',
+    submitter: createStubSubmitter(),
+  });
+
+  context.updateConnectivity(false);
+
+  // seeded on a fresh device: the node's start inputs are cached by reveal, but no activity has
+  // ever installed at this content version here, so the content document itself never cached
+  const seed = createMockNodeSeed({
+    avatarID: 'avatar_offline_no_content_doc',
+    nodeID: '2_1',
+  });
+
+  await writeNodeSeeds(seed.avatarID, [seed]);
+  await writeStartStamps({ keyVersion: 3, secretRef: 'worldmap', secretVersion: 1 });
+
+  const result = await handleStartActivityMessage(context, {
+    avatarID: seed.avatarID,
+    scopeID: seed.nodeID,
+    scopeType: 'world_map_node',
+  });
+
+  expect(result).toStrictEqual({ kind: 'failed' });
+  expect(context.getSimulation().activity).toBeNull();
+  expect(recorded).toStrictEqual([]);
+
+  const rows = await readAllOfflineStartRows();
+
+  expect(rows).toStrictEqual([]);
+});
+
 test('it still starts through the service when connectivity reads online, even with offline start inputs cached', async () => {
   const viewer = await createViewer();
   const ctx = await setupTest({ userID: viewer.user.id });

--- a/libs/game/idle-client/src/worker/handle-start-activity-message.test.ts
+++ b/libs/game/idle-client/src/worker/handle-start-activity-message.test.ts
@@ -1,17 +1,24 @@
 import { expect, mock, onTestFinished, test } from 'bun:test';
 import type { ErrorEvent } from '@sentry/browser';
+import { createMockContentDocument } from '@vers/contract-activity/test-utils';
 import { createSimulation } from '@vers/idle-core';
 import { createAuthedServiceClient, createViewer } from '@vers/mock-services';
 import { mockActivityService } from '@vers/mock-services/activity';
 import * as db from '@vers/mock-services/db';
 import { HttpResponse } from 'msw';
 import invariant from 'tiny-invariant';
+import { writeContentDocumentCache } from '../content/write-content-document-cache';
 import { server } from '../mocks/node';
 import type { CheckpointSubmitter } from '../submission/create-checkpoint-submitter';
+import { readAllOfflineStartRows } from '../submission/read-all-offline-start-rows';
+import { readOfflineStartRow } from '../submission/read-offline-start-row';
 import { readPendingStopIntent } from '../submission/read-pending-stop-intent';
 import type { ActivityServiceClient } from '../submission/types';
+import { writeNodeSeeds } from '../submission/write-node-seeds';
+import { writeStartStamps } from '../submission/write-start-stamps';
 import { createStubSubmitter } from '../test-utils/create-stub-submitter';
 import { createStubWorkerContext } from '../test-utils/create-stub-worker-context';
+import { createMockNodeSeed } from '../test-utils/factories/create-mock-node-seed';
 import { WorkerMessageType } from '../types';
 import { handleStartActivityMessage } from './handle-start-activity-message';
 import { sentryHandle } from './sentry-handle';
@@ -653,4 +660,150 @@ test('it reports no worker fault for a start rejected because the avatar is not 
   });
 
   expect(recorded).toStrictEqual([]);
+});
+
+test('it starts locally from cached inputs and persists the row durably when offline', async () => {
+  const submitter = createStubSubmitter();
+  const context = createStubWorkerContext({ bundledEngineHash: 'engine_hash_offline', submitter });
+
+  context.setSimulation(createSimulation());
+  context.updateConnectivity(false);
+
+  const seed = createMockNodeSeed({
+    avatarID: 'avatar_offline_start',
+    encounterNode: { difficulty: 1 },
+    genesisSeed: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaa6072',
+    nodeID: '2_1',
+  });
+
+  await writeNodeSeeds(seed.avatarID, [seed]);
+  await writeStartStamps({ keyVersion: 3, secretRef: 'worldmap', secretVersion: 1 });
+
+  await writeContentDocumentCache(
+    createMockContentDocument({ contentVersion: seed.contentVersion }),
+  );
+
+  const result = await handleStartActivityMessage(context, {
+    avatarID: seed.avatarID,
+    scopeID: seed.nodeID,
+    scopeType: 'world_map_node',
+  });
+
+  invariant(result.kind === 'started', 'expected a started status');
+
+  expect(context.getSimulation().activity?.id).toBe(result.activity.id);
+  expect(context.getActivity()?.id).toBe(result.activity.id);
+
+  expect(submitter.registerActivity).toHaveBeenCalledExactlyOnceWith({
+    activityID: result.activity.id,
+    appendedHead: 0,
+    lastHash: result.activity.lastHash,
+    startChainIndex: 0,
+  });
+
+  const persisted = await readOfflineStartRow(result.activity.id);
+
+  expect(persisted).toStrictEqual(result.activity);
+
+  const minted = db.activityCollection.findFirst((q) => q.where({ id: result.activity.id }));
+
+  expect(minted).toBeUndefined();
+});
+
+test('it answers failed and persists nothing when offline and the scope was never cached', async () => {
+  const context = createStubWorkerContext({ submitter: createStubSubmitter() });
+
+  context.updateConnectivity(false);
+
+  const result = await handleStartActivityMessage(context, {
+    avatarID: 'avatar_offline_never_cached',
+    scopeID: '0_0',
+    scopeType: 'world_map_node',
+  });
+
+  expect(result).toStrictEqual({ kind: 'failed' });
+  expect(context.getSimulation().activity).toBeNull();
+
+  const rows = await readAllOfflineStartRows();
+
+  expect(rows).toStrictEqual([]);
+});
+
+test('it answers failed and persists nothing when offline and no start stamps are cached', async () => {
+  const context = createStubWorkerContext({ submitter: createStubSubmitter() });
+
+  context.updateConnectivity(false);
+
+  const seed = createMockNodeSeed({ avatarID: 'avatar_offline_no_stamps', nodeID: '1_0' });
+
+  await writeNodeSeeds(seed.avatarID, [seed]);
+
+  const result = await handleStartActivityMessage(context, {
+    avatarID: seed.avatarID,
+    scopeID: seed.nodeID,
+    scopeType: 'world_map_node',
+  });
+
+  expect(result).toStrictEqual({ kind: 'failed' });
+
+  const rows = await readAllOfflineStartRows();
+
+  expect(rows).toStrictEqual([]);
+});
+
+test('it answers failed and persists nothing when offline and the build carries no bundled engine hash', async () => {
+  const context = createStubWorkerContext({ submitter: createStubSubmitter() });
+
+  context.updateConnectivity(false);
+
+  const seed = createMockNodeSeed({ avatarID: 'avatar_offline_no_hash', nodeID: '1_0' });
+
+  await writeNodeSeeds(seed.avatarID, [seed]);
+  await writeStartStamps({ keyVersion: 1, secretRef: 'worldmap', secretVersion: 1 });
+
+  const result = await handleStartActivityMessage(context, {
+    avatarID: seed.avatarID,
+    scopeID: seed.nodeID,
+    scopeType: 'world_map_node',
+  });
+
+  expect(result).toStrictEqual({ kind: 'failed' });
+
+  const rows = await readAllOfflineStartRows();
+
+  expect(rows).toStrictEqual([]);
+});
+
+test('it still starts through the service when connectivity reads online, even with offline start inputs cached', async () => {
+  const viewer = await createViewer();
+  const ctx = await setupTest({ userID: viewer.user.id });
+
+  const context = createStubWorkerContext({
+    bundledEngineHash: 'engine_hash_online',
+    client: ctx.client,
+    submitter: createStubSubmitter(),
+  });
+
+  context.setSimulation(createSimulation());
+
+  const seed = createMockNodeSeed({ avatarID: viewer.avatar.id, nodeID: '0_0' });
+
+  await writeNodeSeeds(seed.avatarID, [seed]);
+  await writeStartStamps({ keyVersion: 1, secretRef: 'worldmap', secretVersion: 1 });
+
+  const result = await handleStartActivityMessage(context, {
+    avatarID: viewer.avatar.id,
+    scopeID: '0_0',
+    scopeType: 'world_map_node',
+  });
+
+  invariant(result.kind === 'started', 'expected a started status');
+
+  const minted = db.activityCollection.findFirst((q) => q.where({ id: result.activity.id }));
+
+  expect(minted).toBeDefined();
+
+  const offlineRow = await readOfflineStartRow(result.activity.id);
+
+  expect(offlineRow).toBeUndefined();
 });

--- a/libs/game/idle-client/src/worker/handle-start-activity-message.ts
+++ b/libs/game/idle-client/src/worker/handle-start-activity-message.ts
@@ -1,6 +1,8 @@
 import type { ORPCError } from '@orpc/client';
 import { isDefinedError, safe } from '@orpc/client';
 import type { ActivityData } from '@vers/contract-activity';
+import { writeOfflineStartRow } from '../submission/write-offline-start-row';
+import { buildOfflineStartRow } from './build-offline-start-row';
 import { handleSetActivityMessage } from './handle-set-activity-message';
 import { isAbortError } from './is-abort-error';
 import { reportWorkerFault } from './report-worker-fault';
@@ -18,7 +20,10 @@ interface StartActivityInput {
 }
 
 /**
- * Begins a run entirely inside the worker, answering with the outcome directly. A same-scope
+ * Begins a run entirely inside the worker, answering with the outcome directly. Offline, the
+ * start mints a row locally from this device's cached start inputs rather than calling
+ * `startActivity` — the tracked connectivity flag decides the branch, never a try-then-fallback,
+ * since a fallback risks minting twice if an in-flight RPC actually lands. Online, a same-scope
  * `CONFLICT` resyncs onto the running row, answering `attached` only once the runtime holds it; a
  * different-scope `CONFLICT` flushes that row, stops it targeted, and retries. The call mints a
  * fresh worker-internal token at entry and re-checks it after every await — a fresher call can
@@ -72,6 +77,21 @@ async function runStart(
 
   // a pure unwind: no row has been minted yet, so there is nothing to compensate
   signals.cancel.throwIfAborted();
+
+  // branches on the tracked connectivity flag rather than trying the RPC and falling back on
+  // failure: a fallback risks minting twice if the RPC actually landed server-side before the
+  // transport reported it unreachable
+  if (!context.getConnectivity()) {
+    const offlineRow = await buildOfflineStartRow(context, { ...input, startKey: token });
+
+    if (offlineRow === null) {
+      return { kind: 'failed' };
+    }
+
+    await writeOfflineStartRow(offlineRow);
+
+    return setLiveStartedRow(context, token, offlineRow, signals);
+  }
 
   const [error, started] = await tryStartActivity(context, { ...input, startKey: token });
 

--- a/libs/game/idle-client/src/worker/types.ts
+++ b/libs/game/idle-client/src/worker/types.ts
@@ -62,6 +62,13 @@ export interface WorkerContext {
   readonly getClient: () => ActivityServiceClient;
 
   /**
+   * The worker's tracked connectivity: `true` until an outage is detected, `false` from then
+   * until a reconnect recovers it. Backs the offline-open start branch's decision to synthesize a
+   * local row instead of calling `startActivity`.
+   */
+  readonly getConnectivity: () => boolean;
+
+  /**
    * The avatar's failure-action preference: the in-session source of truth every simulation input
    * derivation reads from. Seeded from the device-local cache at worker boot, then held here for
    * the worker's lifetime — a live simulation mirrors it, it never reads back from one.

--- a/libs/game/idle-client/test-setup.ts
+++ b/libs/game/idle-client/test-setup.ts
@@ -10,6 +10,7 @@ import {
   CHECKPOINT_QUEUE_STORE_NAME,
   CONTENT_DOCUMENT_STORE_NAME,
   NODE_SEEDS_STORE_NAME,
+  OFFLINE_STARTS_STORE_NAME,
   PREFERENCES_STORE_NAME,
 } from './src/submission/constants';
 import { resolveCheckpointQueueDB } from './src/submission/resolve-checkpoint-queue-db';
@@ -46,4 +47,5 @@ afterEach(async () => {
   await queueDB.clear(PREFERENCES_STORE_NAME);
   await queueDB.clear(CONTENT_DOCUMENT_STORE_NAME);
   await queueDB.clear(NODE_SEEDS_STORE_NAME);
+  await queueDB.clear(OFFLINE_STARTS_STORE_NAME);
 });


### PR DESCRIPTION
## Description

Closes #890

When the idle worker's tracked connectivity is offline, a start on a currently-selectable world-map node now mints its `ActivityData` root row entirely from local cache instead of calling the service, branching on the worker's connectivity flag rather than a try-then-fallback.

- `buildOfflineStartRow` synthesizes the row from cached node seed, start stamps, bundled engine hash, and content document — computing `startHash` via `buildStartHash` — and returns `null` if any input is missing, including an uncached content document.
- `buildSnapshot` sources from the last activity row this worker installed for the avatar, falling back to `{ level: 1, xp: 0 }` as a settled-xp hint, not a reproduction of the server's optimistic total.
- `handle-start-activity-message.ts` branches on `WorkerContext.getConnectivity()` before the RPC call; offline synthesizes and durably persists the row before installing it through the existing `setLiveStartedRow` path. Online behavior is unchanged.
- A new `offline-starts` IndexedDB store (`CHECKPOINT_QUEUE_DB_VERSION` bumped to 6) holds these rows as the future reconcile's drain surface.
- Updated app-web's test-only checkpoint-db mirror to match the v6 schema.
- Documented the mechanism in `docs/architecture/game/seed-chain.md`.

Out of scope: optimistic first-clear/traversal overlay, server reconcile/ingest, traversal validation, new worker-contract rejection reasons.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
