### PR TITLE
docs(#935): correct the app-web proxy traceparent behavior

### DIFF
--- a/docs/architecture/services/error-handling.md
+++ b/docs/architecture/services/error-handling.md
@@ -166,8 +166,10 @@ from an error screen or a support report finds it directly in the logs and the e
 
 - The browser mints a fresh `traceparent` per RPC call from the `@vers/trace` primitives.
 - app-web's server-side service links continue the ambient request's trace when it carries one, and
-  start a fresh trace otherwise. The browser-lane RPC proxy forwards headers wholesale, so browser
-  traces pass through untouched.
+  start a fresh trace otherwise. The browser-lane `/api/rpc/$service` proxy re-injects `traceparent`
+  from its own request span rather than forwarding the browser's header, so the trace continues but
+  the service's span parents to app-web's server span
+  ([observability](../platform/observability.md)).
 - Services parse inbound `traceparent`, mint their hop's span id, and run the whole request inside
   `withTraceContext` (`@vers/service-utils`), which the pino mixin and Sentry tag read.
 


### PR DESCRIPTION
## Description

Closes #935.

Correct `error-handling.md`'s trace-context bullet: the browser-lane `/api/rpc/$service` proxy re-injects `traceparent` from its own request span, it does not forward the browser's header wholesale.

- Verified against `apps/web/src/lib/proxy/send-rpc-request.ts`, which sets `traceparent` from `findSpanTraceContext() ?? findTraceContext() ?? createTraceContext()` (and mints a fresh s2s token) — so headers are not passed through untouched.
- This reconciles the doc with `observability.md`, which already described the re-injection correctly; the bullet now links it as the owner.

## Testing

Documentation only.
