### PR TITLE
feat(#899): widen offline node selection past an unverified clear

### DIFF
--- a/apps/web/src/routes/-game/use-avatar-region-graph.test.tsx
+++ b/apps/web/src/routes/-game/use-avatar-region-graph.test.tsx
@@ -1,5 +1,12 @@
 import { expect, mock, test } from 'bun:test';
 import { waitFor } from '@testing-library/react';
+import { createMockActivityData } from '@vers/contract-activity/test-utils';
+import {
+  setLastCompletedActivityID,
+  writeQueuedCheckpoint,
+  writeStartRow,
+} from '@vers/idle-client';
+import { ActivityCheckpointType } from '@vers/idle-core';
 import { mockActivityService } from '@vers/mock-services/activity';
 import * as db from '@vers/mock-services/db';
 import {
@@ -12,10 +19,11 @@ import {
   useViewport,
   useWorldGraph,
 } from '@vers/worldmap-client';
-import { REVEAL_RADIUS, collectNodeEdges, toNodeID } from '@vers/worldmap-core';
+import { REVEAL_RADIUS, collectNodeEdges, toCellCoord, toNodeID } from '@vers/worldmap-core';
 import invariant from 'tiny-invariant';
 import { server } from '../../mocks/node';
 import { createActiveAvatar } from '../../test-utils/create-active-avatar';
+import { createMockCheckpointBatchEntry } from '../../test-utils/create-mock-checkpoint-batch-entry';
 import { createSignedInUser } from '../../test-utils/create-signed-in-user';
 import { renderHook } from '../../test-utils/render-hook';
 import { withRequestContext } from '../../test-utils/with-request-context';
@@ -697,5 +705,63 @@ test("it returns an empty frontier through an avatar switch, never the outgoing 
     // so the far cell never appears under the incoming avatar while the switch commits
     expect(frontiers.some((frontier) => frontier.size === 0)).toBe(true);
     expect(frontiers.some((frontier) => frontier.has(firstOnlyID))).toBe(false);
+  });
+});
+
+test('it extends the selectable set past a node cleared offline without extending reveal past it', async () => {
+  const signedIn = await createSignedInUser();
+  const avatar = await createActiveAvatar({ seed: 1414, userID: signedIn.userID });
+
+  const originID = toNodeID(0, 0);
+  const [originEdge] = collectNodeEdges(avatar.seed, 0, 0);
+
+  invariant(originEdge, 'the origin connects to at least one neighbour');
+
+  const [oaID = '', obID = ''] = originEdge.id.split('|');
+  const clearedID = oaID === originID ? obID : oaID;
+  const [clearedCX, clearedCY] = toCellCoord(clearedID);
+  const clearedEdges = collectNodeEdges(avatar.seed, clearedCX, clearedCY);
+
+  // a neighbour of the cleared node other than the origin, so its selectability can only follow
+  // from the cleared node opening its own neighbours, never from the origin's own edge set
+  const extendedID = clearedEdges
+    .flatMap((edge) => edge.id.split('|'))
+    .find((id) => id !== clearedID && id !== originID);
+
+  invariant(extendedID !== undefined, 'the cleared node connects to a neighbour beyond the origin');
+
+  await withRequestContext({ cookies: signedIn.cookies }, async () => {
+    const hook = renderHook(() => {
+      useAvatarRegionGraph();
+
+      return { revealSources: useRevealSources(), selectable: useSelectableNodeIDs() };
+    });
+
+    await waitFor(() => {
+      expect(hook.result.current.selectable).toStrictEqual(new Set([originID]));
+    });
+
+    setViewport({ maxCX: 10, maxCY: 10, minCX: -10, minCY: -10 });
+
+    const row = createMockActivityData({ avatarID: avatar.id, scopeID: clearedID });
+
+    await writeStartRow(row);
+
+    await writeQueuedCheckpoint(
+      row.id,
+      createMockCheckpointBatchEntry({ payload: { type: ActivityCheckpointType.Completed } }),
+    );
+
+    setLastCompletedActivityID(row.id);
+
+    await waitFor(() => {
+      expect(hook.result.current.selectable.has(extendedID)).toBe(true);
+    });
+
+    // the offline clear is unverified, so it must never widen the fog reveal — only the origin
+    // disc a server-verified completed set would extend
+    expect(hook.result.current.revealSources).toStrictEqual([
+      { coord: [0, 0], radius: REVEAL_RADIUS },
+    ]);
   });
 });

--- a/apps/web/src/routes/-game/use-avatar-region-graph.ts
+++ b/apps/web/src/routes/-game/use-avatar-region-graph.ts
@@ -19,6 +19,7 @@ import {
 import { useEffect, useRef, useState } from 'react';
 import { buildRevealedNodesQueryOptions } from '../../lib/activity/build-revealed-nodes-query-options';
 import { buildActiveAvatarQueryOptions } from '../../lib/avatar/build-active-avatar-query-options';
+import { useOfflineClearedNodeIDs } from './use-offline-cleared-node-ids';
 
 /**
  * Cell-coordinate box the region graph builds from before the free camera has reported its own
@@ -53,7 +54,9 @@ interface HeldCompletedNodeIDs {
  * connects to a completed node, the same reachability rule the activity service gates starts
  * against — over the full topology, never over the viewport-filtered graph edges, so the client
  * and server always agree at a viewport boundary; and the reveal sources the fog-of-war renderer
- * projects the revealed region from.
+ * projects the revealed region from. The selectable set additionally extends over the avatar's
+ * locally-cleared-but-unverified nodes, so an offline clear opens its neighbours before the server
+ * confirms it; the reveal sources stay verified-only, since fog discloses only after verification.
  *
  * Returns the fog-revealed node id set projected over the loaded region — the same reveal sources
  * published to the store, expanded to the individual node ids their discs cover inside the region
@@ -66,9 +69,11 @@ export function useAvatarRegionGraph(): ReadonlySet<string> {
   const seed = avatarQuery.data?.seed;
   const viewport = useViewport();
   const regionKey = useRegionKey();
+  const optimisticClearedNodeIDs = useOfflineClearedNodeIDs(avatarID);
   const previousAvatarIDRef = useRef<string | undefined>(undefined);
   const previousViewportRef = useRef<null | Viewport>(null);
   const previousCompletedNodeIDsRef = useRef<null | ReadonlySet<string>>(null);
+  const previousOptimisticClearedNodeIDsRef = useRef<null | ReadonlySet<string>>(null);
 
   // The completed set is viewport-independent, but the viewport-carrying query key below means a
   // pan across a chunk boundary re-keys the query and drops its data back to `undefined` for a
@@ -136,18 +141,23 @@ export function useAvatarRegionGraph(): ReadonlySet<string> {
       !isAvatarSwitch && isSameViewport(previousViewportRef.current, regionViewport);
 
     // When the region itself hasn't moved, only recompute the completed-set projections, and only
-    // when the completed set actually changed — not on every cell-granular viewport update the
-    // free camera reports while panning.
+    // when the completed set or the optimistic-cleared set actually changed — not on every
+    // cell-granular viewport update the free camera reports while panning.
     if (regionUnchanged) {
-      if (completedNodeIDs === previousCompletedNodeIDsRef.current) {
+      if (
+        completedNodeIDs === previousCompletedNodeIDsRef.current &&
+        optimisticClearedNodeIDs === previousOptimisticClearedNodeIDsRef.current
+      ) {
         return;
       }
 
       previousCompletedNodeIDsRef.current = completedNodeIDs;
+      previousOptimisticClearedNodeIDsRef.current = optimisticClearedNodeIDs;
 
       const sources = buildRevealSources(completedNodeIDs);
+      const selectableSource = buildSelectableSource(completedNodeIDs, optimisticClearedNodeIDs);
 
-      setCompletedNodeProjections(collectSelectableNodeIDs(seed, completedNodeIDs), sources);
+      setCompletedNodeProjections(collectSelectableNodeIDs(seed, selectableSource), sources);
       setRevealedNodeIDs(collectRevealedNodeIDs(sources, regionViewport));
 
       return;
@@ -155,22 +165,24 @@ export function useAvatarRegionGraph(): ReadonlySet<string> {
 
     previousViewportRef.current = regionViewport;
     previousCompletedNodeIDsRef.current = completedNodeIDs;
+    previousOptimisticClearedNodeIDsRef.current = optimisticClearedNodeIDs;
 
     const worldGraph = buildViewportGraph(seed, regionViewport);
     const originNode = worldGraph.nodes[toNodeID(0, 0)] ?? null;
     const sources = buildRevealSources(completedNodeIDs);
+    const selectableSource = buildSelectableSource(completedNodeIDs, optimisticClearedNodeIDs);
 
     setWorldRegion(
       avatarID,
       seed,
       worldGraph,
       originNode,
-      collectSelectableNodeIDs(seed, completedNodeIDs),
+      collectSelectableNodeIDs(seed, selectableSource),
       sources,
     );
 
     setRevealedNodeIDs(collectRevealedNodeIDs(sources, regionViewport));
-  }, [avatarID, seed, viewport, completedNodeIDs]);
+  }, [avatarID, seed, viewport, completedNodeIDs, optimisticClearedNodeIDs]);
 
   // the frontier state still holds the outgoing avatar's nodes until the effect republishes for the
   // incoming avatar; gating on the projection's avatar keeps a switch from prefetching the wrong
@@ -200,6 +212,21 @@ function isSameViewport(previous: null | Viewport, next: Viewport): boolean {
     previous.minCY === next.minCY &&
     previous.maxCY === next.maxCY
   );
+}
+
+/**
+ * The selectable-set input: the server-verified completed set widened by whatever the avatar has
+ * cleared offline but not yet had verified. Reuses `completedNodeIDs` by reference while nothing is
+ * optimistically cleared, so an unchanged region skips a rebuild the same as before this set
+ * existed.
+ */
+function buildSelectableSource(
+  completedNodeIDs: ReadonlySet<string>,
+  optimisticClearedNodeIDs: ReadonlySet<string>,
+): ReadonlySet<string> {
+  return optimisticClearedNodeIDs.size === 0
+    ? completedNodeIDs
+    : new Set([...completedNodeIDs, ...optimisticClearedNodeIDs]);
 }
 
 /**

--- a/apps/web/src/routes/-game/use-offline-cleared-node-ids.test.tsx
+++ b/apps/web/src/routes/-game/use-offline-cleared-node-ids.test.tsx
@@ -1,0 +1,78 @@
+import { expect, test } from 'bun:test';
+import { waitFor } from '@testing-library/react';
+import { createMockActivityData } from '@vers/contract-activity/test-utils';
+import {
+  setLastCompletedActivityID,
+  writeQueuedCheckpoint,
+  writeStartRow,
+} from '@vers/idle-client';
+import { ActivityCheckpointType } from '@vers/idle-core';
+import { createMockCheckpointBatchEntry } from '../../test-utils/create-mock-checkpoint-batch-entry';
+import { renderHook } from '../../test-utils/render-hook';
+import { useOfflineClearedNodeIDs } from './use-offline-cleared-node-ids';
+
+test('it includes a node whose pending root queued a completed terminal', async () => {
+  const avatarID = 'avatar-offline-cleared-completed';
+  const row = createMockActivityData({ avatarID, scopeID: '2_0' });
+
+  await writeStartRow(row);
+
+  await writeQueuedCheckpoint(
+    row.id,
+    createMockCheckpointBatchEntry({ payload: { type: ActivityCheckpointType.Completed } }),
+  );
+
+  const hook = renderHook(() => useOfflineClearedNodeIDs(avatarID));
+
+  await waitFor(() => {
+    expect(hook.result.current).toStrictEqual(new Set(['2_0']));
+  });
+});
+
+test('it excludes a node whose pending root queued a failed terminal', async () => {
+  const avatarID = 'avatar-offline-cleared-failed';
+  const row = createMockActivityData({ avatarID, scopeID: '3_0' });
+
+  await writeStartRow(row);
+
+  await writeQueuedCheckpoint(
+    row.id,
+    createMockCheckpointBatchEntry({ payload: { type: ActivityCheckpointType.Failed } }),
+  );
+
+  const hook = renderHook(() => useOfflineClearedNodeIDs(avatarID));
+
+  await waitFor(() => {
+    expect(hook.result.current).toStrictEqual(new Set());
+  });
+});
+
+test('it re-derives once a fresh offline clear reports through lastCompletedActivityID', async () => {
+  const avatarID = 'avatar-offline-cleared-rederive';
+  const hook = renderHook(() => useOfflineClearedNodeIDs(avatarID));
+
+  await waitFor(() => {
+    expect(hook.result.current).toStrictEqual(new Set());
+  });
+
+  const row = createMockActivityData({ avatarID, scopeID: '4_0' });
+
+  await writeStartRow(row);
+
+  await writeQueuedCheckpoint(
+    row.id,
+    createMockCheckpointBatchEntry({ payload: { type: ActivityCheckpointType.Completed } }),
+  );
+
+  setLastCompletedActivityID(row.id);
+
+  await waitFor(() => {
+    expect(hook.result.current).toStrictEqual(new Set(['4_0']));
+  });
+});
+
+test('it returns the empty set while no avatar id is given', () => {
+  const hook = renderHook(() => useOfflineClearedNodeIDs(undefined));
+
+  expect(hook.result.current).toStrictEqual(new Set());
+});

--- a/apps/web/src/routes/-game/use-offline-cleared-node-ids.test.tsx
+++ b/apps/web/src/routes/-game/use-offline-cleared-node-ids.test.tsx
@@ -71,6 +71,31 @@ test('it re-derives once a fresh offline clear reports through lastCompletedActi
   });
 });
 
+test('it reads empty across an avatar switch rather than inheriting the outgoing set', async () => {
+  const outgoing = 'avatar-switch-outgoing';
+  const row = createMockActivityData({ avatarID: outgoing, scopeID: '5_0' });
+
+  await writeStartRow(row);
+
+  await writeQueuedCheckpoint(
+    row.id,
+    createMockCheckpointBatchEntry({ payload: { type: ActivityCheckpointType.Completed } }),
+  );
+
+  let currentAvatarID = outgoing;
+  const hook = renderHook(() => useOfflineClearedNodeIDs(currentAvatarID));
+
+  await waitFor(() => {
+    expect(hook.result.current).toStrictEqual(new Set(['5_0']));
+  });
+
+  currentAvatarID = 'avatar-switch-incoming';
+
+  hook.rerender();
+
+  expect(hook.result.current).toStrictEqual(new Set());
+});
+
 test('it returns the empty set while no avatar id is given', () => {
   const hook = renderHook(() => useOfflineClearedNodeIDs(undefined));
 

--- a/apps/web/src/routes/-game/use-offline-cleared-node-ids.ts
+++ b/apps/web/src/routes/-game/use-offline-cleared-node-ids.ts
@@ -8,13 +8,27 @@ import { useEffect, useState } from 'react';
 const EMPTY_NODE_ID_SET: ReadonlySet<string> = new Set();
 
 /**
+ * The last derived cleared-node set paired with the avatar it was derived for, so the held set is
+ * never read across an avatar switch before the incoming avatar's own derive lands.
+ */
+interface DerivedClearedNodeIDs {
+  readonly avatarID: string | undefined;
+  readonly nodeIDs: ReadonlySet<string>;
+}
+
+/**
  * The active avatar's world-map nodes cleared offline but not yet server-verified, re-derived from
  * the durable offline outbox on a fresh offline clear and on a reconnect that settles the outbox —
  * an ingest, verification, or rejection. `undefined` returns the empty set, matching an avatar not
- * yet loaded.
+ * yet loaded; an avatar switch reads empty until the incoming avatar's derive lands, so the new
+ * avatar never briefly inherits the outgoing avatar's cleared nodes.
  */
 export function useOfflineClearedNodeIDs(avatarID: string | undefined): ReadonlySet<string> {
-  const [clearedNodeIDs, setClearedNodeIDs] = useState<ReadonlySet<string>>(EMPTY_NODE_ID_SET);
+  const [derived, setDerived] = useState<DerivedClearedNodeIDs>({
+    avatarID: undefined,
+    nodeIDs: EMPTY_NODE_ID_SET,
+  });
+
   const lastCompletedActivityID = useLastCompletedActivityID();
   const resyncStatus = useResyncStatus();
 
@@ -23,14 +37,18 @@ export function useOfflineClearedNodeIDs(avatarID: string | undefined): Readonly
     let ignore = false;
 
     if (avatarID === undefined) {
-      setClearedNodeIDs(EMPTY_NODE_ID_SET);
+      setDerived({ avatarID: undefined, nodeIDs: EMPTY_NODE_ID_SET });
     } else {
       const derive = async (id: string) => {
         try {
-          const derived = await readOfflineClearedNodeIDs(id);
+          const nodeIDs = await readOfflineClearedNodeIDs(id);
 
           if (!ignore) {
-            setClearedNodeIDs((current) => (isSameNodeIDSet(current, derived) ? current : derived));
+            setDerived((current) =>
+              current.avatarID === id && isSameNodeIDSet(current.nodeIDs, nodeIDs)
+                ? current
+                : { avatarID: id, nodeIDs },
+            );
           }
         } catch {
           // a failed local read leaves the previously derived set in place, retried on the next
@@ -46,7 +64,7 @@ export function useOfflineClearedNodeIDs(avatarID: string | undefined): Readonly
     };
   }, [avatarID, lastCompletedActivityID, resyncStatus]);
 
-  return avatarID === undefined ? EMPTY_NODE_ID_SET : clearedNodeIDs;
+  return derived.avatarID === avatarID ? derived.nodeIDs : EMPTY_NODE_ID_SET;
 }
 
 function isSameNodeIDSet(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {

--- a/apps/web/src/routes/-game/use-offline-cleared-node-ids.ts
+++ b/apps/web/src/routes/-game/use-offline-cleared-node-ids.ts
@@ -1,0 +1,64 @@
+import {
+  readOfflineClearedNodeIDs,
+  useLastCompletedActivityID,
+  useResyncStatus,
+} from '@vers/idle-client';
+import { useEffect, useState } from 'react';
+
+const EMPTY_NODE_ID_SET: ReadonlySet<string> = new Set();
+
+/**
+ * The active avatar's world-map nodes cleared offline but not yet server-verified, re-derived from
+ * the durable offline outbox on a fresh offline clear and on a reconnect that settles the outbox —
+ * an ingest, verification, or rejection. `undefined` returns the empty set, matching an avatar not
+ * yet loaded.
+ */
+export function useOfflineClearedNodeIDs(avatarID: string | undefined): ReadonlySet<string> {
+  const [clearedNodeIDs, setClearedNodeIDs] = useState<ReadonlySet<string>>(EMPTY_NODE_ID_SET);
+  const lastCompletedActivityID = useLastCompletedActivityID();
+  const resyncStatus = useResyncStatus();
+
+  useEffect(() => {
+    // guards against a stale avatar's derive landing after a switch has already moved on
+    let ignore = false;
+
+    if (avatarID === undefined) {
+      setClearedNodeIDs(EMPTY_NODE_ID_SET);
+    } else {
+      const derive = async (id: string) => {
+        try {
+          const derived = await readOfflineClearedNodeIDs(id);
+
+          if (!ignore) {
+            setClearedNodeIDs((current) => (isSameNodeIDSet(current, derived) ? current : derived));
+          }
+        } catch {
+          // a failed local read leaves the previously derived set in place, retried on the next
+          // trigger rather than dropping selection the outbox already proved
+        }
+      };
+
+      void derive(avatarID);
+    }
+
+    return () => {
+      ignore = true;
+    };
+  }, [avatarID, lastCompletedActivityID, resyncStatus]);
+
+  return avatarID === undefined ? EMPTY_NODE_ID_SET : clearedNodeIDs;
+}
+
+function isSameNodeIDSet(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
+  if (a.size !== b.size) {
+    return false;
+  }
+
+  for (const id of a) {
+    if (!b.has(id)) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/apps/web/src/test-utils/create-mock-checkpoint-batch-entry.ts
+++ b/apps/web/src/test-utils/create-mock-checkpoint-batch-entry.ts
@@ -1,0 +1,32 @@
+import { faker } from '@faker-js/faker';
+import type { CheckpointBatchEntry, CheckpointPayload } from '@vers/contract-activity';
+
+interface CreateMockCheckpointBatchEntryOverrides {
+  readonly hash?: string;
+  readonly payload?: Partial<CheckpointPayload>;
+  readonly prevHash?: string;
+  readonly version?: number;
+}
+
+export function createMockCheckpointBatchEntry(
+  overrides: Readonly<CreateMockCheckpointBatchEntryOverrides> = {},
+): CheckpointBatchEntry {
+  return {
+    hash: overrides.hash ?? buildSeed(),
+    payload: {
+      chainIndex: faker.number.int({ max: 1000, min: 0 }),
+      entropySource: 'server-key',
+      nextSeed: buildSeed(),
+      seed: buildSeed(),
+      time: faker.number.int({ max: 60_000, min: 0 }),
+      type: 'progress',
+      ...overrides.payload,
+    },
+    prevHash: overrides.prevHash ?? buildSeed(),
+    version: overrides.version ?? faker.number.int({ max: 1000, min: 1 }),
+  };
+}
+
+function buildSeed(): string {
+  return faker.string.alphanumeric({ casing: 'lower', length: 16 });
+}

--- a/docs/architecture/game/worldmap.md
+++ b/docs/architecture/game/worldmap.md
@@ -120,6 +120,16 @@ Pre-disclosing content into that shell is safe only because the base is flat —
 peeking buys nothing, since all reward magnitude lives in juice salt minted per-run and online. A
 player farms the known offline and ventures into fog online.
 
+Traversal, not just farming, also extends offline: clearing a node offline opens its neighbours for
+selection before the server verifies the clear. The client derives this widened selectable set from
+its durable offline outbox — the client-minted root and queued checkpoints a completed clear leaves
+behind — so the opened neighbours survive an offline restart rather than resetting to the
+last-verified frontier. The widened set only ever adds to selection; reveal stays gated on
+verification, so an offline clear opens ground the player can already see without disclosing any new
+fog. The client-side widening is a convenience, never the boundary: the server's own frontier check
+still rejects a start beyond the avatar's verified first-clear frontier, so an unearned offline jump
+settles nothing it cannot back up once the device reconnects.
+
 ## Content sealing & verification
 
 Every `activities` row carries `secretRef`/`secretVersion`, so the verifier runs the descriptor

--- a/libs/game/idle-client/src/index.ts
+++ b/libs/game/idle-client/src/index.ts
@@ -15,6 +15,7 @@ export type {
 export { advanceWriterGeneration } from './state/advance-writer-generation';
 export { setEngagedActivityID } from './state/set-engaged-activity-id';
 export { setFailureAction } from './state/set-failure-action';
+export { setLastCompletedActivityID } from './state/set-last-completed-activity-id';
 export { setOfflineCapStatus } from './state/set-offline-cap-status';
 export { setResyncStatus } from './state/set-resync-status';
 export { setRewardSlotLedger } from './state/set-reward-slot-ledger';
@@ -38,8 +39,11 @@ export { useWriterGeneration } from './state/use-writer-generation';
 export { readCachedNodeIDs } from './submission/read-cached-node-ids';
 export type { CachedNodeSeed } from './submission/read-node-seed';
 export { readNodeSeed } from './submission/read-node-seed';
+export { readOfflineClearedNodeIDs } from './submission/read-offline-cleared-node-ids';
 export { readPendingStartIntent } from './submission/read-pending-start-intent';
 export { readStartStamps } from './submission/read-start-stamps';
+export { writeQueuedCheckpoint } from './submission/write-queued-checkpoint';
+export { writeStartRow } from './submission/write-start-row';
 
 export type {
   ActivitySubmissionContext,

--- a/libs/game/idle-client/src/submission/read-offline-cleared-node-ids.test.ts
+++ b/libs/game/idle-client/src/submission/read-offline-cleared-node-ids.test.ts
@@ -1,0 +1,97 @@
+import { expect, test } from 'bun:test';
+import { createMockActivityData } from '@vers/contract-activity/test-utils';
+import { ActivityCheckpointType } from '@vers/idle-core';
+import { createMockCheckpointBatchEntry } from '../test-utils/factories/create-mock-checkpoint-batch-entry';
+import { readOfflineClearedNodeIDs } from './read-offline-cleared-node-ids';
+import { writeQueuedCheckpoint } from './write-queued-checkpoint';
+import { writeStartRow } from './write-start-row';
+
+test('it includes a node whose pending root queued a completed terminal', async () => {
+  const avatarID = 'avatar-completed-terminal';
+  const row = createMockActivityData({ avatarID, scopeID: '3_1' });
+
+  await writeStartRow(row);
+
+  await writeQueuedCheckpoint(
+    row.id,
+    createMockCheckpointBatchEntry({ payload: { type: ActivityCheckpointType.Completed } }),
+  );
+
+  const clearedNodeIDs = await readOfflineClearedNodeIDs(avatarID);
+
+  expect(clearedNodeIDs).toStrictEqual(new Set(['3_1']));
+});
+
+test('it excludes a node whose queue holds only non-terminal checkpoints', async () => {
+  const avatarID = 'avatar-progress-only';
+  const row = createMockActivityData({ avatarID, scopeID: '4_2' });
+
+  await writeStartRow(row);
+
+  await writeQueuedCheckpoint(
+    row.id,
+    createMockCheckpointBatchEntry({ payload: { type: ActivityCheckpointType.Progress } }),
+  );
+
+  const clearedNodeIDs = await readOfflineClearedNodeIDs(avatarID);
+
+  expect(clearedNodeIDs).toStrictEqual(new Set());
+});
+
+test('it excludes a node whose pending root queued a failed terminal', async () => {
+  const avatarID = 'avatar-failed-terminal';
+  const row = createMockActivityData({ avatarID, scopeID: '5_3' });
+
+  await writeStartRow(row);
+
+  await writeQueuedCheckpoint(
+    row.id,
+    createMockCheckpointBatchEntry({ payload: { type: ActivityCheckpointType.Failed } }),
+  );
+
+  const clearedNodeIDs = await readOfflineClearedNodeIDs(avatarID);
+
+  expect(clearedNodeIDs).toStrictEqual(new Set());
+});
+
+test('it excludes a pending root belonging to a different avatar', async () => {
+  const row = createMockActivityData({ avatarID: 'avatar-owner', scopeID: '6_4' });
+
+  await writeStartRow(row);
+
+  await writeQueuedCheckpoint(
+    row.id,
+    createMockCheckpointBatchEntry({ payload: { type: ActivityCheckpointType.Completed } }),
+  );
+
+  const clearedNodeIDs = await readOfflineClearedNodeIDs('avatar-other');
+
+  expect(clearedNodeIDs).toStrictEqual(new Set());
+});
+
+test('it excludes a pending root outside the world-map-node scope', async () => {
+  const avatarID = 'avatar-other-scope';
+
+  const row = createMockActivityData({
+    avatarID,
+    scopeID: 'combat_1',
+    scopeType: 'combat_encounter',
+  });
+
+  await writeStartRow(row);
+
+  await writeQueuedCheckpoint(
+    row.id,
+    createMockCheckpointBatchEntry({ payload: { type: ActivityCheckpointType.Completed } }),
+  );
+
+  const clearedNodeIDs = await readOfflineClearedNodeIDs(avatarID);
+
+  expect(clearedNodeIDs).toStrictEqual(new Set());
+});
+
+test('it returns an empty set with no pending root cached', async () => {
+  const clearedNodeIDs = await readOfflineClearedNodeIDs('avatar-no-pending-roots');
+
+  expect(clearedNodeIDs).toStrictEqual(new Set());
+});

--- a/libs/game/idle-client/src/submission/read-offline-cleared-node-ids.ts
+++ b/libs/game/idle-client/src/submission/read-offline-cleared-node-ids.ts
@@ -10,8 +10,9 @@ const COMPLETED_CHECKPOINT_TYPE: string = ActivityCheckpointType.Completed;
  * The avatar's world-map nodes cleared offline but not yet server-verified, derived from the
  * durable offline outbox: a pending root scoped to a `world_map_node` whose queued checkpoints
  * hold a completed terminal. Empty once nothing is pending, so the call stays cheap on the common
- * online path, and it shrinks on its own as ingest drains the outbox — a verified clear needs no
- * removal here, only a re-derive.
+ * online path. A node drops from the result once its root ingests and drains the outbox, which can
+ * precede the server-verified set gaining it — a re-derive in that reconnect window briefly omits
+ * the node until verification lands.
  */
 export async function readOfflineClearedNodeIDs(avatarID: string): Promise<ReadonlySet<string>> {
   const rows = await readAllStartRows();

--- a/libs/game/idle-client/src/submission/read-offline-cleared-node-ids.ts
+++ b/libs/game/idle-client/src/submission/read-offline-cleared-node-ids.ts
@@ -1,0 +1,35 @@
+import { ActivityCheckpointType } from '@vers/idle-core';
+import { readAllStartRows } from './read-all-start-rows';
+import { readQueuedCheckpoints } from './read-queued-checkpoints';
+
+// widened to `string` so the comparison below reads against a checkpoint payload's untyped
+// `type` field without the compiler treating it as a comparison across unrelated enum types
+const COMPLETED_CHECKPOINT_TYPE: string = ActivityCheckpointType.Completed;
+
+/**
+ * The avatar's world-map nodes cleared offline but not yet server-verified, derived from the
+ * durable offline outbox: a pending root scoped to a `world_map_node` whose queued checkpoints
+ * hold a completed terminal. Empty once nothing is pending, so the call stays cheap on the common
+ * online path, and it shrinks on its own as ingest drains the outbox — a verified clear needs no
+ * removal here, only a re-derive.
+ */
+export async function readOfflineClearedNodeIDs(avatarID: string): Promise<ReadonlySet<string>> {
+  const rows = await readAllStartRows();
+
+  const clearedNodeIDs = new Set<string>();
+
+  for (const row of rows) {
+    if (row.avatarID !== avatarID || row.scopeType !== 'world_map_node') {
+      continue;
+    }
+
+    const checkpoints = await readQueuedCheckpoints(row.id);
+
+    // a failed terminal clears nothing; only a completed terminal opens the node's neighbours
+    if (checkpoints.some((checkpoint) => checkpoint.payload.type === COMPLETED_CHECKPOINT_TYPE)) {
+      clearedNodeIDs.add(row.scopeID);
+    }
+  }
+
+  return clearedNodeIDs;
+}


### PR DESCRIPTION
## Description

Closes #899

Widens node selection to cover nodes cleared offline but not yet server-verified, so a player can keep traversing past an offline clear instead of stalling at the last-verified frontier.

- `readOfflineClearedNodeIDs` (idle-client) derives the set from the durable offline outbox: pending `world_map_node` roots whose queued checkpoints hold a `Completed` terminal
- `useOfflineClearedNodeIDs` re-derives on avatar change, activity completion, and resync-status change, holding a stable reference when the derived set is unchanged
- `useAvatarRegionGraph` widens only the selectable-node projection with this optimistic set; reveal sources stay verified-only, so fog never extends ahead of the server
- server frontier check is unchanged — an offline jump beyond the avatar's verified frontier still gets rejected on reconnect
- `worldmap.md` documents the widening and restates the reveal-gated-on-verification invariant

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
