### PR TITLE
docs(#921): rewrite game-simulation.md for clarity

### DIFF
--- a/docs/architecture/game/game-simulation.md
+++ b/docs/architecture/game/game-simulation.md
@@ -1,309 +1,263 @@
 # Game simulation & verification
 
-How gameplay is computed on the client, recorded as checkpoint streams, and trusted through server
-replay.
+How the client computes and records gameplay, and how server replay decides to trust it.
 
-The client runs all real-time simulation as a pure function of server-authored inputs and a seed
-stream, writing each step to an append-only checkpoint stream. The server never simulates on the
-request path: a queue-fed verifier replays submitted checkpoints asynchronously and decides whether
-to trust them. Determinism is the distinction that governs everything else — the same inputs replay
-to byte-identical results, and that reproducibility is what makes both verification and offline
-catch-up exact.
+The client runs every real-time simulation as a pure function of a fixed set of inputs and a seeded
+random stream, writing each step to an append-only checkpoint stream. The server never simulates on
+the request path: a queue-fed verifier re-runs the submitted checkpoints later and decides whether
+to trust them. The one distinction the rest of this page rests on is determinism — the same inputs
+re-run to byte-identical results. That reproducibility is what lets the verifier check a stream it
+did not compute, and what lets a returning client rebuild simulation state it no longer holds.
+
+This page owns the simulation, the checkpoint stream, and the trust decision. The reconcile that
+delivers offline progress on reconnect, and the worker lifecycle that drives it, live in
+[offline reconcile](./offline-reconcile.md).
 
 ## Activities and encounters
 
 An **activity** is one attempt at a piece of content, recorded as a single append-only checkpoint
-stream and verified as a unit. Every activity has a type. A **world map encounter** is the type
-where an avatar fights through a map node's enemies, arranged in **waves** — ordered groups the
-avatar clears one at a time. Each activity type supplies an `ActivityExecutor` that advances its
-simulation. **Combat** is how an encounter resolves: each tick, the world map encounter's executor
-advances the avatar and the current wave's enemies and dispatches their attack events.
-`@vers/idle-core` runs any activity type. `@vers/game-utils` derives a world map encounter's waves,
+stream and verified as a unit. Every activity has a type. A **world-map encounter** is the type
+where an avatar fights through a map node's enemies, arranged in **waves** — ordered enemy groups
+the avatar clears one at a time. Each activity type supplies an `ActivityExecutor` that advances its
+simulation. **Combat** is how a world-map encounter resolves: each tick, its executor advances the
+avatar and the current wave's enemies and dispatches their attack events.
+
+`@vers/idle-core` runs any activity type. `@vers/game-utils` derives a world-map encounter's waves,
 enemies, and timing from `(node, seed, content)` as a pure function.
 
 Activities at the same target chain together: each `(avatar, chain scope)` pair owns one append-only
-[seed chain](./seed-chain.md). A **chain scope** is a stable, returnable target — a world map
-encounter's is its map node (`world_map_node`) — and the seed chain owns its model. The activity
-type says what the avatar does; the scope type says where it returns to.
+[seed chain](./seed-chain.md). A **chain scope** is a stable, returnable target — a world-map
+encounter's scope is its map node (`world_map_node`). The activity type says what the avatar does;
+the scope type says where it returns to.
 
 ## The deterministic core
 
-The simulation is a pure function: a server-authored input snapshot plus a seed stream fully
-determine every tick. The engine `@vers/idle-core` and world map encounter derivation
-`@vers/game-utils` are shared libraries. Both the client worker and the verifier — the server
-process that replays submitted checkpoints — import them and compute byte-identical results from the
-same inputs.
+The simulation is a pure function: a fixed set of inputs plus a seeded random stream fully determine
+every tick. Both the client and the server run it from the same shared libraries (`@vers/idle-core`,
+`@vers/game-utils`), so they compute byte-identical results from identical inputs.
 
-Purity rests on three invariants. Every random draw comes from the seeded `rng` stream, never
-`Math.random` or a wall-clock read. Every entity's id derives from its position in the input — an
-enemy's from its wave index and slot within the wave — never from a randomly minted value. Combat
-events resolve into one total order: ascending time, the avatar's own events before others' at an
-equal timestamp, then the monotonic sequence number the combat executor stamps on each event as it's
-scheduled — never an event id or the scan order that discovered the event that tick.
+Purity rests on three invariants:
+
+- **Every random draw comes from the seeded stream.** No draw reads `Math.random` or a wall clock.
+- **Every entity id derives from its position in the input.** An enemy's id comes from its wave
+  index and its slot within the wave, never from a randomly minted value.
+- **Combat events resolve into one total order.** Events sort by ascending event time. Two rules
+  break a tie at an equal timestamp: the avatar's own events come first; then the monotonic sequence
+  number the executor stamps on each event as it schedules it. The order never depends on an event
+  id or on the scan order that discovered the event that tick.
 
 The client does all real-time simulation. One writer per browser profile runs the fixed-timestep
-loop; every other tab is a pure viewer, rendering the writer's **sim snapshot** — the engine's
-serializable `*Snapshot` projection from `getSnapshot()`, distinct from the server-authored **build
-snapshot** that pins an avatar's build as a simulation input. On returning from offline, the client
-fast-forwards the simulation from the last verified checkpoint. The server never simulates on the
-request path; it replays asynchronously to decide whether to trust what the client submitted.
+loop; every other tab is a viewer that renders the writer's **sim snapshot**, the engine's
+serializable projection from `getSnapshot()`. The sim snapshot is distinct from the **build
+snapshot**, the avatar's equipment, passives, and level pinned as a simulation input.
 
 ### Writer election
 
-The writer is a SharedWorker where the browser has one. Where it doesn't (Android Chrome, older
-Safari), every tab spawns a dedicated worker and the workers race one exclusive Web Locks request
-for the writer lock. The winner boots the same worker runtime, reaches every tab over a pair of
-BroadcastChannels — one per direction, so a tab never receives another tab's client messages — and
-announces itself with a writer-ready broadcast.
+The writer worker is a SharedWorker where the browser has one. Where it does not — Android Chrome,
+older Safari — every tab spawns a dedicated worker, and the workers race one exclusive Web Locks
+request for the writer lock. The winner boots the worker runtime and announces itself with a
+writer-ready broadcast. It reaches every tab over a pair of BroadcastChannels, one for each
+direction. The inbound and outbound channels are separate, so a tab never receives a message another
+tab sent.
 
-The granted lock callback never settles, so the browser releases the lock only when the writer's tab
-dies. The next queued worker then boots exactly as a reloaded worker would, seeding from the durable
-checkpoint queue and pending intents. A frozen background tab's worker keeps the lock while paused:
-the writer stalls until the tab thaws or the browser discards it, and the offline-progress design
-absorbs the stall — the next report-online resyncs and fast-forwards.
+The granted-lock callback never settles, so the browser releases the lock only when the writer's tab
+dies. The next queued worker then boots exactly as a reloaded worker does, seeding from the same
+durable stores a reload reads — its queued checkpoints and its pending-roots store. A frozen
+background tab holds the lock while paused: the writer stalls until the tab thaws or the browser
+discards it, and the offline reconcile absorbs the stall by reconstructing the gap on the next
+reconnect.
 
-Tabs treat the writer-ready broadcast as a fresh worker. Each re-sends its initialize and
-report-online handshake, a pending start intent re-raises under a new request id, and viewers
-briefly render catch-up state until the new writer's resync completes. Initialize is send-and-retry
-until answered — a post while no worker holds the lock reaches nothing. A succession re-report never
-claims the writer, so a dying background tab's promotion cannot take a run from a device the player
-is actively driving.
+The worker lifecycle — the states the writer moves through and how a handoff moves work to a fresh
+worker — lives in [offline reconcile](./offline-reconcile.md#worker-lifecycle).
 
-One-shot intents posted inside the handoff — it spans only lock release plus runtime boot — are
-accepted losses, each with a visible recovery:
+## Authoring and verifying inputs
 
-- a stop: the run reads still-active and the player stops it again
-- a continue-here claim: the displaced notice returns with the next initial-state broadcast and the
-  player claims again
-- a failure-action toggle: the control reverts to the durable cached value
+The client authors every activity input; the server verifies it. Starting an activity is one
+unconditional local synthesis: the client mints the **activity start** — its first record, naming
+the node, seed, and content and version stamps — from materials it cached at reveal, and drops into
+the simulation with no server round trip. The same synthesis covers every start, whether it is the
+player tapping a node, an auto-continuation after a terminal checkpoint, or an offline gap caught up
+on reconnect. The server authors no start on the request path.
 
-The handoff needs no server-side writer coordination: the append path's head-row guarded update plus
-deterministic-content dedupe makes a dying writer's late append and its successor's identical
-checkpoints converge instead of interleaving.
+The client anchors each start at the chain's current head, which `revealNodes` delivers alongside
+the seed (see [seed chain](./seed-chain.md)). It persists the synthesized start to the durable
+pending-roots store before installing it, so a crash between mint and install loses nothing. It
+queues the activity's checkpoints through the durable checkpoint submitter, which lands them
+whenever the server is next reachable.
 
-## Server-authored inputs
+`advanceActivity` is the server's authority over a client-authored start. It re-derives every
+authoritative input from its own truth and trusts none of the payload:
 
-`startActivity` and `advanceActivity` are the server actions that own every simulation input.
-`startActivity` mints a single fresh activity and resolves everything it pins from server truth:
+- It runs the same admission checks a start must pass — node selectability, sim-version validity.
+- It derives the encounter node and its hashed stamps from the server's own content document, never
+  the payload.
+- It re-authors the `buildSnapshot` from the avatar's progression, and rejects a start whose
+  predicted snapshot does not match.
+- It recomputes the `startHash` from the server-derived encounter and stamps, and requires the
+  submitted hash to equal it. The match proves the client simulated against the same content and
+  encounter the server derives.
+- It validates the submitted `seed` and `startChainIndex` against the chain's live appended head,
+  and refuses a start computed against a position the chain has moved past.
 
-- derives the seed: a CSPRNG mint for a node's first-ever activity, or the previous activity's
-  appended checkpoint for a continuation started online (see [the seed chain](./seed-chain.md))
-- resolves the node's enemy content
-- snapshots the avatar's build (equipment, passives, level) from server truth
-- stamps the engine and content versions
+A single `advanceActivity` request carries a whole chain of continuations, so an offline gap the
+client simulated locally verifies in one round trip. Every continuation reuses the start's seed
+chain and its pinned encounter and version context, and the server re-derives each continuation's
+build the same way it re-derives the start's. The stored activity row carries the same columns
+whichever path delivered it, so the replay verifier reproduces it unchanged.
 
-`advanceActivity` mints a whole chain of continuations in one bulk request, replaying an offline gap
-under the exact context the client's own local simulation was pinned to: every continuation it mints
-reuses the initial row's seed chain and pinned encounter/version context unchanged, and re-derives
-each `buildSnapshot` server-side from the avatar's progression rather than resolving a fresh build.
-The client predicts that same snapshot locally so its offline simulation runs against the correct
-build; `advanceActivity` cross-checks the prediction against what it derived and rejects the
-continuation on a mismatch.
+### What replay pins
 
-`advanceActivity` accepts a client-minted root the server has never seen, when `activityID` names no
-existing row and the caller supplies the start context it computed offline: the `seed`, the content
-and sim versions, the `startChainIndex`, its predicted `buildSnapshot`, and the `startHash`. The
-mint derives every authoritative input from server truth, never the payload. It runs the admission
-gates `startActivity` runs — node selectability, sim-version validity — and derives the encounter
-node and the key and secret stamps from its own content document and scope secret, exactly as a
-fresh start does. It validates the client's `seed` and `startChainIndex` against the chain's live
-appended anchor: a mismatch means the client rooted against a stale head, and the mint is refused
-rather than accepted off a moving target. `buildSnapshot` is re-authored from the avatar's own
-progression, and the `startHash` is recomputed from the server-derived encounter and stamps; the
-client's submitted hash must equal that recompute, proving its offline simulation ran against the
-same content and encounter the server derives. The minted row stores the same columns a
-`startActivity` mint would, so the replay verifier reproduces it unchanged.
-
-The `Started` snapshot pins every version a replay needs — the engine and content versions, the roll
+The `Started` checkpoint pins every input a replay needs: the sim and content versions, the roll
 `keyVersion` ([game entropy](./game-entropy.md#version-pinning)), and `start_chain_index`
-([seed chain](./seed-chain.md#seeds-and-chainindex)) — so replay resolves each under the code that
-produced it.
+([seed chain](./seed-chain.md#seeds-and-chainindex)). Each later segment — a run of checkpoints
+under one sim version — replays under the code and content its stamps name.
 
-The activity's own id carries no cryptographic role: its start hash digests only
-`[seed, simVersion, contentVersion, keyVersion, encounterNode]`, since
-`(seed, versions, encounterNode)` already identifies the stream uniquely. A checkpoint's
-`chainIndex` plus its link to the chain's appended anchor — never the id — keeps one activity's
-checkpoints from crossing into another's. The id is a client-assigned label: `advanceActivity`'s
-caller mints each continuation's id itself, so the whole chain a fast-forward walks is computable
-client-side with no round trip per row. Client-submitted activity and avatar payloads are otherwise
-display hints only — a continuation's seed and build snapshot are client computations the verifier
-and `advanceActivity` both reproduce from the appended chain and settled progression, online and
-offline alike, never a round-tripped value taken on trust. The scope node's encounter params resolve
-server-side and freeze onto the activity row at start, inherited unchanged by every continuation
-`advanceActivity` mints in the same request. They fold into the start hash, so a later content
-change can't retroactively alter an activity already in flight.
+The activity's own id carries no cryptographic role. Its `startHash` digests only
+`[seed, simVersion, contentVersion, keyVersion, encounterNode]`, because that tuple already
+identifies the stream uniquely. A checkpoint's `version` — its position in the stream — and its link
+to the previous checkpoint's hash, never the activity id, keep one activity's checkpoints from
+crossing into another's. The id is a client-assigned label: `advanceActivity`'s caller mints each
+continuation's id itself, so the client can compute a whole fast-forward chain with no per-row round
+trip.
 
-Build mutations are gated while an activity is active: level-ups render optimistically and apply
-between activities. A snapshot that cannot change mid-activity is what makes replay exact.
+A node's encounter parameters are fixed at the content version the start pins and freeze onto the
+start row, inherited unchanged by every continuation in the same request. They fold into the
+`startHash`, so a later content change cannot alter an activity already in flight.
+
+The server gates build mutations while an activity is active: a level-up renders optimistically and
+applies between activities. A build snapshot that cannot change mid-activity is what makes a replay
+exact.
 
 ## Checkpoint streams
 
-Each activity is one append-only stream: one checkpoint row per version, keyed
-`(activity_id, version)`, plus a head row. The head row carries the stream's two cursors, its last
-chain hash, and the activity status. `appended_head` tracks how far the client has written;
-`verified_head` how far the server has replayed.
+Each activity is one append-only stream: one checkpoint row per step, keyed
+`(activity_id, version)`, where `version` is the row's position in the stream. A single **head row**
+carries the stream's two cursors, its last chain hash, and the activity status. `appended_head`
+tracks how far the client has written; `verified_head` tracks how far the verifier has trusted.
 
-- Each checkpoint hashes `{seed/nextSeed, time, type, entropySource}` and links the previous
-  checkpoint's hash. The hashed subset is frozen from the first row ever written: it never gains,
-  loses, or repurposes a field. The entropy-source tag inside it makes a checkpoint's provenance
-  derivable from the chain itself.
-- The hash is a chain link, not an outcome proof. Rewards ride outside the hashed subset as signed
-  deltas in an open keyed map, and only replay validates them.
-- Appends compare-and-swap the head row's `appended_head`. A stale head returns a retryable conflict
-  carrying the current head, and the client resends the tail. Resubmission is a free dedupe:
-  `UNIQUE(activity_id, version)` plus deterministic checkpoint content. Dedupe runs before
-  elapsed-time accounting, so replays never inflate duration.
-- Each activity has a single writer: the head row stamps the session allowed to append, and resuming
+- **Each checkpoint links the last.** A checkpoint hashes a frozen set of fields: its position in
+  the chain, its seed and next seed, and its `time`, `type`, and `entropySource`. It also includes
+  the previous checkpoint's hash. The set never gains, loses, or repurposes a field. Its chain
+  position sits inside the hash, so replay reproduces every reward coordinate keyed on it
+  ([seed chain](./seed-chain.md)), and its entropy-source tag makes a checkpoint's provenance
+  derivable from the chain alone.
+- **The hash is a chain link, not an outcome proof.** Rewards ride outside the hashed set as `+`/`-`
+  deltas in an open keyed map, and only a replay validates them.
+- **An append is a guarded update of the head row.** The append advances `appended_head` only if the
+  head still holds its expected value; a stale head returns a retryable conflict carrying the
+  current head, and the client resends the tail. Resubmission deduplicates for free —
+  `UNIQUE(activity_id, version)` plus deterministic checkpoint content — and dedupe runs before
+  elapsed-time accounting, so a replayed tail never inflates duration.
+- **Each activity has one writer.** The head row stamps the session allowed to append, and resuming
   on a new session takes the writer over. An append from any other session fails fatally, so a
-  displaced writer's in-flight submissions die rather than interleave. Terminal statuses (stopped,
-  rejected, capped, quarantined) reject any later append. Together these resolve every race between
-  logout, forced logout, stop, rejection, and cap.
+  displaced writer's in-flight submissions die rather than interleave. A terminal status — stopped,
+  rejected, capped, quarantined — rejects any later append. Together these resolve every race
+  between logout, forced logout, stop, rejection, and cap.
 
 ## Replay
 
-A queue-fed verifier replays submitted checkpoint batches and compares results. Replay is per-stream
-FIFO: version N+1 never verifies before N, because the seed chain would break. The verifier replays
-from the `Started` snapshot under the engine version stamped into it, dispatched through a provider
-registry so old segments replay under the code and content that produced them. For the engine
-version this deploy runs, the worker holds each live stream's simulation in memory at its verified
-head and advances it by each new batch's delta rather than replaying from `Started` every time. A
-worker restart or cache eviction falls back to a from-`Started` rebuild.
+A queue-fed verifier replays submitted checkpoint batches and compares its results against the
+stream. Replay is per-stream FIFO: `version` N+1 never verifies before N, because the seed chain
+would break. The verifier replays from the `Started` checkpoint under the sim version stamped into
+it, dispatched through a provider registry keyed by sim version so an old segment replays under the
+code and content that produced it. For the sim version this deploy runs, the verifier holds each
+live stream's simulation in memory at its verified head and advances it by each batch's delta rather
+than replaying from `Started` every time; a verifier restart or cache eviction falls back to a
+from-`Started` rebuild.
 
-Ambiguity parks, it never rejects: a version mismatch, an unknown engine, or a timeout is held as an
-operational state, not judged as a cheat signal. Only reproducible divergence under a matched
-version and snapshot, on repetition, is treated as cheating. Enforcement lands at a session
-boundary, never mid-session. A stream that fails replay repeatedly is quarantined and alerted on
-rather than retried forever.
+The verifier parks an ambiguous stream rather than rejecting it. A sim-version mismatch, an unknown
+engine, or a timeout is held as an operational state, not judged as a cheat signal. Only
+reproducible divergence under a matched sim version and `Started` checkpoint, on repetition, is
+treated as cheating. Enforcement lands at a session boundary, never mid-session. The verifier
+quarantines a stream that fails replay repeatedly and alerts operators rather than retrying it
+forever.
 
 Replay divergence is not the only cheat signal. Because every attempt at a node is a link in the
-append-only, server-verified chain, reroll-scanning leaves a record. An avatar whose results ride
-the favorable tail of its own verified history stands out from honest play — faster clears, better
-positions, more often than the distribution predicts. The record catches it whether it reached those
-results by failing attempts or by completing and discarding them. This is a behavioural signal, not
-a divergence. It is scored with the same restraint: a soft consequence before a hard one, always at
-a session boundary. Honest grinders swing too, and a false accusation costs more than the edge it
-denies.
+append-only, server-verified chain, **reroll-scanning** — repeatedly attempting a node and
+discarding the unfavorable results to keep a favorable roll — leaves a record. An avatar whose
+results ride the favorable tail of its own verified history stands out from honest play: faster
+clears and better positions, more often than the distribution predicts. The record catches it
+whether it reached those results by failing attempts or by completing and discarding them. This is a
+behavioural signal, not a divergence, and it is scored with the same restraint: a soft consequence
+before a hard one, always at a session boundary. Honest grinders swing too, and a false accusation
+costs more than the edge it denies.
 
-Operating the verifier is an observability task: replay lag and rejection rates split by cause are
-the verification metrics ([observability](../platform/observability.md)). An integrity-mismatch
-spike there is almost always a bad deploy, not a cheating wave.
+Operators watch the verifier through its metrics: replay lag and rejection rates split by cause
+([observability](../platform/observability.md)). An integrity-mismatch spike there is investigated
+as a deploy regression first, not a cheating wave.
 
-An old sim version stays a valid replay target for a retention window (~30 days,
-[deployment](../platform/deployment.md#retention-sweep)) before the sweep tombstones it.
+An old sim version stays a valid replay target for a retention window of ~30 days
+([deployment](../platform/deployment.md#retention-sweep)) before the sweep tombstones it.
 
 ## Applying verified progress
 
-Verified deltas apply exactly once through a cursor-guarded transaction. It advances `verified_head`
-with a compare-and-swap — the update applies only if the cursor still holds its expected value —
-then applies the delta to identity state and appends the settlement's economic-ledger entry, all in
-one local transaction. A crashed worker retries idempotently.
+Verified progress applies exactly once through a cursor-guarded transaction. The transaction
+advances `verified_head` only if it still holds its expected value, then writes the newly verified
+progress to the avatar's identity state and appends the settlement's economic-ledger entry — all in
+one local transaction. A crash mid-apply retries the transaction idempotently.
 
-- First-clears, achievements, and other one-shot grants insert into a unique-keyed grant table with
-  `ON CONFLICT DO NOTHING` inside the same transaction — idempotent across re-farms and replays.
-- Item instances mint at settlement: identity is the reward coordinate, and content is rolled from
-  the avatar's key under the activity's pinned versions (see [game entropy](./game-entropy.md)).
-  Re-verification never duplicates or re-rolls an item.
-- The reveal read path returns a coordinate's content only at or below the verified anchor, never
-  the appended head ([seed chain](./seed-chain.md)); a synced-but-unverified roll holds client-side
-  as pending until settlement. The reveal is a pure function of the coordinate, so append retries
-  and bulk offline resends return identical reveals.
-- A rejected claim rolls back by forward compensating events, never by snapshot restore: settlement
-  resets to the node's verified prefix, and revealed-but-unsettled rewards past it are cleared from
-  optimistic display.
+- **One-shot grants insert idempotently.** First-clears, achievements, and other one-time grants
+  insert into a unique-keyed grant table with `ON CONFLICT DO NOTHING` inside the same transaction,
+  so they hold across re-farms and replays.
+- **Item instances mint at settlement.** An item's identity is its reward coordinate, and its
+  content is rolled from the avatar's key under the activity's pinned versions (see
+  [game entropy](./game-entropy.md)). Re-verification never duplicates or re-rolls an item.
+- **A reward stays hidden until it is verified.** The read path that returns a coordinate's rolled
+  reward for display answers only for a chain position the verifier has confirmed, never one only
+  appended ([seed chain](./seed-chain.md)); a reward that has synced but not yet verified holds on
+  the client as pending until settlement. That read is a pure function of the coordinate, so an
+  append retry or a bulk offline resend returns the same reward every time.
+- **A rejected activity rolls back by compensating forward, never by restoring a prior database
+  state.** Settlement returns the node to its last verified checkpoint, and any reward revealed past
+  that point but not yet settled clears from the optimistic display.
 
-Resume always anchors on the last verified checkpoint. The client rebuilds optimistic state by
-simulating forward from that anchor. It never renders the server's settled progression columns
-directly, because they lag verification by design.
+When play resumes, the client rebuilds its own optimistic state by simulating forward from the
+verified head. It never reads the server's settled progression columns directly, because those
+columns lag verification by design. The order the server settles reconciled activities in — and why
+a later activity waits on an earlier one — lives in
+[offline reconcile](./offline-reconcile.md#settlement-in-order).
 
-## Activity lifecycle
-
-The writer worker owns every lifecycle transition — start, stop, continuation, resync. A tab
-expresses intent in one message and correlates the worker's broadcast outcome by request id; no tab
-calls the activity service for lifecycle work itself, so the tabs and the worker can never disagree
-about which run exists.
-
-- A start intent carries a request id the worker passes as the row's idempotency key (`start_key`).
-  A duplicate delivery of the same start — a retry after a transport failure, a held continuation
-  intent drained later — converges on the row the first attempt minted, while a distinct intent into
-  the same scope conflicts. A superseded start abandons its work, and any row it minted is recovered
-  by the fresher flow.
-- Lifecycle flows — starts, resyncs, continuations — run strictly one at a time through a mailbox in
-  the worker; a queued flow re-checks its claim when its turn arrives.
-- A stop stays outside the mailbox: it halts the local simulation immediately and needs no network.
-  Delivery is a durable intent: earned checkpoints flush first, then a targeted, idempotent server
-  stop lands, retried at every reconnect and resync entry until the row reads closed. An undelivered
-  stop gates resync planning, so a catch-up never revives a run the player ended.
-- Every install path re-checks a stop epoch captured when its flow began, so a resync or
-  continuation abandons its install when a stop landed meanwhile — the one interleaving the mailbox
-  permits.
-- The worker holds a simulation for its whole lifetime; "no run" is an empty simulation with no
-  activity attached, so no lifecycle path ever special-cases a missing one.
-
-## Offline progress
-
-Four processes move simulation results around, each with one name:
-
-- **Replay** is the verifier's asynchronous re-execution of submitted checkpoints: the trust
-  decision, and nothing else.
-- A **resync** is the client's confirmed-state fetch (verified anchor, appended head, server time)
-  and the decision it drives.
-- A **fast-forward** is the client's catch-up simulation of an offline gap, run on return: every
-  attempt the gap covers simulates locally, with no network call, before any of it reaches the
-  server.
-- **Reconstruction** re-runs an activity from its seed to rebuild simulation state the client no
-  longer holds. Determinism makes the result identical to the lost original, and the
-  already-accepted prefix costs nothing against the budget.
-
-### Resync and reconstruction
-
-A resync executes in the writer worker, since only the worker holds the one live simulation a plan
-might attach to. A tab triggers it with the avatar id alone, and the worker derives everything else
-from the confirmed activity row. A negligible gap attaches to the live simulation directly.
-Reconstruction recovers the submission cursor — the chain-link hash and seed the next checkpoint
-continues from — by replaying up to the confirmed head, before the worker resumes ticking from
-there. A larger gap fast-forwards first: the confirmed row's own remaining tail reconstructs for
-free, then each further attempt derives its seed, client-assigned id, and predicted build snapshot
-from the chain position alone — the same computation `advanceActivity` reproduces server-side — so
-the whole gap, however long, simulates before any of it is submitted. The planned chain ships as
-bounded `advanceActivity` batches, sequentially and awaited: batch N's mint is confirmed committed
-before batch N+1 ships, and no other path — in particular not the per-activity checkpoint submitter
-— delivers an offline continuation. On a rejected batch, the client discards every batch still
-unsent and reconciles to whichever continuation last committed anywhere in the request. When at
-least one continuation has committed, the reconciled row is a fresh mint with nothing appended yet,
-and the worker attaches live to it exactly as it would a fresh continuation reached by any other
-path. A request rejected before its first continuation commits mints nothing at all — the bail
-carries only the activity id and the confirmed head unchanged from before the gap, and the worker
-reconciles to that same row through the outer resync's own refetch rather than attaching anywhere
-new.
-
-A live continuation the worker couldn't complete — a same-row race just after a terminal checkpoint,
-or a transport failure starting the next row — leaves a durable start intent that survives a worker
-reload. A resync for the intent's avatar delivers it at entry, before the confirmed-state fetch, so
-the fetch finds the minted row and attaches it through ordinary planning; an intent whose source row
-still reads active waits for the resync's own queued-checkpoint drain to close it, then retries. A
-player stop, or a fresh player-chosen start, clears the intent, so a run the player ended is never
-resumed. A fast-forward needs no such intent: a worker reload mid-drain re-plans the gap from the
-last confirmed row, deterministically reproducing the same chain.
-
-### The offline budget
+## The offline budget
 
 Offline progress is bounded by a per-avatar simulated-time meter, enforced on the append path. The
 budget refills at wall-clock rate since it was last banked, never past the cap
 (`OFFLINE_PROGRESS_CAP_MS`, 24h). Every accepted checkpoint batch debits its simulated-time delta:
 the last checkpoint's cumulative `time` minus the head row's accounted time, never a sum of the
-batch's per-checkpoint times. Because the only credit source is elapsed wall clock, no path earns
-simulated time faster than real time — not activity cycling, stop/start, or avatar rotation. Live
-play self-funds: each flush banks roughly the wall clock it consumes. A small initial grant on the
-meter absorbs tick-boundary and network jitter.
+batch's per-checkpoint times.
 
-A batch whose delta exceeds the accrued budget is rejected whole, and the activity claims the
+Because the only credit source is elapsed wall clock, no path earns simulated time faster than real
+time — not activity cycling, not stop/start, not avatar rotation. Live play self-funds: each flush
+banks roughly the wall clock it consumes. A small initial grant on the meter absorbs tick-boundary
+and network jitter.
+
+A batch whose delta exceeds the accrued budget is rejected whole, and the activity takes the
 terminal `capped` transition at its current head. The `ACTIVITY_CAPPED` error carries that head as
-the exact stop index the client rebases its chain cursor from, and resuming requires a resync. An
-honest client never trips the cap: it plans its catch-up simulation to stop at the last encounter
-boundary at or under the same bound. `getLatestActivityProgress` returns the database's current time
-beside the resume cursors, so the client computes its offline gap against the clock that meters it.
-The fast-forward simulates from the last verified anchor. Re-simulating a few already-submitted
-minutes is harmless: the results are deterministic and resubmission dedupes.
+the exact index the client rebases its chain cursor from, and resuming requires a resync. An honest
+client never trips the cap: it plans its catch-up simulation to stop at the last encounter boundary
+at or under the same bound.
 
-Which rewards offline simulation may produce is an economy rule, not a protocol one: the
-[economy modes note](../../game-design/economy-modes.md) owns it.
+Which rewards an offline simulation may produce is an economy rule, not a protocol one: the
+[economy modes note](../../game-design/economy-modes.md) owns it. How a reconnect delivers and
+settles the offline gap is the subject of [offline reconcile](./offline-reconcile.md).
+
+## Glossary
+
+| Term                | Meaning                                                                                                                                  |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| activity            | One attempt at one piece of content, recorded as a single append-only checkpoint stream and verified as a unit.                          |
+| activity type       | What the avatar does in an activity; supplies the `ActivityExecutor` that advances its simulation.                                       |
+| world-map encounter | The activity type where an avatar fights through a map node's enemies, arranged in waves.                                                |
+| chain scope         | The stable, returnable target activities chain against; a world-map encounter's scope is its map node.                                   |
+| activity start      | An activity's first record — the node, seed, and stamps — synthesized locally by the client and verified by the server on ingest.        |
+| continuation        | An activity that resumes a chain scope from a prior attempt's appended position, in the same chain.                                      |
+| settle              | The server's verified application of an activity's rewards to durable state; the moment provisional progress becomes real.               |
+| build snapshot      | The avatar's equipment, passives, and level pinned as a simulation input; the client predicts it, the server re-derives and verifies it. |
+| sim snapshot        | The engine's serializable projection from `getSnapshot()`, which viewer tabs render.                                                     |
+| writer worker       | The one worker per browser profile that runs the simulation and appends its checkpoints.                                                 |
+| verifier            | The server process that replays a submitted stream to decide whether to trust it.                                                        |
+| checkpoint          | One recorded simulation step: a row keyed `(activity_id, version)` that links the previous checkpoint's hash.                            |
+| head row            | An activity's single row carrying its two cursors, last chain hash, writer session, and status.                                          |
+| appended head       | `appended_head`: how far the client has written the stream.                                                                              |
+| verified head       | `verified_head`: how far the verifier has replayed and trusted the stream.                                                               |
+| sim version         | The engine build's version stamp (`simVersion`); pins which code replays a segment.                                                      |
+| offline budget      | The per-avatar simulated-time meter, refilled at wall-clock rate and debited per accepted batch.                                         |


### PR DESCRIPTION
## Description

Closes #921.

Rewrite `game-simulation.md` for a cold reader — one glossary, self-contained nouns, one fact per sentence — describing the client-authored target model.

- Written to the target design: every activity start is client-authored and server-verified, with no server start-mint. The code delta is tracked in #925.
- Split the offline-reconcile and worker-lifecycle narrative out; link `offline-reconcile.md` rather than restate it.
- Collapsed the overloaded terms the predecessor tangled — two head cursors, sim version vs stream `version`, writer worker vs verifier, the snapshot family — and retired "root" for "activity start".
- Two adversarial cold-read rounds (21/57/17 blockers/majors/minors → 1/9/11 → 0/2/8), all resolved, including a checkpoint-hash `chainIndex` omission caught against code.

## Testing

Documentation only. Target-spec and pinning tests park on #925 per the #920 approach.
