### PR TITLE
docs(docs-writing): require a domain noun to name what it is part of

### DIFF
--- a/.claude/skills/docs-writing/SKILL.md
+++ b/.claude/skills/docs-writing/SKILL.md
@@ -127,10 +127,10 @@ knife.
   is. The same rule covers definite nouns: where the doc has more than one cap, filter, or budget,
   the bare form ("the cap") is legal only after the qualified form ("the cardinality cap") earlier
   in the same paragraph.
-- **Name what a noun is part of.** A domain noun for a part, record, or position of something
-  carries that something in the phrase: `activity start`, never `start`; `chain head`, never `head`.
-  This holds on every use, the first included — the writer knows what the bare noun belongs to, the
-  reader does not.
+- **Name what a noun is part of.** A domain noun for a part, record, or position of something is
+  introduced with that something in the phrase — `activity start`, not a bare `start`; `chain head`,
+  not a bare `head`. This extends the referent rule to opaque part-nouns: the qualified form leads,
+  and a bare form follows only under the same-paragraph allowance above.
 - **First use defines.** Spell an acronym out where it first appears ("Content Security Policy
   (CSP)"); a term of art gets a one-line definition or a link to its owner.
 - **Same term for the same thing.** Varying a term to dodge repetition ("the runner… the executor…

--- a/.claude/skills/docs-writing/SKILL.md
+++ b/.claude/skills/docs-writing/SKILL.md
@@ -127,6 +127,10 @@ knife.
   is. The same rule covers definite nouns: where the doc has more than one cap, filter, or budget,
   the bare form ("the cap") is legal only after the qualified form ("the cardinality cap") earlier
   in the same paragraph.
+- **Name what a noun is part of.** A domain noun for a part, record, or position of something
+  carries that something in the phrase: `activity start`, never `start`; `chain head`, never `head`.
+  This holds on every use, the first included — the writer knows what the bare noun belongs to, the
+  reader does not.
 - **First use defines.** Spell an acronym out where it first appears ("Content Security Policy
   (CSP)"); a term of art gets a one-line definition or a link to its owner.
 - **Same term for the same thing.** Varying a term to dodge repetition ("the runner… the executor…


### PR DESCRIPTION
## Description

Adds one rule to the `docs-writing` skill: a domain noun for a part, record, or position of something must carry that something in the phrase — `activity start`, not `start`; `chain head`, not `head`.

- Closes a gap the existing "Name the referent" rule left: a bare opaque noun the writer can resolve but a cold reader cannot.
- Applies on every use, the first included.

## Testing

- [x] Documentation only — no code changes.
