### PR TITLE
docs(agents): trigger coderabbit review manually on sub-10-star repo

### DIFF
--- a/.claude/workflows/build-feature.js
+++ b/.claude/workflows/build-feature.js
@@ -292,6 +292,7 @@ const pr = await agent(
 1. Bring the branch up to date: \`git -C ${worktree} fetch origin\` then \`git -C ${worktree} rebase origin/main\`. If the rebase hits conflicts, resolve them faithfully to both sides' intent (rerun \`bun install\` in the worktree if dependency manifests changed) and return resolvedConflicts=true; if it was clean or a no-op, return resolvedConflicts=false.
 2. Push with \`git -C ${worktree} push -u origin ${branch}\`, adding \`--force-with-lease\` only if the rebase rewrote commits that were already pushed.
 3. ${prAction}
+4. CodeRabbit's auto-review is off for this repo (under ten stars), so trigger its review exactly once with \`gh pr comment <number> --body "@coderabbitai review"\`. Post this on a freshly opened PR${prNumber ? ', and also when readying the existing PR if no `@coderabbitai review` comment is already present on it (check with `gh pr view <number> --comments` first — never post a second trigger)' : ''}. cubic reviews automatically; do not tag it.
 
 ${prBodySpec}`,
   {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,8 +226,10 @@ it.
 
 ## Review bots
 
-CodeRabbit and cubic review every PR, configured by `.coderabbit.yaml` and `cubic.yaml` at the repo
-root; CodeRabbit reads this file as its guidelines.
+cubic reviews every PR automatically. CodeRabbit's auto-review is off for repositories under ten
+stars, so its review is requested by commenting `@coderabbitai review` on the PR — post that comment
+exactly once, right after the PR opens, and never again on the same PR. Both bots are configured by
+`.coderabbit.yaml` and `cubic.yaml` at the repo root; CodeRabbit reads this file as its guidelines.
 
 - A PR is ready only after both bot reviews are read and every finding is answered on its own
   thread: a fixed finding's reply cites the commit that fixed it; a declined finding's reply states
@@ -237,10 +239,11 @@ root; CodeRabbit reads this file as its guidelines.
 - Resolve a thread once its reply is posted, fixed and declined alike (GraphQL
   `resolveReviewThread`). A finding the agent cannot confidently judge is escalation, not
   disposition: reply saying so and leave the thread open for a human.
-- Never teach a bot through chat (`@coderabbitai` learnings and the like) — a correction to bot
-  behaviour is an edit to `.coderabbit.yaml` or `cubic.yaml`, reviewed in a PR.
-- Bots review a PR once, at open; an agent invokes a re-review only when asked, never on its own
-  initiative.
+- The one chat command an agent posts is the `@coderabbitai review` trigger above. Never teach a bot
+  through chat otherwise (`@coderabbitai` learnings and the like) — a correction to bot behaviour is
+  an edit to `.coderabbit.yaml` or `cubic.yaml`, reviewed in a PR.
+- Bots review a PR once, at open; an agent invokes a re-review — a second `@coderabbitai review`, a
+  `@coderabbitai full review`, or any equivalent — only when asked, never on its own initiative.
 
 ## Issue hygiene
 

--- a/agents/project.md
+++ b/agents/project.md
@@ -78,8 +78,10 @@ it.
 
 ## Review bots
 
-CodeRabbit and cubic review every PR, configured by `.coderabbit.yaml` and `cubic.yaml` at the repo
-root; CodeRabbit reads this file as its guidelines.
+cubic reviews every PR automatically. CodeRabbit's auto-review is off for repositories under ten
+stars, so its review is requested by commenting `@coderabbitai review` on the PR — post that comment
+exactly once, right after the PR opens, and never again on the same PR. Both bots are configured by
+`.coderabbit.yaml` and `cubic.yaml` at the repo root; CodeRabbit reads this file as its guidelines.
 
 - A PR is ready only after both bot reviews are read and every finding is answered on its own
   thread: a fixed finding's reply cites the commit that fixed it; a declined finding's reply states
@@ -89,10 +91,11 @@ root; CodeRabbit reads this file as its guidelines.
 - Resolve a thread once its reply is posted, fixed and declined alike (GraphQL
   `resolveReviewThread`). A finding the agent cannot confidently judge is escalation, not
   disposition: reply saying so and leave the thread open for a human.
-- Never teach a bot through chat (`@coderabbitai` learnings and the like) — a correction to bot
-  behaviour is an edit to `.coderabbit.yaml` or `cubic.yaml`, reviewed in a PR.
-- Bots review a PR once, at open; an agent invokes a re-review only when asked, never on its own
-  initiative.
+- The one chat command an agent posts is the `@coderabbitai review` trigger above. Never teach a bot
+  through chat otherwise (`@coderabbitai` learnings and the like) — a correction to bot behaviour is
+  an edit to `.coderabbit.yaml` or `cubic.yaml`, reviewed in a PR.
+- Bots review a PR once, at open; an agent invokes a re-review — a second `@coderabbitai review`, a
+  `@coderabbitai full review`, or any equivalent — only when asked, never on its own initiative.
 
 ## Issue hygiene
 


### PR DESCRIPTION
## Description

CodeRabbit turns off auto-review for repositories under ten stars, so PRs were opening without its pass. Document the manual trigger and wire it into the build-feature workflow so every PR still gets both bot reviews.

- Post `@coderabbitai review` exactly once, right after the PR opens; never a second time on the same PR.
- build-feature's open-PR step now posts the trigger (checking for an existing one on the ready-existing-PR path before posting).
- cubic still auto-reviews and is never tagged.
- Clarify the review-bots rules: the trigger is the one allowed chat command, and a repeat trigger or `full review` counts as a re-review (only when asked).

## Testing

Docs and workflow prompt only — no code paths changed.

## Context

CodeRabbit documents this on recent PRs: "Reviews should be triggered manually for repositories with fewer than 10 stars."