### PR TITLE
feat(#891): ingest client-minted roots into a stalled checkpoint flush and drain reload-orphaned roots on reconnect

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -27,6 +27,7 @@
           "dispose",
           "flush",
           "fold",
+          "ingest",
           "mint",
           "park",
           "record",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,7 @@ Project-level additions to the shared function-naming taxonomy, under the same r
 | `broadcast` | post one message to every connected client on whichever transport carries it                | `broadcast`              |
 | `dispose`   | release the resources a built entry holds (a GPU buffer, texture, or subscription)          | `disposeBiomeChunkEntry` |
 | `flush`     | attempt delivery of the durable outbound backlog, removing entries confirmed received       | `flush`                  |
+| `ingest`    | submit a locally held record into an external system, settling its local copy by the answer | `ingestStartRow`         |
 | `mint`      | create and persist a new identity-bearing row rooted in a chain or coordinate               | `mintContinuation`       |
 | `park`      | set a work item aside in a parked status for later resumption                               | `parkActivity`           |
 | `record`    | durably note that an event occurred (counter, log, audit row)                               | `recordFailedAttempt`    |

--- a/agents/project.md
+++ b/agents/project.md
@@ -17,6 +17,7 @@ Project-level additions to the shared function-naming taxonomy, under the same r
 | `broadcast` | post one message to every connected client on whichever transport carries it                | `broadcast`              |
 | `dispose`   | release the resources a built entry holds (a GPU buffer, texture, or subscription)          | `disposeBiomeChunkEntry` |
 | `flush`     | attempt delivery of the durable outbound backlog, removing entries confirmed received       | `flush`                  |
+| `ingest`    | submit a locally held record into an external system, settling its local copy by the answer | `ingestStartRow`         |
 | `mint`      | create and persist a new identity-bearing row rooted in a chain or coordinate               | `mintContinuation`       |
 | `park`      | set a work item aside in a parked status for later resumption                               | `parkActivity`           |
 | `record`    | durably note that an event occurred (counter, log, audit row)                               | `recordFailedAttempt`    |

--- a/contracts/activity/src/activity-contract.test.ts
+++ b/contracts/activity/src/activity-contract.test.ts
@@ -159,6 +159,30 @@ test('it accepts an advanceActivity request carrying a root submission', () => {
   );
 });
 
+test('it accepts a root-only advanceActivity request with no continuations', () => {
+  const input = {
+    activityID: 'act_root_only',
+    continuations: [],
+    expectedHead: 0,
+    root: {
+      avatarID: 'avatar_1',
+      buildSnapshot: { level: 1, xp: 0 },
+      contentVersion: '2',
+      scopeID: '0_0',
+      scopeType: 'world_map_node',
+      seed: '0123456789abcdef0123456789abcdef',
+      simVersion: 'engine_hash',
+      startChainIndex: 0,
+      startHash: 'start_hash',
+      startKey: 'root_act_root_only',
+    },
+  };
+
+  expect(activityContract.advanceActivity['~orpc'].inputSchema?.safeParse(input).success).toBe(
+    true,
+  );
+});
+
 test('it rejects an advanceActivity request whose checkpoints exceed the cap across continuations', () => {
   const half = Math.ceil(MAX_CATCH_UP_BATCH_CHECKPOINTS / 2);
 

--- a/contracts/activity/src/activity-contract.ts
+++ b/contracts/activity/src/activity-contract.ts
@@ -140,9 +140,11 @@ export const activityContract = {
       z
         .object({
           activityID: z.string(),
+
+          // Empty when `root` carries the whole request: a root-only ingest mints the row and
+          // appends nothing.
           continuations: z
             .array(CatchUpContinuationSchema)
-            .min(1)
             .max(MAX_CATCH_UP_BATCH_CHECKPOINTS)
             .readonly(),
           expectedHead: z.int().min(0),

--- a/contracts/activity/src/activity-contract.ts
+++ b/contracts/activity/src/activity-contract.ts
@@ -168,7 +168,14 @@ export const activityContract = {
           {
             error: `a request carries at most ${MAX_CATCH_UP_BATCH_CHECKPOINTS} checkpoints across all continuations`,
           },
-        ),
+        )
+
+        // Every request mints or appends something: an empty `continuations` is legal only when
+        // `root` carries the whole request, never a root-less no-op that would return the head
+        // unchanged.
+        .refine((input) => input.root !== undefined || input.continuations.length > 0, {
+          error: 'a request with no continuations must carry a root to mint',
+        }),
     )
     .output(z.object({ activity: ActivityDataSchema, appendedHead: z.int() }))
     .errors(

--- a/contracts/activity/src/build-offline-root-submission.test.ts
+++ b/contracts/activity/src/build-offline-root-submission.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from 'bun:test';
+import { buildOfflineRootSubmission } from './build-offline-root-submission';
+import { createMockActivityData } from './test-utils/factories/create-mock-activity-data';
+
+test('it projects a client-minted root row down to the ten wire fields advanceActivity accepts', () => {
+  const row = createMockActivityData({
+    avatarID: 'avatar_1',
+    buildSnapshot: { level: 3, xp: 120 },
+    contentVersion: '2',
+    scopeID: '0_0',
+    scopeType: 'world_map_node',
+    seed: 'a'.repeat(32),
+    simVersion: '0.0.0-dev',
+    startChainIndex: 4,
+    startHash: 'b'.repeat(64),
+    startKey: 'start_key_1',
+  });
+
+  expect(buildOfflineRootSubmission(row)).toStrictEqual({
+    avatarID: 'avatar_1',
+    buildSnapshot: { level: 3, xp: 120 },
+    contentVersion: '2',
+    scopeID: '0_0',
+    scopeType: 'world_map_node',
+    seed: 'a'.repeat(32),
+    simVersion: '0.0.0-dev',
+    startChainIndex: 4,
+    startHash: 'b'.repeat(64),
+    startKey: 'start_key_1',
+  });
+});
+
+test('it never carries the server-derived encounter and key/secret stamps', () => {
+  const row = createMockActivityData({ startKey: 'start_key_2' });
+
+  expect(buildOfflineRootSubmission(row)).not.toContainAnyKeys([
+    'encounterNode',
+    'keyVersion',
+    'secretRef',
+    'secretVersion',
+  ]);
+});
+
+test('it throws when the row carries no start key', () => {
+  const row = createMockActivityData({ startKey: null });
+
+  expect(() => buildOfflineRootSubmission(row)).toThrow();
+});

--- a/contracts/activity/src/build-offline-root-submission.ts
+++ b/contracts/activity/src/build-offline-root-submission.ts
@@ -1,0 +1,28 @@
+import invariant from 'tiny-invariant';
+import type { ActivityData } from './activity-data-schema';
+import type { OfflineRootSubmission } from './offline-root-submission-schema';
+
+/**
+ * Projects a locally minted root row down to the wire fields `advanceActivity` accepts for
+ * offline-first ingest — every field the server re-derives (`encounterNode`, `keyVersion`,
+ * `secretRef`, `secretVersion`) is dropped, since the row's own values for them were never
+ * server-authoritative to begin with.
+ */
+export function buildOfflineRootSubmission(row: Readonly<ActivityData>): OfflineRootSubmission {
+  // a locally minted root always carries the idempotency key it was minted with; only a
+  // server-derived row's startKey can read null
+  invariant(row.startKey !== null, 'expected a client-minted root row to carry its start key');
+
+  return {
+    avatarID: row.avatarID,
+    buildSnapshot: row.buildSnapshot,
+    contentVersion: row.contentVersion,
+    scopeID: row.scopeID,
+    scopeType: row.scopeType,
+    seed: row.seed,
+    simVersion: row.simVersion,
+    startChainIndex: row.startChainIndex,
+    startHash: row.startHash,
+    startKey: row.startKey,
+  };
+}

--- a/contracts/activity/src/index.ts
+++ b/contracts/activity/src/index.ts
@@ -8,6 +8,7 @@ export type { ActivityStatus } from './activity-status-schema';
 export { ActivityStatusSchema } from './activity-status-schema';
 export { buildCheckpointHash } from './build-checkpoint-hash';
 export { buildCheckpointHashFromEntry } from './build-checkpoint-hash-from-entry';
+export { buildOfflineRootSubmission } from './build-offline-root-submission';
 export { buildStartHash } from './build-start-hash';
 export type { BuildSnapshot } from './build-snapshot-schema';
 export { BuildSnapshotSchema } from './build-snapshot-schema';

--- a/docs/architecture/game/seed-chain.md
+++ b/docs/architecture/game/seed-chain.md
@@ -96,6 +96,14 @@ equal `appendedChainIndex` and its seed must equal `appendedNextSeed` — so a r
 head the chain has since moved past is refused rather than layered onto a position that no longer
 exists.
 
+The client ingests each pending root into the server on first server contact: a `NOT_FOUND` answer
+to its checkpoint flush triggers a one-shot ingest-and-retry of that same batch rather than an
+immediate discard. A root orphaned by a worker reload — no live simulation left to drive its flush —
+ingests on reconnect instead, ahead of the held-checkpoint flush it would otherwise NOT_FOUND
+against. Either path removes the durable `pending-roots` entry once the server has answered
+definitively; a server-refused root is dropped and its queued checkpoints discarded, the same as any
+other stream the server refuses to recognize.
+
 ## Advancing the chain
 
 The chain advances on an activity's transition out of `active`. Which cursor moves depends on

--- a/libs/game/idle-client/src/submission/checkpoint-activity-machine.test.ts
+++ b/libs/game/idle-client/src/submission/checkpoint-activity-machine.test.ts
@@ -489,6 +489,39 @@ test('it ingests a pending root and re-flushes once on NOT_FOUND, succeeding wit
   expect(ctx.onAcked).toHaveBeenCalledExactlyOnceWith('not-found-ingested-activity', 1);
 });
 
+test('it discards the queue after a second NOT_FOUND on the post-ingest retry, ingesting only once', async () => {
+  const track = mock<() => void>();
+
+  const ingestRoot = mock<(activityID: string) => Promise<IngestStartRowOutcome>>(async () => {
+    await Promise.resolve();
+
+    return 'ingested';
+  });
+
+  const ctx = setupTest({ activityID: 'not-found-twice-activity', ingestRoot });
+
+  server.use(
+    mockActivityService.trackActivityProgress.handler((opts) => {
+      track();
+      throw opts.errors.NOT_FOUND({ data: {} });
+    }),
+  );
+
+  await writeQueuedCheckpoint(
+    'not-found-twice-activity',
+    createMockCheckpointBatchEntry({ payload: { type: 'completed' }, version: 1 }),
+  );
+
+  ctx.actor.send({ isTerminal: true, type: 'QUEUED', version: 1 });
+
+  await waitFor(() => {
+    expect(ctx.actor.getSnapshot().matches('evicted')).toBeTrue();
+  });
+
+  expect(track).toHaveBeenCalledTimes(2);
+  expect(ingestRoot).toHaveBeenCalledExactlyOnceWith('not-found-twice-activity');
+});
+
 test('it holds the queue and retries on NOT_FOUND when ingestRoot defers', async () => {
   const track = mock<() => void>();
 

--- a/libs/game/idle-client/src/submission/checkpoint-activity-machine.test.ts
+++ b/libs/game/idle-client/src/submission/checkpoint-activity-machine.test.ts
@@ -489,6 +489,45 @@ test('it ingests a pending root and re-flushes once on NOT_FOUND, succeeding wit
   expect(ctx.onAcked).toHaveBeenCalledExactlyOnceWith('not-found-ingested-activity', 1);
 });
 
+test('it re-flushes on an absent ingest, delivering against a root a concurrent drain minted', async () => {
+  const track = mock<() => void>();
+
+  const ingestRoot = mock<(activityID: string) => Promise<IngestStartRowOutcome>>(async () => {
+    await Promise.resolve();
+
+    return 'absent';
+  });
+
+  const ctx = setupTest({ activityID: 'not-found-absent-activity', ingestRoot });
+
+  server.use(
+    mockActivityService.trackActivityProgress.handler((opts) => {
+      track();
+
+      if (track.mock.calls.length === 1) {
+        throw opts.errors.NOT_FOUND({ data: {} });
+      }
+
+      return { appendedHead: 1 };
+    }),
+  );
+
+  await writeQueuedCheckpoint(
+    'not-found-absent-activity',
+    createMockCheckpointBatchEntry({ payload: { type: 'completed' }, version: 1 }),
+  );
+
+  ctx.actor.send({ isTerminal: true, type: 'QUEUED', version: 1 });
+
+  await waitFor(() => {
+    expect(ctx.actor.getSnapshot().matches('evicted')).toBeTrue();
+  });
+
+  expect(track).toHaveBeenCalledTimes(2);
+  expect(ingestRoot).toHaveBeenCalledExactlyOnceWith('not-found-absent-activity');
+  expect(ctx.onAcked).toHaveBeenCalledExactlyOnceWith('not-found-absent-activity', 1);
+});
+
 test('it discards the queue after a second NOT_FOUND on the post-ingest retry, ingesting only once', async () => {
   const track = mock<() => void>();
 

--- a/libs/game/idle-client/src/submission/checkpoint-activity-machine.test.ts
+++ b/libs/game/idle-client/src/submission/checkpoint-activity-machine.test.ts
@@ -11,12 +11,14 @@ import { createMockCheckpointBatchEntry } from '../test-utils/factories/create-m
 import type { CheckpointActivityEmittedEvent } from './checkpoint-activity-machine';
 import { checkpointActivityMachine } from './checkpoint-activity-machine';
 import { PROGRESS_FLUSH_INTERVAL_MS, RETRY_BACKOFF_CAP_MS } from './constants';
+import type { IngestStartRowOutcome } from './ingest-start-row';
 import type { ActivityServiceClient } from './types';
 import { writeQueuedCheckpoint } from './write-queued-checkpoint';
 
 function setupTest(
   config: Readonly<{
     activityID?: string;
+    ingestRoot?: (activityID: string) => Promise<IngestStartRowOutcome>;
     latestQueuedVersion?: number;
     onAcked?: (activityID: string, appendedHead: number) => void;
     signal?: AbortSignal;
@@ -38,6 +40,7 @@ function setupTest(
       activityID: config.activityID ?? 'activity-machine-test',
       client,
       expectedHead: 0,
+      ingestRoot: config.ingestRoot,
       latestQueuedVersion: config.latestQueuedVersion,
       onAcked,
       onCapped: undefined,
@@ -445,4 +448,130 @@ test('it resets the backoff attempt counter once a retried batch lands, so a lat
   });
 
   expect(ctx.actor.getSnapshot().context.retryAttempt).toBe(0);
+});
+
+test('it ingests a pending root and re-flushes once on NOT_FOUND, succeeding without discarding the queue', async () => {
+  const track = mock<() => void>();
+
+  const ingestRoot = mock<(activityID: string) => Promise<IngestStartRowOutcome>>(async () => {
+    await Promise.resolve();
+
+    return 'ingested';
+  });
+
+  const ctx = setupTest({ activityID: 'not-found-ingested-activity', ingestRoot });
+
+  server.use(
+    mockActivityService.trackActivityProgress.handler((opts) => {
+      track();
+
+      if (track.mock.calls.length === 1) {
+        throw opts.errors.NOT_FOUND({ data: {} });
+      }
+
+      return { appendedHead: 1 };
+    }),
+  );
+
+  await writeQueuedCheckpoint(
+    'not-found-ingested-activity',
+    createMockCheckpointBatchEntry({ payload: { type: 'completed' }, version: 1 }),
+  );
+
+  ctx.actor.send({ isTerminal: true, type: 'QUEUED', version: 1 });
+
+  await waitFor(() => {
+    expect(ctx.actor.getSnapshot().matches('evicted')).toBeTrue();
+  });
+
+  expect(track).toHaveBeenCalledTimes(2);
+  expect(ingestRoot).toHaveBeenCalledExactlyOnceWith('not-found-ingested-activity');
+  expect(ctx.onAcked).toHaveBeenCalledExactlyOnceWith('not-found-ingested-activity', 1);
+});
+
+test('it holds the queue and retries on NOT_FOUND when ingestRoot defers', async () => {
+  const track = mock<() => void>();
+
+  const ingestRoot = mock<(activityID: string) => Promise<IngestStartRowOutcome>>(async () => {
+    await Promise.resolve();
+
+    return 'deferred';
+  });
+
+  const ctx = setupTest({ activityID: 'not-found-deferred-activity', ingestRoot });
+
+  server.use(
+    mockActivityService.trackActivityProgress.handler((opts) => {
+      track();
+      throw opts.errors.NOT_FOUND({ data: {} });
+    }),
+  );
+
+  await writeQueuedCheckpoint(
+    'not-found-deferred-activity',
+    createMockCheckpointBatchEntry({ payload: { type: 'completed' }, version: 1 }),
+  );
+
+  ctx.actor.send({ isTerminal: true, type: 'QUEUED', version: 1 });
+
+  await waitFor(() => {
+    expect(ctx.actor.getSnapshot().matches('retrying')).toBeTrue();
+  });
+
+  expect(track).toHaveBeenCalledOnce();
+  expect(ctx.emitted).toStrictEqual([{ activityID: 'not-found-deferred-activity', type: 'held' }]);
+});
+
+test('it discards the queue on NOT_FOUND when ingestRoot reports the root rejected', async () => {
+  const ingestRoot = mock<(activityID: string) => Promise<IngestStartRowOutcome>>(async () => {
+    await Promise.resolve();
+
+    return 'rejected';
+  });
+
+  const ctx = setupTest({ activityID: 'not-found-rejected-activity', ingestRoot });
+
+  server.use(
+    mockActivityService.trackActivityProgress.handler((opts) => {
+      throw opts.errors.NOT_FOUND({ data: {} });
+    }),
+  );
+
+  await writeQueuedCheckpoint(
+    'not-found-rejected-activity',
+    createMockCheckpointBatchEntry({ payload: { type: 'completed' }, version: 1 }),
+  );
+
+  ctx.actor.send({ isTerminal: true, type: 'QUEUED', version: 1 });
+
+  await waitFor(() => {
+    expect(ctx.actor.getSnapshot().matches('evicted')).toBeTrue();
+  });
+
+  expect(ingestRoot).toHaveBeenCalledExactlyOnceWith('not-found-rejected-activity');
+});
+
+test('it discards the queue on NOT_FOUND with no ingestRoot hook configured', async () => {
+  const track = mock<() => void>();
+  const ctx = setupTest({ activityID: 'not-found-no-hook-activity' });
+
+  server.use(
+    mockActivityService.trackActivityProgress.handler((opts) => {
+      track();
+      throw opts.errors.NOT_FOUND({ data: {} });
+    }),
+  );
+
+  await writeQueuedCheckpoint(
+    'not-found-no-hook-activity',
+    createMockCheckpointBatchEntry({ payload: { type: 'completed' }, version: 1 }),
+  );
+
+  ctx.actor.send({ isTerminal: true, type: 'QUEUED', version: 1 });
+
+  await waitFor(() => {
+    expect(ctx.actor.getSnapshot().matches('evicted')).toBeTrue();
+  });
+
+  expect(track).toHaveBeenCalledOnce();
 });

--- a/libs/game/idle-client/src/submission/checkpoint-activity-machine.ts
+++ b/libs/game/idle-client/src/submission/checkpoint-activity-machine.ts
@@ -2,6 +2,7 @@ import type { ActorRef, Snapshot } from 'xstate';
 import { assign, emit, enqueueActions, raise, setup } from 'xstate';
 import { buildMachineTypes } from './build-machine-types';
 import { FLUSH_STALL_THRESHOLD } from './constants';
+import type { IngestStartRowOutcome } from './ingest-start-row';
 import type { FlushOutcome } from './run-checkpoint-flush-attempt';
 import { runCheckpointFlushAttempt } from './run-checkpoint-flush-attempt';
 import { subscribeToShutdownAbort } from './subscribe-to-shutdown-abort';
@@ -13,6 +14,7 @@ interface CheckpointActivityContext {
   readonly consecutiveFlushFailures: number;
   readonly expectedHead: number;
   readonly flushPending: boolean;
+  readonly ingestRoot: ((activityID: string) => Promise<IngestStartRowOutcome>) | undefined;
   readonly latestQueuedVersion: number | undefined;
   readonly onAcked: ((activityID: string, appendedHead: number) => void) | undefined;
   readonly onCapped: ((activityID: string, appendedHead: number) => void) | undefined;
@@ -37,6 +39,7 @@ export interface CheckpointActivityInput {
   readonly activityID: string;
   readonly client: Pick<ActivityServiceClient, 'trackActivityProgress'>;
   readonly expectedHead: number;
+  readonly ingestRoot: ((activityID: string) => Promise<IngestStartRowOutcome>) | undefined;
   readonly latestQueuedVersion: number | undefined;
   readonly onAcked: ((activityID: string, appendedHead: number) => void) | undefined;
   readonly onCapped: ((activityID: string, appendedHead: number) => void) | undefined;
@@ -142,6 +145,7 @@ export const checkpointActivityMachine = setup({
     consecutiveFlushFailures: 0,
     expectedHead: args.input.expectedHead,
     flushPending: false,
+    ingestRoot: args.input.ingestRoot,
     latestQueuedVersion: args.input.latestQueuedVersion,
     onAcked: args.input.onAcked,
     onCapped: args.input.onCapped,
@@ -169,6 +173,7 @@ export const checkpointActivityMachine = setup({
           activityID: args.context.activityID,
           client: args.context.client,
           expectedHead: args.context.expectedHead,
+          ingestRoot: args.context.ingestRoot,
           onAcked: args.context.onAcked,
           onCapped: args.context.onCapped,
           onEvicted: args.context.onEvicted,

--- a/libs/game/idle-client/src/submission/create-checkpoint-submitter.ts
+++ b/libs/game/idle-client/src/submission/create-checkpoint-submitter.ts
@@ -11,6 +11,7 @@ import {
   PROGRESS_FLUSH_INTERVAL_MS,
   RETRY_BACKOFF_CAP_MS,
 } from './constants';
+import type { IngestStartRowOutcome } from './ingest-start-row';
 import { readQueuedCheckpoints } from './read-queued-checkpoints';
 import type { ActivityServiceClient, ActivitySubmissionContext } from './types';
 import { writeNodeHead } from './write-node-head';
@@ -76,6 +77,13 @@ export interface CheckpointSubmitter {
 
 interface CreateCheckpointSubmitterOptions {
   readonly client: Pick<ActivityServiceClient, 'trackActivityProgress'>;
+
+  /**
+   * Ingests an activity's still-pending client-minted root into the server, tried once against a
+   * `NOT_FOUND` checkpoint-flush answer before the stream discards its queue — undefined for a
+   * caller with no offline-first roots to self-heal from.
+   */
+  readonly ingestRoot?: (activityID: string) => Promise<IngestStartRowOutcome>;
 
   /**
    * Called after every successful flush with the server's fresh appended head — the caller's
@@ -188,7 +196,10 @@ const TERMINAL_CHECKPOINT_TYPES: ReadonlySet<string> = new Set([
  *
  * - a fresh head on success or `CONFLICT` advances the cursor and confirms the queue up to it
  * - `CHECKPOINT_INVALID` stops the stream and keeps its queue rows
- * - `NOT_FOUND` stops the stream and discards its queue rows
+ * - `NOT_FOUND` stops the stream and discards its queue rows — unless an `ingestRoot` hook is
+ *   configured and the activity still has a pending client-minted root, in which case the flush
+ *   ingests that root into the server and retries the same batch once before falling back to the
+ *   discard
  * - `ACTIVITY_CAPPED`, `ACTIVITY_TERMINAL`, and `SESSION_EVICTED` stop the stream and discard its
  *   queue rows — the server accepts nothing further for it
  * - anything else — `UNAUTHORIZED` or a transport failure — holds the queue untouched and starts
@@ -299,6 +310,7 @@ export function createCheckpointSubmitter(
       activityID: context.activityID,
       client: options.client,
       expectedHead: context.appendedHead,
+      ingestRoot: options.ingestRoot,
       latestQueuedVersion,
       onAcked: options.onAcked,
       onCapped: options.onCapped,

--- a/libs/game/idle-client/src/submission/ingest-start-row.test.ts
+++ b/libs/game/idle-client/src/submission/ingest-start-row.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'bun:test';
+import { expect, mock, test } from 'bun:test';
 import { createORPCClient } from '@orpc/client';
 import { RPCLink } from '@orpc/client/fetch';
 import { createMockActivityData } from '@vers/contract-activity/test-utils';
@@ -84,6 +84,31 @@ test('it defers and keeps the root when the avatar reads temporarily inactive', 
   const stored = await readStartRow(row.id);
 
   expect(stored).toStrictEqual(row);
+});
+
+test('it rejects and removes a row with no start key without reaching the server', async () => {
+  const ctx = setupTest();
+  const row = createMockActivityData({ id: 'act_ingest_no_key', startKey: null });
+  const track = mock<() => void>();
+
+  server.use(
+    mockActivityService.advanceActivity.handler(() => {
+      track();
+
+      return { activity: row, appendedHead: 0 };
+    }),
+  );
+
+  await writeStartRow(row);
+
+  const outcome = await ingestStartRow(ctx.client, row.id);
+
+  expect(outcome).toBe('rejected');
+  expect(track).not.toHaveBeenCalled();
+
+  const stored = await readStartRow(row.id);
+
+  expect(stored).toBeUndefined();
 });
 
 test('it rejects and removes the root once the server refuses it with CONFLICT', async () => {

--- a/libs/game/idle-client/src/submission/ingest-start-row.test.ts
+++ b/libs/game/idle-client/src/submission/ingest-start-row.test.ts
@@ -1,0 +1,108 @@
+import { expect, test } from 'bun:test';
+import { createORPCClient } from '@orpc/client';
+import { RPCLink } from '@orpc/client/fetch';
+import { createMockActivityData } from '@vers/contract-activity/test-utils';
+import { resolveServiceURL } from '@vers/mock-services';
+import { mockActivityService } from '@vers/mock-services/activity';
+import { HttpResponse } from 'msw';
+import { server } from '../mocks/node';
+import { ingestStartRow } from './ingest-start-row';
+import { readStartRow } from './read-start-row';
+import type { ActivityServiceClient } from './types';
+import { writeStartRow } from './write-start-row';
+
+function setupTest() {
+  const link = new RPCLink({ url: `${resolveServiceURL('activity')}/rpc` });
+
+  const client: ActivityServiceClient = createORPCClient(link);
+
+  return { client };
+}
+
+test('it ingests a pending root and removes its durable row', async () => {
+  const ctx = setupTest();
+  const row = createMockActivityData({ id: 'act_ingest_ok', startKey: 'start_key_ok' });
+
+  server.use(
+    mockActivityService.advanceActivity.handler(() => ({ activity: row, appendedHead: 0 })),
+  );
+
+  await writeStartRow(row);
+
+  const outcome = await ingestStartRow(ctx.client, row.id);
+
+  expect(outcome).toBe('ingested');
+
+  const stored = await readStartRow(row.id);
+
+  expect(stored).toBeUndefined();
+});
+
+test('it reports absent for an activity id this device holds no pending root for', async () => {
+  const ctx = setupTest();
+
+  const outcome = await ingestStartRow(ctx.client, 'act_ingest_absent');
+
+  expect(outcome).toBe('absent');
+});
+
+test('it defers and keeps the root on a transport failure', async () => {
+  const ctx = setupTest();
+  const row = createMockActivityData({ id: 'act_ingest_transport', startKey: 'start_key_t' });
+
+  server.use(mockActivityService.advanceActivity.handler(() => HttpResponse.error()));
+
+  await writeStartRow(row);
+
+  const outcome = await ingestStartRow(ctx.client, row.id);
+
+  expect(outcome).toBe('deferred');
+
+  const stored = await readStartRow(row.id);
+
+  expect(stored).toStrictEqual(row);
+});
+
+test('it defers and keeps the root when the avatar reads temporarily inactive', async () => {
+  const ctx = setupTest();
+  const row = createMockActivityData({ id: 'act_ingest_inactive', startKey: 'start_key_i' });
+
+  server.use(
+    mockActivityService.advanceActivity.handler((opts) => {
+      throw opts.errors.AVATAR_NOT_ACTIVE({
+        data: { activeAvatarID: 'avatar_other', activeAvatarName: 'Other' },
+      });
+    }),
+  );
+
+  await writeStartRow(row);
+
+  const outcome = await ingestStartRow(ctx.client, row.id);
+
+  expect(outcome).toBe('deferred');
+
+  const stored = await readStartRow(row.id);
+
+  expect(stored).toStrictEqual(row);
+});
+
+test('it rejects and removes the root once the server refuses it with CONFLICT', async () => {
+  const ctx = setupTest();
+  const row = createMockActivityData({ id: 'act_ingest_conflict', startKey: 'start_key_c' });
+
+  server.use(
+    mockActivityService.advanceActivity.handler((opts) => {
+      throw opts.errors.CONFLICT({ data: { activityID: row.id, appendedHead: 3 } });
+    }),
+  );
+
+  await writeStartRow(row);
+
+  const outcome = await ingestStartRow(ctx.client, row.id);
+
+  expect(outcome).toBe('rejected');
+
+  const stored = await readStartRow(row.id);
+
+  expect(stored).toBeUndefined();
+});

--- a/libs/game/idle-client/src/submission/ingest-start-row.ts
+++ b/libs/game/idle-client/src/submission/ingest-start-row.ts
@@ -47,6 +47,14 @@ export async function ingestStartRow(
     return 'absent';
   }
 
+  // a client-minted root always carries its start key; a row missing one can never be projected
+  // into a submission, so drop it rather than let the projection throw and abort a multi-row drain
+  if (row.startKey === null) {
+    await removeStartRow(activityID);
+
+    return 'rejected';
+  }
+
   const root = buildOfflineRootSubmission(row);
 
   const [error] = await safe(

--- a/libs/game/idle-client/src/submission/ingest-start-row.ts
+++ b/libs/game/idle-client/src/submission/ingest-start-row.ts
@@ -1,0 +1,69 @@
+import { isDefinedError, safe } from '@orpc/client';
+import { buildOfflineRootSubmission } from '@vers/contract-activity';
+import { readStartRow } from './read-start-row';
+import { removeStartRow } from './remove-start-row';
+import type { ActivityServiceClient } from './types';
+
+/**
+ * `ingestStartRow`'s settled outcome: `ingested` when the server minted the root and this
+ * device's durable row is gone; `deferred` when the answer says nothing about the root's own
+ * validity — a transport failure, a session lapse, or a temporarily inactive avatar — and the row
+ * stays for a later retry; `rejected` when the server refused the root outright and the row is
+ * gone; `absent` when this device held no pending root for the activity id at all.
+ */
+export type IngestStartRowOutcome = 'absent' | 'deferred' | 'ingested' | 'rejected';
+
+/**
+ * A defined `advanceActivity` error naming the root itself invalid, never the caller's session or
+ * account state — the server's refusal is final, so the pending row is dropped along with the
+ * checkpoints that would have chained onto it.
+ */
+const REJECTED_CODES: ReadonlySet<string> = new Set([
+  'CHAIN_QUARANTINED',
+  'CHECKPOINT_INVALID',
+  'CONFLICT',
+  'NODE_NOT_REVEALED',
+  'NODE_UNKNOWN',
+  'NODE_UNREACHABLE',
+  'NOT_FOUND',
+  'SIM_VERSION_EXPIRED',
+  'SIM_VERSION_UNKNOWN',
+]);
+
+/**
+ * Submits one device's client-minted root into the server through `advanceActivity`'s
+ * offline-first ingest, an empty `continuations` batch minting the row alone and appending
+ * nothing. Removes the durable `pending-roots` row once the server has answered definitively —
+ * accepted or refused — and keeps it untouched on anything that says nothing about the root's own
+ * validity, so a later retry gets another chance.
+ */
+export async function ingestStartRow(
+  client: Pick<ActivityServiceClient, 'advanceActivity'>,
+  activityID: string,
+): Promise<IngestStartRowOutcome> {
+  const row = await readStartRow(activityID);
+
+  if (row === undefined) {
+    return 'absent';
+  }
+
+  const root = buildOfflineRootSubmission(row);
+
+  const [error] = await safe(
+    client.advanceActivity({ activityID, continuations: [], expectedHead: 0, root }),
+  );
+
+  if (error === null) {
+    await removeStartRow(activityID);
+
+    return 'ingested';
+  }
+
+  if (isDefinedError(error) && REJECTED_CODES.has(error.code)) {
+    await removeStartRow(activityID);
+
+    return 'rejected';
+  }
+
+  return 'deferred';
+}

--- a/libs/game/idle-client/src/submission/remove-start-row.test.ts
+++ b/libs/game/idle-client/src/submission/remove-start-row.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from 'bun:test';
+import { createMockActivityData } from '@vers/contract-activity/test-utils';
+import { readStartRow } from './read-start-row';
+import { removeStartRow } from './remove-start-row';
+import { writeStartRow } from './write-start-row';
+
+test('it removes a previously written row', async () => {
+  const row = createMockActivityData({ id: 'act_remove_start_row' });
+
+  await writeStartRow(row);
+  await removeStartRow(row.id);
+
+  const stored = await readStartRow(row.id);
+
+  expect(stored).toBeUndefined();
+});
+
+test('it tolerates removing an activity id this device holds no row for', async () => {
+  await expect(removeStartRow('act_remove_start_row_absent')).toResolve();
+});

--- a/libs/game/idle-client/src/submission/remove-start-row.ts
+++ b/libs/game/idle-client/src/submission/remove-start-row.ts
@@ -1,0 +1,13 @@
+import { PENDING_ROOTS_STORE_NAME } from './constants';
+import { resolveCheckpointQueueDB } from './resolve-checkpoint-queue-db';
+
+/**
+ * Removes one activity's client-minted root row, once the server has accepted it or refused it
+ * outright — the durable record a crash between mint and install would otherwise recover is no
+ * longer needed either way.
+ */
+export async function removeStartRow(activityID: string): Promise<void> {
+  const db = await resolveCheckpointQueueDB();
+
+  await db.delete(PENDING_ROOTS_STORE_NAME, activityID);
+}

--- a/libs/game/idle-client/src/submission/run-checkpoint-flush-attempt.ts
+++ b/libs/game/idle-client/src/submission/run-checkpoint-flush-attempt.ts
@@ -1,6 +1,7 @@
 import { ORPCError, isDefinedError, safe } from '@orpc/client';
 import { buildTraceparent, createTraceContext } from '@vers/trace';
 import { fromPromise } from 'xstate';
+import type { IngestStartRowOutcome } from './ingest-start-row';
 import { readQueuedCheckpoints } from './read-queued-checkpoints';
 import { removeConfirmedCheckpoints } from './remove-confirmed-checkpoints';
 import { removeQueuedCheckpoints } from './remove-queued-checkpoints';
@@ -34,6 +35,14 @@ interface FlushAttemptInput {
   readonly activityID: string;
   readonly client: Pick<ActivityServiceClient, 'trackActivityProgress'>;
   readonly expectedHead: number;
+
+  /**
+   * Ingests this activity's still-pending client-minted root, tried once against a `NOT_FOUND`
+   * answer before it discards the queue — undefined for a caller with no offline-first root to
+   * self-heal from, which keeps a `NOT_FOUND` an unconditional discard.
+   */
+  readonly ingestRoot: ((activityID: string) => Promise<IngestStartRowOutcome>) | undefined;
+
   readonly onAcked: ((activityID: string, appendedHead: number) => void) | undefined;
   readonly onCapped: ((activityID: string, appendedHead: number) => void) | undefined;
   readonly onEvicted: ((activityID: string) => void) | undefined;
@@ -62,79 +71,106 @@ export const runCheckpointFlushAttempt = fromPromise<FlushOutcome, FlushAttemptI
       }
 
       const trace = createTraceContext();
+      let retriedAfterIngest = false;
 
-      const [error, result] = await safe(
-        input.client.trackActivityProgress(
-          { activityID: input.activityID, checkpoints: rows, expectedHead: input.expectedHead },
-          { context: { traceparent: buildTraceparent(trace) } },
-        ),
-      );
+      // The body sends the same batch again only once, after a NOT_FOUND ingests the activity's
+      // still-pending client-minted root — `retriedAfterIngest` turns a second NOT_FOUND into an
+      // unconditional discard rather than ingesting again.
+      while (true) {
+        const [error, result] = await safe(
+          input.client.trackActivityProgress(
+            { activityID: input.activityID, checkpoints: rows, expectedHead: input.expectedHead },
+            { context: { traceparent: buildTraceparent(trace) } },
+          ),
+        );
 
-      if (error === null) {
-        serverAnswered = true;
+        if (error === null) {
+          serverAnswered = true;
 
-        await removeConfirmedCheckpoints(input.activityID, result.appendedHead);
+          await removeConfirmedCheckpoints(input.activityID, result.appendedHead);
 
-        settledHead = result.appendedHead;
-        input.onAcked?.(input.activityID, result.appendedHead);
+          settledHead = result.appendedHead;
+          input.onAcked?.(input.activityID, result.appendedHead);
 
-        return { appendedHead: result.appendedHead, type: 'success' };
-      }
-
-      if (!isDefinedError(error)) {
-        const reason =
-          error instanceof ORPCError ? `${error.code}: ${error.message}` : String(error);
-
-        return { reason, traceID: trace.traceID, type: 'transport-failure' };
-      }
-
-      serverAnswered = true;
-
-      if (error.code === 'ACTIVITY_CAPPED') {
-        await removeQueuedCheckpoints(input.activityID);
-
-        input.onCapped?.(input.activityID, error.data.appendedHead);
-
-        return { appendedHead: error.data.appendedHead, type: 'capped' };
-      }
-
-      if (error.code === 'ACTIVITY_TERMINAL') {
-        await removeQueuedCheckpoints(input.activityID);
-
-        if (error.data.status === 'capped') {
-          input.onCapped?.(input.activityID, error.data.appendedHead);
+          return { appendedHead: result.appendedHead, type: 'success' };
         }
 
-        return { type: 'terminal' };
+        if (!isDefinedError(error)) {
+          const reason =
+            error instanceof ORPCError ? `${error.code}: ${error.message}` : String(error);
+
+          return { reason, traceID: trace.traceID, type: 'transport-failure' };
+        }
+
+        serverAnswered = true;
+
+        if (error.code === 'ACTIVITY_CAPPED') {
+          await removeQueuedCheckpoints(input.activityID);
+
+          input.onCapped?.(input.activityID, error.data.appendedHead);
+
+          return { appendedHead: error.data.appendedHead, type: 'capped' };
+        }
+
+        if (error.code === 'ACTIVITY_TERMINAL') {
+          await removeQueuedCheckpoints(input.activityID);
+
+          if (error.data.status === 'capped') {
+            input.onCapped?.(input.activityID, error.data.appendedHead);
+          }
+
+          return { type: 'terminal' };
+        }
+
+        if (error.code === 'SESSION_EVICTED') {
+          await removeQueuedCheckpoints(input.activityID);
+
+          input.onEvicted?.(input.activityID);
+
+          return { type: 'session-evicted' };
+        }
+
+        if (error.code === 'CONFLICT') {
+          await removeConfirmedCheckpoints(input.activityID, error.data.appendedHead);
+
+          return { appendedHead: error.data.appendedHead, type: 'conflict' };
+        }
+
+        if (error.code === 'CHECKPOINT_INVALID') {
+          input.onInvalid(input.activityID, error.data.reason, trace.traceID);
+
+          return { reason: error.data.reason, type: 'invalid' };
+        }
+
+        if (error.code !== 'NOT_FOUND') {
+          return { type: 'held-defined-error' };
+        }
+
+        if (retriedAfterIngest || input.ingestRoot === undefined) {
+          await removeQueuedCheckpoints(input.activityID);
+
+          return { type: 'not-found' };
+        }
+
+        const ingestOutcome = await input.ingestRoot(input.activityID);
+
+        if (ingestOutcome === 'deferred') {
+          return {
+            reason: 'offline-root-pending',
+            traceID: trace.traceID,
+            type: 'transport-failure',
+          };
+        }
+
+        if (ingestOutcome === 'rejected' || ingestOutcome === 'absent') {
+          await removeQueuedCheckpoints(input.activityID);
+
+          return { type: 'not-found' };
+        }
+
+        // ingested: the root now exists at head 0 server-side — loop back for the one retry
+        retriedAfterIngest = true;
       }
-
-      if (error.code === 'SESSION_EVICTED') {
-        await removeQueuedCheckpoints(input.activityID);
-
-        input.onEvicted?.(input.activityID);
-
-        return { type: 'session-evicted' };
-      }
-
-      if (error.code === 'CONFLICT') {
-        await removeConfirmedCheckpoints(input.activityID, error.data.appendedHead);
-
-        return { appendedHead: error.data.appendedHead, type: 'conflict' };
-      }
-
-      if (error.code === 'CHECKPOINT_INVALID') {
-        input.onInvalid(input.activityID, error.data.reason, trace.traceID);
-
-        return { reason: error.data.reason, type: 'invalid' };
-      }
-
-      if (error.code === 'NOT_FOUND') {
-        await removeQueuedCheckpoints(input.activityID);
-
-        return { type: 'not-found' };
-      }
-
-      return { type: 'held-defined-error' };
     } catch (error) {
       return { appendedHead: settledHead, error, type: 'callback-failed' };
     } finally {

--- a/libs/game/idle-client/src/submission/run-checkpoint-flush-attempt.ts
+++ b/libs/game/idle-client/src/submission/run-checkpoint-flush-attempt.ts
@@ -154,21 +154,24 @@ export const runCheckpointFlushAttempt = fromPromise<FlushOutcome, FlushAttemptI
 
         const ingestOutcome = await input.ingestRoot(input.activityID);
 
+        // the server answered NOT_FOUND — a defined reply, so `onServerContact` fires — but the
+        // root cannot ingest yet: a transport failure, a session lapse, or an inactive avatar. Hold
+        // the queue for retry without feeding the transport-stall counter a genuinely unanswered
+        // flush owns.
         if (ingestOutcome === 'deferred') {
-          return {
-            reason: 'offline-root-pending',
-            traceID: trace.traceID,
-            type: 'transport-failure',
-          };
+          return { type: 'held-defined-error' };
         }
 
-        if (ingestOutcome === 'rejected' || ingestOutcome === 'absent') {
+        if (ingestOutcome === 'rejected') {
           await removeQueuedCheckpoints(input.activityID);
 
           return { type: 'not-found' };
         }
 
-        // ingested: the root now exists at head 0 server-side — loop back for the one retry
+        // ingested or absent: the row exists at head 0 server-side now — this device just minted it,
+        // or a concurrent drain minted and removed the pending copy — so retry the same batch once
+        // against the now-present row. A genuinely gone activity NOT_FOUNDs again and discards under
+        // the `retriedAfterIngest` guard, never ingesting twice.
         retriedAfterIngest = true;
       }
     } catch (error) {

--- a/libs/game/idle-client/src/worker/create-worker-runtime.ts
+++ b/libs/game/idle-client/src/worker/create-worker-runtime.ts
@@ -7,6 +7,7 @@ import { ActivityFailureAction, SIMULATION_TIMESTEP_MS, createSimulation } from 
 import invariant from 'tiny-invariant';
 import { createActivityServiceClient } from '../submission/create-activity-service-client';
 import { createCheckpointSubmitter } from '../submission/create-checkpoint-submitter';
+import { ingestStartRow } from '../submission/ingest-start-row';
 import { readFailureActionCache } from '../submission/read-failure-action-cache';
 import type { ActivityServiceClient } from '../submission/types';
 import { WORKER_TO_CLIENT_CHANNEL } from '../transport/constants';
@@ -144,6 +145,7 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions = {}): W
 
   const submitter = createCheckpointSubmitter({
     client,
+    ingestRoot: (activityID) => ingestStartRow(client, activityID),
     onAcked: () => {
       lastAckAt = Date.now();
     },

--- a/libs/game/idle-client/src/worker/drain-start-rows.test.ts
+++ b/libs/game/idle-client/src/worker/drain-start-rows.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from 'bun:test';
+import { createMockActivityData } from '@vers/contract-activity/test-utils';
+import { mockActivityService } from '@vers/mock-services/activity';
+import { server } from '../mocks/node';
+import { readAllStartRows } from '../submission/read-all-start-rows';
+import { writeStartRow } from '../submission/write-start-row';
+import { createStubSubmitter } from '../test-utils/create-stub-submitter';
+import { createStubWorkerContext } from '../test-utils/create-stub-worker-context';
+import { drainStartRows } from './drain-start-rows';
+
+test("it ingests and registers the recovery avatar's row, leaving another avatar's row untouched", async () => {
+  const submitter = createStubSubmitter();
+  const context = createStubWorkerContext({ submitter });
+
+  const matching = createMockActivityData({
+    avatarID: 'avatar_recovering',
+    id: 'act_drain_matching',
+    scopeID: '1_0',
+    startKey: 'start_key_matching',
+  });
+
+  const other = createMockActivityData({
+    avatarID: 'avatar_other',
+    id: 'act_drain_other',
+    startKey: 'start_key_other',
+  });
+
+  await writeStartRow(matching);
+  await writeStartRow(other);
+
+  server.use(
+    mockActivityService.advanceActivity.handler(() => ({ activity: matching, appendedHead: 0 })),
+  );
+
+  await drainStartRows(context, 'avatar_recovering');
+
+  const remaining = await readAllStartRows();
+
+  expect(remaining).toStrictEqual([other]);
+
+  expect(submitter.registerActivity).toHaveBeenCalledExactlyOnceWith({
+    activityID: matching.id,
+    appendedHead: 0,
+    avatarID: matching.avatarID,
+    lastHash: matching.startHash,
+    previousNextSeed: matching.seed,
+    scopeID: matching.scopeID,
+    startChainIndex: matching.startChainIndex,
+  });
+});
+
+test('it drains nothing when this device holds no pending root', async () => {
+  const submitter = createStubSubmitter();
+  const context = createStubWorkerContext({ submitter });
+
+  await drainStartRows(context, 'avatar_no_rows');
+
+  expect(submitter.registerActivity).not.toHaveBeenCalled();
+});

--- a/libs/game/idle-client/src/worker/drain-start-rows.test.ts
+++ b/libs/game/idle-client/src/worker/drain-start-rows.test.ts
@@ -3,9 +3,12 @@ import { createMockActivityData } from '@vers/contract-activity/test-utils';
 import { mockActivityService } from '@vers/mock-services/activity';
 import { server } from '../mocks/node';
 import { readAllStartRows } from '../submission/read-all-start-rows';
+import { readQueuedCheckpoints } from '../submission/read-queued-checkpoints';
+import { writeQueuedCheckpoint } from '../submission/write-queued-checkpoint';
 import { writeStartRow } from '../submission/write-start-row';
 import { createStubSubmitter } from '../test-utils/create-stub-submitter';
 import { createStubWorkerContext } from '../test-utils/create-stub-worker-context';
+import { createMockCheckpointBatchEntry } from '../test-utils/factories/create-mock-checkpoint-batch-entry';
 import { drainStartRows } from './drain-start-rows';
 
 test("it ingests and registers the recovery avatar's row, leaving another avatar's row untouched", async () => {
@@ -47,6 +50,36 @@ test("it ingests and registers the recovery avatar's row, leaving another avatar
     scopeID: matching.scopeID,
     startChainIndex: matching.startChainIndex,
   });
+});
+
+test('it discards the queued checkpoints of a refused root without registering it', async () => {
+  const submitter = createStubSubmitter();
+  const context = createStubWorkerContext({ submitter });
+
+  const row = createMockActivityData({
+    avatarID: 'avatar_recovering',
+    id: 'act_drain_rejected',
+    scopeID: '1_0',
+    startKey: 'start_key_rejected',
+  });
+
+  await writeStartRow(row);
+  await writeQueuedCheckpoint(row.id, createMockCheckpointBatchEntry({ version: 1 }));
+
+  server.use(
+    mockActivityService.advanceActivity.handler((opts) => {
+      throw opts.errors.CONFLICT({ data: { activityID: row.id, appendedHead: 4 } });
+    }),
+  );
+
+  await drainStartRows(context, 'avatar_recovering');
+
+  const remaining = await readAllStartRows();
+  const queued = await readQueuedCheckpoints(row.id);
+
+  expect(remaining).toStrictEqual([]);
+  expect(queued).toStrictEqual([]);
+  expect(submitter.registerActivity).not.toHaveBeenCalled();
 });
 
 test('it drains nothing when this device holds no pending root', async () => {

--- a/libs/game/idle-client/src/worker/drain-start-rows.ts
+++ b/libs/game/idle-client/src/worker/drain-start-rows.ts
@@ -1,5 +1,6 @@
 import { ingestStartRow } from '../submission/ingest-start-row';
 import { readAllStartRows } from '../submission/read-all-start-rows';
+import { removeQueuedCheckpoints } from '../submission/remove-queued-checkpoints';
 import type { WorkerContext } from './types';
 
 /**
@@ -20,6 +21,14 @@ export async function drainStartRows(context: WorkerContext, avatarID: string): 
     }
 
     const outcome = await ingestStartRow(context.getClient(), row.id);
+
+    if (outcome === 'rejected') {
+      // the server refused the root; its durably queued checkpoints can never chain onto a row
+      // that will not exist, so drop them here as the flush path drops a refused stream's
+      await removeQueuedCheckpoints(row.id);
+
+      continue;
+    }
 
     if (outcome !== 'ingested') {
       continue;

--- a/libs/game/idle-client/src/worker/drain-start-rows.ts
+++ b/libs/game/idle-client/src/worker/drain-start-rows.ts
@@ -1,0 +1,39 @@
+import { ingestStartRow } from '../submission/ingest-start-row';
+import { readAllStartRows } from '../submission/read-all-start-rows';
+import type { WorkerContext } from './types';
+
+/**
+ * Drains this avatar's reload-orphaned client-minted roots — a root whose live simulation was
+ * lost to a worker reload, so nothing is registered to drive its checkpoint flush. Each pending
+ * row for the avatar is ingested in turn, sequentially and awaited, one activity's ingest failure
+ * never blocking the next: an `ingested` outcome registers the activity so its durably queued
+ * checkpoints seed and flush; `deferred` leaves the row for a later recovery; `rejected` and
+ * `absent` need nothing further, the row already gone. A row for a different avatar this device
+ * also owns is left untouched — it drains on that avatar's own recovery, since minting its root
+ * needs it as the active avatar.
+ */
+export async function drainStartRows(context: WorkerContext, avatarID: string): Promise<void> {
+  const rows = await readAllStartRows();
+
+  for (const row of rows) {
+    if (row.avatarID !== avatarID) {
+      continue;
+    }
+
+    const outcome = await ingestStartRow(context.getClient(), row.id);
+
+    if (outcome !== 'ingested') {
+      continue;
+    }
+
+    await context.getSubmitter().registerActivity({
+      activityID: row.id,
+      appendedHead: 0,
+      avatarID: row.avatarID,
+      lastHash: row.startHash,
+      previousNextSeed: row.seed,
+      scopeID: row.scopeID,
+      startChainIndex: row.startChainIndex,
+    });
+  }
+}

--- a/libs/game/idle-client/src/worker/drain-start-rows.ts
+++ b/libs/game/idle-client/src/worker/drain-start-rows.ts
@@ -4,13 +4,12 @@ import type { WorkerContext } from './types';
 
 /**
  * Drains this avatar's reload-orphaned client-minted roots — a root whose live simulation was
- * lost to a worker reload, so nothing is registered to drive its checkpoint flush. Each pending
- * row for the avatar is ingested in turn, sequentially and awaited, one activity's ingest failure
- * never blocking the next: an `ingested` outcome registers the activity so its durably queued
- * checkpoints seed and flush; `deferred` leaves the row for a later recovery; `rejected` and
- * `absent` need nothing further, the row already gone. A row for a different avatar this device
- * also owns is left untouched — it drains on that avatar's own recovery, since minting its root
- * needs it as the active avatar.
+ * lost to a worker reload, so nothing is registered to drive its checkpoint flush. Per pending row
+ * for the avatar, the ingest outcome decides the action: `ingested` registers the activity so its
+ * durably queued checkpoints seed and flush; `deferred` leaves the row for a later recovery;
+ * `rejected` and `absent` need nothing further, the row already gone. A row for a different avatar
+ * this device also owns is left untouched — it drains on that avatar's own recovery, since minting
+ * its root needs it as the active avatar.
  */
 export async function drainStartRows(context: WorkerContext, avatarID: string): Promise<void> {
   const rows = await readAllStartRows();

--- a/libs/game/idle-client/src/worker/run-reconnect-recovery.ts
+++ b/libs/game/idle-client/src/worker/run-reconnect-recovery.ts
@@ -1,6 +1,7 @@
 import { readPendingStartIntent } from '../submission/read-pending-start-intent';
 import { drainStartRows } from './drain-start-rows';
 import { flushPendingStop } from './flush-pending-stop';
+import { reportWorkerFault } from './report-worker-fault';
 import { runResyncTurn } from './run-resync-turn';
 import type { WorkerContext } from './types';
 
@@ -31,7 +32,13 @@ export async function runReconnectRecovery(
   // must precede flushHeld: an orphan's checkpoints would otherwise NOT_FOUND-discard on the
   // held flush before this ingests the root they chain onto
   if (avatarID !== undefined) {
-    await drainStartRows(context, avatarID);
+    try {
+      await drainStartRows(context, avatarID);
+    } catch (error) {
+      // a drain failure must not strand the held checkpoints and offline stop the steps below
+      // deliver; the orphan rows persist for the next recovery to retry
+      reportWorkerFault('reconnect', error);
+    }
   }
 
   await context.getSubmitter().flushHeld();

--- a/libs/game/idle-client/src/worker/run-reconnect-recovery.ts
+++ b/libs/game/idle-client/src/worker/run-reconnect-recovery.ts
@@ -1,13 +1,15 @@
 import { readPendingStartIntent } from '../submission/read-pending-start-intent';
+import { drainStartRows } from './drain-start-rows';
 import { flushPendingStop } from './flush-pending-stop';
 import { runResyncTurn } from './run-resync-turn';
 import type { WorkerContext } from './types';
 
 /**
  * The worker's one decision point for self-scheduled catch-ups, run on every connectivity proof:
- * resends whatever the submitter held, delivers a stop raised offline, then — once the held tail
- * is drained, so a resync never reads a stale appended head — resyncs while no run is live. The
- * avatar comes from the durable start intent first (recorded at the most recent boundary
+ * drains the reporting or last-resynced avatar's reload-orphaned client-minted roots, resends
+ * whatever the submitter held, delivers a stop raised offline, then — once the held tail is
+ * drained, so a resync never reads a stale appended head — resyncs while no run is live. The
+ * resync's avatar comes from the durable start intent first (recorded at the most recent boundary
  * failure), else the reporting tab's session avatar, else the last avatar a resync ran for; with
  * none of the three, there is nothing to catch up. An intent's avatar can be stale — the account
  * switched away from it while the intent was held — but the resync flow discovers that itself
@@ -21,6 +23,14 @@ export async function runReconnectRecovery(
   signalAvatarID?: string,
   claim = false,
 ): Promise<void> {
+  const drainAvatarID = signalAvatarID ?? context.getResyncAvatarID() ?? undefined;
+
+  // must precede flushHeld: an orphan's checkpoints would otherwise NOT_FOUND-discard on the
+  // held flush before this ingests the root they chain onto
+  if (drainAvatarID !== undefined) {
+    await drainStartRows(context, drainAvatarID);
+  }
+
   await context.getSubmitter().flushHeld();
 
   // A stop raised offline delivers here even when no resync will follow — the self-resync below

--- a/libs/game/idle-client/src/worker/run-reconnect-recovery.ts
+++ b/libs/game/idle-client/src/worker/run-reconnect-recovery.ts
@@ -6,29 +6,32 @@ import type { WorkerContext } from './types';
 
 /**
  * The worker's one decision point for self-scheduled catch-ups, run on every connectivity proof:
- * drains the reporting or last-resynced avatar's reload-orphaned client-minted roots, resends
- * whatever the submitter held, delivers a stop raised offline, then — once the held tail is
- * drained, so a resync never reads a stale appended head — resyncs while no run is live. The
- * resync's avatar comes from the durable start intent first (recorded at the most recent boundary
- * failure), else the reporting tab's session avatar, else the last avatar a resync ran for; with
- * none of the three, there is nothing to catch up. An intent's avatar can be stale — the account
- * switched away from it while the intent was held — but the resync flow discovers that itself
- * from the service's own rejection and catches up the account's real active avatar in the same
- * call, so nothing needs deriving here. `claim` carries a reporting tab's deliberate presence into
- * the resync so it may take an active run's writer; the worker's own triggers — a reconnect, a
- * flush answer — never claim.
+ * drains the recovery avatar's reload-orphaned client-minted roots, resends whatever the submitter
+ * held, delivers a stop raised offline, then — once the held tail is drained, so a resync never
+ * reads a stale appended head — resyncs while no run is live. The recovery avatar comes from the
+ * durable start intent first (recorded at the most recent boundary failure), else the reporting
+ * tab's session avatar, else the last avatar a resync ran for; with none of the three, there is
+ * nothing to catch up, and both the drain and the resync are skipped. An intent's avatar can be
+ * stale — the account switched away from it while the intent was held — but the resync flow
+ * discovers that itself from the service's own rejection and catches up the account's real active
+ * avatar in the same call, so nothing needs deriving here. `claim` carries a reporting tab's
+ * deliberate presence into the resync so it may take an active run's writer; the worker's own
+ * triggers — a reconnect, a flush answer — never claim.
  */
 export async function runReconnectRecovery(
   context: WorkerContext,
   signalAvatarID?: string,
   claim = false,
 ): Promise<void> {
-  const drainAvatarID = signalAvatarID ?? context.getResyncAvatarID() ?? undefined;
+  const heldIntent = await readPendingStartIntent();
+
+  const avatarID =
+    heldIntent?.avatarID ?? signalAvatarID ?? context.getResyncAvatarID() ?? undefined;
 
   // must precede flushHeld: an orphan's checkpoints would otherwise NOT_FOUND-discard on the
   // held flush before this ingests the root they chain onto
-  if (drainAvatarID !== undefined) {
-    await drainStartRows(context, drainAvatarID);
+  if (avatarID !== undefined) {
+    await drainStartRows(context, avatarID);
   }
 
   await context.getSubmitter().flushHeld();
@@ -36,11 +39,6 @@ export async function runReconnectRecovery(
   // A stop raised offline delivers here even when no resync will follow — the self-resync below
   // runs only while no run is live.
   await flushPendingStop(context);
-
-  const heldIntent = await readPendingStartIntent();
-
-  const avatarID =
-    heldIntent?.avatarID ?? signalAvatarID ?? context.getResyncAvatarID() ?? undefined;
 
   if (context.getActivity() === null && avatarID !== undefined) {
     await runResyncTurn(context, avatarID, claim);


### PR DESCRIPTION
## Description

Closes #891

Client-side ingest and drain for offline-first activity roots: a pending root minted while
offline is submitted through `advanceActivity` once connectivity returns, a stalled checkpoint
flush self-heals by ingesting its root first, and a reconnect recovers any root orphaned by a
worker reload.

- `buildOfflineRootSubmission` projects a client-minted `ActivityData` row to the wire fields
  `advanceActivity` accepts, dropping the server-derived fields the row never owned.
- `ingestStartRow` submits a pending root and classifies the answer into
  `ingested` / `deferred` / `rejected` / `absent`, removing the durable row once the server has
  answered definitively.
- A `NOT_FOUND` during checkpoint flush now ingests the root and retries the same batch once,
  before falling back to the existing discard path.
- `drainStartRows` ingests and re-registers a recovery avatar's reload-orphaned pending roots,
  wired into reconnect recovery ahead of `flushHeld()`.
- Relaxed `activity-contract`'s `continuations` bound from `.min(1)` to allow an empty batch: a
  root-only submission mints the row and appends nothing, which the handler already supports but
  the schema rejected — a gap in the prior stage's contract, not the handler.
- Added the `ingest` verb to the function-naming taxonomy (`agents/project.md`, `.oxlintrc.json`).

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
