### PR TITLE
feat(#905): warn of un-synced offline loss on takeover

### DIFF
--- a/apps/web/src/routes/-game/playing-elsewhere-notice.test.tsx
+++ b/apps/web/src/routes/-game/playing-elsewhere-notice.test.tsx
@@ -1,15 +1,11 @@
 import { expect, test } from 'bun:test';
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { setWriterDisplacedActivityID } from '@vers/idle-client';
 import { ActivityFailureAction } from '@vers/idle-core';
-import { buildActiveAvatarQueryOptions } from '../../lib/avatar/build-active-avatar-query-options';
-import { createActiveAvatar } from '../../test-utils/create-active-avatar';
-import { createSignedInUser } from '../../test-utils/create-signed-in-user';
 import { createStubWorkerClient } from '../../test-utils/create-stub-worker-client';
 import { render } from '../../test-utils/render';
 import { setIdleWorkerHandle } from '../../test-utils/set-idle-worker-handle';
-import { withRequestContext } from '../../test-utils/with-request-context';
 import { PlayingElsewhereNotice } from './playing-elsewhere-notice';
 
 test('it renders nothing while no displacement is reported', () => {
@@ -18,20 +14,16 @@ test('it renders nothing while no displacement is reported', () => {
   expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 });
 
-test('it tells the player their run picked up on another device', () => {
+test('it tells the player their run has been picked up on another device, with no way back in', () => {
   setWriterDisplacedActivityID('activity_1');
   render(<PlayingElsewhereNotice />);
 
   expect(screen.getByText('Playing on another device')).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: 'Continue here' })).toBeInTheDocument();
+  expect(screen.getByText('Your run has been picked up on another device.')).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'Continue here' })).not.toBeInTheDocument();
 });
 
-test('it claims the run back with a claiming report on continue-here', async () => {
-  const user = userEvent.setup();
-
-  const signedIn = await createSignedInUser();
-  const avatar = await createActiveAvatar({ userID: signedIn.userID });
-
+test('it never reports the client back online, since the notice offers no reclaim path', () => {
   const client = createStubWorkerClient();
 
   setIdleWorkerHandle({
@@ -43,29 +35,9 @@ test('it claims the run back with a claiming report on continue-here', async () 
   });
 
   setWriterDisplacedActivityID('activity_1');
+  render(<PlayingElsewhereNotice />);
 
-  await withRequestContext({ cookies: signedIn.cookies }, async () => {
-    const rendered = render(<PlayingElsewhereNotice />);
-
-    // a click lands only once the avatar id has resolved; awaiting the cached query result before
-    // clicking, rather than retrying the click itself, keeps the click a single user action
-    await waitFor(() => {
-      expect(
-        rendered.queryClient.getQueryState(buildActiveAvatarQueryOptions().queryKey)?.status,
-      ).toBe('success');
-    });
-
-    await user.click(screen.getByRole('button', { name: 'Continue here' }));
-
-    await waitFor(() => {
-      expect(client.reportOnline).toHaveBeenCalledExactlyOnceWith(
-        { avatarID: avatar.id, claim: true },
-        expect.anything(),
-      );
-    });
-
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-  });
+  expect(client.reportOnline).not.toHaveBeenCalled();
 });
 
 test('it dismisses by clearing the displaced state, and a fresh displacement re-opens it', async () => {
@@ -78,8 +50,8 @@ test('it dismisses by clearing the displaced state, and a fresh displacement re-
 
   expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 
-  // any later displacement — the same run taken again after a take-back included — arrives as a
-  // fresh worker broadcast and re-opens the notice
+  // any later displacement — the same run taken again after the player signs back in — arrives as
+  // a fresh worker broadcast and re-opens the notice
   setWriterDisplacedActivityID('activity_1');
 
   const dialog = await screen.findByRole('dialog');

--- a/apps/web/src/routes/-game/playing-elsewhere-notice.tsx
+++ b/apps/web/src/routes/-game/playing-elsewhere-notice.tsx
@@ -1,24 +1,16 @@
-import { useQuery } from '@tanstack/react-query';
-import { Button, Dialog, Text } from '@vers/design-system';
+import { Dialog, Text } from '@vers/design-system';
 import { setWriterDisplacedActivityID, useWriterDisplacedActivityID } from '@vers/idle-client';
-import { buildActiveAvatarQueryOptions } from '../../lib/avatar/build-active-avatar-query-options';
-import { runIgnoringRejection } from '../../lib/idle/run-ignoring-rejection';
-import { sendIdleReportOnline } from '../../lib/idle/send-idle-report-online';
-import { useIdleWorkerHandle } from '../../lib/idle/use-idle-worker-handle';
 
 /**
- * Tells the player their run is being played on another device: this device's simulation stopped
- * and nothing it submits persists. "Continue here" claims the run back through a claiming report;
- * dismissing leaves the run to the other device. Both clear the tab's displaced state while the
- * worker keeps its own record, whose transition-only broadcast never re-raises an unchanged
- * displacement — but a fresh one (the same run displaced again after a take-back) transitions
- * through null and re-opens the notice.
+ * Tells the player their run has been picked up on another device: this device's simulation
+ * stopped and nothing it submits persists. The notice is terminal — there is no in-app way to
+ * take the run back; dismissing it only clears the tab's displaced state, which the worker keeps
+ * its own record of. The worker's transition-only broadcast never re-raises an unchanged
+ * displacement, but a fresh one (the same run displaced again after the player signs back in)
+ * transitions through null and re-opens the notice.
  */
 export function PlayingElsewhereNotice() {
   const displacedActivityID = useWriterDisplacedActivityID();
-  const idleWorkerHandle = useIdleWorkerHandle();
-  const avatarQuery = useQuery(buildActiveAvatarQueryOptions());
-  const avatarID = avatarQuery.data?.id;
 
   if (displacedActivityID === null) {
     return null;
@@ -34,33 +26,7 @@ export function PlayingElsewhereNotice() {
       open
       title="Playing on another device"
     >
-      <Text>
-        Your run picked up on another device, so it&rsquo;s paused here. Everything you earn over
-        there is saved.
-      </Text>
-      <Button
-        onClick={() => {
-          // The displaced state clears only once the claim is actually sent — clearing without
-          // sending would dismiss the player's one recovery notice with nothing claimed. A click
-          // before the worker or avatar id resolves leaves the notice open for the next try.
-          if (idleWorkerHandle.client === undefined || avatarID === undefined) {
-            return;
-          }
-
-          runIgnoringRejection(
-            sendIdleReportOnline(
-              idleWorkerHandle.client,
-              avatarID,
-              true,
-              idleWorkerHandle.writerAbortSignal,
-            ),
-          );
-
-          setWriterDisplacedActivityID(null);
-        }}
-      >
-        Continue here
-      </Button>
+      <Text>Your run has been picked up on another device.</Text>
     </Dialog>
   );
 }

--- a/apps/web/src/routes/-game/welcome-back-modal.tsx
+++ b/apps/web/src/routes/-game/welcome-back-modal.tsx
@@ -30,8 +30,8 @@ export function WelcomeBackModal() {
     return null;
   }
 
-  // a catch-up ended by another device taking the run resolves in the playing-elsewhere notice,
-  // which carries the take-back action — a second dialog saying the same thing helps nobody
+  // a catch-up ended by another device taking the run resolves in the playing-elsewhere notice —
+  // a second dialog saying the same thing helps nobody
   if (resyncStatus.kind === 'active-elsewhere') {
     return null;
   }

--- a/apps/web/src/routes/-login-force-logout/force-logout-form.test.tsx
+++ b/apps/web/src/routes/-login-force-logout/force-logout-form.test.tsx
@@ -52,7 +52,7 @@ test('it renders the informational copy explaining why a force logout is needed'
   await withRequestContext({}, async () => {
     renderWithRouter(<ForceLogoutForm />);
 
-    const infoText = await screen.findByText('You are currently logged in somewhere else.', {
+    const infoText = await screen.findByText('Logging in here picks your run up', {
       exact: false,
     });
 

--- a/apps/web/src/routes/-login-force-logout/force-logout-form.test.tsx
+++ b/apps/web/src/routes/-login-force-logout/force-logout-form.test.tsx
@@ -57,5 +57,6 @@ test('it renders the informational copy explaining why a force logout is needed'
     });
 
     expect(infoText).toBeVisible();
+    expect(screen.getByText('synced yet may be lost', { exact: false })).toBeVisible();
   });
 });

--- a/apps/web/src/routes/-login-force-logout/force-logout-form.tsx
+++ b/apps/web/src/routes/-login-force-logout/force-logout-form.tsx
@@ -43,10 +43,10 @@ export function ForceLogoutForm(props: ForceLogoutFormProps) {
         </Link>
         <Heading level={2}>You are logged in elsewhere</Heading>
         <Text className={infoText}>
-          You are currently logged in somewhere else. To ensure your account can be properly
-          synchronized, we need to log you out there, before we can log you in here.
+          Logging in here picks your run up from the last activity you&rsquo;d started. Any progress
+          the other device made offline and hasn&rsquo;t synced yet may be lost.
         </Text>
-        <Text>Would you like to logout your other sessions?</Text>
+        <Text>Would you like to log out your other session?</Text>
       </section>
 
       <form {...getFormProps(form)} className={buttonContainer} method="post">


### PR DESCRIPTION
Closes #905. Splits the single-active-session copy across its two real moments and drops the stale in-app take-back.

- **Hijack confirm** (`force-logout-form.tsx`): warns that logging in picks the run up from the last *started* activity and that the other device's un-synced offline progress may be lost.
- **Booted notice** (`playing-elsewhere-notice.tsx`): terminal now — "Your run has been picked up on another device." The "Continue here" reclaim button and its claim call are removed; to return, the player logs in again and hits the confirm.
- Reconciled the stale take-back comment in `welcome-back-modal.tsx`.

Copy-only; the loss itself is unchanged anti-cheat behaviour (build-snapshot-mismatch at reconnect).
