### PR TITLE
feat(#907): split the client checkpoint-queue stores by durability

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -41,6 +41,14 @@ reviews:
         awaited: Bun's matcher types declare them synchronous, per the AGENTS.md
         testing rules. Only toResolve()/toReject() return promises and are
         awaited. Never flag an unawaited .rejects/.resolves chain.
+    - path: 'libs/game/idle-client/**'
+      instructions: |
+        The node-seeds and content-documents IndexedDB stores are caches: a row
+        that fails its current contract schema self-heals on read (the row is
+        deleted and the read reports a miss), so do not request a per-version
+        cache-migration test for either store. Only the outbox stores —
+        pending-checkpoints and pending-roots — hold un-synced local progress
+        and keep real versioned migrations.
     - path: 'AGENTS.md'
       instructions: |
         AGENTS.md is generated from agents/shared.md and agents/project.md and

--- a/contracts/activity/src/index.ts
+++ b/contracts/activity/src/index.ts
@@ -31,6 +31,8 @@ export { EntropySourceSchema } from './entropy-source-schema';
 export { LootTablesSchema } from './loot-tables-schema';
 export { MAX_CATCH_UP_BATCH_CHECKPOINTS } from './max-catch-up-batch-checkpoints';
 export { MAX_REVEAL_BATCH_NODES } from './max-reveal-batch-nodes';
+export type { NodeSeed } from './node-seed-schema';
+export { NodeSeedSchema } from './node-seed-schema';
 export { OFFLINE_PROGRESS_CAP_MS } from './offline-progress-cap-ms';
 export type { OfflineRootSubmission } from './offline-root-submission-schema';
 export { OfflineRootSubmissionSchema } from './offline-root-submission-schema';

--- a/contracts/activity/src/node-seed-schema.test.ts
+++ b/contracts/activity/src/node-seed-schema.test.ts
@@ -1,24 +1,27 @@
 import { expect, test } from 'bun:test';
 import { NodeSeedSchema } from './node-seed-schema';
 
-const wellFormed = {
-  avatarID: 'avatar-a',
-  contentVersion: '1',
-  encounterNode: { difficulty: 3 },
-  genesisSeed: 'seed-a',
-  head: { chainIndex: 0, nextSeed: 'seed-a' },
-  nodeID: '1_0',
-};
-
 test('it accepts a well-formed node seed', () => {
-  const result = NodeSeedSchema.safeParse(wellFormed);
+  const result = NodeSeedSchema.safeParse({
+    avatarID: 'avatar-a',
+    contentVersion: '1',
+    encounterNode: { difficulty: 3 },
+    genesisSeed: 'seed-a',
+    head: { chainIndex: 0, nextSeed: 'seed-a' },
+    nodeID: '1_0',
+  });
 
   expect(result.success).toBeTrue();
 });
 
 test('it rejects a row missing head', () => {
-  const { head: _head, ...withoutHead } = wellFormed;
-  const result = NodeSeedSchema.safeParse(withoutHead);
+  const result = NodeSeedSchema.safeParse({
+    avatarID: 'avatar-a',
+    contentVersion: '1',
+    encounterNode: { difficulty: 3 },
+    genesisSeed: 'seed-a',
+    nodeID: '1_0',
+  });
 
   expect(result.success).toBeFalse();
   expect(result.error?.issues).toPartiallyContain(expect.objectContaining({ path: ['head'] }));
@@ -26,8 +29,12 @@ test('it rejects a row missing head', () => {
 
 test('it rejects a row whose encounterNode fails its own schema', () => {
   const result = NodeSeedSchema.safeParse({
-    ...wellFormed,
+    avatarID: 'avatar-a',
+    contentVersion: '1',
     encounterNode: { difficulty: 'not-a-number' },
+    genesisSeed: 'seed-a',
+    head: { chainIndex: 0, nextSeed: 'seed-a' },
+    nodeID: '1_0',
   });
 
   expect(result.success).toBeFalse();

--- a/contracts/activity/src/node-seed-schema.test.ts
+++ b/contracts/activity/src/node-seed-schema.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from 'bun:test';
+import { NodeSeedSchema } from './node-seed-schema';
+
+const wellFormed = {
+  avatarID: 'avatar-a',
+  contentVersion: '1',
+  encounterNode: { difficulty: 3 },
+  genesisSeed: 'seed-a',
+  head: { chainIndex: 0, nextSeed: 'seed-a' },
+  nodeID: '1_0',
+};
+
+test('it accepts a well-formed node seed', () => {
+  const result = NodeSeedSchema.safeParse(wellFormed);
+
+  expect(result.success).toBeTrue();
+});
+
+test('it rejects a row missing head', () => {
+  const { head: _head, ...withoutHead } = wellFormed;
+  const result = NodeSeedSchema.safeParse(withoutHead);
+
+  expect(result.success).toBeFalse();
+  expect(result.error?.issues).toPartiallyContain(expect.objectContaining({ path: ['head'] }));
+});
+
+test('it rejects a row whose encounterNode fails its own schema', () => {
+  const result = NodeSeedSchema.safeParse({
+    ...wellFormed,
+    encounterNode: { difficulty: 'not-a-number' },
+  });
+
+  expect(result.success).toBeFalse();
+
+  expect(result.error?.issues).toPartiallyContain(
+    expect.objectContaining({ path: ['encounterNode', 'difficulty'] }),
+  );
+});

--- a/contracts/activity/src/node-seed-schema.ts
+++ b/contracts/activity/src/node-seed-schema.ts
@@ -1,0 +1,21 @@
+import * as z from 'zod';
+import { EncounterNodeSchema } from './encounter-node-schema';
+
+/**
+ * A world-map node's revealed start inputs as the client's durable cache holds them, keyed by the
+ * `[avatarID, nodeID]` pair it was cached under: the genesis seed the chain originated from, its
+ * current head, and the encounter and content version a local start synthesizes a start hash from.
+ */
+export const NodeSeedSchema = z.object({
+  avatarID: z.string(),
+  contentVersion: z.string(),
+  encounterNode: EncounterNodeSchema,
+  genesisSeed: z.string(),
+  head: z.object({
+    chainIndex: z.number(),
+    nextSeed: z.string(),
+  }),
+  nodeID: z.string(),
+});
+
+export type NodeSeed = z.infer<typeof NodeSeedSchema>;

--- a/contracts/activity/src/node-seed-schema.ts
+++ b/contracts/activity/src/node-seed-schema.ts
@@ -6,16 +6,20 @@ import { EncounterNodeSchema } from './encounter-node-schema';
  * `[avatarID, nodeID]` pair it was cached under: the genesis seed the chain originated from, its
  * current head, and the encounter and content version a local start synthesizes a start hash from.
  */
-export const NodeSeedSchema = z.object({
-  avatarID: z.string(),
-  contentVersion: z.string(),
-  encounterNode: EncounterNodeSchema,
-  genesisSeed: z.string(),
-  head: z.object({
-    chainIndex: z.number(),
-    nextSeed: z.string(),
-  }),
-  nodeID: z.string(),
-});
+export const NodeSeedSchema = z
+  .object({
+    avatarID: z.string(),
+    contentVersion: z.string(),
+    encounterNode: EncounterNodeSchema,
+    genesisSeed: z.string(),
+    head: z
+      .object({
+        chainIndex: z.number(),
+        nextSeed: z.string(),
+      })
+      .readonly(),
+    nodeID: z.string(),
+  })
+  .readonly();
 
 export type NodeSeed = z.infer<typeof NodeSeedSchema>;

--- a/cubic.yaml
+++ b/cubic.yaml
@@ -14,6 +14,13 @@ reviews:
     bunfig.toml preload (@zgeoff/bun-test-extended), so tests use matchers
     beyond Bun's built-in expect API — an unknown matcher name is caught by
     typecheck, not a runtime bug.
+
+    In libs/game/idle-client, the node-seeds and content-documents IndexedDB
+    stores are caches: a row that fails its current contract schema self-heals
+    on read (the row is deleted and the read reports a miss), so do not request
+    a per-version cache-migration test for either store. Only the outbox stores
+    — pending-checkpoints and pending-roots — hold un-synced local progress and
+    keep real versioned migrations.
   ignore:
     files:
       - bun.lock

--- a/libs/game/idle-client/src/submission/read-node-seed.ts
+++ b/libs/game/idle-client/src/submission/read-node-seed.ts
@@ -20,9 +20,17 @@ export async function readNodeSeed(
   nodeID: string,
 ): Promise<CachedNodeSeed | undefined> {
   const db = await resolveCheckpointQueueDB();
-  const record = await db.get(NODE_SEEDS_STORE_NAME, [avatarID, nodeID]);
+
+  // Read, validate, and delete a mismatched row inside one readwrite transaction so a concurrent
+  // reveal that repopulates the row can't have its fresh value deleted between a separate read and
+  // delete.
+  const tx = db.transaction(NODE_SEEDS_STORE_NAME, 'readwrite');
+
+  const record = await tx.store.get([avatarID, nodeID]);
 
   if (record === undefined) {
+    await tx.done;
+
     return undefined;
   }
 
@@ -32,10 +40,14 @@ export async function readNodeSeed(
   const result = NodeSeedSchema.safeParse(record);
 
   if (!result.success) {
-    await db.delete(NODE_SEEDS_STORE_NAME, [avatarID, nodeID]);
+    await tx.store.delete([avatarID, nodeID]);
+
+    await tx.done;
 
     return undefined;
   }
+
+  await tx.done;
 
   return {
     contentVersion: result.data.contentVersion,

--- a/libs/game/idle-client/src/submission/read-node-seed.ts
+++ b/libs/game/idle-client/src/submission/read-node-seed.ts
@@ -1,3 +1,4 @@
+import { NodeSeedSchema } from '@vers/contract-activity';
 import { NODE_SEEDS_STORE_NAME } from './constants';
 import { resolveCheckpointQueueDB } from './resolve-checkpoint-queue-db';
 import type { NodeSeed } from './types';
@@ -10,7 +11,9 @@ export type CachedNodeSeed = Omit<NodeSeed, 'avatarID' | 'nodeID'>;
 
 /**
  * Reads an avatar's cached start inputs — genesis seed, encounter, and content version — for a
- * world-map node, `undefined` when this device has never revealed that node for that avatar.
+ * world-map node, `undefined` when this device has never revealed that node for that avatar. A
+ * stored row that fails the contract schema is self-healing: the row is deleted so the next reveal
+ * repopulates it, rather than serving a value that could never have come from a real reveal.
  */
 export async function readNodeSeed(
   avatarID: string,
@@ -19,12 +22,25 @@ export async function readNodeSeed(
   const db = await resolveCheckpointQueueDB();
   const record = await db.get(NODE_SEEDS_STORE_NAME, [avatarID, nodeID]);
 
-  return record === undefined
-    ? undefined
-    : {
-        contentVersion: record.contentVersion,
-        encounterNode: record.encounterNode,
-        genesisSeed: record.genesisSeed,
-        head: record.head,
-      };
+  if (record === undefined) {
+    return undefined;
+  }
+
+  // A cache-store read resolves a schema mismatch as a miss rather than throwing: the row is
+  // rebuildable from the next reveal, unlike a server jsonb/text column an untyped-boundary
+  // `.parse` guards.
+  const result = NodeSeedSchema.safeParse(record);
+
+  if (!result.success) {
+    await db.delete(NODE_SEEDS_STORE_NAME, [avatarID, nodeID]);
+
+    return undefined;
+  }
+
+  return {
+    contentVersion: result.data.contentVersion,
+    encounterNode: result.data.encounterNode,
+    genesisSeed: result.data.genesisSeed,
+    head: result.data.head,
+  };
 }

--- a/libs/game/idle-client/src/submission/resolve-checkpoint-queue-db.test.ts
+++ b/libs/game/idle-client/src/submission/resolve-checkpoint-queue-db.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from 'bun:test';
+import { createMockActivityData } from '@vers/contract-activity/test-utils';
 import { ActivityFailureAction } from '@vers/idle-core';
 import type { IDBPDatabase } from 'idb';
 import { deleteDB, openDB } from 'idb';
-import { createMockNodeSeed } from '../test-utils/factories/create-mock-node-seed';
+import { createMockCheckpointBatchEntry } from '../test-utils/factories/create-mock-checkpoint-batch-entry';
 import {
   CHECKPOINT_QUEUE_STORE_NAME,
   CONTENT_DOCUMENT_STORE_NAME,
@@ -11,7 +12,9 @@ import {
   PENDING_ROOTS_STORE_NAME,
   PREFERENCES_STORE_NAME,
 } from './constants';
-import type { CheckpointQueueSchema, NodeSeed } from './types';
+import { readNodeSeed } from './read-node-seed';
+import { resolveCheckpointQueueDB } from './resolve-checkpoint-queue-db';
+import type { CheckpointQueueSchema } from './types';
 import { upgradeCheckpointQueueDB } from './upgrade-checkpoint-queue-db';
 
 /**
@@ -74,131 +77,73 @@ test('it creates the node-seeds store on an upgrade from v3 without dropping the
   }
 });
 
-test('it clears the node-seeds cache on the v4-to-v5 upgrade while preserving the other stores and their rows', async () => {
-  const upgradeTestV5DBName = 'vers-idle-checkpoint-queue-upgrade-v5-test';
+test('a node-seeds cache row failing its schema reads as a miss, while an outbox row survives a version upgrade unchanged', async () => {
+  // (a) node-seeds is a cache: a row that no longer matches its contract schema self-heals on
+  // read against the real queue database, independent of any version upgrade running at all.
+  const cacheDB = await resolveCheckpointQueueDB();
 
-  const preference = {
-    avatarID: 'avatar-upgrade-v5',
-    dirty: false,
-    failureAction: ActivityFailureAction.Abort,
-  } as const;
-
-  const nodeSeed = createMockNodeSeed({ avatarID: 'avatar-upgrade-v5', nodeID: '1_0' });
-
-  // a prior run that threw before its own cleanup could leave a v5 database behind, which would
-  // block this run's open at v4 with a version error — drop any leftover before opening
-  await deleteDB(upgradeTestV5DBName);
-
-  let v4: IDBPDatabase<CheckpointQueueSchema> | undefined;
-  let v5: IDBPDatabase<CheckpointQueueSchema> | undefined;
-
-  try {
-    v4 = await openDB<CheckpointQueueSchema>(upgradeTestV5DBName, 4, {
-      upgrade: upgradeCheckpointQueueDB,
-    });
-
-    await v4.put(PREFERENCES_STORE_NAME, preference, FAILURE_ACTION_PREFERENCE_KEY);
-    await v4.put(NODE_SEEDS_STORE_NAME, nodeSeed);
-
-    v4.close();
-
-    v5 = await openDB<CheckpointQueueSchema>(upgradeTestV5DBName, 5, {
-      upgrade: upgradeCheckpointQueueDB,
-    });
-
-    const existingPreference = await v5.get(PREFERENCES_STORE_NAME, FAILURE_ACTION_PREFERENCE_KEY);
-
-    const clearedNodeSeed = await v5.get(NODE_SEEDS_STORE_NAME, [
-      nodeSeed.avatarID,
-      nodeSeed.nodeID,
-    ]);
-
-    expect([...v5.objectStoreNames]).toIncludeAllMembers([
-      CHECKPOINT_QUEUE_STORE_NAME,
-      PREFERENCES_STORE_NAME,
-      CONTENT_DOCUMENT_STORE_NAME,
-      NODE_SEEDS_STORE_NAME,
-    ]);
-
-    expect(existingPreference).toStrictEqual(preference);
-    expect(clearedNodeSeed).toBeUndefined();
-  } finally {
-    v4?.close();
-    v5?.close();
-
-    await deleteDB(upgradeTestV5DBName);
-  }
-});
-
-test('it creates pending-roots and clears the head-less node-seeds rows on the v5-to-v6 upgrade while preserving the other stores and their rows', async () => {
-  const upgradeTestV6DBName = 'vers-idle-checkpoint-queue-upgrade-v6-test';
-
-  const preference = {
-    avatarID: 'avatar-upgrade-v6',
-    dirty: false,
-    failureAction: ActivityFailureAction.Abort,
-  } as const;
-
-  // the real v5 schema: node-seeds rows carried no `head`, and `pending-roots` did not exist yet.
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- a genuine pre-v6 node-seeds row predating the `head` field, which the current `NodeSeed` type can no longer express
-  const legacyNodeSeed = {
-    avatarID: 'avatar-upgrade-v6',
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- a deliberately malformed row (missing `head`) exercising the self-healing parse failure path
+  await cacheDB.put(NODE_SEEDS_STORE_NAME, {
+    avatarID: 'avatar-self-heal',
     contentVersion: '1',
-    encounterNode: { difficulty: 1, poolID: 'pool_legacy' },
-    genesisSeed: 'seed-legacy',
+    encounterNode: { difficulty: 1 },
+    genesisSeed: 'seed-self-heal',
     nodeID: '1_0',
-  } as unknown as NodeSeed;
+  } as never);
 
-  // a prior run that threw before its own cleanup could leave a v6 database behind, which would
-  // block this run's open at v5 with a version error — drop any leftover before opening
-  await deleteDB(upgradeTestV6DBName);
+  const readAfterMalformedPut = await readNodeSeed('avatar-self-heal', '1_0');
 
-  let v5: IDBPDatabase<CheckpointQueueSchema> | undefined;
-  let v6: IDBPDatabase<CheckpointQueueSchema> | undefined;
+  expect(readAfterMalformedPut).toBeUndefined();
+
+  const stillStored = await cacheDB.get(NODE_SEEDS_STORE_NAME, ['avatar-self-heal', '1_0']);
+
+  expect(stillStored).toBeUndefined();
+
+  // (b) pending-checkpoints and pending-roots are the outbox: a version upgrade must never drop
+  // their rows, since a miss there would silently discard un-synced local progress.
+  const upgradeTestDBName = 'vers-idle-checkpoint-queue-outbox-upgrade-test';
+
+  const queuedCheckpoint = {
+    ...createMockCheckpointBatchEntry({ version: 1 }),
+    activityID: 'activity-outbox-upgrade',
+  };
+
+  const pendingRoot = createMockActivityData({ id: 'act_outbox_upgrade' });
+
+  // a prior run that threw before its own cleanup could leave a database behind, which would
+  // block this run's open at version 1 with a version error — drop any leftover before opening
+  await deleteDB(upgradeTestDBName);
+
+  let vOld: IDBPDatabase<CheckpointQueueSchema> | undefined;
+  let vNew: IDBPDatabase<CheckpointQueueSchema> | undefined;
 
   try {
-    v5 = await openDB<CheckpointQueueSchema>(upgradeTestV6DBName, 5, {
-      upgrade(database) {
-        database.createObjectStore(CHECKPOINT_QUEUE_STORE_NAME, {
-          keyPath: ['activityID', 'version'],
-        });
-
-        database.createObjectStore(PREFERENCES_STORE_NAME);
-        database.createObjectStore(CONTENT_DOCUMENT_STORE_NAME, { keyPath: 'contentVersion' });
-        database.createObjectStore(NODE_SEEDS_STORE_NAME, { keyPath: ['avatarID', 'nodeID'] });
-      },
-    });
-
-    await v5.put(PREFERENCES_STORE_NAME, preference, FAILURE_ACTION_PREFERENCE_KEY);
-    await v5.put(NODE_SEEDS_STORE_NAME, legacyNodeSeed);
-
-    v5.close();
-
-    v6 = await openDB<CheckpointQueueSchema>(upgradeTestV6DBName, 6, {
+    vOld = await openDB<CheckpointQueueSchema>(upgradeTestDBName, 1, {
       upgrade: upgradeCheckpointQueueDB,
     });
 
-    const existingPreference = await v6.get(PREFERENCES_STORE_NAME, FAILURE_ACTION_PREFERENCE_KEY);
+    await vOld.put(CHECKPOINT_QUEUE_STORE_NAME, queuedCheckpoint);
+    await vOld.put(PENDING_ROOTS_STORE_NAME, pendingRoot);
 
-    const clearedNodeSeed = await v6.get(NODE_SEEDS_STORE_NAME, [
-      legacyNodeSeed.avatarID,
-      legacyNodeSeed.nodeID,
+    vOld.close();
+
+    vNew = await openDB<CheckpointQueueSchema>(upgradeTestDBName, 2, {
+      upgrade: upgradeCheckpointQueueDB,
+    });
+
+    const existingCheckpoint = await vNew.get(CHECKPOINT_QUEUE_STORE_NAME, [
+      queuedCheckpoint.activityID,
+      queuedCheckpoint.version,
     ]);
 
-    expect([...v6.objectStoreNames]).toIncludeAllMembers([
-      CHECKPOINT_QUEUE_STORE_NAME,
-      PREFERENCES_STORE_NAME,
-      CONTENT_DOCUMENT_STORE_NAME,
-      NODE_SEEDS_STORE_NAME,
-      PENDING_ROOTS_STORE_NAME,
-    ]);
+    const existingRoot = await vNew.get(PENDING_ROOTS_STORE_NAME, pendingRoot.id);
 
-    expect(existingPreference).toStrictEqual(preference);
-    expect(clearedNodeSeed).toBeUndefined();
+    expect(existingCheckpoint).toStrictEqual(queuedCheckpoint);
+    expect(existingRoot).toStrictEqual(pendingRoot);
   } finally {
-    v5?.close();
-    v6?.close();
+    vOld?.close();
+    vNew?.close();
 
-    await deleteDB(upgradeTestV6DBName);
+    await deleteDB(upgradeTestDBName);
   }
 });

--- a/libs/game/idle-client/src/submission/resolve-checkpoint-queue-db.test.ts
+++ b/libs/game/idle-client/src/submission/resolve-checkpoint-queue-db.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from 'bun:test';
-import { createMockActivityData } from '@vers/contract-activity/test-utils';
 import { ActivityFailureAction } from '@vers/idle-core';
 import type { IDBPDatabase } from 'idb';
 import { deleteDB, openDB } from 'idb';
 import { createMockCheckpointBatchEntry } from '../test-utils/factories/create-mock-checkpoint-batch-entry';
 import {
+  CHECKPOINT_QUEUE_DB_VERSION,
   CHECKPOINT_QUEUE_STORE_NAME,
   CONTENT_DOCUMENT_STORE_NAME,
   FAILURE_ACTION_PREFERENCE_KEY,
@@ -77,9 +77,9 @@ test('it creates the node-seeds store on an upgrade from v3 without dropping the
   }
 });
 
-test('a node-seeds cache row failing its schema reads as a miss, while an outbox row survives a version upgrade unchanged', async () => {
-  // (a) node-seeds is a cache: a row that no longer matches its contract schema self-heals on
-  // read against the real queue database, independent of any version upgrade running at all.
+test('a node-seeds cache row failing its schema reads as a miss and is deleted', async () => {
+  // node-seeds is a cache: a row that no longer matches its contract schema self-heals on read
+  // against the real queue database, independent of any version upgrade running at all.
   const cacheDB = await resolveCheckpointQueueDB();
 
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- a deliberately malformed row (missing `head`) exercising the self-healing parse failure path
@@ -98,9 +98,12 @@ test('a node-seeds cache row failing its schema reads as a miss, while an outbox
   const stillStored = await cacheDB.get(NODE_SEEDS_STORE_NAME, ['avatar-self-heal', '1_0']);
 
   expect(stillStored).toBeUndefined();
+});
 
-  // (b) pending-checkpoints and pending-roots are the outbox: a version upgrade must never drop
-  // their rows, since a miss there would silently discard un-synced local progress.
+test('adding the pending-roots outbox store on an upgrade preserves the pending-checkpoints rows', async () => {
+  // pending-checkpoints and pending-roots are the outbox: adding the outbox store a database
+  // predates must preserve the queued checkpoints already there, since a miss would silently
+  // discard un-synced local progress.
   const upgradeTestDBName = 'vers-idle-checkpoint-queue-outbox-upgrade-test';
 
   const queuedCheckpoint = {
@@ -108,26 +111,32 @@ test('a node-seeds cache row failing its schema reads as a miss, while an outbox
     activityID: 'activity-outbox-upgrade',
   };
 
-  const pendingRoot = createMockActivityData({ id: 'act_outbox_upgrade' });
-
   // a prior run that threw before its own cleanup could leave a database behind, which would
-  // block this run's open at version 1 with a version error — drop any leftover before opening
+  // block this run's open at the older version with a version error — drop any leftover first
   await deleteDB(upgradeTestDBName);
 
   let vOld: IDBPDatabase<CheckpointQueueSchema> | undefined;
   let vNew: IDBPDatabase<CheckpointQueueSchema> | undefined;
 
   try {
-    vOld = await openDB<CheckpointQueueSchema>(upgradeTestDBName, 1, {
-      upgrade: upgradeCheckpointQueueDB,
+    // an older database predating pending-roots: every cache and outbox store except it
+    vOld = await openDB<CheckpointQueueSchema>(upgradeTestDBName, 5, {
+      upgrade(database) {
+        database.createObjectStore(CHECKPOINT_QUEUE_STORE_NAME, {
+          keyPath: ['activityID', 'version'],
+        });
+
+        database.createObjectStore(PREFERENCES_STORE_NAME);
+        database.createObjectStore(CONTENT_DOCUMENT_STORE_NAME, { keyPath: 'contentVersion' });
+        database.createObjectStore(NODE_SEEDS_STORE_NAME, { keyPath: ['avatarID', 'nodeID'] });
+      },
     });
 
     await vOld.put(CHECKPOINT_QUEUE_STORE_NAME, queuedCheckpoint);
-    await vOld.put(PENDING_ROOTS_STORE_NAME, pendingRoot);
 
     vOld.close();
 
-    vNew = await openDB<CheckpointQueueSchema>(upgradeTestDBName, 2, {
+    vNew = await openDB<CheckpointQueueSchema>(upgradeTestDBName, CHECKPOINT_QUEUE_DB_VERSION, {
       upgrade: upgradeCheckpointQueueDB,
     });
 
@@ -136,10 +145,8 @@ test('a node-seeds cache row failing its schema reads as a miss, while an outbox
       queuedCheckpoint.version,
     ]);
 
-    const existingRoot = await vNew.get(PENDING_ROOTS_STORE_NAME, pendingRoot.id);
-
+    expect([...vNew.objectStoreNames]).toContain(PENDING_ROOTS_STORE_NAME);
     expect(existingCheckpoint).toStrictEqual(queuedCheckpoint);
-    expect(existingRoot).toStrictEqual(pendingRoot);
   } finally {
     vOld?.close();
     vNew?.close();

--- a/libs/game/idle-client/src/submission/types.ts
+++ b/libs/game/idle-client/src/submission/types.ts
@@ -4,6 +4,7 @@ import type {
   CheckpointBatchEntry,
   ContentDocument,
   EncounterNode,
+  NodeSeed,
   activityContract,
 } from '@vers/contract-activity';
 import type { ActivityFailureAction } from '@vers/idle-core';
@@ -67,26 +68,6 @@ export interface NodeSeedHead {
 }
 
 /**
- * A world-map node's revealed start inputs as the worker's durable cache holds them, keyed by the
- * `[avatarID, nodeID]` pair: the genesis seed the chain originated from, its current head, plus the
- * encounter and content version `buildStartHash` needs alongside it — every per-node input a local
- * start synthesizes a valid activity start from, short of the avatar- and account-global stamps
- * `readStartStamps` holds separately. A node's genesis seed is per avatar — two avatars sharing a
- * coordinate root distinct chains against distinct seeds — so the cache scopes every row to its
- * avatar rather than letting one avatar's reveal overwrite another's. Revealing an already-cached
- * node writes the server's current head back in place: the reveal round trip is idempotent per
- * avatar and node, so the cache write is too.
- */
-export interface NodeSeed {
-  readonly avatarID: string;
-  readonly contentVersion: string;
-  readonly encounterNode: EncounterNode;
-  readonly genesisSeed: string;
-  readonly head: NodeSeedHead;
-  readonly nodeID: string;
-}
-
-/**
  * A revealed node's start inputs as they arrive over the worker message and off the reveal round
  * trip, before the avatar they belong to is threaded onto them. The relayed batch carries one
  * avatarID for every entry in it, so an entry on the wire holds only its node id and the fields
@@ -112,6 +93,8 @@ export interface StartStampsPreference {
   readonly secretRef: string;
   readonly secretVersion: number;
 }
+
+export type { NodeSeed } from '@vers/contract-activity';
 
 export interface CheckpointQueueSchema extends DBSchema {
   'content-documents': {

--- a/libs/game/idle-client/src/submission/upgrade-checkpoint-queue-db.ts
+++ b/libs/game/idle-client/src/submission/upgrade-checkpoint-queue-db.ts
@@ -13,17 +13,19 @@ import type { CheckpointQueueSchema } from './types';
  * upgrade. Each store is created only if missing, so an upgrade from an earlier version adds the
  * stores that version lacks without dropping the ones it already holds or their rows.
  *
- * The one exception is `node-seeds`: an upgrade from a version predating v6 clears it. A pre-v5 row
- * carried only a genesis seed and misses the encounter and content version a v5 row declares; a
- * pre-v6 row misses the `head` that `readNodeSeed`'s type declares non-optional, so leaving it
- * would let a headless row re-enter typed code. Clearing the rebuildable cache leaves only
- * full-shape rows behind, and the prefetch re-reveals and repopulates them.
+ * The stores split by durability. `content-documents` and `node-seeds` are caches: a row that no
+ * longer matches its current contract schema self-heals on read — the read boundary
+ * (`findCachedContentDocument`, `readNodeSeed`) deletes the row and reads it as a miss, and the
+ * next fetch or reveal repopulates it — so neither store carries a version-specific migration here.
+ * `pending-checkpoints` and `pending-roots` are the outbox: un-synced local progress a device has
+ * not yet delivered to the server, which a cache-style miss would silently drop, so a shape change
+ * to either needs a real versioned migration in this function instead.
  */
 export function upgradeCheckpointQueueDB(
   database: IDBPDatabase<CheckpointQueueSchema>,
-  oldVersion: number,
+  _oldVersion: number,
   _newVersion: number | null,
-  transaction: IDBPTransaction<
+  _transaction: IDBPTransaction<
     CheckpointQueueSchema,
     Array<StoreNames<CheckpointQueueSchema>>,
     'versionchange'
@@ -53,8 +55,6 @@ export function upgradeCheckpointQueueDB(
   // content version — by its `[avatarID, nodeID]` pair.
   if (!database.objectStoreNames.contains(NODE_SEEDS_STORE_NAME)) {
     database.createObjectStore(NODE_SEEDS_STORE_NAME, { keyPath: ['avatarID', 'nodeID'] });
-  } else if (oldVersion < 6) {
-    void transaction.objectStore(NODE_SEEDS_STORE_NAME).clear();
   }
 
   if (!database.objectStoreNames.contains(PENDING_ROOTS_STORE_NAME)) {

--- a/libs/game/idle-client/src/submission/upgrade-checkpoint-queue-db.ts
+++ b/libs/game/idle-client/src/submission/upgrade-checkpoint-queue-db.ts
@@ -19,7 +19,9 @@ import type { CheckpointQueueSchema } from './types';
  * version-specific migration here. `pending-checkpoints` and `pending-roots` are the outbox:
  * un-synced local progress a device has not yet delivered to the server, which a cache-style miss
  * would silently drop, so a shape change to either needs a real versioned migration in this function
- * instead.
+ * instead. Cache self-healing catches shape drift only: a row whose meaning changed while its shape
+ * still satisfies its schema reads as a hit, so a semantic change to a cached value needs an
+ * explicit version bump too.
  */
 export function upgradeCheckpointQueueDB(
   database: IDBPDatabase<CheckpointQueueSchema>,

--- a/libs/game/idle-client/src/submission/upgrade-checkpoint-queue-db.ts
+++ b/libs/game/idle-client/src/submission/upgrade-checkpoint-queue-db.ts
@@ -14,12 +14,12 @@ import type { CheckpointQueueSchema } from './types';
  * stores that version lacks without dropping the ones it already holds or their rows.
  *
  * The stores split by durability. `content-documents` and `node-seeds` are caches: a row that no
- * longer matches its current contract schema self-heals on read — the read boundary
- * (`findCachedContentDocument`, `readNodeSeed`) deletes the row and reads it as a miss, and the
- * next fetch or reveal repopulates it — so neither store carries a version-specific migration here.
- * `pending-checkpoints` and `pending-roots` are the outbox: un-synced local progress a device has
- * not yet delivered to the server, which a cache-style miss would silently drop, so a shape change
- * to either needs a real versioned migration in this function instead.
+ * longer matches its current contract schema self-heals on read — its read boundary deletes the row
+ * and reads it as a miss, and the next fetch or reveal repopulates it — so neither store carries a
+ * version-specific migration here. `pending-checkpoints` and `pending-roots` are the outbox:
+ * un-synced local progress a device has not yet delivered to the server, which a cache-style miss
+ * would silently drop, so a shape change to either needs a real versioned migration in this function
+ * instead.
  */
 export function upgradeCheckpointQueueDB(
   database: IDBPDatabase<CheckpointQueueSchema>,


### PR DESCRIPTION
## Description

Closes #907

Splits the client checkpoint-queue IndexedDB stores by durability: `node-seeds` and `content-documents` are caches that self-heal on a schema mismatch, while `pending-checkpoints` and `pending-roots` are the outbox and keep real versioned migrations.

- Add `NodeSeedSchema` (zod) to `@vers/contract-activity`, composing `EncounterNodeSchema` plus the primitive fields; `idle-client` now re-exports its `NodeSeed` type from the contract instead of hand-rolling it.
- `readNodeSeed` safeParses the stored row and, on failure, deletes it and reports a miss, mirroring `findCachedContentDocument`'s existing precedent.
- Drop the `oldVersion < 6` node-seeds clear from `upgradeCheckpointQueueDB`, and rewrite its doc comment to state the durability split.
- Replace the two version-specific node-seeds-clear tests with one test proving a malformed row reads as a miss independent of any upgrade, and an outbox row survives an upgrade unchanged.
- Tell CodeRabbit and cubic the cache stores self-heal on read, so they don't request per-version cache-migration tests for them.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] `bun run lint` passes
- [x] New tests added for new functionality
